### PR TITLE
ci: add agent-skills validation to pre-commit hook

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -2,5 +2,6 @@
   "**/*.{js,ts,jsx,tsx}": ["prettier --write"],
   "**/*.{md,markdown}": ["npm run check:dashes", "prettier --write", "markdownlint --fix"],
   "**/*.{json,yml,yaml}": ["prettier --write"],
-  "skills/**/*.md": ["npm run skills:validate"]
+  "skills/**/*.md": ["npm run skills:validate"],
+  "skills/agent-skills/**/*.md": ["npm run agent-skills:validate"]
 }

--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -40,10 +40,16 @@ async function validateSkills() {
   for (const filePath of files) {
     const relativePath = path.relative(defaultPaths.repoRoot, filePath);
 
-    // Skip Registry format skill.yaml files (validated by validate:skill-yaml)
+    // Skip Registry format skill.yaml files
     const basename = path.basename(filePath);
     if (basename === 'skill.yaml' || basename === 'skill.yml') {
       console.log(`ℹ️  ${relativePath} (skipped - registry format, use npm run validate:skill-yaml)`);
+      continue;
+    }
+
+    // Skip new Agent Skills format (validated by npm run agent-skills:validate)
+    if (relativePath.includes('agent-skills')) {
+      console.log(`ℹ️  ${relativePath} (skipped - agent skill)`);
       continue;
     }
 


### PR DESCRIPTION
Issue #315: pre-commit フックへ仕様違反ブロック

## 変更内容
- .lintstagedrc.json に agent-skills 検証を追加
- skills/agent-skills/**/*.md のコミット時に npm run agent-skills:validate を実行

## 効果
- コミット前に Agent Skills 仕様違反を検知
- CI を待たずにローカルで検証可能

Closes #315