### PR TITLE
Husky v10 互換: hook の deprecation 警告を解消

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx --no-install commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx --no-install lint-staged || exit 1


### PR DESCRIPTION
## 概要
Husky v10 で既存の hook スクリプトが動かなくなる旨の警告が、コミットのたびに出ていたため解消しました。

## 変更内容
- `.husky/pre-commit` と `.husky/commit-msg` から、v10 で失敗する互換レイヤ（shebang + `husky.sh` の sourcing）を削除

## 影響範囲
- hook の実行コマンド自体（`lint-staged` / `commitlint`）は変更なし

## 動作確認
- `npm test`
- `npm run lint`
