### PR TITLE
v0.3準備: planner切替（off/order/prune）を追加

### DIFF
--- a/.github/actions/river-reviewer/action.yml
+++ b/.github/actions/river-reviewer/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'Review phase (upstream|midstream|downstream).'
     required: false
     default: 'midstream'
+  planner:
+    description: 'Planner mode (off|order|prune).'
+    required: false
+    default: 'off'
   target:
     description: 'Path to the git repository to review.'
     required: false
@@ -58,7 +62,7 @@ runs:
         action_root="$(cd "${GITHUB_ACTION_PATH}/../../.." && pwd)"
         repo_path="$(cd "${{ inputs.target }}" && pwd)"
 
-        cmd=(node "${action_root}/src/cli.mjs" run "${repo_path}" --phase "${{ inputs.phase }}" --output markdown)
+        cmd=(node "${action_root}/src/cli.mjs" run "${repo_path}" --phase "${{ inputs.phase }}" --planner "${{ inputs.planner }}" --output markdown)
         if [ "${{ inputs.dry_run }}" = "true" ]; then
           cmd+=("--dry-run")
         fi

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -7,11 +7,11 @@ import { SkillLoaderError } from './lib/skill-loader.mjs';
 import CostEstimator from './core/cost-estimator.mjs';
 import { ProjectRulesError } from './lib/rules.mjs';
 import { parseList } from './lib/utils.mjs';
+import { PLANNER_MODES } from './lib/planner-utils.mjs';
 
 const MAX_PROMPT_PREVIEW_LENGTH = 800;
 const MAX_DIFF_PREVIEW_LINES = 200;
 const COMMENT_MARKER = '<!-- river-reviewer -->';
