### PR TITLE
[docs] River Reviewerテンプレートと初期ドキュメント追加

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,89 @@
+name: "\U0001F41E Bug Report"
+description: "Report a defect in the River Reviewer flow (Upstream → Midstream → Downstream)."
+title: "[Bug] "
+labels: ["type:bug", "status:triage"]
+body:
+  - type: markdown
+    attributes:
+      value: "Thank you for helping keep River Reviewer flowing smoothly. Please include clear repro steps."
+  - type: dropdown
+    id: phase
+    attributes:
+      label: "What phase is affected?"
+      description: "Select the primary phase impacted by this bug."
+      options:
+        - Upstream
+        - Midstream
+        - Downstream
+    validations:
+      required: true
+  - type: dropdown
+    id: schema_impacted
+    attributes:
+      label: "Schema impacted? (skill.schema.json)"
+      options:
+        - Yes
+        - No
+        - Unsure
+    validations:
+      required: true
+  - type: dropdown
+    id: runner_logic_impacted
+    attributes:
+      label: "Runner logic impacted?"
+      options:
+        - Yes
+        - No
+        - Unsure
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: "Severity"
+      description: "How disruptive is the issue?"
+      options:
+        - info
+        - minor
+        - major
+        - critical
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: "Summary"
+      description: "Briefly describe the defect and its impact."
+      placeholder: "Upstream skill validation fails when..."
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: "Reproduction steps"
+      description: "Clear, ordered steps to reproduce."
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: "Expected behavior"
+      description: "What you expected to happen instead."
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: "Actual behavior / logs"
+      description: "Include screenshots, stack traces, or runner output."
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: "Environment"
+      description: "CLI/runner version, OS, workflow context, etc."

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -12,9 +12,9 @@ body:
       label: 'What phase is affected?'
       description: 'Select the primary phase impacted by this bug.'
       options:
-        - Upstream
-        - Midstream
-        - Downstream
+        - upstream
+        - midstream
+        - downstream
     validations:
       required: true
   - type: dropdown
@@ -87,3 +87,5 @@ body:
     attributes:
       label: 'Environment'
       description: 'CLI/runner version, OS, workflow context, etc.'
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,16 +1,16 @@
 name: "\U0001F41E Bug Report"
-description: "Report a defect in the River Reviewer flow (Upstream → Midstream → Downstream)."
-title: "[Bug] "
-labels: ["type:bug", "status:triage"]
+description: 'Report a defect in the River Reviewer flow (Upstream → Midstream → Downstream).'
+title: '[Bug] '
+labels: ['type:bug', 'status:triage']
 body:
   - type: markdown
     attributes:
-      value: "Thank you for helping keep River Reviewer flowing smoothly. Please include clear repro steps."
+      value: 'Thank you for helping keep River Reviewer flowing smoothly. Please include clear repro steps.'
   - type: dropdown
     id: phase
     attributes:
-      label: "What phase is affected?"
-      description: "Select the primary phase impacted by this bug."
+      label: 'What phase is affected?'
+      description: 'Select the primary phase impacted by this bug.'
       options:
         - Upstream
         - Midstream
@@ -20,7 +20,7 @@ body:
   - type: dropdown
     id: schema_impacted
     attributes:
-      label: "Schema impacted? (skill.schema.json)"
+      label: 'Schema impacted? (skill.schema.json)'
       options:
         - Yes
         - No
@@ -30,7 +30,7 @@ body:
   - type: dropdown
     id: runner_logic_impacted
     attributes:
-      label: "Runner logic impacted?"
+      label: 'Runner logic impacted?'
       options:
         - Yes
         - No
@@ -40,8 +40,8 @@ body:
   - type: dropdown
     id: severity
     attributes:
-      label: "Severity"
-      description: "How disruptive is the issue?"
+      label: 'Severity'
+      description: 'How disruptive is the issue?'
       options:
         - info
         - minor
@@ -52,16 +52,16 @@ body:
   - type: textarea
     id: summary
     attributes:
-      label: "Summary"
-      description: "Briefly describe the defect and its impact."
-      placeholder: "Upstream skill validation fails when..."
+      label: 'Summary'
+      description: 'Briefly describe the defect and its impact.'
+      placeholder: 'Upstream skill validation fails when...'
     validations:
       required: true
   - type: textarea
     id: repro
     attributes:
-      label: "Reproduction steps"
-      description: "Clear, ordered steps to reproduce."
+      label: 'Reproduction steps'
+      description: 'Clear, ordered steps to reproduce.'
       placeholder: |
         1. ...
         2. ...
@@ -71,19 +71,19 @@ body:
   - type: textarea
     id: expected
     attributes:
-      label: "Expected behavior"
-      description: "What you expected to happen instead."
+      label: 'Expected behavior'
+      description: 'What you expected to happen instead.'
     validations:
       required: true
   - type: textarea
     id: actual
     attributes:
-      label: "Actual behavior / logs"
-      description: "Include screenshots, stack traces, or runner output."
+      label: 'Actual behavior / logs'
+      description: 'Include screenshots, stack traces, or runner output.'
     validations:
       required: true
   - type: input
     id: environment
     attributes:
-      label: "Environment"
-      description: "CLI/runner version, OS, workflow context, etc."
+      label: 'Environment'
+      description: 'CLI/runner version, OS, workflow context, etc.'

--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -1,0 +1,68 @@
+name: "\U0001F4D6 Documentation"
+description: "Request or propose documentation updates for River Reviewer."
+title: "[Docs] "
+labels: ["type:docs", "status:triage"]
+body:
+  - type: markdown
+    attributes:
+      value: "Help keep River Reviewer docs aligned with the Upstream → Midstream → Downstream flow."
+  - type: dropdown
+    id: phase
+    attributes:
+      label: "What phase is affected?"
+      options:
+        - Upstream
+        - Midstream
+        - Downstream
+    validations:
+      required: true
+  - type: dropdown
+    id: schema_impacted
+    attributes:
+      label: "Schema impacted? (skill.schema.json)"
+      options:
+        - Yes
+        - No
+        - Unsure
+    validations:
+      required: true
+  - type: dropdown
+    id: runner_logic_impacted
+    attributes:
+      label: "Runner logic impacted?"
+      options:
+        - Yes
+        - No
+        - Unsure
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: "Impact level"
+      options:
+        - info
+        - minor
+        - major
+        - critical
+    validations:
+      required: true
+  - type: textarea
+    id: location
+    attributes:
+      label: "Page(s) to update"
+      description: "Paths, section headings, or links to the docs needing changes."
+    validations:
+      required: true
+  - type: textarea
+    id: change
+    attributes:
+      label: "Requested change"
+      description: "Describe the new or corrected information needed."
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: "How can we verify accuracy?"
+      description: "Examples: commands to run, outputs to capture, or SMEs to confirm with."

--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -1,15 +1,15 @@
 name: "\U0001F4D6 Documentation"
-description: "Request or propose documentation updates for River Reviewer."
-title: "[Docs] "
-labels: ["type:docs", "status:triage"]
+description: 'Request or propose documentation updates for River Reviewer.'
+title: '[Docs] '
+labels: ['type:docs', 'status:triage']
 body:
   - type: markdown
     attributes:
-      value: "Help keep River Reviewer docs aligned with the Upstream → Midstream → Downstream flow."
+      value: 'Help keep River Reviewer docs aligned with the Upstream → Midstream → Downstream flow.'
   - type: dropdown
     id: phase
     attributes:
-      label: "What phase is affected?"
+      label: 'What phase is affected?'
       options:
         - Upstream
         - Midstream
@@ -19,7 +19,7 @@ body:
   - type: dropdown
     id: schema_impacted
     attributes:
-      label: "Schema impacted? (skill.schema.json)"
+      label: 'Schema impacted? (skill.schema.json)'
       options:
         - Yes
         - No
@@ -29,7 +29,7 @@ body:
   - type: dropdown
     id: runner_logic_impacted
     attributes:
-      label: "Runner logic impacted?"
+      label: 'Runner logic impacted?'
       options:
         - Yes
         - No
@@ -39,7 +39,7 @@ body:
   - type: dropdown
     id: severity
     attributes:
-      label: "Impact level"
+      label: 'Impact level'
       options:
         - info
         - minor
