### PR TITLE
docs: examples/ に最小サンプルを追加 (#61)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -80,6 +80,7 @@ severity: minor
 ```
 
 - Sample skills: `skills/upstream/sample-architecture-review.md`, `skills/midstream/sample-code-quality.md`, `skills/downstream/sample-test-review.md`
+- Examples: `examples/README.md`
 - Schemas: `schemas/skill.schema.json` (skill metadata) and `schemas/output.schema.json` (structured review output)
 - References: Skill schema details live in `pages/reference/skill-schema-reference.md`; Riverbed Memory design draft lives in `pages/explanation/riverbed-memory.md`.
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ severity: minor
 ```
 
 - サンプル: `skills/upstream/sample-architecture-review.md`, `skills/midstream/sample-code-quality.md`, `skills/downstream/sample-test-review.md`
+- examples: `examples/README.md`
 - スキーマ: スキルメタデータは `schemas/skill.schema.json`, レビュー出力は `schemas/output.schema.json`
 - 参考: スキルスキーマの詳細は `pages/reference/skill-schema-reference.md`、Riverbed Memory の設計ドラフトは `pages/explanation/riverbed-memory.md`
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,5 @@
+# examples/
+
+River Reviewer の利用イメージを掴むための最小構成サンプルです。各ディレクトリを自分のリポジトリにコピーして試してください。
+
+- `examples/minimal-js/`: 最小の JavaScript プロジェクト + River Reviewer の GitHub Actions ワークフロー例

--- a/examples/minimal-js/.github/workflows/river-reviewer.yml
+++ b/examples/minimal-js/.github/workflows/river-reviewer.yml
@@ -1,0 +1,21 @@
+name: River Reviewer (example)
+
+on:
+  pull_request:
+
+jobs:
+  river-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run River Reviewer (midstream)
+        uses: s977043/river-reviewer/.github/actions/river-reviewer@v0
+        with:
+          phase: midstream
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/examples/minimal-js/README.md
+++ b/examples/minimal-js/README.md
@@ -1,0 +1,24 @@
+# minimal-js
+
+最小の JavaScript プロジェクト例です。
+
+## 含まれるもの
+
+- Node.js の最小コード（`src/`）
+- `node --test` の最小テスト
+- River Reviewer を組み込む GitHub Actions の例（`.github/workflows/river-reviewer.yml`）
+
+## 使い方（手元で試す）
+
+```bash
+npm install
+npm test
+```
+
+## GitHub Actions への組み込み
+
+このディレクトリの `.github/workflows/river-reviewer.yml` を、対象リポジトリの `.github/workflows/` にコピーしてください。
+
+- `actions/checkout` は `fetch-depth: 0` を推奨（merge-base を安定取得）
+- `OPENAI_API_KEY` は Secrets に設定
+- Action はリリースタグにピン留め（例: `@v0.1.0`）。必要なら `@v0` のようなエイリアスタグ運用も可能

--- a/examples/minimal-js/package.json
+++ b/examples/minimal-js/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "river-reviewer-example-minimal-js",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test src/add.test-example.js"
+  }
+}

--- a/examples/minimal-js/src/add.js
+++ b/examples/minimal-js/src/add.js
@@ -1,0 +1,3 @@
+export function add(a, b) {
+  return a + b;
+}

--- a/examples/minimal-js/src/add.test-example.js
+++ b/examples/minimal-js/src/add.test-example.js
@@ -1,0 +1,7 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { add } from './add.js';
+
+test('add', () => {
+  assert.equal(add(1, 2), 3);
+});


### PR DESCRIPTION
Fixes #61

### 目的
README だけでは掴みにくい「動く最小例」を提供し、採用側が手元で試しやすくします。

### 変更内容
- `examples/` を追加
- `examples/minimal-js/` に最小プロジェクトと River Reviewer の workflow 例を追加
- README から `examples/` への導線を追加

### 確認
- npm test
- npm run lint
