### PR TITLE
Add Git worktree guidance for parallel tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,7 @@ AI エージェントは「主に編集対象」を優先し、それ以外は�
 - タスク完了（マージまたは PR 作成）後は、速やかに Worktree を削除しリソースを解放する。
 
   ```bash
-  git worktree remove <path>; git branch -d <branch-name>
+  git worktree remove <path> && git branch -d <branch-name>
   ```
 
 - 定期的にメタデータの整合性を保つため `git worktree prune` を実行する。


### PR DESCRIPTION
## Summary
- add a Git Worktree section that standardizes how to separate parallel tasks
- outline directory, naming, creation, verification, and cleanup steps
- shift subsequent sections to keep numbering consistent

## Testing
- Not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957441e5ae0832a901a9cacf2e01176)