### PR TITLE
docs: ライセンス適用範囲を明文化 (#54)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -120,7 +120,7 @@ This repository uses multiple licenses by asset type.
 - `LICENSE-CODE` (MIT): code and scripts
   - Examples: `src/**`, `scripts/**`, `tests/**`
 - `LICENSE-CONTENT` (CC BY 4.0): documentation, text, and media
-  - Examples: `pages/**`, `skills/**`, `assets/**`, `README*.md`
+  - Examples: `pages/**`, `skills/**`, `assets/**`, root `*.md`
 - `LICENSE` (Apache-2.0): repository scaffolding and configuration
   - Examples: `.github/**`, `docusaurus.config.js`, `sidebars.js`, `package*.json`, `*.config.*`, `.*rc*`
 

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ River Reviewer の技術ドキュメントは、[Diátaxis ドキュメントフ
 - `LICENSE-CODE`（MIT）: コードとスクリプト
   - 例: `src/**`, `scripts/**`, `tests/**`
 - `LICENSE-CONTENT`（CC BY 4.0）: ドキュメント、テキスト、メディア
-  - 例: `pages/**`, `skills/**`, `assets/**`, `README*.md`
+  - 例: `pages/**`, `skills/**`, `assets/**`,（ルート直下の）`*.md`
 - `LICENSE`（Apache-2.0）: リポジトリ構成（scaffolding）と設定（configuration）
   - 例: `.github/**`, `docusaurus.config.js`, `sidebars.js`, `package*.json`, `*.config.*`, `.*rc*`
 


### PR DESCRIPTION
Fixes #54

### 目的
複数ライセンスの適用範囲が第三者から分かりづらかったため、README に対象例と方針を明記して混乱を減らします。

### 変更内容
- `README.md` / `README.en.md` の「ライセンス」セクションに、対象ディレクトリ例と運用ガイドを追記

### 確認
- npm test
- npm run lint
