### PR TITLE
fix: keep vercel root at /

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,13 +2,13 @@
   "trailingSlash": true,
   "redirects": [
     {
-      "source": "/",
-      "destination": "/docs/",
+      "source": "/docs",
+      "destination": "/",
       "permanent": true
     },
     {
-      "source": "/docs",
-      "destination": "/docs/",
+      "source": "/docs/",
+      "destination": "/",
       "permanent": true
     }
   ]

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "trailingSlash": true,
   "redirects": [
     {
-      "source": "/docs/?",
+      "source": "/docs/",
       "destination": "/",
       "permanent": true
     }

--- a/vercel.json
+++ b/vercel.json
@@ -2,12 +2,7 @@
   "trailingSlash": true,
   "redirects": [
     {
-      "source": "/docs",
-      "destination": "/",
-      "permanent": true
-    },
-    {
-      "source": "/docs/",
+      "source": "/docs/?",
       "destination": "/",
       "permanent": true
     }


### PR DESCRIPTION
## 目的
- Vercel で `/` が `/docs/` にリダイレクトされる不具合を解消する

## 変更
- `vercel.json` のリダイレクトを見直し、`/docs` と `/docs/` を `/` に集約
- `/` から `/docs/` へのリダイレクト設定を削除

## テスト
- 未実施（リダイレクト設定のみの変更）