### PR TITLE
chore: unify milestones and improve roadmap links

### DIFF
--- a/.github/workflows/auto-milestone.yml
+++ b/.github/workflows/auto-milestone.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign milestone
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const owner = context.repo.owner;

--- a/README.en.md
+++ b/README.en.md
@@ -117,7 +117,7 @@ We organize content into four types, mapped by directory under `pages/` and serv
 Milestones and the GitHub Project are the source of truth for progress (this README list is only a high-level overview).
 
 - Milestones: [river-reviewer/milestones](https://github.com/s977043/river-reviewer/milestones)
-- Project: [users/s977043/projects/2](https://github.com/users/s977043/projects/2)
+- Project: [Project Board](https://github.com/users/s977043/projects/2)
 
 (Optional) Add one of `m1-public` / `m2-dx` / `m3-smart` / `m4-community` to an issue to auto-assign the corresponding milestone (`.github/workflows/auto-milestone.yml`).
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ River Reviewer の技術ドキュメントは、[Diátaxis ドキュメントフ
 進捗のソース・オブ・トゥルースは Milestones と Project です（README の箇条書きは概観のみ）。
 
 - Milestones: [river-reviewer/milestones](https://github.com/s977043/river-reviewer/milestones)
-- Project: [users/s977043/projects/2](https://github.com/users/s977043/projects/2)
+- Project: [プロジェクトボード](https://github.com/users/s977043/projects/2)
 
 （任意）Issue に `m1-public` / `m2-dx` / `m3-smart` / `m4-community` のいずれかを付与すると、Milestone を自動で設定します（`.github/workflows/auto-milestone.yml`）。
 


### PR DESCRIPTION
### 目的
Issue運用の見え方（Milestone/README導線）を改善し、外部から進捗が追いやすい状態にします。

### 変更内容
- Milestone 運用の統一（SemVer 系を正）
- README の Roadmap に導線追加（Milestones/Project）
- （任意）ラベル→Milestone 自動付与 Workflow を追加

$(cat /tmp/milestone-note.md)

### 確認
- npm test
- npm run lint
