### PR TITLE
test: add coverage for skills and metadata-driven runner (issue #73)

### DIFF
--- a/tests/fixtures/execution-plan-midstream.json
+++ b/tests/fixtures/execution-plan-midstream.json
@@ -1,0 +1,27 @@
+{
+  "selected": [
+    {
+      "id": "rr-midstream-code-quality-sample-001",
+      "phase": "midstream",
+      "modelHint": "balanced",
+      "outputKind": ["findings", "actions"],
+      "dependencies": ["code_search"]
+    }
+  ],
+  "skipped": [
+    {
+      "id": "rr-downstream-test-review-sample-001",
+      "reasons": [
+        "phase mismatch: downstream !== midstream",
+        "applyTo did not match any changed file"
+      ]
+    },
+    {
+      "id": "rr-upstream-architecture-sample-001",
+      "reasons": [
+        "phase mismatch: upstream !== midstream",
+        "applyTo did not match any changed file"
+      ]
+    }
+  ]
+}

--- a/tests/review-runner.snapshot.test.mjs
+++ b/tests/review-runner.snapshot.test.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { buildExecutionPlan } from '../src/lib/review-runner.mjs';
+
+const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const snapshotPath = path.join(repoRoot, 'tests', 'fixtures', 'execution-plan-midstream.json');
+
+async function loadSnapshot() {
+  const raw = await fs.readFile(snapshotPath, 'utf8');
+  return JSON.parse(raw);
+}
+
+function summarizePlan(plan) {
+  return {
+    selected: plan.selected.map(s => ({
+      id: s.metadata.id,
+      phase: s.metadata.phase,
+      modelHint: s.metadata.modelHint ?? null,
+      outputKind: s.metadata.outputKind,
+      dependencies: s.metadata.dependencies ?? [],
+    })),
+    skipped: plan.skipped.map(entry => ({
+      id: entry.skill.metadata.id,
+      reasons: entry.reasons,
+    })),
+  };
+}
+
+test('execution plan for midstream diff matches snapshot', async () => {
+  const plan = await buildExecutionPlan({
+    phase: 'midstream',
+    changedFiles: ['src/app.ts'],
+    availableContexts: ['diff'],
+    preferredModelHint: 'balanced',
+  });
+  const summarized = summarizePlan(plan);
+  const snapshot = await loadSnapshot();
+  assert.deepEqual(summarized, snapshot);
+});

--- a/tests/review-runner.snapshot.test.mjs
+++ b/tests/review-runner.snapshot.test.mjs
@@ -2,9 +2,10 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { buildExecutionPlan } from '../src/lib/review-runner.mjs';
 
-const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const snapshotPath = path.join(repoRoot, 'tests', 'fixtures', 'execution-plan-midstream.json');
 
 async function loadSnapshot() {

--- a/tests/skill-loader.test.mjs
+++ b/tests/skill-loader.test.mjs
@@ -53,6 +53,32 @@ Body content
   assert.deepEqual(loaded.metadata.dependencies, ['code_search', 'custom:embedding']);
 });
 
+test('fails when dependencies contain unsupported values', async () => {
+  const validator = await buildValidator();
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'skill-loader-'));
+  const skillPath = path.join(tmpDir, 'invalid-deps.md');
+  const content = `---
+id: rr-upstream-invalid-deps-001
+name: 'Invalid deps'
+description: 'Contains unsupported dependency'
+phase: upstream
+applyTo:
+  - 'src/**/*.ts'
+dependencies:
+  - unknown_tool
+---
+`;
+  await writeFile(skillPath, content, 'utf8');
+
+  await assert.rejects(
+    loadSkillFile(skillPath, { validator }),
+    err => {
+      assert.match(err.message, /validation failed/i);
+      return true;
+    }
+  );
+});
+
 test('fails validation when required fields are missing', async () => {
   const validator = await buildValidator();
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'skill-loader-'));


### PR DESCRIPTION
Issue #73 に対応し、メタデ対応スキルとランナーのテスト/スナップショットを追加しました。

- skill-loader: dependencies のバリデーションを追加テスト（未知の依存で fail-fast）、新フィールドを含む正常系を確認
- review-runner: midstream ケースの execution plan をスナップショット比較（selected/skipped の要約）
- fixtures: tests/fixtures/execution-plan-midstream.json を追加

Tests:
- npm test
- npm run lint

Closes #73