### PR TITLE
docs: align issue ops docs and roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,27 +23,25 @@
 
 ## Phase 1: Skill Migration & Coverage
 
-- [ ] 既存プロンプトを `skills/**/*.md` へ移行（YAML frontmatter をスキーマ準拠で付与）
-- [ ] ID プレフィックスを `rr-` に正規化（`scripts/rr_validate_skills.py` を活用）
-- [ ] Upstream/Midstream/Downstream それぞれに種スキルを追加（設計ガードレール、実装レビュー、QA/回帰確認など） → 現在サンプルのみで最小本数は未達
-- [ ] Quality/Domain タグ付け（例: `performance`, `security`, `reliability`）
+- [x] スキル定義を `skills/**/*.md` に集約（YAML frontmatter をスキーマ準拠で付与）
+- [x] ID プレフィックスを `rr-` に正規化
+- [x] Upstream/Midstream/Downstream それぞれに本番想定スキルを追加（設計ガードレール、実装レビュー、QA/回帰確認など）
+- [x] Quality/Domain タグ付け（例: `performance`, `security`, `reliability`）
 - Exit Criteria: 各フェーズに少なくとも1つ以上の本番想定スキルが配置され、スキーマ検証を通過する。
 
 ## Phase 2: Loader & Runner (Phase-aware Routing)
 
-- [ ] `skills/**/*.md` を再帰的に読み込み、`phase` でフィルタ可能なローダーを実装（`RR_PHASE` 環境変数/引数対応）
-- [ ] スキルメタデータの JSON Schema バリデーションを組み込み（例: `ajv` or Python の `jsonschema`）→ スクリプトはあるが Runner への組み込み未着手
-- [ ] GitHub Actions/CLI ラッパーを整備し、midstream をデフォルトにフェーズ切替を可能にする
-- [ ] Stream Router の下地として、変更ファイルのグロブと `applyTo` の突合を追加（安全な範囲で）
+- [x] `skills/**/*.md` を再帰的に読み込み、`phase` でフィルタ可能なローダーを実装（`RIVER_PHASE` / `--phase` 対応）
+- [x] スキルメタデータの JSON Schema バリデーションを Runner に組み込み（Ajv）
+- [x] GitHub Actions/CLI ラッパーを整備し、midstream をデフォルトにフェーズ切替を可能にする
+- [x] Stream Router の下地として、変更ファイルのグロブと `applyTo` の突合を追加
 - Exit Criteria: フェーズ指定でスキルを実行でき、メタデータのバリデーションを通過したものだけが走る。
 
-### 次の具体タスク案（Phase 1〜2 着手用）
+### 次の具体タスク案（Phase 3 着手用）
 
-- [ ] 既存プロンプトの移行計画を Issue 化（対象リスト、優先度、担当）
-- [ ] 既存サンプル以外の本番想定スキルを各フェーズ1本以上追加（ID 正規化含む）
-- [ ] Node 版ローダー最小実装：`skills/**/*.md` を読み込み、`phase` フィルタと `applyTo` 突合で対象スキル集合を返す
-- [ ] Runner プロトタイプ：`RR_PHASE` または引数でフェーズを選択し、バリデーション通過スキルのみ出力する CLI
-- [ ] GitHub Actions ラッパー更新：midstream デフォルトで Runner を呼び出す Job を作成（既存 placeholder を置き換え）
+- [ ] ゴールデンケース（差分・期待出力）を fixtures として追加し、回帰を検知できるテストを追加
+- [ ] スキルごとの失敗パス（コンテキスト不足/依存不足）をテストで検知
+- [ ] Evals/回帰テストを CI へ組み込み、スキル変更時に必ず実行
 
 ## Phase 3: Reliability & Evals
 

--- a/docs/issue-management.md
+++ b/docs/issue-management.md
@@ -2,7 +2,7 @@
 
 ## 🌟 目的
 
-River Reviewer プロジェクトでは、機能開発・スキル設計・エージェント基盤拡張を持続的に進めるため、**Issue と GitHub Projects を一調したフォーマット・フローで運用する**ことを定めています。
+River Reviewer プロジェクトでは、機能開発・スキル設計・エージェント基盤拡張を持続的に進めるため、**Issue と GitHub Projects を一貫したフォーマット・フローで運用する**ことを定めています。
 
 この文書は、Issue 作成者・レビュアー・メンテナーが同じ前提で進められるようにするための運用ルールをまとめたものです。
 
