### PR TITLE
feat: 型駆動設計ガードとレビュー自動化境界ガードを追加

### DIFF
--- a/skills/midstream/rr-midstream-review-automation-boundary-001.md
+++ b/skills/midstream/rr-midstream-review-automation-boundary-001.md
@@ -1,0 +1,137 @@
+---
+id: rr-midstream-review-automation-boundary-001
+name: Review Automation Boundary Guard
+description: Detect review findings that belong in CI/lint/formatter rather than human review.
+category: midstream
+phase: midstream
+applyTo:
+  - '**/*'
+tags:
+  - review-process
+  - automation
+  - ci
+  - meta-review
+  - midstream
+severity: minor
+inputContext:
+  - diff
+outputKind:
+  - findings
+  - actions
+  - metrics
+modelHint: balanced
+---
+
+## Goal / 目的
+
+- レビュー指摘の中から「自動化できるはずの指摘」を検出し、CI/lint/フォーマッタに委ねることで人間レビューの密度を高める。
+- 「機械が判定できること」をレビューに持ち込まず、人間にしか判断できない設計・仕様・セキュリティ判断に集中させる。
+
+## Non-goals / 扱わないこと
+
+- 自動化できない判断（設計方針、セキュリティ上のトレードオフ、仕様の解釈）への言及。
+- 実際のコード修正の提案（このスキルはツール設定の提案のみを行う）。
+- プロジェクトのスタイルガイドや規約そのものの是非を評価すること。
+- 既に CI に設定が存在するルールへの重複指摘。
+
+## False-positive guards / 抑制条件
+
+- 差分が`.eslintrc`, `.prettierrc`, `tsconfig.json`等のツール設定ファイル自体であれば、設定追加の提案は不要（すでに対応中の可能性が高い）。
+- 差分内に該当ツールの設定ファイル変更が含まれている場合、そのルールは追加中と判断し指摘しない。差分外のリポジトリ設定は確認できないため、断定ではなく「設定がなければ」という条件付きで提案する。
+- マイグレーションや一時的な移行期であることが PR 説明から明確な場合は抑制する。
+- 差分がテスト/フィクスチャのみで、意図的にスタイルを崩している場合は指摘しない。
+
+## Rule / ルール
+
+- 差分に「フォーマッタで自動修正できるはずのパターン」（インデント、末尾スペース、クォートスタイル等）が含まれる場合、CI へのフォーマッタ追加を促す。
+- 差分に「lint ルールで自動検出できるはずのパターン」（未使用変数、`console.log` の残留、コメントアウトコード等）が含まれる場合、対応する lint ルールの追加を促す。
+- 差分に「命名規則の逸脱」が含まれる場合、命名規則チェッカー（ESLint の `naming-convention` ルール等）の追加を促す。
+- import 順序の乱れ、ファイル末尾改行の欠如など、ツールで強制できる規約の逸脱を見つけた場合、人間レビューで指摘するのではなくツール設定を提案する。
+
+## Evidence / 根拠の取り方
+
+- 指摘は差分に紐づける（`<file>:<line>` で追える内容）。
+- 自動化提案には具体的なツール名とルール名を添える。
+- 推測を断定しない（不確実なら "可能性" として書く）。
+
+## Output / 出力
+
+`<file>:<line>: <message>` 形式。コメントは日本語で返す。
+
+- Finding: 自動化できるパターンの検出（1文）
+- Impact: 人間レビューの負荷（短く）
+- Fix: 導入すべきツール/ルール名
+
+自動化カテゴリごとに集約して出力する（同じパターンが複数箇所にある場合は件数を添える）。
+
+例:
+
+- `src/api.ts:23: console.log が 3 箇所残留。レビューでの指摘は属人的。Fix: ESLint no-console: error を追加し CI で強制`
+
+## Heuristics / 判定の手がかり
+
+### Level 1: フォーマッタで解決すべきパターン
+
+- インデントの不一致、末尾スペース、クォートスタイルの混在
+- `prettier` / `gofmt` / `black` 等のフォーマッタで自動修正可能なもの
+- ファイル末尾の改行有無
+
+### Level 2: Linter で解決すべきパターン
+
+- `console.log` / `console.error` のまま残ったデバッグ出力（`no-console` ルール）
+- コメントアウトされたコードブロック
+- 未使用の変数・import（`no-unused-vars`, `@typescript-eslint/no-unused-vars`）
+- マジックナンバー（`no-magic-numbers` ルール）
+- ネストが深すぎる関数（`max-depth` ルール）
+
+### Level 3: CI/型チェックで解決すべきパターン
+
+注: このレベルでは`any`や`!`の**コード品質上の問題**を指摘しない（それは`rr-midstream-typescript-strict-001` / `rr-midstream-typescript-nullcheck-001`のスコープ）。ここでは「そのルールがCIで強制されていない」という**プロセスの不備**のみを指摘し、ツール設定の追加を提案する。
+
+- `any` の使用（`@typescript-eslint/no-explicit-any` でゼロトレランスにできる）
+- 非 null アサーション `!` の使用（`@typescript-eslint/no-non-null-assertion`）
+- import 順序（`import/order`, `simple-import-sort` ルール）
+- テストカバレッジの閾値（CI の coverage threshold で強制できる）
+
+## Good / Bad Examples
+
+### フォーマッタで対応すべき例
+
+Bad（人間レビューで指摘）: 「インデントが 2 スペースではなく 4 スペースになっています」
+
+Good（自動化）: `prettier --write .` を CI に組み込み、フォーマット差分は PR マージブロックにする。
+
+### Linter で対応すべき例
+
+Bad（人間レビューで指摘）: 「`console.log` が残っています」
+
+Good（自動化）: ESLint の `no-console` ルールを `error` にし、CI で強制する。
+
+### 型チェックで対応すべき例
+
+Bad（人間レビューで指摘）: 「`any` を使っています」
+
+Good（自動化）: `@typescript-eslint/no-explicit-any: error` と `tsconfig.json` の `strict: true` を CI で強制する。
+
+## Actions / 改善案
+
+- フォーマッタで解決できるパターン: `.prettierrc` / `.editorconfig` の導入と CI への `format:check` ステップ追加を提案する。
+- lint ルールで解決できるパターン: 対応する ESLint / Ruff / golangci-lint ルール名と設定例を提示する。
+- 型チェックで解決できるパターン: `tsconfig.json` の strict オプション名と対応する ESLint ルール名を提示する。
+- 提案は「人間レビューのコメントをなくすためにツールを追加する」方向性で出力する。
+
+## Metrics / 計測指標
+
+- 自動化可能な指摘の数（このスキルが検出したパターン数）を`automation_debt`メトリクスとして出力する。
+- 出力形式: `{ "automation_debt": <integer> }`をメトリクスブロックのトップレベルキーとして返す。値は検出パターン数の合計。
+- 目標: 各PRでこのスキルの指摘が0件になるよう、チームがCI/lintを整備する。
+
+## 評価指標（Evaluation）
+
+- 合格基準: 「このパターンは X というツールで自動化できる」という具体的な根拠（ツール名、ルール名）が添えられている。
+- 不合格基準: 人間レビューの指摘をそのまま繰り返す（「`console.log` を消してください」と言うだけで自動化の提案がない）、ツールが存在しない自動化の提案。
+
+## 人間に返す条件（Human Handoff）
+
+- ツール導入がプロジェクトの既存設定と競合する可能性がある場合。
+- チームの規約策定そのものが未完了で、何を自動化すべきか合意が必要な場合は人間レビューへ返す。