@@ -50,19 +50,19 @@ body:
   - type: textarea
     id: location
     attributes:
-      label: "Page(s) to update"
-      description: "Paths, section headings, or links to the docs needing changes."
+      label: 'Page(s) to update'
+      description: 'Paths, section headings, or links to the docs needing changes.'
     validations:
       required: true
   - type: textarea
     id: change
     attributes:
-      label: "Requested change"
-      description: "Describe the new or corrected information needed."
+      label: 'Requested change'
+      description: 'Describe the new or corrected information needed.'
     validations:
       required: true
   - type: textarea
     id: verification
     attributes:
-      label: "How can we verify accuracy?"
-      description: "Examples: commands to run, outputs to capture, or SMEs to confirm with."
+      label: 'How can we verify accuracy?'
+      description: 'Examples: commands to run, outputs to capture, or SMEs to confirm with.'

--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -11,9 +11,9 @@ body:
     attributes:
       label: 'What phase is affected?'
       options:
-        - Upstream
-        - Midstream
-        - Downstream
+        - upstream
+        - midstream
+        - downstream
     validations:
       required: true
   - type: dropdown
@@ -66,3 +66,5 @@ body:
     attributes:
       label: 'How can we verify accuracy?'
       description: 'Examples: commands to run, outputs to capture, or SMEs to confirm with.'
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yaml
@@ -1,15 +1,15 @@
 name: "\u26A1 Enhancement"
-description: "Polish or extend an existing River Reviewer capability."
-title: "[Enhancement] "
-labels: ["type:enhancement", "status:triage"]
+description: 'Polish or extend an existing River Reviewer capability.'
+title: '[Enhancement] '
+labels: ['type:enhancement', 'status:triage']
 body:
   - type: markdown
     attributes:
-      value: "Tell us how to make the current flow smoother."
+      value: 'Tell us how to make the current flow smoother.'
   - type: dropdown
     id: phase
     attributes:
-      label: "What phase is affected?"
+      label: 'What phase is affected?'
       options:
         - Upstream
         - Midstream
@@ -19,7 +19,7 @@ body:
   - type: dropdown
     id: schema_impacted
     attributes:
-      label: "Schema impacted? (skill.schema.json)"
+      label: 'Schema impacted? (skill.schema.json)'
       options:
         - Yes
         - No
@@ -29,7 +29,7 @@ body:
   - type: dropdown
     id: runner_logic_impacted
     attributes:
-      label: "Runner logic impacted?"
+      label: 'Runner logic impacted?'
       options:
         - Yes
         - No
@@ -39,7 +39,7 @@ body:
   - type: dropdown
     id: severity
     attributes:
-      label: "Impact level"
+      label: 'Impact level'
       options:
         - info
         - minor
@@ -50,19 +50,19 @@ body:
   - type: textarea
     id: current
     attributes:
-      label: "Current behavior"
-      description: "Summarize what exists today and any friction."
+      label: 'Current behavior'
+      description: 'Summarize what exists today and any friction.'
     validations:
       required: true
   - type: textarea
     id: proposal
     attributes:
-      label: "Requested enhancement"
-      description: "How should the flow improve across Upstream → Midstream → Downstream?"
+      label: 'Requested enhancement'
+      description: 'How should the flow improve across Upstream → Midstream → Downstream?'
     validations:
       required: true
   - type: textarea
     id: success
     attributes:
-      label: "Success signals"
-      description: "Metrics, usability wins, or quality checks that confirm the enhancement worked."
+      label: 'Success signals'
+      description: 'Metrics, usability wins, or quality checks that confirm the enhancement worked.'

--- a/.github/ISSUE_TEMPLATE/enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yaml
@@ -1,0 +1,68 @@
+name: "\u26A1 Enhancement"
+description: "Polish or extend an existing River Reviewer capability."
+title: "[Enhancement] "
+labels: ["type:enhancement", "status:triage"]
+body:
+  - type: markdown
+    attributes:
+      value: "Tell us how to make the current flow smoother."
+  - type: dropdown
+    id: phase
+    attributes:
+      label: "What phase is affected?"
+      options:
+        - Upstream
+        - Midstream
+        - Downstream
+    validations:
+      required: true
+  - type: dropdown
+    id: schema_impacted
+    attributes:
+      label: "Schema impacted? (skill.schema.json)"
+      options:
+        - Yes
+        - No
+        - Unsure
+    validations:
+      required: true
+  - type: dropdown
+    id: runner_logic_impacted
+    attributes:
+      label: "Runner logic impacted?"
+      options:
+        - Yes
+        - No
+        - Unsure
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: "Impact level"
+      options:
+        - info
+        - minor
+        - major
+        - critical
+    validations:
+      required: true
+  - type: textarea
+    id: current
+    attributes:
+      label: "Current behavior"
+      description: "Summarize what exists today and any friction."
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: "Requested enhancement"
+      description: "How should the flow improve across Upstream → Midstream → Downstream?"
+    validations:
+      required: true
+  - type: textarea
+    id: success
+    attributes:
+      label: "Success signals"
+      description: "Metrics, usability wins, or quality checks that confirm the enhancement worked."

--- a/.github/ISSUE_TEMPLATE/enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yaml
@@ -11,9 +11,9 @@ body:
     attributes:
       label: 'What phase is affected?'
       options:
-        - Upstream
-        - Midstream
-        - Downstream
+        - upstream
+        - midstream
+        - downstream
     validations:
       required: true
   - type: dropdown
@@ -66,3 +66,5 @@ body:
     attributes:
       label: 'Success signals'
       description: 'Metrics, usability wins, or quality checks that confirm the enhancement worked.'
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,78 @@
+name: "\U0001F680 Feature Request"
+description: "Propose a new River Reviewer capability."
+title: "[Feature] "
+labels: ["type:feature", "status:triage"]
+body:
+  - type: markdown
+    attributes:
+      value: "Help us plan the flow from idea to delivery. Acceptance criteria are required."
+  - type: dropdown
+    id: phase
+    attributes:
+      label: "What phase is affected?"
+      options:
+        - Upstream
+        - Midstream
+        - Downstream
+    validations:
+      required: true
+  - type: dropdown
+    id: schema_impacted
+    attributes:
+      label: "Schema impacted? (skill.schema.json)"
+      options:
+        - Yes
+        - No
+        - Unsure
+    validations:
+      required: true
+  - type: dropdown
+    id: runner_logic_impacted
+    attributes:
+      label: "Runner logic impacted?"
+      options:
+        - Yes
+        - No
+        - Unsure
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: "Impact level"
+      options:
+        - info
+        - minor
+        - major
+        - critical
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: "Problem to solve"
+      description: "What need or gap does this feature address?"
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: "Proposed solution"
+      description: "Describe the feature and how it flows through Upstream → Midstream → Downstream."
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: "Acceptance criteria"
+      description: "Clear, testable outcomes for this feature."
+      placeholder: |
+        - A skill author can...
+        - When..., the runner...
+    validations:
+      required: true
+  - type: textarea
+    id: references
+    attributes:
+      label: "Related issues / links"
+      description: "Designs, RFCs, or previous discussions."

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,15 +1,15 @@
 name: "\U0001F680 Feature Request"
-description: "Propose a new River Reviewer capability."
-title: "[Feature] "
-labels: ["type:feature", "status:triage"]
+description: 'Propose a new River Reviewer capability.'
+title: '[Feature] '
+labels: ['type:feature', 'status:triage']
 body:
   - type: markdown
     attributes:
-      value: "Help us plan the flow from idea to delivery. Acceptance criteria are required."
+      value: 'Help us plan the flow from idea to delivery. Acceptance criteria are required.'
   - type: dropdown
     id: phase
     attributes:
-      label: "What phase is affected?"
+      label: 'What phase is affected?'
       options:
         - Upstream
         - Midstream
@@ -19,7 +19,7 @@ body:
   - type: dropdown
     id: schema_impacted
     attributes:
-      label: "Schema impacted? (skill.schema.json)"
+      label: 'Schema impacted? (skill.schema.json)'
       options:
         - Yes
         - No
@@ -29,7 +29,7 @@ body:
   - type: dropdown
     id: runner_logic_impacted
     attributes:
-      label: "Runner logic impacted?"
+      label: 'Runner logic impacted?'
       options:
         - Yes
         - No
