### PR TITLE
feat(output): スキル単位で指摘をグループ化

### DIFF
--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -223,9 +223,38 @@ function formatMessageForMarkdown(message) {
   return result;
 }
 
+function groupCommentsBySkill(comments) {
+  const groups = {};
+  for (const c of comments) {
+    const key = c.skillId || '';
+    if (!groups[key]) groups[key] = [];
+    groups[key].push(c);
+  }
+  return groups;
+}
+
 function formatCommentsMarkdown(comments) {
   if (!comments?.length) return '_No findings._';
-  return comments.map(c => `- \`${c.file}:${c.line}\`${formatMessageForMarkdown(c.message)}`).join('\n');
+
+  // スキル単位でグループ化
+  const bySkill = groupCommentsBySkill(comments);
+  const entries = Object.entries(bySkill);
+
+  // スキルIDがないグループのみの場合は従来形式
+  if (entries.length === 1 && entries[0][0] === '') {
+    return comments.map(c => `- \`${c.file}:${c.line}\`${formatMessageForMarkdown(c.message)}`).join('\n');
+  }
+
+  // スキル単位でセクション化
+  return entries
+    .map(([skillId, items]) => {
+      const header = skillId ? `#### 🔍 ${skillId}` : '#### その他';
+      const body = items
+        .map(c => `- \`${c.file}:${c.line}\`${formatMessageForMarkdown(c.message)}`)
+        .join('\n');
+      return `${header}\n${body}`;
+    })
+    .join('\n\n');
 }
 
 function formatPlanMarkdown(plan) {

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -224,13 +224,11 @@ function formatMessageForMarkdown(message) {
 }
 
 function groupCommentsBySkill(comments) {
-  const groups = {};
-  for (const c of comments) {
-    const key = c.skillId || '';
-    if (!groups[key]) groups[key] = [];
-    groups[key].push(c);
-  }
-  return groups;
+  return (comments ?? []).reduce((groups, comment) => {
+    const key = comment.skillId || '';
+    (groups[key] = groups[key] || []).push(comment);
+    return groups;
+  }, {});
 }
 
 /**

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -233,6 +233,16 @@ function groupCommentsBySkill(comments) {
   return groups;
 }
 
+/**
+ * Markdown インジェクション対策: 特殊文字をエスケープ
+ */
+function sanitizeForMarkdown(text) {
+  if (!text) return '';
+  return String(text)
+    .replace(/[\\`*_{}[\]()#+\-.!|<>]/g, '\\$&')
+    .replace(/\n/g, ' ');
+}
+
 function formatCommentsMarkdown(comments) {
   if (!comments?.length) return '_No findings._';
 
@@ -245,10 +255,15 @@ function formatCommentsMarkdown(comments) {
     return comments.map(c => `- \`${c.file}:${c.line}\`${formatMessageForMarkdown(c.message)}`).join('\n');
   }
 
+  // skillId でソートして出力順序を安定化
+  entries.sort((a, b) => a[0].localeCompare(b[0]));
+
   // スキル単位でセクション化
   return entries
     .map(([skillId, items]) => {
-      const header = skillId ? `#### 🔍 ${skillId}` : '#### その他';
+      // skillId をサニタイズして Markdown インジェクションを防止
+      const safeSkillId = sanitizeForMarkdown(skillId);
+      const header = skillId ? `#### 🔍 ${safeSkillId}` : '#### その他';
       const body = items
         .map(c => `- \`${c.file}:${c.line}\`${formatMessageForMarkdown(c.message)}`)
         .join('\n');

--- a/src/lib/local-runner.mjs
+++ b/src/lib/local-runner.mjs
@@ -230,6 +230,7 @@ export async function planLocalReview({
     preferredModelHint,
     planner: planner ?? undefined,
     plannerMode: requestedPlannerMode,
+    dryRun,
   });
 
   const plannerUsed = planner ? !plan.plannerFallback : false;

--- a/src/lib/review-engine.mjs
+++ b/src/lib/review-engine.mjs
@@ -10,6 +10,14 @@ const MAX_PROMPT_PREVIEW_CHARS = 2000;
 const NO_ISSUES_REGEX = /^NO_ISSUES/i;
 const LINE_COMMENT_REGEX = /^(.+?):(\d+):\s*(.+)$/;
 
+/**
+ * スキル名のサニタイズ: Markdown インジェクション対策
+ */
+function sanitizeSkillName(name) {
+  if (!name) return '';
+  return String(name).replace(/[\[\]`*_{}()#+\-.!|<>\n]/g, '');
+}
+
 function buildSystemMessage(language) {
   return language === 'en'
     ? 'You are River Reviewer, an expert code review assistant. Respond in English. You excel at spotting risky changes and explaining them briefly.'
@@ -217,7 +225,8 @@ function buildFallbackComments(diff, plan, { llmSkipReason = null } = {}) {
   // スキル単位でコメントを生成
   return skills.map(skill => {
     const skillId = skill.metadata?.id ?? skill.id;
-    const skillName = skill.metadata?.name ?? skillId;
+    const rawSkillName = skill.metadata?.name ?? skillId;
+    const skillName = sanitizeSkillName(rawSkillName);
     return {
       file: firstFile.path,
       line,


### PR DESCRIPTION
## 概要

River Reviewer の PR コメント出力をスキル単位でグループ化するよう改善しました。

## 変更内容

### Before
```markdown
### 指摘
- `.github/prompts/review.prompt.md:11`
  Finding: 5件のスキルがマッチしたが自動指摘を生成できなかった
  ...
```

### After
```markdown
### 指摘

#### 🔍 rr-midstream-logging-observability-001
- `src/cli.mjs:226`
  - **Finding:** スキル「Logging and Observability Guard」の観点で自動指摘を生成できなかった
  ...

#### 🔍 rr-midstream-gh-address-comments-001
- `src/cli.mjs:226`
  - **Finding:** スキル「GitHubレビューコメント対応（修正案つき）」の観点で自動指摘を生成できなかった
  ...
```

## 技術的変更

- `src/lib/review-engine.mjs`: `buildFallbackComments` をスキル単位でコメント生成するよう修正、`skillId` フィールドを追加
- `src/cli.mjs`: `groupCommentsBySkill` ヘルパー関数を追加、`formatCommentsMarkdown` をスキル単位グループ化に対応

## 検証

- 構文チェック: ✅
- Dry-run テスト: ✅