-const PLANNER_MODES = ['off', 'order', 'prune'];
 
 function printHintLines(lines = []) {
   const hints = lines.filter(Boolean);
@@ -235,7 +235,7 @@ function formatPlannerStatus(plan, { markdown = false } = {}) {
   if (!requested || mode === 'off') return wrap('off');
   if (plan?.plannerSkipped) return `${wrap(mode)} skipped (${plan.plannerSkipped})`;
   if (plan?.plannerFallback) {
-    const reason = Array.isArray(plan?.plannerReasons) && plan.plannerReasons.length ? plan.plannerReasons[0].reason : '';
+    const reason = plan?.plannerError || '';
     return reason ? `${wrap(mode)} fallback (${reason})` : `${wrap(mode)} fallback`;
   }
   return plan?.plannerUsed ? `${wrap(mode)} used` : `${wrap(mode)} not used`;

--- a/src/lib/openai-planner.mjs
+++ b/src/lib/openai-planner.mjs
@@ -1,0 +1,111 @@
+const DEFAULT_PLANNER_MODEL =
+  process.env.RIVER_PLANNER_MODEL ||
+  process.env.RIVER_OPENAI_MODEL ||
+  process.env.OPENAI_MODEL ||
+  'gpt-4o-mini';
+
+function resolveOpenAIConfig(options = {}) {
+  return {
+    apiKey: options.apiKey || process.env.RIVER_OPENAI_API_KEY || process.env.OPENAI_API_KEY,
+    model: options.model || DEFAULT_PLANNER_MODEL,
+    endpoint: options.endpoint || process.env.RIVER_OPENAI_BASE_URL || 'https://api.openai.com/v1/chat/completions',
+  };
+}
+
+function buildPlannerPrompt({ skills, context }) {
+  const phase = context?.phase ?? 'midstream';
+  const changedFiles = Array.isArray(context?.changedFiles) ? context.changedFiles : [];
+  const availableContexts = Array.isArray(context?.availableContexts) ? context.availableContexts : [];
+  const skillsText = (skills || [])
+    .map(s => `- ${s.id}: ${s.name} (${s.phase}) — ${s.description}`)
+    .join('\n');
+
+  return `You are River Reviewer, an AI skill planner.
+
+Goal: pick the most relevant review skills for this PR diff, and order them by priority.
+
+Context:
+- phase: ${phase}
+- changedFiles: ${changedFiles.join(', ') || '(none)'}
+- availableContexts: ${availableContexts.join(', ') || '(none)'}
+
+Candidate skills:
+${skillsText}
+
+Rules:
+- Output MUST be valid JSON only (no markdown, no code fences).
+- Output format: [{"id":"<skill id>","priority":<number>,"reason":"<short reason>"}]
+- Include only skills you recommend to run. If none are needed, output [].
+- Do not invent ids; use only ids from the candidate list.
+`;
+}
+
+async function callOpenAI({ prompt, apiKey, model, endpoint }) {
+  const controller = AbortSignal.timeout(15000);
+  const res = await fetch(endpoint, {
+    method: 'POST',
+    signal: controller,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model,
+      temperature: 0,
+      max_tokens: 600,
+      messages: [
+        {
+          role: 'system',
+          content:
+            'You are River Reviewer, an expert code review skill planner. Return valid JSON only; do not wrap in Markdown.',
+        },
+        { role: 'user', content: prompt },
+      ],
+    }),
+  });
+
+  if (!res.ok) {
+    const detail = await res.text();
+    throw new Error(`OpenAI API error ${res.status}: ${detail}`);
+  }
+  const json = await res.json();
+  return json.choices?.[0]?.message?.content?.trim() ?? '';
+}
+
+function parsePlannerJson(text) {
+  const trimmed = (text || '').trim();
+  if (!trimmed) return [];
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    const start = trimmed.indexOf('[');
+    const end = trimmed.lastIndexOf(']');
+    if (start >= 0 && end > start) {
+      return JSON.parse(trimmed.slice(start, end + 1));
+    }
+    throw new Error('planner output is not valid JSON');
+  }
+}
+
+export function createOpenAIPlanner(options = {}) {
+  const config = resolveOpenAIConfig(options);
+  return {
+    model: config.model,
+    endpoint: config.endpoint,
+    plan: async ({ skills, context }) => {
+      if (!config.apiKey) {
+        throw new Error('OPENAI_API_KEY (or RIVER_OPENAI_API_KEY) not set');
+      }
+      const prompt = buildPlannerPrompt({ skills, context });
+      const output = await callOpenAI({
+        prompt,
+        apiKey: config.apiKey,
+        model: config.model,
+        endpoint: config.endpoint,
+      });
+      const parsed = parsePlannerJson(output);
+      return Array.isArray(parsed) ? parsed : [];
+    },
+  };
+}
+

--- a/src/lib/planner-utils.mjs
+++ b/src/lib/planner-utils.mjs
@@ -1,0 +1,9 @@
+export const PLANNER_MODES = /** @type {const} */ (['off', 'order', 'prune']);
+
+export function normalizePlannerMode(mode, { defaultMode = 'off' } = {}) {
+  const fallback = PLANNER_MODES.includes(defaultMode) ? defaultMode : 'off';
+  const normalized = (mode || '').toLowerCase();
+  if (PLANNER_MODES.includes(normalized)) return normalized;
+  return fallback;
+}
+