--- a/skills/midstream/rr-midstream-type-driven-design-001.md
+++ b/skills/midstream/rr-midstream-type-driven-design-001.md
@@ -1,0 +1,145 @@
+---
+id: rr-midstream-type-driven-design-001
+name: Type-Driven Design Guard
+description: Detect primitive obsession and missing domain/brand types; check that state is modeled via discriminated unions.
+category: midstream
+phase: midstream
+applyTo:
+  - '**/*.ts'
+  - '**/*.tsx'
+tags:
+  - typescript
+  - type-driven-design
+  - domain-modeling
+  - midstream
+severity: major
+inputContext:
+  - diff
+  - fullFile
+outputKind:
+  - findings
+  - actions
+modelHint: balanced
+dependencies:
+  - code_search
+---
+
+## Goal / 目的
+
+- 型を「仕様書」として扱い、ドメイン概念をプリミティブ型のまま放置しないようにする。
+- 不正な状態を型レベルで表現不可能にする（"make illegal states unrepresentable"）。
+
+## Non-goals / 扱わないこと
+
+- `any` の排除や型アサーションの削減（`rr-midstream-typescript-strict-001` のスコープ）。
+- null/undefined のガードや非 null アサーションの排除（`rr-midstream-typescript-nullcheck-001` のスコープ）。
+- 既存の関数シグネチャ（差分に含まれていない）のリファクタ提案。
+- `tsconfig.json` の設定変更。
+- スタイル/命名規則のレビュー（nit は出さない）。
+
+## False-positive guards / 抑制条件
+
+- 差分がテストファイル (`*.spec.ts`, `*.test.ts`, `__tests__/**`) のみで、ブランド型の不在がテストの意図的な緩和である場合。
+- ブランド型がリポジトリに既に存在し、差分コードがそれを正しく使用している場合（`code_search` で確認）。
+- `string` の引数が 1 つしかなく、他のプリミティブとの混入可能性がない場合。
+- 外部 API レスポンスやライブラリ型を直接扱う境界コードで、ブランド型の適用範囲が明確でない場合（注記として返す）。
+- 小さなユーティリティ関数で、ドメインの文脈を持たない場合。
+
+## Rule / ルール
+
+- ドメイン概念を表す `string` / `number` にはブランド型 (`UserId`, `OrderId`, `Price` 等) を使う。
+- 複数の状態を `boolean` フラグや `status: string` で表現するのではなく、判別可能なユニオン型（Discriminated Union）でモデリングする。
+- 新規の public 関数/メソッドのシグネチャに `string` / `number` が連続して並ぶ場合、引数が混入可能か確認する。
+- リテラルユニオンが複数箇所でインライン定義されている場合、型エイリアスへの切り出しを促す。
+
+## Evidence / 根拠の取り方
+
+- 指摘は差分に紐づける（`<file>:<line>` で追える内容）。
+- ブランド型が既にコードベースに存在するかを `code_search` で確認し、根拠を示す。
+- 推測を断定しない（不確実なら "可能性" として書く）。
+
+## Output / 出力
+
+`<file>:<line>: <message>` 形式。コメントは日本語で返す。
+
+- Finding: 何が問題か（1文）
+- Impact: 何が困るか（短く）
+- Fix: 次の一手（最小の修正案）
+
+例:
+
+- `src/order.ts:15: userId と orderId が同じ string 型。引数の順序を間違えてもコンパイルエラーにならない。Fix: ブランド型 UserId / OrderId を導入`
+
+## Heuristics / 判定の手がかり
+
+- `(userId: string, orderId: string)` のように同じプリミティブ型が複数の引数に並ぶ。
+- `status: 'pending' | 'active' | 'deleted'` のようなリテラルユニオンが型エイリアスに切り出されていない。
+- `isLoading: boolean; isError: boolean; isSuccess: boolean` のように boolean フラグが複数並び、排他性が型で表現されていない。
+- `type State = { loading: true } | { error: Error } | { data: Data }` のような判別可能なユニオンが使えるのに使われていない。
+- ブランド型が既にコードベースに存在するのに、差分では素の `string` / `number` を使っている。
+
+## Good / Bad Examples
+
+### ブランド型（Branded Types）
+
+Bad:
+
+```ts
+function getOrder(userId: string, orderId: string): Order;
+// userId と orderId が型レベルで区別されず、引数の順序ミスがコンパイルエラーにならない
+```
+
+Good:
+
+```ts
+type UserId = string & { readonly __brand: 'UserId' };
+type OrderId = string & { readonly __brand: 'OrderId' };
+function getOrder(userId: UserId, orderId: OrderId): Order;
+// getOrder(orderId, userId) は型エラーになる
+```
+
+### 判別可能なユニオン（Discriminated Unions）
+
+Bad:
+
+```ts
+type RequestState = {
+  isLoading: boolean;
+  isError: boolean;
+  data?: Data;
+  error?: Error;
+};
+// isLoading: true かつ data が存在する無効な状態が許可される
+```
+
+Good:
+
+```ts
+type RequestState =
+  | { kind: 'loading' }
+  | { kind: 'error'; error: Error }
+  | { kind: 'success'; data: Data };
+// 無効な状態が型で表現不可能
+```
+
+### リテラルユニオンの切り出し
+
+Bad: `status: 'pending' | 'processing' | 'shipped' | 'delivered'` がインラインで重複定義。
+
+Good: `type OrderStatus = 'pending' | 'processing' | 'shipped' | 'delivered'` と型エイリアスに切り出す。
+
+## Actions / 改善案
+
+- `string` / `number` の引数が並ぶ場合、ブランド型パターン (`type UserId = string & { readonly __brand: 'UserId' }`) の導入を提案する。
+- boolean フラグ群を判別可能なユニオン型に置き換え、無効状態を型レベルで排除する。
+- リテラルユニオンが複数箇所で繰り返されている場合、型エイリアスへの切り出しを促す。
+
+## 評価指標（Evaluation）
+
+- 合格基準: 指摘が差分に紐づき、「なぜこの型が混入可能か」の根拠と、ブランド型または判別可能ユニオンへの具体的な改善案がある。
+- 不合格基準: 差分と無関係な既存コードへの指摘、根拠のない断定、抑制条件の無視、`any` や null 問題との混同。
+
+## 人間に返す条件（Human Handoff）
+
+- ブランド型の導入がプロジェクト全体の型定義戦略に影響する場合（大規模な型リファクタが必要）は人間レビューへ返す。
+- 外部パッケージとの型互換性の問題でブランド型が適用困難な場合は、選択肢を提示して判断を仰ぐ。

