### PR TITLE
chore: make auto-milestone work with closed milestones

### DIFF
--- a/.github/workflows/auto-milestone.yml
+++ b/.github/workflows/auto-milestone.yml
@@ -49,7 +49,7 @@ jobs:
             const milestoneList = await github.paginate(github.rest.issues.listMilestones, {
               owner,
               repo,
-              state: 'open',
+              state: 'all',
               per_page: 100,
             });
 


### PR DESCRIPTION
## 背景
README では `m1-public` / `m2-dx` / `m3-smart` / `m4-community` を付与すると Milestone を自動設定できる旨を書いていますが、ワークフロー側が open milestone のみ検索していたため、`v0.1.0 – Public Ready`（closed）には割り当てできませんでした。

## 変更内容
- `.github/workflows/auto-milestone.yml` の milestone 検索を `state: 'all'` に変更し、closed milestone も解決できるようにしました。

## 確認
- `npm test`
- `npm run lint`
