### PR TITLE
chore: clarify skip reasons for missing inputContext

### DIFF
--- a/src/lib/review-runner.mjs
+++ b/src/lib/review-runner.mjs
@@ -29,11 +29,11 @@ function matchesApplyTo(skill, changedFiles) {
   return changedFiles.some(file => globs.some(pattern => minimatch(file, pattern, { dot: true })));
 }
 
-function hasRequiredContext(skill, availableContexts) {
+function missingInputContexts(skill, availableContexts) {
   const meta = getMeta(skill);
-  if (!meta.inputContext || meta.inputContext.length === 0) return true;
+  if (!meta.inputContext || meta.inputContext.length === 0) return [];
   const available = new Set(availableContexts);
-  return meta.inputContext.every(ctx => available.has(ctx));
+  return meta.inputContext.filter(ctx => !available.has(ctx));
 }
 
 function missingDependencies(skill, availableDependencies) {
@@ -54,8 +54,9 @@ function evaluateSkill(skill, options) {
   if (!matchesApplyTo(meta, options.changedFiles)) {
     reasons.push('applyTo did not match any changed file');
   }
-  if (!hasRequiredContext(meta, options.availableContexts)) {
-    reasons.push('missing required inputContext');
+  const missingContexts = missingInputContexts(meta, options.availableContexts);
+  if (missingContexts.length) {
+    reasons.push(`missing inputContext: ${missingContexts.join(', ')}`);
   }
   const depsMissing = missingDependencies(meta, options.availableDependencies);
   if (depsMissing.length) {

--- a/tests/fixtures/execution-plan-midstream.json
+++ b/tests/fixtures/execution-plan-midstream.json
@@ -21,12 +21,12 @@
       "reasons": [
         "phase mismatch: downstream !== midstream",
         "applyTo did not match any changed file",
-        "missing required inputContext"
+        "missing inputContext: tests"
       ]
     },
     {
       "id": "rr-downstream-coverage-gap-001",
-      "reasons": ["phase mismatch: downstream !== midstream", "missing required inputContext"]
+      "reasons": ["phase mismatch: downstream !== midstream", "missing inputContext: tests"]
     },
     {
       "id": "rr-downstream-flaky-test-001",
@@ -37,14 +37,14 @@
     },
     {
       "id": "rr-downstream-test-existence-001",
-      "reasons": ["phase mismatch: downstream !== midstream", "missing required inputContext"]
+      "reasons": ["phase mismatch: downstream !== midstream", "missing inputContext: tests"]
     },
     {
       "id": "rr-downstream-test-naming-001",
       "reasons": [
         "phase mismatch: downstream !== midstream",
         "applyTo did not match any changed file",
-        "missing required inputContext"
+        "missing inputContext: tests"
       ]
     },
     {
@@ -52,28 +52,28 @@
       "reasons": [
         "phase mismatch: downstream !== midstream",
         "applyTo did not match any changed file",
-        "missing required inputContext"
+        "missing inputContext: tests"
       ]
     },
     {
       "id": "rr-midstream-review-policy-standard-001",
-      "reasons": ["missing required inputContext"]
+      "reasons": ["missing inputContext: fullFile"]
     },
     {
       "id": "rr-midstream-logging-observability-001",
-      "reasons": ["missing required inputContext"]
+      "reasons": ["missing inputContext: fullFile"]
     },
     {
       "id": "rr-midstream-security-basic-001",
-      "reasons": ["missing required inputContext"]
+      "reasons": ["missing inputContext: fullFile"]
     },
     {
       "id": "rr-midstream-typescript-nullcheck-001",
-      "reasons": ["missing required inputContext"]
+      "reasons": ["missing inputContext: fullFile"]
     },
     {
       "id": "rr-midstream-typescript-strict-001",
-      "reasons": ["missing required inputContext"]
+      "reasons": ["missing inputContext: fullFile"]
     },
     {
       "id": "rr-upstream-review-policy-standard-001",
@@ -87,7 +87,7 @@
       "reasons": [
         "phase mismatch: upstream !== midstream",
         "applyTo did not match any changed file",
-        "missing required inputContext"
+        "missing inputContext: adr"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "reasons": [
         "phase mismatch: upstream !== midstream",
         "applyTo did not match any changed file",
-        "missing required inputContext"
+        "missing inputContext: adr"
       ]
     },
     {

--- a/tests/skill-routing-regression.test.mjs
+++ b/tests/skill-routing-regression.test.mjs
@@ -21,7 +21,7 @@ test('upstream skill is gated by inputContext', async () => {
   });
   assert.deepEqual(findSkillInPlan(withoutAdr, skillId), {
     status: 'skipped',
-    reasons: ['missing required inputContext'],
+    reasons: ['missing inputContext: adr'],
   });
 
   const withAdr = await buildExecutionPlan({
@@ -56,4 +56,3 @@ test('downstream skills are gated by declared dependencies when enabled', async 
   });
   assert.equal(findSkillInPlan(withDeps, skillId).status, 'selected');
 });
-


### PR DESCRIPTION
## 目的
`buildExecutionPlan` の skipped 理由から「どの inputContext が不足しているか」を一目で分かるようにし、デバッグ/運用を楽にします。

## 変更内容
- `src/lib/review-runner.mjs`: `missing required inputContext` を `missing inputContext: <list>` に変更（不足しているコンテキスト名を明示）。
- `tests/fixtures/execution-plan-midstream.json` と `tests/skill-routing-regression.test.mjs`: 変更に合わせて更新。

## 確認
- `npm test`
- `npm run lint`