--- a/src/lib/skill-planner.mjs
+++ b/src/lib/skill-planner.mjs
@@ -27,9 +27,10 @@ export function summarizeSkill(skill) {
  * @param {Array} options.skills - candidate skills (already filtered)
  * @param {Object} options.context - review context (e.g., changedFiles/diff summary/prompt)
  * @param {Function} [options.llmPlan] - async function receiving {skills, context}, returning [{id, priority, reason}]
+ * @param {boolean} [options.appendRemaining=true] - whether to append unreferenced skills in deterministic order
  * @returns {Promise<{planned: Array, reasons: Array, fallback: boolean}>}
  */
-export async function planSkills({ skills, context, llmPlan }) {
+export async function planSkills({ skills, context, llmPlan, appendRemaining = true }) {
   const summaries = skills.map(summarizeSkill);
 
   if (!llmPlan) {
@@ -42,24 +43,34 @@ export async function planSkills({ skills, context, llmPlan }) {
 
   try {
     const plan = await llmPlan({ skills: summaries, context });
-    const order = Array.isArray(plan) ? plan : [];
+    if (!Array.isArray(plan)) {
+      throw new Error('planner returned non-array response');
+    }
+    const order = plan;
     const byId = new Map(summaries.map((summary, idx) => [summary.id, skills[idx]]));
     const planned = [];
     const reasons = [];
+    let matchedCount = 0;
 
     for (const entry of order) {
       if (!entry?.id) continue;
       const candidate = byId.get(entry.id);
       if (candidate) {
         planned.push(candidate);
+        matchedCount += 1;
         if (entry.reason) reasons.push({ id: entry.id, reason: entry.reason });
         byId.delete(entry.id);
       }
     }
 
-    // append any not referenced by LLM in deterministic order
-    const remaining = rankByModelHint(Array.from(byId.values()));
-    planned.push(...remaining);
+    if (appendRemaining) {
+      // append any not referenced by LLM in deterministic order
+      const remaining = rankByModelHint(Array.from(byId.values()));
+      planned.push(...remaining);
+    } else if (matchedCount === 0 && order.length > 0) {
+      // In prune mode, a non-empty plan that matches nothing is almost certainly invalid output.
+      throw new Error('planner returned no known skill ids');
+    }
 
     return { planned, reasons, fallback: false };
   } catch (err) {

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -108,7 +108,20 @@ test('river run falls back gracefully without API key', async () => {
     assert.strictEqual(result.code, 0, result.stderr);
     assert.match(result.stdout, /River Reviewer/);
     assert.match(result.stdout, /LLM: OPENAI_API_KEY/i);
+    assert.match(result.stdout, /Planner: off/i);
     assert.match(result.stdout, /Review comments/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('river run reports planner skip reason when requested without API key', async () => {
+  const { dir } = await createRepoWithChange();
+  try {
+    const result = await runCli(['run', '.', '--planner', 'order', '--debug'], dir);
+    assert.strictEqual(result.code, 0, result.stderr);
+    assert.match(result.stdout, /Planner: order skipped/i);
+    assert.match(result.stdout, /OPENAI_API_KEY/i);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/tests/skill-planner.test.mjs
+++ b/tests/skill-planner.test.mjs
@@ -45,3 +45,18 @@ test('planSkills falls back on error', async () => {
   assert.equal(planned.length, skills.length);
   assert.equal(fallback, true);
 });
+
+test('planSkills can prune when appendRemaining is false', async () => {
+  const skills = await loadSkills();
+  const target = skills[0].metadata.id;
+  const llmPlan = async () => [{ id: target, priority: 0, reason: 'only this' }];
+  const { planned, fallback } = await planSkills({
+    skills,
+    context: mockContext,
+    llmPlan,
+    appendRemaining: false,
+  });
+  assert.equal(fallback, false);
+  assert.equal(planned.length, 1);
+  assert.equal(planned[0].metadata.id, target);
+});


### PR DESCRIPTION
## 概要
v0.3（Smart Reviewer）のDoDのうち「plannerのON/OFFをフラグ1つで切替」「絞り込み（prune）/優先度づけ（order）」を実装しました。

## 変更内容
- CLIに `--planner <off|order|prune>` を追加（既定: `RIVER_PLANNER_MODE` or `off`）
- plannerを要求したが実行できない場合（dry-run / API key未設定）に、理由を表示
- `prune` モードでは、LLMが返したスキルのみを実行（不正な出力は決定論にフォールバック）
- GitHub Actionに `planner` input を追加（既定: `off`）

## 影響範囲
- 既存のデフォルト挙動（planner未指定）は変わりません（`off`）

## 動作確認
- `npm test`
- `npm run lint`

## 補足
- plannerは `OPENAI_API_KEY`（または `RIVER_OPENAI_API_KEY`）が無い場合は呼び出さず、スキップ理由を表示します。
