### PR TITLE
docs: CONTRIBUTING を具体化 (#59)

### DIFF
--- a/CONTRIBUTING.en.md
+++ b/CONTRIBUTING.en.md
@@ -62,15 +62,16 @@ npm run lint
 Depending on what you change:
 
 - If you changed skills (`skills/`): `npm run skills:validate`
-- If you changed agents/tracing: `npm run agents:validate` (and `npm run trace:validate` if needed)
+- If you changed agent definitions: `npm run agents:validate`
+- If you changed tracing functionality: `npm run trace:validate` (when OpenTelemetry validation is needed)
 
 ### 🧭 Coding/ops conventions (summary)
 
 - JS/Node uses ESM; tests use `node --test`
 - Formatting is enforced by Prettier (checked via `npm run lint`)
-- Do not commit secrets (`.env*` is not allowed); use dummy values in examples
-- Doc sources live under `pages/` (Docusaurus). The `docs/` directory is intended for generated artifacts/internal usage
-- Do not hand-edit `package-lock.json`; update it via `npm ci` / `npm install` when needed
+- Do not commit secrets in `.env*` files; use dummy values in examples
+- Doc site sources live under `pages/` (Docusaurus). The `docs/` directory is treated as internal docs (not served)
+- Do not hand-edit `package-lock.json`; update it by running `npm install` when you change dependencies in `package.json` (`npm ci` installs from the lock file)
 
 ## 📚 Documentation contributions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,15 +68,16 @@ npm run lint
 変更内容に応じて、以下も実行してください:
 
 - スキル（`skills/`）を変更した: `npm run skills:validate`
-- エージェント定義/トレース関連を変更した: `npm run agents:validate`（必要に応じて `npm run trace:validate`）
+- エージェント定義を変更した: `npm run agents:validate`
+- トレース関連の機能を変更した: `npm run trace:validate`（OpenTelemetry 検証が必要な場合）
 
 ### 🧭 コーディング/運用ルール（要約）
 
 - JS/Node は ESM を前提とし、テストは `node --test` を使用します
 - フォーマットは Prettier を使用します（`npm run lint` でチェック）
-- `.env*` などの秘密情報はコミットしません（例示はダミー値を使ってください）
-- ドキュメントのソースは `pages/`（Docusaurus）です。`docs/` は原則として生成物/内部用途を想定しています
-- `package-lock.json` は手動編集せず、必要なら `npm ci` / `npm install` で更新してください
+- `.env*` などの秘密情報はコミットしないでください（例示はダミー値を使ってください）
+- ドキュメントサイトのソースは `pages/`（Docusaurus）です。`docs/` は内部向けドキュメント（サイトに配信しない）として扱っています
+- `package-lock.json` は手動編集せず、依存関係を変更した場合は `npm install` で更新してください（`npm ci` はロックファイルに従うクリーンインストールです）
 
 ## 📚 Documentation contributions
 


### PR DESCRIPTION
Fixes #59

### 目的
外部コントリビューターが迷わず参加できるよう、Issue/PR の具体フローと必要なローカルチェックを CONTRIBUTING に追記します。

### 変更内容
- Issue 作成前の確認事項、Issue 種別の目安、テンプレート導線を追加
- PR フローに「最低限の実行コマンド（npm test / npm run lint）」と、変更内容に応じた追加コマンドを追記
- コーディング/運用ルール（ESM/Prettier/秘密情報/`pages/` など）を要約

### 確認
- npm test
- npm run lint
