### PR TITLE
ci: add agent-skills validation to PR checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,8 @@ jobs:
         run: npm ci
       - name: Validate skills
         run: npm run skills:validate
+      - name: Validate agent-skills
+        run: npm run agent-skills:validate
 
   integration-test:
     name: Integration (CLI)


### PR DESCRIPTION
Issue #314: skills-ref validate を CI に導入

## 変更内容
- test.yml の skill-validation ジョブに agent-skills:validate を追加
- PR で Agent Skills 仕様違反を検知可能に

## 検証
- skills:validate と agent-skills:validate が両方実行される
- 違反があれば CI が失敗する

Closes #314