### PR TITLE
docs: emphasize philosophy in readmes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@ Flow your changes from Upstream to Midstream to Downstream with clear validation
 
 ## Overview / 説明
 
-- [ ] Briefly describe what's changing and why (1-2 lines)（このPRの変更内容を簡潔に説明してください。概要・説明は日本語で記載してください）
+- [ ] Briefly describe what's changing and why (1-2 lines)（このPRの変更内容を簡潔に説明してください）
 - Primary phase focus: Upstream / Midstream / Downstream
 
 ## Flow Consistency

--- a/README.en.md
+++ b/README.en.md
@@ -4,7 +4,7 @@
 **An experimental AI code review framework that turns tacit knowledge into reusable Agent Skills.**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Documentation](https://img.shields.io/badge/docs-available-blue)](https://ai-review-kit.vercel.app/docs/explanation/intro)
+[![Documentation](https://img.shields.io/badge/docs-available-blue)](https://river-reviewer.vercel.app/explanation/intro/)
 
 ![River Reviewer logo](assets/logo/river-reviewer-logo.svg)
 
@@ -21,7 +21,7 @@ River Reviewer is a flow-based, metadata-driven AI review agent. It travels the 
 
 ## The Philosophy (Why we built it)
 
-> **We stopped believing “polish the prompt and you win.”**
+> **We stopped believing "polish the prompt and you win."**
 
 The biggest barrier to production AI review is not prompt quality but repeatability of review findings and operating cost.
 River Reviewer is not just a tool that lets an AI read code.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **暗黙知を再現可能な「Agent Skills」に変える、AIコードレビューの実験的フレームワーク**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Documentation](https://img.shields.io/badge/docs-available-blue)](https://ai-review-kit.vercel.app/docs/explanation/intro)
+[![Documentation](https://img.shields.io/badge/docs-available-blue)](https://river-reviewer.vercel.app/explanation/intro/)
 
 ![River Reviewer logo](assets/logo/river-reviewer-logo.svg)
 
@@ -18,11 +18,11 @@ Philosophy: [なぜ作ったのか](#philosophy)
 
 ## 📖 The Philosophy (なぜ作ったのか)
 
-> **"I stopped thinking 'Polishing Prompts Wins'."**
+> **We stopped believing "polish the prompt and you win."**
 > **「プロンプトを磨けば勝てる」をやめました。**
 
 AIレビューの実用化における最大の壁は、プロンプトの精度ではなく「レビュー指摘の再現性」と「運用コスト」でした。
-River Reviewerは、単にコードをAIに読ませるツールではありません。
+River Reviewer は、単にコードをAIに読ませるツールではありません。
 
 チーム固有の「判断基準」や「手順」といった暗黙知を、**再利用可能な「Agent Skills（マニュアル付きの道具箱）」** として定義し、組織の資産として育てるための実験的フレームワークです。
 

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -266,6 +266,14 @@ function formatPlannerStatus(plan, { markdown = false } = {}) {
   return plan?.plannerUsed ? `${wrap(mode)} used` : `${wrap(mode)} not used`;
 }
 
+function logPreview(title, text, maxLength, log, { leadingNewline = false } = {}) {
+  if (!text) return;
+  const preview = text.length > maxLength ? `${text.slice(0, maxLength)}...` : text;
+  const prefix = leadingNewline ? '\n' : '';
+  log(`${prefix}${title}:`);
+  log(preview);
+}
+
 function printMarkdownReport(result, phase) {
   const header = `${COMMENT_MARKER}
 ## River Reviewer
@@ -300,22 +308,14 @@ function printDebugInfo(result, { log = console.log } = {}) {
   if (debug.llmError) {
     log(`LLM error: ${debug.llmError}`);
   }
-  if (debug.promptPreview) {
-    const trimmed =
-      debug.promptPreview.length > MAX_PROMPT_PREVIEW_LENGTH
-        ? `${debug.promptPreview.slice(0, MAX_PROMPT_PREVIEW_LENGTH)}...`
-        : debug.promptPreview;
-    log('Prompt preview:');
-    log(trimmed);
-  }
-  if (result.projectRules) {
-    const rulesPreview =
-      result.projectRules.length > MAX_PROMPT_PREVIEW_LENGTH
-        ? `${result.projectRules.slice(0, MAX_PROMPT_PREVIEW_LENGTH)}...`
-        : result.projectRules;
-    log('\nProject-specific review rules (preview):');
-    log(rulesPreview);
-  }
+  logPreview('Prompt preview', debug.promptPreview, MAX_PROMPT_PREVIEW_LENGTH, log);
+  logPreview(
+    'Project-specific review rules (preview)',
+    result.projectRules,
+    MAX_PROMPT_PREVIEW_LENGTH,
+    log,
+    { leadingNewline: true },
+  );
   if (result.plan?.skipped?.length) {
     log('\nSkipped skills detail:');
     result.plan.skipped.forEach(item => {


### PR DESCRIPTION
## Summary
- add philosophy-focused intro and article link in README
- mirror philosophy section in README.en
- add a quick philosophy anchor link near the top

## Testing
- lintstaged (prettier/markdownlint)