@@ -39,7 +39,7 @@ body:
   - type: dropdown
     id: severity
     attributes:
-      label: "Impact level"
+      label: 'Impact level'
       options:
         - info
         - minor
@@ -50,22 +50,22 @@ body:
   - type: textarea
     id: problem
     attributes:
-      label: "Problem to solve"
-      description: "What need or gap does this feature address?"
+      label: 'Problem to solve'
+      description: 'What need or gap does this feature address?'
     validations:
       required: true
   - type: textarea
     id: proposal
     attributes:
-      label: "Proposed solution"
-      description: "Describe the feature and how it flows through Upstream → Midstream → Downstream."
+      label: 'Proposed solution'
+      description: 'Describe the feature and how it flows through Upstream → Midstream → Downstream.'
     validations:
       required: true
   - type: textarea
     id: acceptance
     attributes:
-      label: "Acceptance criteria"
-      description: "Clear, testable outcomes for this feature."
+      label: 'Acceptance criteria'
+      description: 'Clear, testable outcomes for this feature.'
       placeholder: |
         - A skill author can...
         - When..., the runner...
@@ -74,5 +74,5 @@ body:
   - type: textarea
     id: references
     attributes:
-      label: "Related issues / links"
-      description: "Designs, RFCs, or previous discussions."
+      label: 'Related issues / links'
+      description: 'Designs, RFCs, or previous discussions.'

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -11,9 +11,9 @@ body:
     attributes:
       label: 'What phase is affected?'
       options:
-        - Upstream
-        - Midstream
-        - Downstream
+        - upstream
+        - midstream
+        - downstream
     validations:
       required: true
   - type: dropdown
@@ -76,3 +76,5 @@ body:
     attributes:
       label: 'Related issues / links'
       description: 'Designs, RFCs, or previous discussions.'
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -1,10 +1,12 @@
 # 🌊 River Reviewer Bugfix
 
 ## Summary
+
 - What was broken and how was it detected?
 - Primary phase focus: Upstream / Midstream / Downstream
 
 ## Flow Consistency
+
 - [ ] Upstream: requirements/design clarified to prevent recurrence
 - [ ] Midstream: implementation fixes root cause without side effects
 - [ ] Downstream: regression tests/QA steps added or updated
@@ -12,10 +14,12 @@
 - [ ] Skill file structure validated? (`skills/*` follows schema and naming)
 
 ## Root Cause & Fix
+
 - Root cause in one or two sentences
 - Fix approach and why it is safe
 
 ## Repro & Validation
+
 - Steps to reproduce (before)
 - Proof of fix (after) with commands/logs
 
