### PR TITLE
fix(docs): resolve lychee link errors and add evaluation fixture documentation

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -2,7 +2,7 @@
 
 ![River Reviewer logo](assets/logo/river-reviewer-logo.svg)
 
-English edition. The primary Japanese README lives in `README.md`.  
+English edition. The primary Japanese README lives in `README.md`.
 [日本語の README はここ](./README.md)—the Japanese copy is the source of truth; English may lag.
 
 Review that Flows With You. 流れに寄り添う AI レビューエージェント。
@@ -120,12 +120,13 @@ We organize content into four types, mapped by directory under `pages/` and serv
 - Riverbed Memory to retain ADR links, WontFix decisions, and past findings
 - Evals/CI integration to keep the agent trustworthy over time
 
-Milestones and the GitHub Project are the source of truth for progress (this README list is only a high-level overview).
+Milestones and the repository Projects are the source of truth for progress (this README list is only a high-level overview).
 
 - Milestones: [river-reviewer/milestones](https://github.com/s977043/river-reviewer/milestones)
-- Project: [Project Board](https://github.com/users/s977043/projects/2)
+- Projects: [Repository Projects page](https://github.com/s977043/river-reviewer/projects)
 
-(Optional) Add one of `m1-public` / `m2-dx` / `m3-smart` / `m4-community` to an issue to auto-assign the corresponding milestone (`.github/workflows/auto-milestone.yml`).
+(Optional) Add one of `m1-public` / `m2-dx` / `m3-smart` / `m4-community` to an issue.
+This will auto-assign the corresponding milestone (`.github/workflows/auto-milestone.yml`).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -315,10 +315,10 @@ River Reviewer の技術ドキュメントは、[Diátaxis ドキュメントフ
 - ADR などの履歴を保持する Riverbed Memory（WontFix や過去指摘も含む）
 - Evals / CI 連携による継続的な信頼性検証
 
-進捗のソース・オブ・トゥルースは Milestones と Project です（README の箇条書きは概観のみ）。
+進捗のソース・オブ・トゥルースは Milestones と Projects です（README の箇条書きは概観のみ）。
 
 - Milestones: [river-reviewer/milestones](https://github.com/s977043/river-reviewer/milestones)
-- Project: [プロジェクトボード](https://github.com/users/s977043/projects/2)
+- Projects: [リポジトリの Projects ページ](https://github.com/s977043/river-reviewer/projects)
 
 （任意）Issue に `m1-public` / `m2-dx` / `m3-smart` / `m4-community` のいずれかを付与すると、Milestone を自動で設定します（`.github/workflows/auto-milestone.yml`）。
 

--- a/pages/reference/_meta.json
+++ b/pages/reference/_meta.json
@@ -9,5 +9,6 @@
   "riverbed-storage": "Riverbed Memory ストレージ設計",
   "stable-interfaces": "安定インターフェース（CLI / GitHub Actions）",
   "runner-cli-reference": "Runner CLI Reference",
+  "evaluation-fixture-format": "Evaluation Fixture Format",
   "glossary": "River Reviewer Glossary"
 }

--- a/pages/reference/evaluation-fixture-format.md
+++ b/pages/reference/evaluation-fixture-format.md
@@ -1,0 +1,85 @@
+# 評価フィクスチャ形式（fixtures-based eval）
+
+River Reviewer は、差分に対するレビュー出力の品質を継続的に確認するために、フィクスチャ（入力と期待）を用いた評価をサポートします。本ページではフィクスチャ形式と評価ランナーの使い方を定義します。
+
+## 目的
+
+- スキルの出力形式（ラベル、Severity/Confidence）の整合性を自動で検証
+- 代表的な変更に対して、最低限含まれるべき語句（must_include）をチェック
+- 継続的評価（ローカル/CI）により、破壊的変更を早期検出
+
+## 入力形式（cases.json）
+
+フィクスチャは JSON で定義します。デフォルトの読み込み先は `tests/fixtures/review-eval/cases.json` です。
+
+各ケースは次のフィールドを持ちます。
+
+- `name`（string）: ケース名
+- `phase`（string, optional）: 適用フェーズ（例: `upstream`/`midstream`/`downstream`）
+- `diffFile`（string）: Unified Diff 形式のファイルへの相対パス（`cases.json` からの相対）
+- `planSkills`（string[]）: このケースで適用するスキルの ID（簡易プラン）
+- `mustInclude`（string[]）: 出力に必ず含まれてほしい語句（AND 条件）
+- `expectNoFindings`（boolean, optional）: 指摘ゼロを期待する場合に `true`
+- `minFindings`（number, optional）: 最低指摘数（`expectNoFindings` が `true` の場合は 0）
+- `maxFindings`（number, optional）: 最大指摘数の上限
+
+### 例
+
+```json
+{
+  "name": "secrets: hardcoded token (export const)",
+  "phase": "midstream",
+  "diffFile": "../planner-dataset/diffs/midstream-security-hardcoded-token.diff",
+  "planSkills": ["rr-midstream-security-basic-001"],
+  "mustInclude": [
+    "Finding:",
+    "Evidence:",
+    "Fix:",
+    "GitHub Secrets",
+    "Severity: blocker",
+    "Confidence: high"
+  ],
+  "maxFindings": 3
+}
+```
+
+## 実行方法（ローカル）
+
+- 依存導入: `npm ci`
+- 実行: `npm run eval:fixtures`
+  - オプション: `--cases <path>`（デフォルトは `tests/fixtures/review-eval/cases.json`）
+  - オプション: `--phase <upstream|midstream|downstream>`（各ケースの `phase` を上書き）
+  - オプション: `--verbose`（詳細ログ）
+
+評価ランナーの実体は `scripts/evaluate-review-fixtures.mjs` で、内部では `src/lib/review-fixtures-eval.mjs` を呼び出します。
+
+## 判定仕様
+
+- 出力形式検証: `Finding:`/`Evidence:`/`Fix:`、`Severity:`/`Confidence:` の整合を確認
+- 指摘数: `minFindings` 以上、`maxFindings` 以下
+- 語句検査: `mustInclude` の各語句がすべて含まれていること
+
+いずれかのチェックに失敗した場合、終了コード 1 を返します。
+
+## CI 連携（任意）
+
+GitHub Actions での実行は任意です。CI へ統合する場合は、以下のようなステップを追加します。
+
+```yaml
+- name: Evaluate review fixtures
+  run: npm run eval:fixtures -- --verbose
+```
+
+`must_include` の期待に合致しない場合はジョブが失敗します。
+
+## 既知の制限
+
+- LLM を使わずヒューリスティック出力のみで評価する（`dryRun: true`）
+- `planSkills` は ID のみ指定可能である（メタデータを最小限にモック）
+- Diff の最適化は行わず、フィクスチャに含まれるハンクをそのまま評価する
+
+## 関連ファイル
+
+- `scripts/evaluate-review-fixtures.mjs`
+- `src/lib/review-fixtures-eval.mjs`
+- `tests/fixtures/review-eval/cases.json`


### PR DESCRIPTION
## 概要

lycheeのリンクチェックで検出された404エラーを修正し、評価機能のドキュメントを追加します。

## 変更内容

### 1. リンク修正 (Fixes #198)
- README.md と README.en.md のProjectsリンクを修正
- `https://github.com/users/s977043/projects/2` (404) → `https://github.com/s977043/river-reviewer/projects`

### 2. 評価機能ドキュメント追加 (Closes #144)
- `pages/reference/evaluation-fixture-format.md` を追加
- フィクスチャ形式の正式定義と使用方法を記載
- `pages/reference/_meta.json` に項目追加（ナビゲーション反映）

## 関連Issue

- Fixes #198 - リンクチェック失敗
- Closes #144 - フィクスチャ形式の定義
- 補足: #146/#145 は既に実装済み、#142 はサブ課題完了によりクローズ可能

## 検証

```bash
npm ci
npm test     # 96 tests passed
npm run lint # All checks passed
```

## チェックリスト

- [x] テストがすべてパス
- [x] Lintエラーなし
- [x] ドキュメント追加（Diátaxis: Reference）
- [x] 既存機能への影響なし