### PR TITLE
feat(skills): add observability and failure-mode skills

### DIFF
--- a/skills/midstream/rr-midstream-logging-observability-001.md
+++ b/skills/midstream/rr-midstream-logging-observability-001.md
@@ -1,0 +1,38 @@
+---
+id: rr-midstream-logging-observability-001
+name: Logging and Observability Guard
+description: Ensure code changes keep logs/metrics/traces useful for debugging failures and regressions.
+phase: midstream
+applyTo:
+  - 'src/**/*'
+  - 'lib/**/*'
+  - '**/*.js'
+  - '**/*.mjs'
+  - '**/*.ts'
+  - '**/*.tsx'
+tags: [observability, logging, reliability, midstream]
+severity: minor
+inputContext: [diff, fullFile]
+outputKind: [findings, actions]
+modelHint: balanced
+dependencies: [tracing, code_search]
+---
+
+## Rule / ルール
+
+- 失敗時に原因が追えるログ/メトリクス/トレースが残ること（過不足なく、PII を含めない）。
+- 例外を握りつぶさず、エラー文脈（requestId、入力の要約、外部依存の種別）を付与する。
+- 重要な分岐（フォールバック、リトライ、キャッシュヒット/ミス）を観測できること。
+
+## Heuristics / 判定の手がかり
+
+- `catch` でエラーを握りつぶしている、またはログが無い（silent failure）。
+- ログが「固定文言のみ」で、どのリクエスト/入力が原因か追えない。
+- 失敗時にスタックトレースやエラーコードが残らず、再現が困難。
+- 新しいリトライ/フォールバック/キャッシュが入ったのに、観測ポイントが無い。
+
+## Actions / 改善案
+
+- 失敗ログに `requestId`（相関ID）と、入力の最小要約（サイズ/件数/キー）を追加する。
+- 例外は `cause` を保持し、上位へ伝播するか、適切にラップして意味を残す。
+- 重大な分岐にメトリクス（成功/失敗/リトライ回数）や span 属性を追加する。

--- a/skills/upstream/rr-upstream-failure-modes-observability-001.md
+++ b/skills/upstream/rr-upstream-failure-modes-observability-001.md
@@ -1,0 +1,42 @@
+---
+id: rr-upstream-failure-modes-observability-001
+name: Failure Modes & Observability in Design
+description: Ensure designs specify failure modes, timeouts, error contracts, and observability for critical flows.
+phase: upstream
+applyTo:
+  - '**/api/**'
+  - '**/routes/**'
+  - 'docs/**/*'
+  - 'pages/**/*'
+tags: [reliability, observability, api, design, upstream]
+severity: major
+inputContext: [diff, adr]
+outputKind: [findings, actions, questions, summary]
+modelHint: balanced
+dependencies: [repo_metadata, tracing]
+---
+
+## Rule / ルール
+
+- クリティカルフロー（認証、課金、データ保存など）の**失敗モード**（タイムアウト、リトライ、フォールバック、外部障害、権限不備）を明示する。
+- エラー応答（ステータス、エラーコード、message/detail）の**契約**を一貫させ、クライアントが判断できる形にする。
+- SLO/監視、ログ、メトリクス、トレースなどの**観測性**を設計に含める。
+
+## Heuristics / 判定の手がかり
+
+- 外部依存（DB/HTTP/Queue）の失敗時に「何が起きるか」が仕様に無い（例: リトライ方針、タイムアウト、冪等性）。
+- 4xx/5xx の使い分け、エラー構造がエンドポイントごとに不揃い。
+- Rate limit / backoff / circuit breaker の前提があるのに、設計/ADR で触れられていない。
+- 障害時の切り分けに必要なログ（相関ID、requestId、重要な属性）やメトリクスの設計が無い。
+
+## Questions / 確認質問（不明な場合は質問として出す）
+
+- 代表的な失敗モード（タイムアウト、外部 5xx、バリデーション、権限、競合）はどれですか？
+- 冪等性キーやリトライ可否の判断はどこで担保しますか？
+- 監視対象（SLO、エラーバジェット、アラート条件）はありますか？
+
+## Actions / 改善案
+
+- タイムアウト値、リトライ回数、バックオフ、フォールバックを ADR/設計に追記する。
+- エラー応答の共通スキーマ（code/message/detail/requestId など）を定義し、例を載せる。
+- クリティカルフローに相関IDを付与し、ログ/トレースのキーを設計に含める。

--- a/tests/fixtures/execution-plan-midstream.json
+++ b/tests/fixtures/execution-plan-midstream.json
@@ -60,6 +60,10 @@
       "reasons": ["missing required inputContext"]
     },
     {
+      "id": "rr-midstream-logging-observability-001",
+      "reasons": ["missing required inputContext"]
+    },
+    {
       "id": "rr-midstream-security-basic-001",
       "reasons": ["missing required inputContext"]
     },
@@ -80,6 +84,14 @@
     },
     {
       "id": "rr-upstream-api-design-001",
+      "reasons": [
+        "phase mismatch: upstream !== midstream",
+        "applyTo did not match any changed file",
+        "missing required inputContext"
+      ]
+    },
+    {
+      "id": "rr-upstream-failure-modes-observability-001",
       "reasons": [
         "phase mismatch: upstream !== midstream",
         "applyTo did not match any changed file",


### PR DESCRIPTION
## 目的
スキル棚卸し（Phase 1 継続）として、運用で効きやすい「失敗モード/観測性」観点のスキルを追加します。

## 変更内容
- `skills/upstream/rr-upstream-failure-modes-observability-001.md`: 設計段階で失敗モード・エラー契約・観測性（ログ/メトリクス/トレース）をチェックするスキルを追加。
- `skills/midstream/rr-midstream-logging-observability-001.md`: 実装差分に対してログ/観測性の劣化（silent failure等）を検出するスキルを追加。
- `tests/fixtures/execution-plan-midstream.json`: 新規スキル追加に伴いスナップショットを更新。

## 確認
- `npm run skills:validate`
- `npm test`
- `npm run lint`
