### PR TITLE
chore(docs): normalize dash spacing across docs (automated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ jobs:
 
 ## 📁 主なディレクトリ
 
-- `docs/` — Docusaurus用ドキュメント。各章にガイド・リファレンス・ガバナンスを配置しています。
-- `coding-review-checklist.md` — レビュー観点のクイックリファレンス。
-- `AGENTS.md` — AIエージェント向けの作業ガイドライン。
-- `docusaurus.config.js`, `sidebars.js` — ドキュメントサイトの設定ファイル。
+- `docs/`—Docusaurus用ドキュメント。各章にガイド・リファレンス・ガバナンスを配置しています。
+- `coding-review-checklist.md`—レビュー観点のクイックリファレンス。
+- `AGENTS.md`—AIエージェント向けの作業ガイドライン。
+- `docusaurus.config.js`, `sidebars.js`—ドキュメントサイトの設定ファイル。
 
 ## 🤝 コントリビューション
 


### PR DESCRIPTION
Automated dash normalization across docs & ai-review checklists (headings, YAML titles, list items).

- Normalizes en-dash (–) and em-dash (—) spacing to match Microsoft.Dashes (Vale) style — em-dash without spaces in headings/titles & list items.
- Skips numeric ranges (e.g., 0.0–1.0) and code blocks; targets only docs, README.md, AGENTS.md, and .github/ai-review/checklists

Validation: ran 
> format:check
> prettier --check "**/*.{js,json,md,yml,yaml}"

Checking formatting...
All matched files use Prettier code style!, 
> lint:md
> markdownlint '**/*.md' --ignore node_modules, and 
> lint:text
> textlint 'docs/**/*.md' locally.