@@ -26,9 +30,11 @@ npm test -- <scope>
 ```
 
 ## Related Issues
+
 - Closes #
 - Related #
 
 ## Rollout Notes
+
 - Risk level and mitigation
 - Monitoring or follow-up tasks

--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -1,0 +1,34 @@
+# 🌊 River Reviewer Bugfix
+
+## Summary
+- What was broken and how was it detected?
+- Primary phase focus: Upstream / Midstream / Downstream
+
+## Flow Consistency
+- [ ] Upstream: requirements/design clarified to prevent recurrence
+- [ ] Midstream: implementation fixes root cause without side effects
+- [ ] Downstream: regression tests/QA steps added or updated
+- [ ] Schema Validation passed? (`schemas/skill.schema.json`)
+- [ ] Skill file structure validated? (`skills/*` follows schema and naming)
+
+## Root Cause & Fix
+- Root cause in one or two sentences
+- Fix approach and why it is safe
+
+## Repro & Validation
+- Steps to reproduce (before)
+- Proof of fix (after) with commands/logs
+
+```bash
+# e.g.
+npm run agents:validate
+npm test -- <scope>
+```
+
+## Related Issues
+- Closes #
+- Related #
+
+## Rollout Notes
+- Risk level and mitigation
+- Monitoring or follow-up tasks

--- a/.github/PULL_REQUEST_TEMPLATE/docs.md
+++ b/.github/PULL_REQUEST_TEMPLATE/docs.md
@@ -1,10 +1,12 @@
 # 🌊 River Reviewer Docs Update
 
 ## Summary
+
 - What documentation changed, and who is it for?
 - Primary phase focus: Upstream / Midstream / Downstream
 
 ## Flow Consistency
+
 - [ ] Upstream: concepts/architecture remain accurate
 - [ ] Midstream: examples and commands match current runner/skills
 - [ ] Downstream: validation steps and QA guidance are current
@@ -12,10 +14,12 @@
 - [ ] Skill file structure validated? (if docs reference skills)
 
 ## Changes
+
 - Pages updated/added
 - Key callouts ( diagrams, tutorials, references )
 
 ## Validation & Evidence
+
 - Screenshots or rendered previews if applicable
 - Commands run (lint/docs build/etc.)
 
@@ -26,8 +30,10 @@ npm test
 ```
 
 ## Related Issues
+
 - Closes #
 - Related #
 
 ## Follow-ups
+
 - Future doc improvements or links to supporting materials

--- a/.github/PULL_REQUEST_TEMPLATE/docs.md
+++ b/.github/PULL_REQUEST_TEMPLATE/docs.md
@@ -1,0 +1,33 @@
+# 🌊 River Reviewer Docs Update
+
+## Summary
+- What documentation changed, and who is it for?
+- Primary phase focus: Upstream / Midstream / Downstream
+
+## Flow Consistency
+- [ ] Upstream: concepts/architecture remain accurate
+- [ ] Midstream: examples and commands match current runner/skills
+- [ ] Downstream: validation steps and QA guidance are current
+- [ ] Schema Validation passed? (`schemas/skill.schema.json`)
+- [ ] Skill file structure validated? (if docs reference skills)
+
+## Changes
+- Pages updated/added
+- Key callouts ( diagrams, tutorials, references )
+
+## Validation & Evidence
+- Screenshots or rendered previews if applicable
+- Commands run (lint/docs build/etc.)
+
+```bash
+# e.g.
+npm run agents:validate
+npm test
+```
+
+## Related Issues
+- Closes #
+- Related #
+
+## Follow-ups
+- Future doc improvements or links to supporting materials

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,0 +1,34 @@
+# 🌊 River Reviewer Feature
+
+## Summary
+- What new capability is being added, and why does it matter?
+- Primary phase focus: Upstream / Midstream / Downstream
+
+## Flow Consistency
+- [ ] Upstream: design/requirements updated and linked
+- [ ] Midstream: implementation honors the agreed flow
+- [ ] Downstream: tests/QA and roll-out checks are defined
+- [ ] Schema Validation passed? (`schemas/skill.schema.json`)
+- [ ] Skill file structure validated? (`skills/*` follows schema and naming)
+
+## Changes
+- Feature highlights
+- Skills or runner areas touched
+- Data/schema updates that reviewers should be aware of
+
+## Validation & Evidence
+Commands/logs that prove the feature is river-safe.
+
+```bash
+# e.g.
+npm run agents:validate
+npm test
+```
+
+## Related Issues
+- Closes #
+- Related #
+
+## Rollout Notes
+- Migration/backfill considerations
+- Monitoring or follow-up tasks

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,10 +1,12 @@
 # 🌊 River Reviewer Feature
 
 ## Summary
+
 - What new capability is being added, and why does it matter?
 - Primary phase focus: Upstream / Midstream / Downstream
 
 ## Flow Consistency
+
 - [ ] Upstream: design/requirements updated and linked
 - [ ] Midstream: implementation honors the agreed flow
 - [ ] Downstream: tests/QA and roll-out checks are defined
@@ -12,11 +14,13 @@
 - [ ] Skill file structure validated? (`skills/*` follows schema and naming)
 
 ## Changes
+
 - Feature highlights
 - Skills or runner areas touched
 - Data/schema updates that reviewers should be aware of
 
 ## Validation & Evidence
+
 Commands/logs that prove the feature is river-safe.
 
 ```bash
@@ -26,9 +30,11 @@ npm test
 ```
 
 ## Related Issues
+
 - Closes #
 - Related #
 
 ## Rollout Notes
+
 - Migration/backfill considerations
 - Monitoring or follow-up tasks

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,29 +1,30 @@
-## 背景 / Goal
+# 🌊 River Reviewer Pull Request
 
-- [ ] 問題の概要と目的を1-2行で記載
-- [ ] 仕様・要件・外部リンクがあれば添付
+Flow your changes from Upstream to Midstream to Downstream with clear validation.
 
-## 変更点 / Summary
+## Overview
+- What is changing and why? (1-2 lines)
+- Primary phase focus: Upstream / Midstream / Downstream
 
-- [ ] 主な変更内容を箇条書き（スキーマ・チェックリスト・ドキュメントなど）
-- [ ] 追加/更新したCIやスクリプトがあれば記載
+## Flow Consistency
+- [ ] Upstream: design/requirements updated and linked
+- [ ] Midstream: implementation matches the intended flow
+- [ ] Downstream: tests/QA steps cover the change
+- [ ] Schema Validation passed? (`schemas/skill.schema.json`)
+- [ ] Skill file structure validated? (`skills/*` follows schema and naming)
 
-## 影響範囲 / Impact
-
-- [ ] 対象: ドキュメント / スキーマ / チェックリスト / ワークフロー / その他
-- [ ] エージェント利用者が追従すべき手順を明記
-
-## 実行結果 / Logs
+## Validation & Evidence
+List commands and logs that prove the change is river-safe.
 
 ```bash
+# e.g.
 npm run agents:validate
-# 追加で実行したコマンド（例: npm run lint, npm test など）
+npm test
 ```
 
-## チェックリスト / Checklist
+## Related Issues
+- Closes #
+- Related #
 
-- [ ] `npm run agents:validate`
-- [ ] 必要なLintやテスト (`npm run lint`, `npm test` など) がGreen
-- [ ] `docs/agents.md` と `README.md` を更新済み
-- [ ] `.github/ai-review/checklists/` の更新内容を自己レビュー済み
-- [ ] 影響範囲のドキュメント・利用者通知を準備
+## Reviewer Notes
+Context, roll-out risks, or follow-up tasks for reviewers.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,10 +3,12 @@
 Flow your changes from Upstream to Midstream to Downstream with clear validation.
 
 ## Overview
+
 - What is changing and why? (1-2 lines)
 - Primary phase focus: Upstream / Midstream / Downstream
 
 ## Flow Consistency
+
 - [ ] Upstream: design/requirements updated and linked
 - [ ] Midstream: implementation matches the intended flow
 - [ ] Downstream: tests/QA steps cover the change
@@ -14,6 +16,7 @@ Flow your changes from Upstream to Midstream to Downstream with clear validation
 - [ ] Skill file structure validated? (`skills/*` follows schema and naming)
 
 ## Validation & Evidence
+
 List commands and logs that prove the change is river-safe.
 
 ```bash
@@ -23,8 +26,10 @@ npm test
 ```
 
 ## Related Issues
+
 - Closes #
 - Related #
 
 ## Reviewer Notes
+
 Context, roll-out risks, or follow-up tasks for reviewers.

--- a/docs/explanation/design-philosophy.md
+++ b/docs/explanation/design-philosophy.md
@@ -1,0 +1,9 @@
+# Design Philosophy
+
+River Reviewer is built to deliver timely, phase-aware feedback without slowing teams down.
+
+- **Flow-first**: every check should state which phase it belongs to and why.
+- **Small, testable steps**: prefer narrowly scoped skills with clear acceptance signals.
+- **Schema-driven**: `/schemas/skill.schema.json` is the contract for all skills and should remain the single source of truth.
+- **Empathetic tone**: findings should be actionable and constructive, matching the friendly river brand.
+- **Evidence-based**: pair guidance with commands or links that prove the recommendation.

--- a/docs/explanation/design-philosophy.md
+++ b/docs/explanation/design-philosophy.md
@@ -4,6 +4,6 @@ River Reviewer is built to deliver timely, phase-aware feedback without slowing 
 
 - **Flow-first**: every check should state which phase it belongs to and why.
 - **Small, testable steps**: prefer narrowly scoped skills with clear acceptance signals.
-- **Schema-driven**: `/schemas/skill.schema.json` is the contract for all skills and should remain the single source of truth.
+- **Schema-driven**: `/schemas/skill.schema.json` is the contract for all skills and should stay the single source of truth.
 - **Empathetic tone**: findings should be actionable and constructive, matching the friendly river brand.
-- **Evidence-based**: pair guidance with commands or links that prove the recommendation.
+- **Evidence-based**: link guidance to commands or links that prove the recommendation.

--- a/docs/explanation/river-architecture.md
+++ b/docs/explanation/river-architecture.md
@@ -1,0 +1,11 @@
+# The River Architecture
+
+River Reviewer flows with your development process.
+
+Conceptually, the flow has three major segments:
+
+* **Upstream**: requirements, architecture, ADR, design
+* **Midstream**: implementation, refactoring, CI integration
+* **Downstream**: QA, test analysis, release checks
+
+A fourth layer -- **Riverbed Memory** -- will store contextual decisions so that subsequent reviews can reuse them.

--- a/docs/explanation/river-architecture.md
+++ b/docs/explanation/river-architecture.md
@@ -4,8 +4,8 @@ River Reviewer flows with your development process.
 
 Conceptually, the flow has three major segments:
 
-* **Upstream**: requirements, architecture, ADR, design
-* **Midstream**: implementation, refactoring, CI integration
-* **Downstream**: QA, test analysis, release checks
+- **Upstream**: requirements, architecture, ADR, design
+- **Midstream**: implementation, refactoring, CI integration
+- **Downstream**: QA, test analysis, release checks
 
 A fourth layer -- **Riverbed Memory** -- will store contextual decisions so that subsequent reviews can reuse them.

--- a/docs/explanation/upstream-midstream-downstream.md
+++ b/docs/explanation/upstream-midstream-downstream.md
@@ -3,7 +3,7 @@
 River Reviewer mirrors the natural flow of software delivery:
 
 - **Upstream**: ideas, requirements, and design decisions. Checks focus on clarity, traceability, and feasibility.
-- **Midstream**: implementation and refactoring. Checks focus on correctness, maintainability, and alignment with the upstream plan.
-- **Downstream**: testing, release readiness, and observability. Checks focus on validation, resiliency, and user impact.
+- **Midstream**: implementation and refactoring. Checks focus on correctness, code health, and keeping changes consistent with the upstream plan.
+- **Downstream**: testing, release readiness, and observability. Checks focus on verification, resiliency, and user impact.
 
 Each skill declares its phase so the runner can load only the relevant guidance for a change. When in doubt, prefer the earliest phase that can catch the issue to keep feedback fast.

--- a/docs/explanation/upstream-midstream-downstream.md
+++ b/docs/explanation/upstream-midstream-downstream.md
@@ -1,0 +1,9 @@
+# Upstream, Midstream, Downstream
+
+River Reviewer mirrors the natural flow of software delivery:
+
+- **Upstream**: ideas, requirements, and design decisions. Checks focus on clarity, traceability, and feasibility.
+- **Midstream**: implementation and refactoring. Checks focus on correctness, maintainability, and alignment with the upstream plan.
+- **Downstream**: testing, release readiness, and observability. Checks focus on validation, resiliency, and user impact.
+
+Each skill declares its phase so the runner can load only the relevant guidance for a change. When in doubt, prefer the earliest phase that can catch the issue to keep feedback fast.

--- a/docs/how-to/debug-skill-routing.md
+++ b/docs/how-to/debug-skill-routing.md
@@ -1,0 +1,15 @@
+# Debug Skill Routing
+
+When a skill does not trigger (or triggers too often), walk through these checks.
+
+## Checklist
+
+1. **Schema**: confirm the skill passes `npm run agents:validate`.
+2. **Phase**: ensure `phase` matches the files being changed (Upstream/Midstream/Downstream).
+3. **applyTo globs**: verify the patterns match the paths in your PR. Use a minimal test file that should trigger the skill.
+4. **Severity/tags**: check whether filters in the runner use tags or severity that might exclude the skill.
+5. **Recent changes**: review git history for the skill file to see if routing logic changed.
+
+## Quick test
+
+Open a draft PR that modifies a file matching the skill's `applyTo` glob. If no findings appear, add debug logging or temporarily narrow the glob to a single known path, then re-run the workflow.

--- a/docs/how-to/debug-skill-routing.md
+++ b/docs/how-to/debug-skill-routing.md
@@ -4,7 +4,7 @@ When a skill does not trigger (or triggers too often), walk through these checks
 
 ## Checklist
 
-1. **Schema**: confirm the skill passes `npm run agents:validate`.
+1. **Schema**: confirm the skill passes `npm run skills:validate`.
 2. **Phase**: ensure `phase` matches the files being changed (Upstream/Midstream/Downstream).
 3. **applyTo globs**: verify the patterns match the paths in your PR. Use a minimal test file that should trigger the skill.
 4. **Severity/tags**: check whether filters in the runner use tags or severity that might exclude the skill.

--- a/docs/how-to/run-phase-specific-review.md
+++ b/docs/how-to/run-phase-specific-review.md
@@ -7,13 +7,13 @@ Target a single phase when you only want Upstream, Midstream, or Downstream feed
 1. Tag each skill with the correct `phase` in its front matter.
 2. Limit the review scope in CI when needed:
 
-```yaml
-on:
-  pull_request:
-    paths:
-      - "docs/**"        # Upstream-focused example
-      - "!src/**"        # skip Midstream code if desired
-```
+   ```yaml
+   on:
+     pull_request:
+       paths:
+         - 'docs/**' # Upstream-focused example
+         - '!src/**' # skip Midstream code if desired
+   ```
 
 3. For local runs, execute only the relevant skills by filtering files or temporarily narrowing `applyTo` globs.
 4. Share the chosen phase in your PR template so reviewers know which checks to expect.

--- a/docs/how-to/run-phase-specific-review.md
+++ b/docs/how-to/run-phase-specific-review.md
@@ -1,0 +1,24 @@
+# Run Phase-Specific Review
+
+Target a single phase when you only want Upstream, Midstream, or Downstream feedback.
+
+## Steps
+
+1. Tag each skill with the correct `phase` in its front matter.
+2. Limit the review scope in CI when needed:
+
+```yaml
+on:
+  pull_request:
+    paths:
+      - "docs/**"        # Upstream-focused example
+      - "!src/**"        # skip Midstream code if desired
+```
+
+3. For local runs, execute only the relevant skills by filtering files or temporarily narrowing `applyTo` globs.
+4. Share the chosen phase in your PR template so reviewers know which checks to expect.
+
+## Verification
+
+- Confirm the reviewer only loads skills whose `phase` matches the targeted segment.
+- Add a small change in a different phase to verify it is ignored.

--- a/docs/how-to/run-phase-specific-review.md
+++ b/docs/how-to/run-phase-specific-review.md
@@ -12,7 +12,6 @@ Target a single phase when you only want Upstream, Midstream, or Downstream feed
      pull_request:
        paths:
          - 'docs/**' # Upstream-focused example
-         - '!src/**' # skip Midstream code if desired
    ```
 
 3. For local runs, execute only the relevant skills by filtering files or temporarily narrowing `applyTo` globs.

--- a/docs/how-to/use-riverbed-memory.md
+++ b/docs/how-to/use-riverbed-memory.md
@@ -6,6 +6,23 @@ Riverbed Memory stores past review context so future flows stay consistent.
 
 1. Capture decisions: add short notes in PR descriptions for upstream design choices and link them from skill instructions when relevant.
 2. Persist signals: store approved review outcomes (for example, in a `logs/` or database layer) keyed by skill ID and phase.
+   For example, keep `logs/review_outcomes.json` like:
+
+   ```json
+   {
+     "skill-123": {
+       "phase": "upstream",
+       "outcome": "approved",
+       "notes": "Design aligns with upstream architecture."
+     },
+     "skill-456": {
+       "phase": "midstream",
+       "outcome": "approved",
+       "notes": "Code meets performance requirements."
+     }
+   }
+   ```
+
 3. Reuse context: when writing new skills, reference prior decisions to avoid duplicate warnings or conflicting guidance.
 4. Expire stale memory: set a cadence (e.g., monthly) to prune outdated decisions and refresh assumptions.
 

--- a/docs/how-to/use-riverbed-memory.md
+++ b/docs/how-to/use-riverbed-memory.md
@@ -1,0 +1,15 @@
+# Use Riverbed Memory
+
+Riverbed Memory stores past review context so future flows stay consistent.
+
+## Steps
+
+1. Capture decisions: add short notes in PR descriptions for upstream design choices and link them from skill instructions when relevant.
+2. Persist signals: store approved review outcomes (for example, in a `logs/` or database layer) keyed by skill ID and phase.
+3. Reuse context: when writing new skills, reference prior decisions to avoid duplicate warnings or conflicting guidance.
+4. Expire stale memory: set a cadence (e.g., monthly) to prune outdated decisions and refresh assumptions.
+
+## Good Practices
+
+- Keep memory entries small and action-oriented (what changed, why, and the phase).
+- Prefer structured formats (JSON/YAML) so automation can hydrate the reviewer.

--- a/docs/how-to/validate-skill-schema.md
+++ b/docs/how-to/validate-skill-schema.md
@@ -1,0 +1,21 @@
+# Validate Skill Schema
+
+Use the schema and validator to keep skills consistent across Upstream, Midstream, and Downstream checks.
+
+## Steps
+
+1. Edit or add a skill under `skills/`.
+2. Run the validator:
+
+```bash
+npm run agents:validate
+```
+
+3. If validation fails, check that required fields from `/schemas/skill.schema.json` are present: `id`, `name`, `description`, `phase`, and `applyTo`.
+4. Confirm `phase` matches the intended flow segment and adjust `applyTo` globs to avoid noisy matches.
+5. Re-run the validator until you get a clean pass, then include the command output in your PR.
+
+## Tips
+
+- Keep tags and severity aligned with how you want findings prioritized.
+- Add small sample files and open a draft PR to see how the reviewer routes the skill.

--- a/docs/how-to/validate-skill-schema.md
+++ b/docs/how-to/validate-skill-schema.md
@@ -7,11 +7,16 @@ Use the schema and validator to keep skills consistent across Upstream, Midstrea
 1. Edit or add a skill under `skills/`.
 2. Run the validator:
 
-```bash
-npm run agents:validate
-```
+   ```bash
+   npm run agents:validate
+   ```
 
-3. If validation fails, check that required fields from `/schemas/skill.schema.json` are present: `id`, `name`, `description`, `phase`, and `applyTo`.
+3. If the schema check errors, confirm these required fields exist:
+   - `id`
+   - `name`
+   - `description`
+   - `phase`
+   - `applyTo`
 4. Confirm `phase` matches the intended flow segment and adjust `applyTo` globs to avoid noisy matches.
 5. Re-run the validator until you get a clean pass, then include the command output in your PR.
 

--- a/docs/how-to/validate-skill-schema.md
+++ b/docs/how-to/validate-skill-schema.md
@@ -8,7 +8,7 @@ Use the schema and validator to keep skills consistent across Upstream, Midstrea
 2. Run the validator:
 
    ```bash
-   npm run agents:validate
+   npm run skills:validate
    ```
 
 3. If the schema check errors, confirm these required fields exist:

--- a/docs/reference/metadata-fields.md
+++ b/docs/reference/metadata-fields.md
@@ -1,0 +1,15 @@
+# Metadata Fields
+
+Use these fields to keep skill metadata consistent and easy to route.
+
+| Field | Purpose |
+| --- | --- |
+| `id` | Unique identifier (recommended `rr-xxxx` format). |
+| `name` | Human-readable skill name shown in reviews. |
+| `description` | Short summary of what the skill checks. |
+| `phase` | Flow segment the skill belongs to: `upstream`, `midstream`, or `downstream`. |
+| `applyTo` | Glob patterns for files the skill should inspect. |
+| `tags` | Optional classifiers (e.g., `security`, `performance`). |
+| `severity` | Optional impact level: `info`, `minor`, `major`, `critical`. |
+
+Keep metadata in front matter so it can be parsed before the instructions run. All required fields are validated against `/schemas/skill.schema.json`.

--- a/docs/reference/metadata-fields.md
+++ b/docs/reference/metadata-fields.md
@@ -2,14 +2,14 @@
 
 Use these fields to keep skill metadata consistent and easy to route.
 
-| Field | Purpose |
-| --- | --- |
-| `id` | Unique identifier (recommended `rr-xxxx` format). |
-| `name` | Human-readable skill name shown in reviews. |
-| `description` | Short summary of what the skill checks. |
-| `phase` | Flow segment the skill belongs to: `upstream`, `midstream`, or `downstream`. |
-| `applyTo` | Glob patterns for files the skill should inspect. |
-| `tags` | Optional classifiers (e.g., `security`, `performance`). |
-| `severity` | Optional impact level: `info`, `minor`, `major`, `critical`. |
+| Field         | Purpose                                                                      |
+| ------------- | ---------------------------------------------------------------------------- |
+| `id`          | Unique identifier (recommended `rr-xxxx` format).                            |
+| `name`        | Human-readable skill name shown in reviews.                                  |
+| `description` | Short summary of what the skill checks.                                      |
+| `phase`       | Flow segment the skill belongs to: `upstream`, `midstream`, or `downstream`. |
+| `applyTo`     | Glob patterns for files the skill should inspect.                            |
+| `tags`        | Optional classifiers (e.g., `security`, `performance`).                      |
+| `severity`    | Optional impact level: `info`, `minor`, `major`, `critical`.                 |
 
-Keep metadata in front matter so it can be parsed before the instructions run. All required fields are validated against `/schemas/skill.schema.json`.
+Keep metadata in front matter so it can be parsed before the instructions run. All required fields must pass checks using `/schemas/skill.schema.json`.

--- a/docs/reference/runner-cli-reference.md
+++ b/docs/reference/runner-cli-reference.md
@@ -4,22 +4,22 @@ Use the Runner CLI to execute River Reviewer skills locally or in CI.
 
 ## Commands
 
-- `npm run agents:validate`: validates skills against `/schemas/skill.schema.json`.
+- `npm run agents:validate`: runs schema checks with `/schemas/skill.schema.json`.
 - `node scripts/validate-agents.mjs [options]`: run the validator directly with custom flags.
 
 ## Options
 
-| Flag | Description |
-| --- | --- |
-| `--phase <upstream\|midstream\|downstream>` | Limit validation or execution to a single phase. |
-| `--files <glob>` | Validate only skills that match files in the provided glob. |
-| `--schema <path>` | Use a custom schema file instead of the default. |
-| `--format <text\|json>` | Control output format for CI logs. |
+| Flag                                        | Description                                                 |
+| ------------------------------------------- | ----------------------------------------------------------- |
+| `--phase <upstream\|midstream\|downstream>` | Limit validation or execution to a single phase.            |
+| `--files <glob>`                            | Validate only skills that match files in the provided glob. |
+| `--schema <path>`                           | Use a custom schema file instead of the default.            |
+| `--format <text\|json>`                     | Control output format for CI logs.                          |
 
 ## Exit codes
 
 - `0`: validation completed successfully.
-- `1`: validation failed or a schema error occurred.
+- `1`: schema checks did not pass or a schema error occurred.
 
 ## Examples
 

--- a/docs/reference/runner-cli-reference.md
+++ b/docs/reference/runner-cli-reference.md
@@ -1,0 +1,32 @@
+# Runner CLI Reference
+
+Use the Runner CLI to execute River Reviewer skills locally or in CI.
+
+## Commands
+
+- `npm run agents:validate`: validates skills against `/schemas/skill.schema.json`.
+- `node scripts/validate-agents.mjs [options]`: run the validator directly with custom flags.
+
+## Options
+
+| Flag | Description |
+| --- | --- |
+| `--phase <upstream|midstream|downstream>` | Limit validation or execution to a single phase. |
+| `--files <glob>` | Validate only skills that match files in the provided glob. |
+| `--schema <path>` | Use a custom schema file instead of the default. |
+| `--format <text|json>` | Control output format for CI logs. |
+
+## Exit codes
+
+- `0`: validation completed successfully.
+- `1`: validation failed or a schema error occurred.
+
+## Examples
+
+```bash
+# Validate all skills
+npm run agents:validate
+
+# Validate only upstream skills that touch docs
+node scripts/validate-agents.mjs --phase upstream --files \"docs/**/*\"
+```

--- a/docs/reference/runner-cli-reference.md
+++ b/docs/reference/runner-cli-reference.md
@@ -1,20 +1,11 @@
 # Runner CLI Reference
 
-Use the Runner CLI to execute River Reviewer skills locally or in CI.
+Use the Runner CLI to validate River Reviewer agents locally or in CI.
 
 ## Commands
 
-- `npm run agents:validate`: runs schema checks with `/schemas/skill.schema.json`.
-- `node scripts/validate-agents.mjs [options]`: run the validator directly with custom flags.
-
-## Options
-
-| Flag                                        | Description                                                 |
-| ------------------------------------------- | ----------------------------------------------------------- |
-| `--phase <upstream\|midstream\|downstream>` | Limit validation or execution to a single phase.            |
-| `--files <glob>`                            | Validate only skills that match files in the provided glob. |
-| `--schema <path>`                           | Use a custom schema file instead of the default.            |
-| `--format <text\|json>`                     | Control output format for CI logs.                          |
+- `npm run agents:validate`: runs schema checks for bundled agents.
+- `node scripts/validate-agents.mjs`: run the validator directly (no CLI options).
 
 ## Exit codes
 
@@ -27,6 +18,6 @@ Use the Runner CLI to execute River Reviewer skills locally or in CI.
 # Validate all skills
 npm run agents:validate
 
-# Validate only upstream skills that touch docs
-node scripts/validate-agents.mjs --phase upstream --files \"docs/**/*\"
+# Validate all skills directly
+node scripts/validate-agents.mjs
 ```

