### PR TITLE
docs: align label examples with current ops

### DIFF
--- a/docs/issue-management.md
+++ b/docs/issue-management.md
@@ -71,9 +71,9 @@ Roadmap Project には下記のカスタムフィールドを追加し、Issue �
 
 以下のソート順を推奨します。
 
-1. Phase (昇順)
-2. Depends On が解決済みかどうか
-3. Issue タイトル (昇順)
+1. Priority（P0 → P2）
+2. Milestone（任意）
+3. Issue タイトル（昇順）
 
 ## 📍 4. Issue のライフサイクル
 

--- a/pages/guides/governance/roadmap-guide.md
+++ b/pages/guides/governance/roadmap-guide.md
@@ -52,5 +52,5 @@ title: Roadmap & Project Board 運用ガイド
 
 - Issue テンプレを用意し、目的/完了条件/テスト観点を書く欄を設ける。
 - 大きいタスクはチェックリストで分割し、サブタスクを Todo として管理。
-- ラベルを少数に絞る（例: `phase:1`, `priority:p1`, `kind:docs/code`）。
+- ラベルを少数に絞る（例: `type:task`, `P1`, `m2-dx`）。
 - ロードマップ更新時は、対応する Issue にリンクを張り、重複や抜けを防ぐ。


### PR DESCRIPTION
## 目的
運用ドキュメント内のラベル例を、現在のラベル体系（`type:*`, `P0/P1/P2`, `m1-*` など）に合わせます。

## 変更内容
- `pages/guides/governance/roadmap-guide.md`: ラベル例を `type:task` / `P1` / `m2-dx` に更新。
- `docs/issue-management.md`: Project の推奨ソート順を Priority/Milestone 前提に更新。

## 確認
- `npm run lint`
- `npm test`
