### PR TITLE
docs: SECURITY.md を追加 (#57)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,18 +1,24 @@
-# SECURITY
+# セキュリティポリシー (Security Policy)
 
-## 脆弱性の報告方法
+## 脆弱性の報告 (Reporting a Vulnerability)
 
-River Reviewer に関する脆弱性の可能性を見つけた場合は、公開 Issue や PR には投稿せず、GitHub の「Private vulnerability reporting（Report a vulnerability）」から非公開で報告してください。
+River Reviewer に関する脆弱性の可能性を見つけた場合は、公開 Issue や PR には投稿せず、GitHub のプライベート脆弱性報告機能から非公開で報告してください。
 
-- リポジトリの `Security` タブ → `Advisories` → `Report a vulnerability`
-- 可能であれば PoC、影響範囲、再現手順、想定される悪用シナリオ、暫定回避策を含めてください
+- 報告フォーム: [security/advisories/new](https://github.com/s977043/river-reviewer/security/advisories/new)
+- UI から辿る場合: リポジトリの `Security` タブ → `Advisories` → `Report a vulnerability`
 
-## 対応方針
+可能であれば、PoC、影響範囲、再現手順、想定される悪用シナリオ、暫定回避策を含めてください。
+
+If you believe you have found a security vulnerability, please do not file a public issue or pull request. Instead, report it privately via GitHub's private vulnerability reporting:
+
+- Report form: [security/advisories/new](https://github.com/s977043/river-reviewer/security/advisories/new)
+
+## 対応方針 (Our Process)
 
 - 受領確認と初期トリアージを行い、必要に応じて追加情報をお願いする場合があります
 - 影響範囲と深刻度に応じて、修正版の準備と公開（リリースノート等）を行います
 - 公開前の情報共有は、最小限の関係者のみに限定します
 
-## サポート範囲
+## サポート範囲 (Supported Versions)
 
 - 現時点では、`main` ブランチと最新リリースを優先して対応します


### PR DESCRIPTION
Fixes #57

### 目的
脆弱性報告の導線を整備し、公開 Issue/PR での誤った情報公開を防ぎます。

### 変更内容
- `SECURITY.md` を追加し、Private vulnerability reporting の利用を明記

### 確認
- npm test
- npm run lint