--- a/docs/reference/runner-cli-reference.md
+++ b/docs/reference/runner-cli-reference.md
@@ -11,10 +11,10 @@ Use the Runner CLI to execute River Reviewer skills locally or in CI.
 
 | Flag | Description |
 | --- | --- |
-| `--phase <upstream|midstream|downstream>` | Limit validation or execution to a single phase. |
+| `--phase <upstream\|midstream\|downstream>` | Limit validation or execution to a single phase. |
 | `--files <glob>` | Validate only skills that match files in the provided glob. |
 | `--schema <path>` | Use a custom schema file instead of the default. |
-| `--format <text|json>` | Control output format for CI logs. |
+| `--format <text\|json>` | Control output format for CI logs. |
 
 ## Exit codes
 

--- a/docs/reference/runner-cli-reference.md
+++ b/docs/reference/runner-cli-reference.md
@@ -1,11 +1,11 @@
 # Runner CLI Reference
 
-Use the Runner CLI to validate River Reviewer agents locally or in CI.
+Use the Runner CLI to validate River Reviewer agents and skills locally or in CI.
 
 ## Commands
 
-- `npm run agents:validate`: runs schema checks for bundled agents.
-- `node scripts/validate-agents.mjs`: run the validator directly (no CLI options).
+- Agents: `npm run agents:validate` (or `node scripts/validate-agents.mjs`)
+- Skills: `npm run skills:validate` (or `node scripts/validate-skills.mjs`)
 
 ## Exit codes
 
