### PR TITLE
docs: tailor AGENTS guide to river reviewer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENTS.md – River Reviewer agent guide
+# AGENTS.md—River Reviewer agent guide
 
 River Reviewer は「流れに寄り添う」AI レビューエージェントです。  
 このリポジトリには、River Reviewer のドキュメント、スキーマ、検証ユーティリティがまとまっています。  
@@ -9,7 +9,7 @@ River Reviewer は「流れに寄り添う」AI レビューエージェント�
 ## 0. 原則
 
 - 小さく変更 → 検証コマンド → PR → Green 確認 → レビュー
-- 設定ファイルを真実の源泉とし、フォーマッタ/ lint を必ず通す
+- 設定ファイルを真実の源泉とし、フォーマッタ / lint を必ず通す
 - 秘密情報は持ち込まない（`.env*` は禁止、例示はダミー値で）
 
 ---
@@ -45,7 +45,7 @@ PR/CI では少なくとも `npm test` と `npm run lint` を通し、変更内�
 慎重に扱う/原則手動編集しない:
 
 - `docs/`: 公開用生成物を想定。編集は通常 `pages/` 側で行う
-- `assets/` 各種アセット
+- `assets/`: 各種アセット
 - `LICENSE*`, `CITATION.cff`: ライセンス/引用情報
 - `package-lock.json`: `npm ci` で再生成。手作業で書き換えない
 


### PR DESCRIPTION
AGENTS.md をテンプレートから River Reviewer 向けの具体内容に置き換えました。

- npm 前提のセットアップ/共通コマンドを明記（test/lint/agents:validate/skills:validate/planner:eval 等）
- ディレクトリ構成と編集範囲をリポ固有のものに修正（pages/skills/schemas/scripts/tests/.github）
- コーディング/ドキュメントスタイル（Prettier, markdownlint, textlint, 日本語優先）を明記
- スキル/エージェント定義の検証ルールを追記
- セキュリティ・PR運用メモをリポに合わせて整理

テスト: npm test