@@ -10,36 +10,28 @@ River Reviewer プロジェクトでは、機能開発・スキル設計・エ�
 
 ### 1-1. Issue テンプレートを必ず利用する
 
-新規 Issue は `.github/ISSUE_TEMPLATE/task.yaml` を使用します。テンプレートには以下の項目が含まれます：
+新規 Issue は、目的に合った `.github/ISSUE_TEMPLATE/*` を使用します（迷ったら `.github/ISSUE_TEMPLATE/task.yaml`）。テンプレートには以下の項目が含まれます：
 
 - **概要**—このタスクが何をするものなのか（必須）
 - **前タスク**—直前の Issue 番号（任意）
 - **次タスク**—次に着手する Issue 番号（任意）
 - **受け入れ条件**—完了条件を明記する（必須）
 
-### 1-2. 必ず「フェーズラベル」を付与する
+### 1-2. 必ず「タイプ」ラベルを付与する
 
-エージェント化ロードマップに正则って、Issue 作成時に下記のいずれかを付けます。フェーズなし Issue は原則受け付けません。
+Issue の種類が一目で分かるように、Issue 作成時に `type:` ラベルを 1 つ付けます。
 
-| ラベル                | 説明                                     |
-| --------------------- | ---------------------------------------- |
-| `phase:0-planning`    | 設計・要件整理フェーズ                   |
-| `phase:1-schema`      | schema・型・ローダ周りの実装フェーズ     |
-| `phase:2-runtime`     | ランナーや選択ロジックなど実行系フェーズ |
-| `phase:3-skills`      | 個別スキルの実装フェーズ                 |
-| `phase:4-integration` | GitHub Actions 等への統合フェーズ        |
+例: `type:task`, `type:bug`, `type:feature`, `type:enhancement`, `type:docs`, `type:content`
 
-### 1-3. 作業分類ラベル（kind）を付ける
+### 1-3. 優先度ラベルを付与する
 
-Issue には必ず下記のような **kind ラベル** を付け、作業の種類を明示します。
+優先度を揃えるため、Issue 作成時に `P0` / `P1` / `P2` のいずれかを付けます。
 
-| ラベル                | 説明             |
-| --------------------- | ---------------- |
-| `kind:design`         | 設計タスク       |
-| `kind:implementation` | 実装タスク       |
-| `kind:documentation`  | ドキュメント作成 |
-| `kind:test`           | テスト追加       |
-| `kind:refactor`       | 改善・リファクタ |
+### 1-4. Milestone は SemVer 系に統一する（任意だが推奨）
+
+進捗の「見え方」を揃えるため、Milestone は SemVer 系（例: `v0.2.0—Developer Experience`）に統一します。
+
+（任意）`m1-public` / `m2-dx` / `m3-smart` / `m4-community` を付与すると、Milestone を自動設定できます（`.github/workflows/auto-milestone.yml`）。
 
 ## 📍 2. 依存関係ルール（連続性の可視化）
 
@@ -50,31 +42,30 @@ Issue には必ず下記のような **kind ラベル** を付け、作業の種
 - `前タスク`: この Issue の前に完了すべき Issue 番号。
 - `次タスク`: この Issue 完了後に着手すべき次の Issue 番号。
 
-### 2-2. 依存ラベルを付ける
+### 2-2. 依存関係は本文で明示する
 
-Issue 間の依存関係を明示するため、以下のラベルを利用します。
+Issue 間の依存関係は、テンプレートの**前タスク/次タスク**とリンクで明示します（ラベル運用は追加導入が必要なため、本リポジトリのデフォルトでは必須にしません）。
 
-- `depends-on:#<番号>`—この Issue が依存している Issue。
-- `blocks:#<番号>`—この Issue が完了しないと進めない Issue。
+- 例: `前タスク: #123`, `次タスク: #124`
 
 ## 📍 3. GitHub Projects への自動追加と同期ルール
 