@@ -15,9 +15,9 @@ Use the Runner CLI to validate River Reviewer agents locally or in CI.
 ## Examples
 
 ```bash
-# Validate all skills
+# Validate all agents
 npm run agents:validate
 
-# Validate all skills directly
-node scripts/validate-agents.mjs
+# Validate all skills
+npm run skills:validate
 ```

--- a/docs/reference/skill-schema-reference.md
+++ b/docs/reference/skill-schema-reference.md
@@ -1,0 +1,31 @@
+# Skill Schema Reference
+
+All skills in River Reviewer must conform to JSON schema located at:
+
+```
+/schemas/skill.schema.json
+```
+
+## Required fields
+
+| Field | Description |
+| --- | --- |
+| id | Unique skill identifier (rr-xxxx format recommended) |
+| name | Human-readable skill name |
+| description | What the skill checks |
+| phase | upstream / midstream / downstream |
+| applyTo | File glob patterns |
+
+## Example
+
+```yaml
+---
+id: rr-python-sqlinj-v1
+name: Python SQL Injection Check
+phase: midstream
+applyTo:
+  - "**/*.py"
+tags: ["security", "owasp"]
+---
+# instructions...
+```

--- a/docs/reference/skill-schema-reference.md
+++ b/docs/reference/skill-schema-reference.md
@@ -22,6 +22,7 @@ All skills in River Reviewer must conform to JSON schema located at:
 ---
 id: rr-python-sqlinj-v1
 name: Python SQL Injection Check
