### PR TITLE
docs: require Japanese in Copilot reviews

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,7 +14,7 @@ Always search `skills/` before starting a task. Use both English and Japanese ke
 - Prompts: `/skill`, `/review` (in `.github/prompts/`)
 - Reviews: Use `coding-review-checklist.md` as baseline rubric
 - Docs: Japanese is source of truth; English translations use `.en.md` suffix
-- Reviews and review comments must be written in Japanese.
+- Reviews and review comments must be written in Japanese.（レビューとレビューコメントは日本語で記載すること）
 
 ## Quick reference (from AGENTS.md)
 


### PR DESCRIPTION
## 目的
- Copilot レビューが日本語以外になるケースを防ぐ

## 変更内容
- Copilot instructions にレビュー日本語指定を追加

## 動作確認
- 未実施