-### 3-1. Issue は自動的に Roadmap Project に登録
+### 3-1. Issue は Project に登録する
 
-Automation rules により、`phase:` ラベルの付いた Issue は Roadmap Project の `Idea` 列に自動で追加されます。
+必要に応じて Issue を GitHub Projects に登録し、Status で進行を管理します（自動化は任意）。
 
-### 3-2. Project 上のカスタムフィールド
+### 3-2. Project 上のフィールド（例）
 
 Roadmap Project には下記のカスタムフィールドを追加し、Issue ラベルや依存関係と同期します。
 
-| フィールド名 | 種類          | 説明                        |
-| ------------ | ------------- | --------------------------- |
-| Phase        | Single select | `phase:` ラベルに対当       |
-| Kind         | Single select | `kind:` ラベルに対当        |
-| Prev Task    | Text          | 前タスク番号                |
-| Next Task    | Text          | 次タスク番号                |
-| Depends On   | Text          | 依存 Issue 番号             |
-| Blocks       | Text          | ブロックしている Issue 番号 |
+| フィールド名 | 種類          | 説明                          |
+| ------------ | ------------- | ----------------------------- |
+| Status       | Single select | Todo / Doing / Blocked / Done |
+| Priority     | Single select | P0 / P1 / P2                  |
+| Type         | Single select | `type:` ラベルに対応          |
+| Milestone    | Single select | SemVer milestone（任意）      |
+| Prev Task    | Text          | 前タスク番号（任意）          |
+| Next Task    | Text          | 次タスク番号（任意）          |
 
 ### 3-3. Project 内での並び順
 
@@ -97,7 +88,7 @@ Roadmap Project 上での進行ステータスを定義します。
 
 ## 📍 5. Epic（親Issue）運用ルール
 
-大規模な取り組みやフェーズ全体をまとめる Issue には `epic` ラベルを付けます。例えば、`River Reviewer—Agent Roadmap` が Epic となります。
+大規模な取り組みやフェーズ全体をまとめる親 Issue（Epic）を作成する場合は、チェックリストで関連 Issue を列挙します（ラベル運用は必要に応じて導入します）。
 
 Epic Issue には関連タスク Issue をチェックリストとして列挙し、全体の進捗を把握できるようにします。
 
@@ -118,10 +109,10 @@ Epic Issue には関連タスク Issue をチェックリストとして列挙�
 - スキーマ化しやすい形式になっている
 
 ラベル:
-- phase:0-planning
-- kind:design
+- type:task
+- P1
 ```
 
-## 📍 7. ドキュメントの改証ルール
+## 📍 7. ドキュメントの改訂ルール
 
 このドキュメントを変更する場合、必ず Pull Request を作成し、メンテナーの承認を得てください。プロジェクト運用に影響する変更は Epic Issue にリンクしておくこと。

--- a/pages/guides/governance/roadmap-guide.md
+++ b/pages/guides/governance/roadmap-guide.md
@@ -32,7 +32,7 @@ title: Roadmap & Project Board 運用ガイド
 ## 登録フロー
 
 1. Issue を作成し、`Phase`/`Priority`/`Status=Todo` を設定。
-2. 必要ならマイルストン（Phase 1 など）に紐付ける。
+2. 必要ならマイルストン（`v0.2.0 – Developer Experience` など）に紐付ける（Milestone は SemVer 系に統一）。
 3. プロジェクトボードに追加（Board でカードが自動生成される）。
 
 ## 運用フロー（カンバン）


### PR DESCRIPTION
## 目的
Milestone を SemVer 系に統一した現在の運用と、リポジトリ内ドキュメント/ロードマップの記述を揃えます。

## 変更内容
- `docs/issue-management.md`: 実在しないラベル運用（`phase:*` / `kind:*` など）を削除し、現行ラベル（`type:*`, `P0/P1/P2`）と SemVer milestone（+ `m1-*` などの自動割当）前提に更新。
- `pages/guides/governance/roadmap-guide.md`: 「Phase 1 などのマイルストン」表現を SemVer milestone へ修正。
- `ROADMAP.md`: Phase 1/2 の達成状況を実態に合わせて更新し、Phase 3 着手用の次タスクを整理。

## 確認
- `npm run lint`
- `npm test`
