### PR TITLE
feat: add planner evaluation harness and docs (issue #85)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ LLM を使ったスキル選択はプランナー関数を差し込むだけで�
 
 Planner 統合後の全体アーキテクチャ（metadata → loader → planner → runner）は `docs/architecture.md` にまとめています。
 
+Planner の出力品質を簡易評価する手順とメトリクスは `docs/planner-evaluation.md` を参照してください（`npm run planner:eval` で実行）。
+
 ```markdown
 ---
 id: rr-midstream-code-quality-sample-001

--- a/docs/planner-evaluation.md
+++ b/docs/planner-evaluation.md
@@ -1,10 +1,12 @@
 # Skill Planner の評価と最適化のためのミニガイド
 
 ## 目的
+
 - Planner の出力品質を可視化し、改善のベースラインを作る。
 - LLM プロンプトやヒューリスティックを変えた際に、差分を簡易評価できるようにする。
 
 ## 評価の単位
+
 - ケースごとの期待順序（`expectedOrder`）と、Planner 出力（`plan` または LLM 応答）を比較。
 - メトリクス（簡易版）:
   - `exactMatch`: 期待順序と完全一致の割合
@@ -18,23 +20,26 @@
    `tests/fixtures/planner-eval-cases.json` に、`skills` / `context` / `plan` / `expectedOrder` を記述します。  
    ※ `plan` が未指定なら `expectedOrder` をそのまま LLM 応答として使います（オフライン評価用）。
 
-2. 評価を実行  
+2. 評価を実行
+
    ```bash
    npm run planner:eval  # デフォルトで上記フィクスチャを評価
    # または任意のフィクスチャを指定
    node scripts/evaluate-planner.mjs path/to/your-cases.json
    ```
 
-3. 出力  
+3. 出力
    - サマリ（件数、exactMatch/top1/coverage/MRR）と各ケースの詳細を標準出力します。
 
 ## 実装メモ
+
 - コア: `src/lib/planner-eval.mjs`（`planSkills` を呼び出してメトリクスを算出）
 - CLI: `scripts/evaluate-planner.mjs`
 - サンプル: `tests/fixtures/planner-eval-cases.json`
 - テスト: `tests/planner-eval.test.mjs`（メトリクス計算の妥当性を確認）
 
 ## 改善アイデア（今後）
+
 - 評価メトリクスの拡充（Normalized DCG など）
 - 実際の LLM 応答をキャプチャして再生する仕組み
 - 代表 PR / diff セットを固定し、スナップショット的に比較する仕組み

--- a/docs/planner-evaluation.md
+++ b/docs/planner-evaluation.md
@@ -1,0 +1,40 @@
+# Skill Planner の評価と最適化のためのミニガイド
+
+## 目的
+- Planner の出力品質を可視化し、改善のベースラインを作る。
+- LLM プロンプトやヒューリスティックを変えた際に、差分を簡易評価できるようにする。
+
+## 評価の単位
+- ケースごとの期待順序（`expectedOrder`）と、Planner 出力（`plan` または LLM 応答）を比較。
+- メトリクス（簡易版）:
+  - `exactMatch`: 期待順序と完全一致の割合
+  - `top1Match`: 先頭要素が一致する割合
+  - `coverage`: 期待に含まれる ID が出力に含まれる割合
+  - `MRR`: 期待先頭 ID の平均逆順位（Mean Reciprocal Rank）
+
+## 使い方
+
+1. 評価ケースを用意  
+   `tests/fixtures/planner-eval-cases.json` に、`skills` / `context` / `plan` / `expectedOrder` を記述します。  
+   ※ `plan` が未指定なら `expectedOrder` をそのまま LLM 応答として使います（オフライン評価用）。
+
+2. 評価を実行  
+   ```bash
+   npm run planner:eval  # デフォルトで上記フィクスチャを評価
+   # または任意のフィクスチャを指定
+   node scripts/evaluate-planner.mjs path/to/your-cases.json
+   ```
+
+3. 出力  
+   - サマリ（件数、exactMatch/top1/coverage/MRR）と各ケースの詳細を標準出力します。
+
+## 実装メモ
+- コア: `src/lib/planner-eval.mjs`（`planSkills` を呼び出してメトリクスを算出）
+- CLI: `scripts/evaluate-planner.mjs`
+- サンプル: `tests/fixtures/planner-eval-cases.json`
+- テスト: `tests/planner-eval.test.mjs`（メトリクス計算の妥当性を確認）
+
+## 改善アイデア（今後）
+- 評価メトリクスの拡充（Normalized DCG など）
+- 実際の LLM 応答をキャプチャして再生する仕組み
+- 代表 PR / diff セットを固定し、スナップショット的に比較する仕組み

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "skills:validate": "node scripts/validate-skills.mjs",
     "trace:validate": "OTEL_ENABLED=1 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 node scripts/validate-agents.mjs",
     "fix:dashes": "node scripts/fix-dashes.mjs",
+    "planner:eval": "node scripts/evaluate-planner.mjs",
     "prepare": "husky install"
   },
   "dependencies": {

--- a/scripts/evaluate-planner.mjs
+++ b/scripts/evaluate-planner.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+import url from 'url';
+import { evaluatePlanner } from '../src/lib/planner-eval.mjs';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const fixturePath =
+  process.argv[2] ?? path.join(__dirname, '..', 'tests', 'fixtures', 'planner-eval-cases.json');
+
+async function main() {
+  const raw = fs.readFileSync(fixturePath, 'utf-8');
+  const data = JSON.parse(raw);
+  // revive llmPlan by wrapping provided plan array (offline eval用)
+  const cases = data.map(c => ({
+    ...c,
+    llmPlan: async ({ skills, context }) => c.llmPlan ?? c.plan ?? c.expectedOrder.map(id => ({ id })),
+    skills: c.skills,
+    context: c.context,
+  }));
+
+  const { summary, cases: results } = await evaluatePlanner(cases);
+  console.log('Planner evaluation summary:');
+  console.log(`- cases: ${summary.cases}`);
+  console.log(`- exactMatch: ${(summary.exactMatch * 100).toFixed(1)}%`);
+  console.log(`- top1Match: ${(summary.top1Match * 100).toFixed(1)}%`);
+  console.log(`- coverage: ${(summary.coverage * 100).toFixed(1)}%`);
+  console.log(`- MRR: ${summary.mrr.toFixed(3)}`);
+  console.log('\nDetails:');
+  for (const r of results) {
+    console.log(
+      `* ${r.name}: expected=${r.expected.join(',')} planned=${r.plannedIds.join(',')} top1=${r.top1Match} coverage=${r.coverage.toFixed(
+        2
+      )}`
+    );
+  }
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/lib/planner-eval.mjs
+++ b/src/lib/planner-eval.mjs
@@ -1,0 +1,60 @@
+import { planSkills } from './skill-planner.mjs';
+
+/**
+ * Evaluate planner outputs against expected orders.
+ * Metrics are intentionallyシンプルなオフライン評価用。
+ * @param {Array} cases - [{skills, context, llmPlan, expectedOrder}]
+ * @returns {{summary: object, cases: Array}}
+ */
+export async function evaluatePlanner(cases) {
+  const results = [];
+  for (const c of cases) {
+    const planned = await planSkills({
+      skills: c.skills,
+      context: c.context,
+      llmPlan: c.llmPlan,
+    });
+    const plannedIds = planned.planned.map(s => s.id ?? s.metadata?.id);
+    const expected = c.expectedOrder ?? [];
+    const top1Match = plannedIds[0] === expected[0] ? 1 : 0;
+    const coverage =
+      expected.length === 0
+        ? 1
+        : expected.filter(id => plannedIds.includes(id)).length / expected.length;
+    const mrr = (() => {
+      if (!expected.length) return 1;
+      const idx = plannedIds.indexOf(expected[0]);
+      return idx >= 0 ? 1 / (idx + 1) : 0;
+    })();
+    const exactMatch =
+      expected.length === plannedIds.length &&
+      expected.every((id, idx) => id === plannedIds[idx])
+        ? 1
+        : 0;
+    results.push({
+      name: c.name ?? 'case',
+      plannedIds,
+      expected,
+      exactMatch,
+      top1Match,
+      coverage,
+      mrr,
+      reasons: planned.reasons ?? [],
+    });
+  }
+
+  const summary = {
+    cases: cases.length,
+    exactMatch: average(results.map(r => r.exactMatch)),
+    top1Match: average(results.map(r => r.top1Match)),
+    coverage: average(results.map(r => r.coverage)),
+    mrr: average(results.map(r => r.mrr)),
+  };
+
+  return { summary, cases: results };
+}
+
+function average(arr) {
+  if (!arr.length) return 0;
+  return arr.reduce((a, b) => a + b, 0) / arr.length;
+}

--- a/tests/fixtures/planner-eval-cases.json
+++ b/tests/fixtures/planner-eval-cases.json
@@ -1,0 +1,73 @@
+[
+  {
+    "name": "midstream diff heavy",
+    "context": {
+      "phase": "midstream",
+      "changedFiles": ["src/foo.js"],
+      "availableContexts": ["diff", "fullFile"]
+    },
+    "skills": [
+      {
+        "id": "code-quality",
+        "name": "Code quality",
+        "phase": "midstream",
+        "applyTo": ["src/**/*.js"],
+        "inputContext": ["diff"],
+        "modelHint": "balanced"
+      },
+      {
+        "id": "tests",
+        "name": "Test suggestions",
+        "phase": "midstream",
+        "applyTo": ["src/**/*.js"],
+        "inputContext": ["diff", "tests"],
+        "modelHint": "high-accuracy"
+      },
+      {
+        "id": "summary",
+        "name": "Summary",
+        "phase": "midstream",
+        "applyTo": ["src/**/*.js"],
+        "inputContext": ["diff"],
+        "modelHint": "cheap"
+      }
+    ],
+    "plan": [
+      { "id": "code-quality", "reason": "diff size moderate" },
+      { "id": "tests", "reason": "touching logic needs tests" },
+      { "id": "summary", "reason": "summarize for PR body" }
+    ],
+    "expectedOrder": ["code-quality", "tests", "summary"]
+  },
+  {
+    "name": "missing tests context fallback",
+    "context": {
+      "phase": "midstream",
+      "changedFiles": ["src/bar.js"],
+      "availableContexts": ["diff"]
+    },
+    "skills": [
+      {
+        "id": "code-quality",
+        "name": "Code quality",
+        "phase": "midstream",
+        "applyTo": ["src/**/*.js"],
+        "inputContext": ["diff"],
+        "modelHint": "balanced"
+      },
+      {
+        "id": "tests",
+        "name": "Test suggestions",
+        "phase": "midstream",
+        "applyTo": ["src/**/*.js"],
+        "inputContext": ["diff", "tests"],
+        "modelHint": "high-accuracy"
+      }
+    ],
+    "plan": [
+      { "id": "tests", "reason": "prefer tests when available" },
+      { "id": "code-quality", "reason": "always run quality" }
+    ],
+    "expectedOrder": ["code-quality", "tests"]
+  }
+]

--- a/tests/planner-eval.test.mjs
+++ b/tests/planner-eval.test.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+import { evaluatePlanner } from '../src/lib/planner-eval.mjs';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const cases = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures', 'planner-eval-cases.json'), 'utf8'));
+
+const revived = cases.map(c => ({
+  ...c,
+  llmPlan: async () => c.plan,
+}));
+
+test('evaluatePlanner aggregates simple metrics', async () => {
+  const { summary, cases: results } = await evaluatePlanner(revived);
+  assert.strictEqual(summary.cases, 2);
+  // case1 exact match、case2 は top1 違いで exact 0
+  assert.ok(summary.exactMatch < 1 && summary.exactMatch > 0);
+  // coverage はどちらも全要素含む
+  assert.strictEqual(summary.coverage, 1);
+  // MRR は 1 と 0.5 の平均
+  assert.strictEqual(Number(summary.mrr.toFixed(3)), 0.75);
+  assert.strictEqual(results[0].plannedIds[0], 'code-quality');
+});


### PR DESCRIPTION
Issue #85 に対応し、Skill Planner の評価と最適化に向けたハーネスを追加しました。

- 新規ドキュメント: docs/planner-evaluation.md（メトリクスと実行手順を明記）
- 評価コア: src/lib/planner-eval.mjs（planSkills を呼び出し、exactMatch/top1/coverage/MRR を算出）
- CLI: scripts/evaluate-planner.mjs と npm script 
- フィクスチャ: tests/fixtures/planner-eval-cases.json（オフライン評価用サンプル）
- テスト: tests/planner-eval.test.mjs でメトリクス計算を検証
- package.json に  を追加、README からドキュメントへ導線を追加

テスト: npm test

Closes #85