### PR TITLE
test(cli): Add output format verification test

### DIFF
--- a/src/lib/review-engine.mjs
+++ b/src/lib/review-engine.mjs
@@ -250,6 +250,7 @@ function normalizeHeuristicComments(rawComments) {
         return {
           file: c.file,
           line: c.line,
+          skillId: c.skillId,
           message: formatFindingMessage({
             finding: 'catch で例外が握りつぶされる可能性がある',
             evidence: 'catch 内で return（ログ/再throwなし）',
@@ -263,6 +264,7 @@ function normalizeHeuristicComments(rawComments) {
         return {
           file: c.file,
           line: c.line,
+          skillId: c.skillId,
           message: formatFindingMessage({
             finding: '挙動変更に対するテスト差分が見当たらない',
             evidence: 'コード差分あり・テスト差分なし',
@@ -276,6 +278,7 @@ function normalizeHeuristicComments(rawComments) {
         return {
           file: c.file,
           line: c.line,
+          skillId: c.skillId,
           message: formatFindingMessage({
             finding: '秘密情報（トークン/キー）の直書きの可能性がある',
             evidence: 'トークン/キーらしい文字列が追加されている',
@@ -289,6 +292,7 @@ function normalizeHeuristicComments(rawComments) {
         return {
           file: c.file,
           line: c.line,
+          skillId: c.skillId,
           message: formatFindingMessage({
             finding: 'pull_request_targetイベントは権限昇格のリスクがある',
             evidence: 'pull_request_targetトリガーが追加されている',
@@ -302,6 +306,7 @@ function normalizeHeuristicComments(rawComments) {
         return {
           file: c.file,
           line: c.line,
+          skillId: c.skillId,
           message: formatFindingMessage({
             finding: '過剰な権限設定（write-all）が検出された',
             evidence: 'permissions: write-all が設定されている',
@@ -315,6 +320,7 @@ function normalizeHeuristicComments(rawComments) {
         return {
           file: c.file,
           line: c.line,
+          skillId: c.skillId,
           message: formatFindingMessage({
             finding: 'runブロック内でsecretsを直接使用している',
             evidence: 'run: と secrets.* が同一行に存在',
@@ -328,6 +334,7 @@ function normalizeHeuristicComments(rawComments) {
         return {
           file: c.file,
           line: c.line,
+          skillId: c.skillId,
           message: formatFindingMessage({
             finding: 'ユーザー入力がサニタイズされずに使用されている',
             evidence: 'github.event.*.title/body/name がrunブロックで直接使用',

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -81,6 +81,8 @@ test('river run supports markdown output for PR comments', async () => {
     assert.match(result.stdout, /^<!-- river-reviewer -->/);
     assert.match(result.stdout, /## River Reviewer/);
     assert.match(result.stdout, /### 指摘/);
+    // Verify skill grouping header is present (skillId is sanitized, so hyphens are escaped)
+    assert.match(result.stdout, /#### 🔍 rr\\-midstream\\-logging\\-observability\\-001/);
     assert.doesNotMatch(result.stdout, /--- diff preview ---/);
     assert.match(result.stderr, /River Reviewer \(local\)/);
   } finally {


### PR DESCRIPTION
## 概要

Markdown 出力時のスキル単位グループ化フォーマット (\#### 🔍 <skillId>\) を検証するテストを追加しました。

## 修正内容

- \	ests/cli.test.mjs\: 出力ヘッダーの検証を追加
- \src/lib/review-engine.mjs\: ormalizeHeuristicComments\ で \skillId\ が失われるバグを修正（テスト中に発見）

## 検証

ode tests/cli.test.mjs\ がパスすることを確認済みです。