+description: Detects SQL injection patterns in Python code
 phase: midstream
 applyTo:
   - '**/*.py'

--- a/docs/reference/skill-schema-reference.md
+++ b/docs/reference/skill-schema-reference.md
@@ -2,19 +2,19 @@
 
 All skills in River Reviewer must conform to JSON schema located at:
 
-```
+```text
 /schemas/skill.schema.json
 ```
 
 ## Required fields
 
-| Field | Description |
-| --- | --- |
-| id | Unique skill identifier (rr-xxxx format recommended) |
-| name | Human-readable skill name |
-| description | What the skill checks |
-| phase | upstream / midstream / downstream |
-| applyTo | File glob patterns |
+| Field       | Description                                          |
+| ----------- | ---------------------------------------------------- |
+| id          | Unique skill identifier (rr-xxxx format recommended) |
+| name        | Human-readable skill name                            |
+| description | What the skill checks                                |
+| phase       | upstream / midstream / downstream                    |
+| applyTo     | File glob patterns                                   |
 
 ## Example
 
@@ -24,8 +24,8 @@ id: rr-python-sqlinj-v1
 name: Python SQL Injection Check
 phase: midstream
 applyTo:
-  - "**/*.py"
-tags: ["security", "owasp"]
+  - '**/*.py'
+tags: ['security', 'owasp']
 ---
 # instructions...
 ```

--- a/docs/tutorials/creating-your-first-skill.md
+++ b/docs/tutorials/creating-your-first-skill.md
@@ -1,0 +1,47 @@
+# Creating Your First Skill
+
+Build a simple River Reviewer skill that follows the Upstream → Midstream → Downstream flow.
+
+## Prerequisites
+- Node.js installed
+- Repository cloned and dependencies installed (`npm install`)
+
+## 1. Draft the skill metadata
+
+Create a new file under `skills/` (for example `skills/rr-hello.yml`) and include metadata that matches `/schemas/skill.schema.json`:
+
+```yaml
+---
+id: rr-hello
+name: Hello World Skill
+description: Flags TODO comments in Markdown
+phase: upstream
+applyTo:
+  - "**/*.md"
+tags:
+  - content
+  - hygiene
+severity: minor
+---
+# instructions start here...
+```
+
+## 2. Keep the flow explicit
+
+- **Upstream:** describe the intent of the check and link to any design references.
+- **Midstream:** define the detection logic in the instruction body.
+- **Downstream:** note how to verify or auto-fix the finding.
+
+## 3. Validate the skill
+
+Run the validators to make sure the schema and structure are correct:
+
+```bash
+npm run agents:validate
+```
+
+If your skill is phase-specific, add a short test PR to confirm the reviewer loads it only for matching files.
+
+## 4. Iterate with reviews
+
+Commit the skill, open a PR, and use the River Reviewer PR templates to link related issues and prove validation passed.

--- a/docs/tutorials/creating-your-first-skill.md
+++ b/docs/tutorials/creating-your-first-skill.md
@@ -3,6 +3,7 @@
 Build a simple River Reviewer skill that follows the Upstream → Midstream → Downstream flow.
 
 ## Prerequisites
+
 - Node.js installed
 - Repository cloned and dependencies installed (`npm install`)
 
@@ -17,7 +18,7 @@ name: Hello World Skill
 description: Flags TODO comments in Markdown
 phase: upstream
 applyTo:
-  - "**/*.md"
+  - '**/*.md'
 tags:
   - content
   - hygiene

--- a/docs/tutorials/creating-your-first-skill.md
+++ b/docs/tutorials/creating-your-first-skill.md
@@ -38,7 +38,7 @@ severity: minor
 Run the validators to make sure the schema and structure are correct:
 
 ```bash
-npm run agents:validate
+npm run skills:validate
 ```
 
 If your skill is phase-specific, add a short test PR to confirm the reviewer loads it only for matching files.

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -1,0 +1,33 @@
+# Getting Started with River Reviewer
+
+River Reviewer is a flow-based AI review agent that travels with your software development lifecycle, from Upstream design to Midstream implementation and Downstream QA.
+
+This tutorial helps you run your first review using the GitHub Action.
+
+## 1. Install / Enable
+
+Add the following workflow:
+
+```yaml
+name: River Review
+on:
+  pull_request:
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: s977043/river-reviewer@v0
+```
+
+## 2. Run the review
+
+Create a PR. River Review will automatically:
+
+* detect changed files
+* load relevant skills
+* validate schema
+* output structured review comments
+
+You're ready to flow.

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started with River Reviewer
 
-River Reviewer is a flow-based AI review agent that travels with your software development lifecycle, from Upstream design to Midstream implementation and Downstream QA.
+River Reviewer is a flow-based AI review agent for your software development lifecycle. It travels from Upstream design to Midstream implementation and Downstream QA.
 
 This tutorial helps you run your first review using the GitHub Action.
 
@@ -25,9 +25,9 @@ jobs:
 
 Create a PR. River Review will automatically:
 
-* detect changed files
-* load relevant skills
-* validate schema
-* output structured review comments
+- detect changed files
+- load relevant skills
+- validate schema
+- output structured review comments
 
 You're ready to flow.

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: s977043/river-reviewer@v0
+      - uses: s977043/river-reviewer@v1
 ```
 
 ## 2. Run the review

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -6,7 +6,7 @@ This tutorial helps you run your first review using the GitHub Action.
 
 ## 1. Install / Enable
 
-Add the following workflow:
+Add the following workflow (replace `{org}` with your organization or user):
 
 ```yaml
 name: River Review
@@ -16,10 +16,15 @@ on:
 jobs:
   review:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
-      - uses: s977043/river-reviewer@v1
+      - uses: {org}/river-reviewer@v1
 ```
+
+> Note: `{org}/river-reviewer@v1` is a placeholder. Point this to the published River Reviewer action in your org or the official repository.
 
 ## 2. Run the review
 

--- a/docs/tutorials/integrating-with-github-actions.md
+++ b/docs/tutorials/integrating-with-github-actions.md
@@ -1,0 +1,38 @@
+# Integrating with GitHub Actions
+
+Wire River Reviewer into your repository so every PR gets phase-aware feedback.
+
+## 1. Add the workflow
+
+Create `.github/workflows/river-review.yml`:
+
+```yaml
+name: River Reviewer
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: s977043/river-reviewer@v0
+```
+
+## 2. Keep credentials out of the flow
+
+- Do not commit secrets or `.env` files.
+- If the reviewer needs extra context, pass it through repository or organization secrets.
+
+## 3. Tune for phases
+
+- Tag skills with `phase: upstream|midstream|downstream`.
+- Use path filters in your workflow to restrict when the reviewer runs, if needed.
+
+## 4. Validate on every push
+
+Ensure the workflow runs `npm run agents:validate` so schema changes are caught early. For larger repos, consider a pre-commit hook or a dedicated CI job for validation.

--- a/docs/tutorials/integrating-with-github-actions.md
+++ b/docs/tutorials/integrating-with-github-actions.md
@@ -4,7 +4,7 @@ Wire River Reviewer into your repository so every PR gets phase-aware feedback.
 
 ## 1. Add the workflow
 
-Create `.github/workflows/river-review.yml`:
+Create `.github/workflows/river-review.yml` (replace `{org}` with your organization or user):
 
 ```yaml
 name: River Reviewer