--- a/skills/registry.yaml
+++ b/skills/registry.yaml
@@ -228,6 +228,28 @@ skills:
     recommended: false
     description: 'Enforces standard review policies'
 
+  - id: rr-midstream-type-driven-design-001
+    version: '0.1.0'
+    name: 'Type-Driven Design Guard'
+    path: skills/midstream/rr-midstream-type-driven-design-001.md
+    category: midstream
+    phase: midstream
+    tags: [typescript, type-driven-design, domain-modeling, midstream]
+    severity: major
+    recommended: true
+    description: 'Detects primitive obsession and missing domain/brand types; checks that state is modeled via discriminated unions'
+
+  - id: rr-midstream-review-automation-boundary-001
+    version: '0.1.0'
+    name: 'Review Automation Boundary Guard'
+    path: skills/midstream/rr-midstream-review-automation-boundary-001.md
+    category: midstream
+    phase: midstream
+    tags: [review-process, automation, ci, meta-review, midstream]
+    severity: minor
+    recommended: true
+    description: 'Meta-review skill: detects review findings that belong in CI/lint/formatter rather than human review'
+
   # Downstream Skills (Testing & Release)
   - id: agent-qa-regression
     version: '0.1.0'
@@ -639,6 +661,7 @@ recommendations:
     skills:
       - rr-midstream-typescript-strict-001
       - rr-midstream-typescript-nullcheck-001
