### PR TITLE
fix: improve markdown output format for review findings

### DIFF
--- a/skills/midstream/rr-midstream-config-json-001.md
+++ b/skills/midstream/rr-midstream-config-json-001.md
@@ -1,0 +1,51 @@
+---
+id: rr-midstream-config-json-001
+name: Configuration File Review
+description: Review JSON/YAML configuration files for common issues and best practices.
+version: 0.1.0
+category: midstream
+phase: midstream
+applyTo:
+  - '**/*.json'
+  - '**/*.yml'
+  - '**/*.yaml'
+tags:
+  - config
+  - json
+  - yaml
+  - midstream
+severity: minor
+inputContext:
+  - diff
+outputKind:
+  - findings
+modelHint: cheap
+---
+
+## Goal
+
+設定ファイル（JSON/YAML）の変更をレビューし、一般的な問題やベストプラクティス違反を検出する。
+
+## Guidance
+
+- スキーマ違反や構文エラーの可能性を指摘する
+- 機密情報（API キー、パスワード、トークン）の直書きを検出する
+- 廃止された設定項目や非推奨オプションの使用を指摘する
+- 設定値の妥当性（範囲外の数値、無効な組み合わせ）を確認する
+- 環境固有の設定が誤ってコミットされていないか確認する
+
+## Non-goals
+
+- `package-lock.json` や自動生成ファイルはレビュー対象外（ノイズ削減のため）
+- `node_modules/` 内のファイルは対象外
+- テスト用フィクスチャファイルの内容は厳密にチェックしない
+
+## False-positive guards
+
+- `.example` や `.sample` 接尾辞のファイルはダミー値を許容する
+- テストディレクトリ内のファイルは緩和する
+- 明示的にコメントで意図が説明されている場合は抑制する
+
+## Output
+
+標準フォーマット: `<file>:<line>: Finding: ... Evidence: ... Impact: ... Fix: ... Severity: ... Confidence: ...`

--- a/skills/midstream/rr-midstream-config-json-001.md
+++ b/skills/midstream/rr-midstream-config-json-001.md
@@ -46,6 +46,13 @@ modelHint: cheap
 - テストディレクトリ内のファイルは緩和する
 - 明示的にコメントで意図が説明されている場合は抑制する
 
+## Rule / ルール
+
+- 機密情報（APIキー、パスワード、トークン）の直書きは blocker として報告する
+- JSON/YAML の構文エラーや不正なスキーマは major として報告する
+- 非推奨オプションや廃止された設定項目は minor として報告する
+- 環境固有の設定（localhost、開発用URL等）の混入は warning として報告する
+
 ## Output
 
 標準フォーマット: `<file>:<line>: Finding: ... Evidence: ... Impact: ... Fix: ... Severity: ... Confidence: ...`

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -214,9 +214,18 @@ function printComments(comments) {
   });
 }
 
+function formatMessageForMarkdown(message) {
+  const labels = ['Finding', 'Evidence', 'Impact', 'Fix', 'Severity', 'Confidence'];
+  let result = message;
+  for (const label of labels) {
+    result = result.replace(new RegExp(`\\s*${label}:`, 'g'), `\n  - **${label}:**`);
+  }
+  return result.trim();
+}
+
 function formatCommentsMarkdown(comments) {
   if (!comments?.length) return '_No findings._';
-  return comments.map(c => `- \`${c.file}:${c.line}\` ${c.message}`).join('\n');
+  return comments.map(c => `- \`${c.file}:${c.line}\`${formatMessageForMarkdown(c.message)}`).join('\n');
 }
 
 function formatPlanMarkdown(plan) {

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -220,7 +220,7 @@ function formatMessageForMarkdown(message) {
   for (const label of labels) {
     result = result.replace(new RegExp(`\\s*${label}:`, 'g'), `\n  - **${label}:**`);
   }
-  return result.trim();
+  return result;
 }
 
 function formatCommentsMarkdown(comments) {


### PR DESCRIPTION
## Summary

PR コメントの「指摘」セクションの改善と、設定ファイルレビュー機能を追加しました。

## 変更内容

### 1. Markdown 出力フォーマットの改善

各フィールドが1行に詰め込まれて読みにくかった問題を修正しました。

**Before:**
```markdown
- `.claude/settings.json:3` Finding: xxx Evidence: yyy Impact: zzz ...
```

**After:**
```markdown
- `.claude/settings.json:3`
  - **Finding:** xxx
  - **Evidence:** yyy
  - **Impact:** zzz
  ...
```

### 2. 設定ファイル用スキルを追加 (`rr-midstream-config-json-001`)

- JSON/YAML ファイルのレビューに対応
- 機密情報の直書き、構文エラー、非推奨設定を検出

### 3. フォールバックメッセージの改善

より具体的な理由を表示するよう改善：

**Before:**
```
Finding: 自動レビューの指摘を生成できなかった
Evidence: Changed around line 1
Fix: 手動レビューを行い...（Matched skills: ...）
```

**After:**
```
Finding: 2件のスキルがマッチしたが自動指摘を生成できなかった
Evidence: LLM: dry-run enabled; ヒューリスティック検出パターンに該当なし
Fix: 手動レビューを実施する（選択スキル: Hello Skill, Review Comment Triage）
```

## Test plan

- [x] `npm run lint` - passed
- [x] `npm test` - 120 tests passed
- [x] `npm run skills:validate` - passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)