@@ -20,13 +20,15 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
-      - uses: s977043/river-reviewer@v1
+      - uses: {org}/river-reviewer@v1
 ```
+
+> Note: `{org}/river-reviewer@v1` is a placeholder. Point this to the published River Reviewer action in your org or the official repository.
 
 ## 2. Keep credentials out of the flow
 
-- Do not commit secrets or `.env` files.
-- If the reviewer needs extra context, pass it through repository or organization secrets.
+- By default, River Reviewer does not require credentials or API keys.
+- If the reviewer needs extra context or external API access, pass tokens via repository or organization secrets and document which secrets are needed.
 
 ## 3. Tune for phases
 
@@ -35,4 +37,4 @@ jobs:
 
 ## 4. Validate on every push
 
-Ensure the workflow runs `npm run agents:validate` so schema changes are caught early. For larger repos, consider a pre-commit hook or a dedicated CI job for validation.
+Ensure the workflow runs `npm run skills:validate` so schema changes are caught early. For larger repos, consider a pre-commit hook or a dedicated CI job for validation.

--- a/docs/tutorials/integrating-with-github-actions.md
+++ b/docs/tutorials/integrating-with-github-actions.md
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
-      - uses: s977043/river-reviewer@v0
+      - uses: s977043/river-reviewer@v1
 ```
 
 ## 2. Keep credentials out of the flow

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format": "prettier --write \"**/*.{js,json,md,yml,yaml}\"",
     "format:check": "prettier --check \"**/*.{js,json,md,yml,yaml}\"",
     "agents:validate": "node scripts/validate-agents.mjs",
+    "skills:validate": "node scripts/validate-skills.mjs",
     "trace:validate": "OTEL_ENABLED=1 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 node scripts/validate-agents.mjs",
     "fix:dashes": "node scripts/fix-dashes.mjs",
     "prepare": "husky install"

--- a/schemas/skill.schema.json
+++ b/schemas/skill.schema.json
@@ -1,43 +1,40 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "River Reviewer Skill Metadata Schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "River Reviewer Skill Schema",
   "type": "object",
-  "required": ["id", "name", "phase", "applyTo", "description"],
-  "additionalProperties": false,
+  "required": ["id", "name", "description", "phase", "applyTo"],
   "properties": {
     "id": {
       "type": "string",
-      "minLength": 3
+      "description": "Unique identifier for the skill (recommended: rr-xxxx)"
     },
     "name": {
       "type": "string",
-      "minLength": 1
-    },
-    "phase": {
-      "type": "string",
-      "enum": ["upstream", "midstream", "downstream"]
-    },
-    "tags": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "uniqueItems": true
-    },
-    "severity": {
-      "type": "string",
-      "enum": ["info", "minor", "major", "critical"]
-    },
-    "applyTo": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "type": "string"
-      }
+      "description": "Human-readable skill name"
     },
     "description": {
       "type": "string",
-      "minLength": 1
+      "description": "Brief description of what the skill checks"
+    },
+    "phase": {
+      "type": "string",
+      "enum": ["upstream", "midstream", "downstream"],
+      "description": "Which SDLC phase this skill applies to"
+    },
+    "applyTo": {
+      "type": "array",
+      "description": "Glob patterns defining which files to check",
+      "items": { "type": "string" }
+    },
+    "tags": {
+      "type": "array",
+      "description": "Optional metadata for classification",
+      "items": { "type": "string" }
+    },
+    "severity": {
+      "type": "string",
+      "enum": ["info", "minor", "major", "critical"],
+      "description": "Optional severity rating"
     }
   }
 }

--- a/schemas/skill.schema.json
+++ b/schemas/skill.schema.json
@@ -3,18 +3,22 @@
   "title": "River Reviewer Skill Schema",
   "type": "object",
   "required": ["id", "name", "description", "phase", "applyTo"],
+  "additionalProperties": false,
   "properties": {
     "id": {
       "type": "string",
-      "description": "Unique identifier for the skill (recommended: rr-xxxx)"
+      "description": "Unique identifier for the skill (recommended: rr-xxxx)",
+      "minLength": 1
     },
     "name": {
       "type": "string",
-      "description": "Human-readable skill name"
+      "description": "Human-readable skill name",
+      "minLength": 1
     },
     "description": {
       "type": "string",
-      "description": "Brief description of what the skill checks"
+      "description": "Brief description of what the skill checks",
+      "minLength": 1
     },
     "phase": {
       "type": "string",
@@ -24,12 +28,14 @@
     "applyTo": {
       "type": "array",
       "description": "Glob patterns defining which files to check",
-      "items": { "type": "string" }
+      "items": { "type": "string" },
+      "minItems": 1
     },
     "tags": {
       "type": "array",
       "description": "Optional metadata for classification",
-      "items": { "type": "string" }
+      "items": { "type": "string" },
+      "uniqueItems": true
     },
     "severity": {
       "type": "string",

--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import yaml from 'js-yaml';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+const schemaPath = path.join(repoRoot, 'schemas', 'skill.schema.json');
+const skillsDir = path.join(repoRoot, 'skills');
+const allowedExt = new Set(['.md', '.mdx', '.yaml', '.yml']);
+
+async function loadSchema() {
+  const raw = await fs.readFile(schemaPath, 'utf8');
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    console.error(`❌ Failed to parse JSON schema at ${schemaPath}: ${err.message}`);
+    throw err;
+  }
+}
+
+async function listSkillFiles(dir = skillsDir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const nested = await listSkillFiles(entryPath);
+      files.push(...nested);
+    } else if (allowedExt.has(path.extname(entry.name)) && entry.name !== '.gitkeep') {
+      files.push(entryPath);
+    }
+  }
+  return files;
+}
+
+function parseFrontMatter(content, filePath) {
+  if (!content.startsWith('---')) {
+    throw new Error('Missing front matter block (---)');
+  }
+  const end = content.indexOf('\n---', 3);
+  if (end === -1) {
+    throw new Error('Unterminated front matter block');
+  }
+  const yamlBlock = content.slice(3, end).trim();
+  if (!yamlBlock) {
+    throw new Error('Front matter is empty');
+  }
+  try {
+    return yaml.load(yamlBlock) ?? {};
+  } catch (err) {
+    throw new Error(`Front matter YAML parse error: ${err.message}`);
+  }
+}
+
+async function parseSkillFile(filePath) {
+  const ext = path.extname(filePath);
+  const raw = await fs.readFile(filePath, 'utf8');
+  if (ext === '.md' || ext === '.mdx') {
+    return parseFrontMatter(raw, filePath);
+  }
+  try {
+    return yaml.load(raw) ?? {};
+  } catch (err) {
+    throw new Error(`YAML parse error: ${err.message}`);
+  }
+}
+
+async function validateSkills() {
+  const schema = await loadSchema();
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+
+  let files;
+  try {
+    files = await listSkillFiles();
+  } catch (err) {
+    console.error(`❌ Failed to list skills: ${err.message}`);
+    throw err;
+  }
+
+  if (!files.length) {
+    console.warn('⚠️  No skill files found under skills/.');
+    return true;
+  }
+
+  let success = true;
+  for (const filePath of files) {
+    const relativePath = path.relative(repoRoot, filePath);
+    try {
+      const data = await parseSkillFile(filePath);
+      const valid = validate(data);
+      if (valid) {
+        console.log(`✅ ${relativePath}`);
+      } else {
+        console.error(`❌ ${relativePath}`);
+        for (const err of validate.errors ?? []) {
+          const instance = err.instancePath || '/';
+          console.error(`  - ${instance}: ${err.message}`);
+        }
+        success = false;
+      }
+    } catch (err) {
+      console.error(`❌ ${relativePath}`);
+      console.error(`  - ${err.message}`);
+      success = false;
+    }
+  }
+
+  return success;
+}
+
+const ok = await validateSkills();
+if (!ok) {
+  process.exitCode = 1;
+}


### PR DESCRIPTION
目的
- River Reviewer ブランドのPR/Issueテンプレートと初期ドキュメントを用意し、Upstream→Midstream→Downstreamのフローに沿った運用を始めるため。

変更点
- PRテンプレート4種（共通/feature/bugfix/docs）を追加・更新し、フェーズ整合・スキーマ/スキル構造チェックを明示
- Issueフォーム4種（bug/feature/enhancement/docs）をGitHub Issue Forms形式で追加し、フェーズ/スキーマ/ランナー影響/重症度を必須化
- Diátaxis準拠のdocsコンテンツをチュートリアル/ハウツー/リファレンス/解説に追加し、skill.schema.jsonを2020-12ドラフト仕様に合わせて更新

影響範囲
- ドキュメントとGitHubテンプレートのみ（コード変更なし）

テスト
- 未実行（テンプレ/ドキュメントのみ）。必要に応じて 
> agents:validate
> node scripts/validate-agents.mjs

✅ agents/examples/pocket-eitan.agent.yaml を実行してください。