+      - rr-midstream-type-driven-design-001
       - rr-midstream-security-basic-001
       - rr-midstream-logging-observability-001
 
@@ -650,6 +673,15 @@ recommendations:
       - rr-midstream-logging-observability-001
       - rr-midstream-typescript-strict-001
       - rr-midstream-typescript-nullcheck-001
+      - rr-midstream-type-driven-design-001
+      - rr-midstream-review-automation-boundary-001
+
+  review-quality:
+    description: 'Skills that maximize human review value by pushing automatable concerns to CI'
+    skills:
+      - rr-midstream-review-automation-boundary-001
+      - rr-midstream-review-comment-triage-001
+      - rr-midstream-review-policy-standard-001
 
   multitenancy:
     description: 'Recommended skills for multi-tenant SaaS applications'

--- a/tests/fixtures/execution-plan-midstream.json
+++ b/tests/fixtures/execution-plan-midstream.json
@@ -22,6 +22,13 @@
       "dependencies": ["tracing", "code_search"]
     },
     {
+      "id": "rr-midstream-review-automation-boundary-001",
+      "phase": "midstream",
+      "modelHint": "balanced",
+      "outputKind": ["findings", "actions", "metrics"],
+      "dependencies": []
+    },
+    {
       "id": "rr-midstream-gh-address-comments-001",
       "phase": "midstream",
       "modelHint": "high-accuracy",

--- a/tests/fixtures/planner-dataset/cases.json
+++ b/tests/fixtures/planner-dataset/cases.json
@@ -6,7 +6,11 @@
     "availableContexts": ["diff", "fullFile"],
     "availableDependencies": ["code_search"],
     "expectedAny": ["rr-midstream-typescript-nullcheck-001", "rr-midstream-typescript-strict-001"],
-    "expectedTop1": ["rr-midstream-typescript-nullcheck-001", "rr-midstream-typescript-strict-001"]
+    "expectedTop1": [
+      "rr-midstream-typescript-nullcheck-001",
+      "rr-midstream-typescript-strict-001",
+      "rr-midstream-type-driven-design-001"
+    ]
   },
   {
     "name": "midstream: security risky patterns (XSS/SQLi)",
@@ -116,7 +120,11 @@
     "availableContexts": ["diff", "fullFile"],
     "availableDependencies": ["code_search"],
     "expectedAny": ["rr-midstream-typescript-strict-001"],
-    "expectedTop1": ["rr-midstream-typescript-strict-001", "rr-midstream-typescript-nullcheck-001"]
+    "expectedTop1": [
+      "rr-midstream-typescript-strict-001",
+      "rr-midstream-typescript-nullcheck-001",
+      "rr-midstream-type-driven-design-001"
+    ]
   },
   {
     "name": "midstream: silent failure (return null)",


### PR DESCRIPTION
## Summary

レビューの価値を「人間にしかできない判断の密度」で測る設計思想に基づき、2つの新スキルを追加。

- **rr-midstream-type-driven-design-001（型駆動設計ガード）**: ブランド型/Discriminated Unionによる型設計レビュー。`string`でドメイン概念を扱うプリミティブ型の乱用を検出し、型で仕様を表現するパターンを促進
- **rr-midstream-review-automation-boundary-001（レビュー自動化境界ガード）**: CI/lint/フォーマッタで自動化すべき指摘を検出するメタレビュースキル。3段階（フォーマッタ→Linter→CI/型チェック）の自動化レベルで具体的なツール設定を提案
- レジストリ更新: `typescript`/`comprehensive`推奨セットへの追加、新規`review-quality`推奨セットの作成

## Test plan

- [x] `npm run skills:validate` — 全スキルのスキーマ検証通過
- [x] `npm run lint` — Prettier/markdownlint/textlint全通過
- [x] `npm test` — 149テスト全通過（スナップショット・plannerデータセット更新済み）
- [ ] 実際のTypeScript PRで`type-driven-design`スキルの指摘精度を確認
- [ ] `review-automation-boundary`スキルがフォーマット系指摘を正しく検出するか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)