### PR TITLE
fix(skills): add explicit category and version to all skill frontmatter

### DIFF
--- a/skills/downstream/agent-qa-regression.md
+++ b/skills/downstream/agent-qa-regression.md
@@ -2,6 +2,7 @@
 id: agent-qa-regression
 name: QA Regression (Playwright)
 description: Playwright を使った回帰テストの設計と実行をガイドする。
+version: 0.1.0
 category: downstream
 phase: downstream
 applyTo:

--- a/skills/downstream/agent-webapp-testing.md
+++ b/skills/downstream/agent-webapp-testing.md
@@ -2,6 +2,7 @@
 id: agent-webapp-testing
 name: Web App Testing (Playwright)
 description: Playwright でローカル/プレビュー環境の Web アプリを操作・検証するための手順をまとめる。
+version: 0.1.0
 category: downstream
 phase: downstream
 applyTo:

--- a/skills/downstream/review-policy-standard.md
+++ b/skills/downstream/review-policy-standard.md
@@ -2,6 +2,8 @@
 id: rr-downstream-review-policy-standard-001
 name: 'Standard Review Policy for Downstream'
 description: 'Applies standard AI review policy guidelines for downstream (test/QA) phase reviews.'
+version: 0.1.0
+category: downstream
 phase: downstream
 applyTo:
   - 'test/**/*'

--- a/skills/downstream/rr-downstream-coverage-gap-001.md
+++ b/skills/downstream/rr-downstream-coverage-gap-001.md
@@ -2,6 +2,8 @@
 id: rr-downstream-coverage-gap-001
 name: Coverage and Failure Path Gaps
 description: Find missing tests for critical paths, edge cases, and failure handling in changed code.
+version: 0.1.0
+category: downstream
 phase: downstream
 applyTo:
   - 'src/**/*'

--- a/skills/downstream/rr-downstream-flaky-test-001.md
+++ b/skills/downstream/rr-downstream-flaky-test-001.md
@@ -2,6 +2,8 @@
 id: rr-downstream-flaky-test-001
 name: Flaky Test Risk Check
 description: Detects patterns that make tests flaky and proposes stabilization steps.
+version: 0.1.0
+category: downstream
 phase: downstream
 applyTo:
   - '**/*.test.ts'

--- a/skills/downstream/rr-downstream-test-existence-001.md
+++ b/skills/downstream/rr-downstream-test-existence-001.md
@@ -2,6 +2,8 @@
 id: rr-downstream-test-existence-001
 name: Test Presence for Changed Code
 description: Check whether changed code paths have corresponding tests and suggest minimal coverage.
+version: 0.1.0
+category: downstream
 phase: downstream
 applyTo:
   - 'src/**/*'

--- a/skills/downstream/rr-downstream-test-naming-001.md
+++ b/skills/downstream/rr-downstream-test-naming-001.md
@@ -2,6 +2,8 @@
 id: rr-downstream-test-naming-001
 name: Test Naming and Structure
 description: Ensure tests use clear naming and cover edge cases with proper describe/it structure.
+version: 0.1.0
+category: downstream
 phase: downstream
 applyTo:
   - '**/*.test.ts'

--- a/skills/downstream/rr-downstream-test-plan-review-001.md
+++ b/skills/downstream/rr-downstream-test-plan-review-001.md
@@ -2,6 +2,8 @@
 id: rr-downstream-test-plan-review-001
 name: テスト観点レビュー（差分ドリブン）
 description: 変更差分から重要なテスト観点と欠落を洗い出し、優先度付きでテストケース案を提示する
+version: 0.1.0
+category: downstream
 phase: downstream
 applyTo:
   - 'src/**/*'

--- a/skills/downstream/sample-test-review.md
+++ b/skills/downstream/sample-test-review.md
@@ -2,6 +2,8 @@
 id: rr-downstream-test-review-sample-001
 name: 'Sample Test Coverage Review'
 description: 'Evaluates downstream tests for coverage and edge cases.'
+version: 0.1.0
+category: downstream
 phase: downstream
 applyTo:
   - 'tests/**/*.ts'

--- a/skills/midstream/agent-agentcheck-code-review.md
+++ b/skills/midstream/agent-agentcheck-code-review.md
@@ -2,6 +2,7 @@
 id: agent-agentcheck-code-review
 name: AgentCheck Code Review
 description: AgentCheck ベースでローカルリポジトリを走査し、PR 前のコードレビューを実行するスキル。
+version: 0.1.0
 category: midstream
 phase: midstream
 applyTo:

--- a/skills/midstream/agent-code-quality.md
+++ b/skills/midstream/agent-code-quality.md
@@ -2,6 +2,7 @@
 id: agent-code-quality
 name: Code Quality
 description: 可読性と保守性を中心に、コード品質の基本的な劣化を検知する。
+version: 0.1.0
 category: midstream
 phase: midstream
 applyTo:

--- a/skills/midstream/agent-code-refactoring.md
+++ b/skills/midstream/agent-code-refactoring.md
@@ -2,6 +2,7 @@
 id: agent-code-refactoring
 name: Code Refactoring
 description: 挙動を変えずに設計を整えるためのリファクタリング手順をガイドする。
+version: 0.1.0
 category: midstream
 phase: midstream
 applyTo:

--- a/skills/midstream/agent-code-review.md
+++ b/skills/midstream/agent-code-review.md
@@ -2,6 +2,7 @@
 id: agent-code-review
 name: Code Review (Multi-perspective)
 description: PR 向けの自動コードレビュー。セキュリティ・性能・品質・テスト観点で差分を評価する。
+version: 0.1.0
 category: midstream
 phase: midstream
 applyTo:

--- a/skills/midstream/agent-test-coverage.md
+++ b/skills/midstream/agent-test-coverage.md
@@ -2,6 +2,7 @@
 id: agent-test-coverage
 name: Test Coverage
 description: 変更に対するテスト不足を検知し、最低限の補完方針を提示する。
+version: 0.1.0
 category: midstream
 phase: midstream
 applyTo:

--- a/skills/midstream/community/rr-midstream-a11y-accessible-name-001.md
+++ b/skills/midstream/community/rr-midstream-a11y-accessible-name-001.md
@@ -2,6 +2,7 @@
 id: rr-midstream-a11y-accessible-name-001
 name: a11y Accessible Name Basics
 description: 画像・ボタン・フォーム要素に適切なアクセシブルネームがあるか確認する。
+version: 0.1.0
 category: midstream
 phase: midstream
 applyTo:

--- a/skills/midstream/community/rr-midstream-nextjs-app-router-boundary-001.md
+++ b/skills/midstream/community/rr-midstream-nextjs-app-router-boundary-001.md
@@ -2,6 +2,7 @@
 id: rr-midstream-nextjs-app-router-boundary-001
 name: Next.js App Router Client/Server Boundary
 description: App Router の Server Component でクライアント専用APIを使っていないか確認する。
+version: 0.1.0
 category: midstream
 phase: midstream
 applyTo:

--- a/skills/midstream/review-policy-standard.md
+++ b/skills/midstream/review-policy-standard.md
@@ -2,6 +2,8 @@
 id: rr-midstream-review-policy-standard-001
 name: 'Standard Review Policy for Midstream'
 description: 'Applies standard AI review policy guidelines for midstream (implementation) phase reviews.'
+version: 0.1.0
+category: midstream
 phase: midstream
 applyTo:
   - 'src/**/*.ts'

--- a/skills/midstream/rr-midstream-agent-skill-bridge-001.md
+++ b/skills/midstream/rr-midstream-agent-skill-bridge-001.md
@@ -3,6 +3,7 @@ id: rr-midstream-agent-skill-bridge-001
 name: Agent Skill Bridge Review
 description: Review changes to the Agent Skills import/export bridge for path safety, round-trip fidelity, and validation correctness.
 version: 0.1.0
+category: midstream
 phase: midstream
 applyTo:
   - 'src/lib/agent-skill-bridge.mjs'

--- a/skills/midstream/rr-midstream-gh-address-comments-001.md
+++ b/skills/midstream/rr-midstream-gh-address-comments-001.md
@@ -2,6 +2,8 @@
 id: rr-midstream-gh-address-comments-001
 name: GitHubレビューコメント対応（修正案つき）
 description: PRレビューコメントを重要度ごとに整理し、対応方針・修正案・質問をまとめて返信案を作る
+version: 0.1.0
+category: midstream
 phase: midstream
 applyTo:
   - 'src/**/*'

--- a/skills/midstream/rr-midstream-hello-skill-001.md
+++ b/skills/midstream/rr-midstream-hello-skill-001.md
@@ -2,6 +2,8 @@
 id: rr-midstream-hello-skill-001
 name: Hello Skill (Always-On Sample)
 description: Minimal always-on sample skill to guarantee an end-to-end review experience.
+version: 0.1.0
+category: midstream
 phase: midstream
 applyTo:
   - '**/*'

--- a/skills/midstream/rr-midstream-logging-observability-001.md
+++ b/skills/midstream/rr-midstream-logging-observability-001.md
@@ -3,6 +3,7 @@ id: rr-midstream-logging-observability-001
 name: Logging and Observability Guard
 description: Ensure code changes keep logs/metrics/traces useful for debugging failures and regressions.
 version: 0.1.0
+category: midstream
 phase: midstream
 applyTo:
   - 'src/**/*'

--- a/skills/midstream/rr-midstream-logic-torturing-001.md
+++ b/skills/midstream/rr-midstream-logic-torturing-001.md
@@ -2,6 +2,7 @@
 id: rr-midstream-logic-torturing-001
 name: 'Logic Torturing 論理検証'
 description: '変更に含まれる設計判断・実装選択の論理的整合性を徹底的に検証し、確証バイアスを排除して判断精度を高める'
+version: 0.1.0
 category: midstream
 phase: [upstream, midstream]
 applyTo:

--- a/skills/midstream/rr-midstream-review-automation-boundary-001.md
+++ b/skills/midstream/rr-midstream-review-automation-boundary-001.md
@@ -2,6 +2,7 @@
 id: rr-midstream-review-automation-boundary-001
 name: Review Automation Boundary Guard
 description: Detect review findings that belong in CI/lint/formatter rather than human review.
+version: 0.1.0
 category: midstream
 phase: midstream
 applyTo:

--- a/skills/midstream/rr-midstream-review-comment-triage-001.md
+++ b/skills/midstream/rr-midstream-review-comment-triage-001.md
@@ -2,6 +2,8 @@
 id: rr-midstream-review-comment-triage-001
 name: 'Review Comment Triage (No-Code-Fix Mode)'
 description: 'レビューコメントの重要度ラベリングと対応方針・返信案を整理する。AI はコード修正やパッチ提案を行わない。'
+version: 0.1.0
+category: midstream
 phase: midstream
 applyTo:
   - '**/*'

--- a/skills/midstream/rr-midstream-security-basic-001.md
+++ b/skills/midstream/rr-midstream-security-basic-001.md
@@ -3,6 +3,7 @@ id: rr-midstream-security-basic-001
 name: Baseline Security Checks
 description: Check common security risks in application code (SQLi, XSS, secrets).
 version: 0.1.0
+category: midstream
 phase: midstream
 applyTo:
   - '**/{api,routes,db,ui,components,auth,security,config}/**/*.{ts,tsx,js,jsx}'

--- a/skills/midstream/rr-midstream-type-driven-design-001.md
+++ b/skills/midstream/rr-midstream-type-driven-design-001.md
@@ -2,6 +2,7 @@
 id: rr-midstream-type-driven-design-001
 name: Type-Driven Design Guard
 description: Detect primitive obsession and missing domain/brand types; check that state is modeled via discriminated unions.
+version: 0.1.0
 category: midstream
 phase: midstream
 applyTo:

--- a/skills/midstream/rr-midstream-typescript-nullcheck-001.md
+++ b/skills/midstream/rr-midstream-typescript-nullcheck-001.md
@@ -2,6 +2,8 @@
 id: rr-midstream-typescript-nullcheck-001
 name: TypeScript Null Safety Guardrails
 description: Enforce null/undefined safety for changed TypeScript code and suggest safer patterns.
+version: 0.1.0
+category: midstream
 phase: midstream
 applyTo:
   - '**/*.ts'

--- a/skills/midstream/rr-midstream-typescript-strict-001.md
+++ b/skills/midstream/rr-midstream-typescript-strict-001.md
@@ -2,6 +2,8 @@
 id: rr-midstream-typescript-strict-001
 name: TypeScript Strictness Guard
 description: Enforce TypeScript strictness by reducing any/unsafe assertions and ensuring null handling.
+version: 0.1.0
+category: midstream
 phase: midstream
 applyTo:
   - '**/*.ts'

--- a/skills/midstream/rr-midstream-war-game-001.md
+++ b/skills/midstream/rr-midstream-war-game-001.md
@@ -2,6 +2,7 @@
 id: rr-midstream-war-game-001
 name: 'War Game 敵対的シミュレーション'
 description: '攻撃者・競合・悪意あるユーザーの視点で変更を分析し、防御の盲点と悪用シナリオを可視化する'
+version: 0.1.0
 category: midstream
 phase: midstream
 applyTo:

--- a/skills/midstream/sample-code-quality.md
+++ b/skills/midstream/sample-code-quality.md
@@ -2,6 +2,8 @@
 id: rr-midstream-code-quality-sample-001
 name: 'Sample Code Quality Pass'
 description: 'Checks common code quality and maintainability risks.'
+version: 0.1.0
+category: midstream
 phase: midstream
 applyTo:
   - 'src/**/*.ts'

--- a/skills/upstream/agent-architecture-review.md
+++ b/skills/upstream/agent-architecture-review.md
@@ -2,6 +2,7 @@
 id: agent-architecture-review
 name: Architecture Review
 description: 変更の全体設計、責務分離、境界の破綻を検知するためのレビュー手順。
+version: 0.1.0
 category: upstream
 phase: upstream
 applyTo:

--- a/skills/upstream/agent-code-documentation.md
+++ b/skills/upstream/agent-code-documentation.md
@@ -2,6 +2,7 @@
 id: agent-code-documentation
 name: Code Documentation
 description: コードや API の意図を短時間で共有できるドキュメントの書き方をガイドする。
+version: 0.1.0
 category: upstream
 phase: upstream
 applyTo:

--- a/skills/upstream/review-policy-standard.md
+++ b/skills/upstream/review-policy-standard.md
@@ -2,6 +2,8 @@
 id: rr-upstream-review-policy-standard-001
 name: 'Standard Review Policy for Upstream'
 description: 'Applies standard AI review policy guidelines for upstream (design) phase reviews.'
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - '**/*.md'

--- a/skills/upstream/rr-test-code-nextjs-001.md
+++ b/skills/upstream/rr-test-code-nextjs-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-test-code-nextjs-001
 name: Component Test Scaffold (Next.js)
 description: Generate React/Next.js component test skeletons (RTL) from specifications.
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - 'docs/**/*.md'

--- a/skills/upstream/rr-test-code-php-laravel-001.md
+++ b/skills/upstream/rr-test-code-php-laravel-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-test-code-php-laravel-001
 name: Test Scaffold (Laravel/PHPUnit)
 description: Generate PHP/Laravel (PHPUnit) test skeletons from specifications.
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - 'docs/**/*.md'

--- a/skills/upstream/rr-test-code-react-001.md
+++ b/skills/upstream/rr-test-code-react-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-test-code-react-001
 name: Component Test Scaffold (React)
 description: Generate generic React component test skeletons (RTL) from specifications.
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - 'docs/**/*.md'

--- a/skills/upstream/rr-test-code-remix-001.md
+++ b/skills/upstream/rr-test-code-remix-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-test-code-remix-001
 name: Route/Function Test Scaffold (Remix)
 description: Generate Remix loader/action and route component test skeletons.
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - 'docs/**/*.md'

--- a/skills/upstream/rr-test-code-unit-python-pytest-001.md
+++ b/skills/upstream/rr-test-code-unit-python-pytest-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-test-code-unit-python-pytest-001
 name: Unit Test Scaffold (Python/pytest)
 description: Generate Python/pytest unit test skeletons from specifications.
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - 'docs/**/*.md'

--- a/skills/upstream/rr-test-code-unit-ts-jest-001.md
+++ b/skills/upstream/rr-test-code-unit-ts-jest-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-test-code-unit-ts-jest-001
 name: Unit Test Scaffold (TypeScript)
 description: Generate TypeScript unit test skeletons (Jest/Vitest) from specifications.
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - 'docs/**/*.md'

--- a/skills/upstream/rr-test-code-vue-001.md
+++ b/skills/upstream/rr-test-code-vue-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-test-code-vue-001
 name: Component Test Scaffold (Vue.js)
 description: Generate Vue.js component test skeletons (Vue Test Utils) from specifications.
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - 'docs/**/*.md'

--- a/skills/upstream/rr-upstream-adr-decision-quality-001.md
+++ b/skills/upstream/rr-upstream-adr-decision-quality-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-adr-decision-quality-001
 name: ADR Decision Quality
 description: Ensure ADRs capture context, decision, alternatives, tradeoffs, and follow-ups in a way that prevents future drift.
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - 'docs/adr/**/*'

--- a/skills/upstream/rr-upstream-api-design-001.md
+++ b/skills/upstream/rr-upstream-api-design-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-api-design-001
 name: API Design Consistency
 description: Ensure API design follows RESTful naming and consistent conventions.
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - '**/api/**'

--- a/skills/upstream/rr-upstream-api-versioning-compat-001.md
+++ b/skills/upstream/rr-upstream-api-versioning-compat-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-api-versioning-compat-001
 name: 'API Versioning & Backward Compatibility'
 description: 'Ensure API/contract changes specify versioning strategy, backward compatibility, deprecation plan, and migration guidance.'
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - 'docs/**/*api*.md'

--- a/skills/upstream/rr-upstream-architecture-boundaries-001.md
+++ b/skills/upstream/rr-upstream-architecture-boundaries-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-architecture-boundaries-001
 name: 'Architecture Boundaries & Dependencies'
 description: 'Ensure architecture/design docs define clear boundaries, ownership, dependency direction, and change impact to avoid tight coupling.'
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - 'docs/architecture/**/*'

--- a/skills/upstream/rr-upstream-architecture-diagrams-001.md
+++ b/skills/upstream/rr-upstream-architecture-diagrams-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-architecture-diagrams-001
 name: 'Architecture Diagrams Readiness'
 description: 'Ensure architecture diagrams are readable, consistent with text, and clear on scope, boundaries, and data flow.'
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - 'docs/architecture/**/*'

--- a/skills/upstream/rr-upstream-architecture-risk-register-001.md
+++ b/skills/upstream/rr-upstream-architecture-risk-register-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-architecture-risk-register-001
 name: 'Architecture Risks, Assumptions & Open Questions'
 description: 'Ensure design docs explicitly capture risks, assumptions, and open questions with owners, deadlines, and mitigation plans.'
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - 'docs/**/*design*.md'

--- a/skills/upstream/rr-upstream-architecture-traceability-001.md
+++ b/skills/upstream/rr-upstream-architecture-traceability-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-architecture-traceability-001
 name: 'Architecture Traceability & Consistency'
 description: 'Ensure design changes stay consistent across ADRs, diagrams, and specs; decisions are traceable; and drift is explicitly managed.'
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - 'docs/architecture/**/*'

--- a/skills/upstream/rr-upstream-architecture-validation-plan-001.md
+++ b/skills/upstream/rr-upstream-architecture-validation-plan-001.md
@@ -3,6 +3,7 @@ id: rr-upstream-architecture-validation-plan-001
 name: Architecture Validation Plan Guard
 description: Detect missing validation plans (how to verify the design is correct) in design documents and ADRs.
 version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - 'docs/**/*design*.md'

--- a/skills/upstream/rr-upstream-availability-architecture-001.md
+++ b/skills/upstream/rr-upstream-availability-architecture-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-availability-architecture-001
 name: 'Availability & Resilience Architecture'
 description: 'Ensure architecture docs capture availability targets, failover strategy, capacity headroom, and resilience trade-offs for critical services.'
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - 'docs/architecture/**/*'

--- a/skills/upstream/rr-upstream-bounded-context-language-001.md
+++ b/skills/upstream/rr-upstream-bounded-context-language-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-bounded-context-language-001
 name: 'Bounded Context & Ubiquitous Language'
 description: 'Ensure architecture docs define bounded contexts, ownership, and a consistent ubiquitous language to prevent domain drift and coupling.'
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - 'docs/**/*design*.md'

--- a/skills/upstream/rr-upstream-cache-strategy-consistency-001.md
+++ b/skills/upstream/rr-upstream-cache-strategy-consistency-001.md
@@ -3,6 +3,7 @@ id: rr-upstream-cache-strategy-consistency-001
 name: Cache Strategy Consistency Guard
 description: Detect undefined or inconsistent cache strategies (layers, consistency, invalidation, TTL, failure handling) in design documents.
 version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - 'docs/**/*.md'

--- a/skills/upstream/rr-upstream-capacity-cost-design-001.md
+++ b/skills/upstream/rr-upstream-capacity-cost-design-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-capacity-cost-design-001
 name: 'Capacity, Performance & Cost Assumptions'
 description: 'Ensure architecture/design docs state traffic assumptions, performance budgets, resource limits, and cost risks for critical paths.'
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - 'docs/**/*performance*.md'

--- a/skills/upstream/rr-upstream-change-communication-001.md
+++ b/skills/upstream/rr-upstream-change-communication-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-change-communication-001
 name: 'Architecture Change Communication'
 description: 'Ensure architecture updates document affected stakeholders, notification plan, and deprecation/retirement signals to keep knowledge aligned.'
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - 'docs/architecture/**/*'

--- a/skills/upstream/rr-upstream-create-plan-001.md
+++ b/skills/upstream/rr-upstream-create-plan-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-create-plan-001
 name: 計画作成とレビュー
 description: 課題のゴールと制約を整理し、仮説・リスク付きの実行計画を段階的に提示して人間レビューにかける
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - 'docs/**/*'

--- a/skills/upstream/rr-upstream-data-flow-state-ownership-001.md
+++ b/skills/upstream/rr-upstream-data-flow-state-ownership-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-data-flow-state-ownership-001
 name: 'Data Flow & State Ownership'
 description: 'Ensure designs define data flow, state ownership, consistency boundaries, and cross-boundary writes to prevent drift and incidents.'
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - 'docs/**/*flow*.md'

--- a/skills/upstream/rr-upstream-data-model-db-design-001.md
+++ b/skills/upstream/rr-upstream-data-model-db-design-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-data-model-db-design-001
 name: 'Data Model & DB Design Review'
 description: 'Ensure data model/DB designs cover constraints, integrity, indexes, migrations, rollback, and operational impacts.'
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - '**/*schema*.{sql,prisma}'

--- a/skills/upstream/rr-upstream-dr-multiregion-001.md
+++ b/skills/upstream/rr-upstream-dr-multiregion-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-dr-multiregion-001
 name: 'Disaster Recovery & Multi-Region Readiness'
 description: 'Ensure architecture docs define RPO/RTO, failover paths, data consistency, and DR drillability.'
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - 'docs/**/*dr*.md'

--- a/skills/upstream/rr-upstream-event-driven-semantics-001.md
+++ b/skills/upstream/rr-upstream-event-driven-semantics-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-event-driven-semantics-001
 name: 'Event-Driven Semantics & Delivery Guarantees'
 description: 'Ensure event-driven designs specify delivery guarantees, ordering, idempotency, schema evolution, and replay/backfill strategy.'
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - 'docs/**/*event*.md'

--- a/skills/upstream/rr-upstream-external-dependencies-001.md
+++ b/skills/upstream/rr-upstream-external-dependencies-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-external-dependencies-001
 name: 'External Dependencies & Vendor Risks'
 description: 'Ensure designs document third-party dependencies, SLAs, quotas, failure modes, and vendor lock-in mitigation.'
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - 'docs/**/*design*.md'

--- a/skills/upstream/rr-upstream-failure-modes-observability-001.md
+++ b/skills/upstream/rr-upstream-failure-modes-observability-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-failure-modes-observability-001
 name: Failure Modes & Observability in Design
 description: Ensure designs specify failure modes, timeouts, error contracts, and observability for critical flows.
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - '**/api/**'

--- a/skills/upstream/rr-upstream-integration-contracts-001.md
+++ b/skills/upstream/rr-upstream-integration-contracts-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-integration-contracts-001
 name: 'Service Integration & Contracts'
 description: 'Ensure cross-service integration defines contracts, ownership, failure handling, versioning, and rollout/rollback expectations.'
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - 'docs/**/*integration*.md'

--- a/skills/upstream/rr-upstream-migration-rollout-rollback-001.md
+++ b/skills/upstream/rr-upstream-migration-rollout-rollback-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-migration-rollout-rollback-001
 name: Migration, Rollout & Rollback Plan
 description: Ensure design/ADR changes include a concrete migration plan, rollout strategy, rollback conditions, and compatibility considerations.
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - 'docs/**/*'

--- a/skills/upstream/rr-upstream-multitenancy-isolation-001.md
+++ b/skills/upstream/rr-upstream-multitenancy-isolation-001.md
@@ -3,6 +3,7 @@ id: rr-upstream-multitenancy-isolation-001
 name: Multitenancy Isolation Guard
 description: マルチテナント前提の設計差分から、テナント分離（データ/権限/リソース/障害影響）の抜けや越境リスクを検出
 version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - '**/*.md'

--- a/skills/upstream/rr-upstream-openapi-contract-001.md
+++ b/skills/upstream/rr-upstream-openapi-contract-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-openapi-contract-001
 name: 'OpenAPI Contract Completeness'
 description: 'Ensure OpenAPI specs define consistent request/response schemas, error model, auth, pagination, and backward compatibility.'
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - '**/openapi/**/*.{yml,yaml,json}'

--- a/skills/upstream/rr-upstream-operability-slo-001.md
+++ b/skills/upstream/rr-upstream-operability-slo-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-operability-slo-001
 name: 'Operability, SLO & Runbook Readiness'
 description: 'Ensure designs define operability basics: SLO/SLI, monitoring, alerting, on-call actions, and incident handling expectations.'
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - 'docs/**/*'

--- a/skills/upstream/rr-upstream-pr-template-qa-001.md
+++ b/skills/upstream/rr-upstream-pr-template-qa-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-pr-template-qa-001
 name: PRテンプレート品質チェック
 description: PRテンプレートの必須項目（日本語記載、Diátaxis、検証コマンド、チェックリスト）が明確かを確認し、抜けや誤解を生む文言を指摘する
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - '.github/pull_request_template.md'

--- a/skills/upstream/rr-upstream-pre-mortem-001.md
+++ b/skills/upstream/rr-upstream-pre-mortem-001.md
@@ -2,6 +2,7 @@
 id: rr-upstream-pre-mortem-001
 name: 'Pre-mortem 失敗シナリオ分析'
 description: '変更が将来インシデントや技術的負債を引き起こすと仮定し、その原因と経路を逆算して設計の盲点を可視化する'
+version: 0.1.0
 category: upstream
 phase: upstream
 applyTo:

--- a/skills/upstream/rr-upstream-requirements-acceptance-001.md
+++ b/skills/upstream/rr-upstream-requirements-acceptance-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-requirements-acceptance-001
 name: Requirements Clarity & Acceptance Criteria
 description: Ensure requirement docs define scope, terminology, acceptance criteria, edge cases, and non-functional requirements.
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - 'docs/**/*'

--- a/skills/upstream/rr-upstream-security-privacy-design-001.md
+++ b/skills/upstream/rr-upstream-security-privacy-design-001.md
@@ -3,6 +3,7 @@ id: rr-upstream-security-privacy-design-001
 name: Security & Privacy Design Review
 description: Review data retention, deletion, backup residency, and cross-border data transfer.
 version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - '**/*.md'

--- a/skills/upstream/rr-upstream-trust-boundaries-authz-001.md
+++ b/skills/upstream/rr-upstream-trust-boundaries-authz-001.md
@@ -2,6 +2,8 @@
 id: rr-upstream-trust-boundaries-authz-001
 name: 'Trust Boundaries & Authorization Architecture'
 description: 'Ensure designs define trust boundaries, authn/authz responsibilities, and propagation of identity/claims across services.'
+version: 0.1.0
+category: upstream
 phase: upstream
 applyTo:
   - 'docs/**/*security*.md'

--- a/skills/upstream/sample-architecture-review.md
+++ b/skills/upstream/sample-architecture-review.md
@@ -2,6 +2,7 @@
 id: rr-upstream-architecture-sample-001
 name: 'Sample Architecture Consistency Review'
 description: 'Checks design/ADR docs for consistency and missing decisions.'
+version: 0.1.0
 category: upstream
 phase: upstream
 applyTo:


### PR DESCRIPTION
## Summary
- 全71スキルファイルの frontmatter に `version: 0.1.0` を明示的に追加
- `category` フィールドが欠落していたスキルに追加（downstream: 7件、midstream: 10件、upstream: 37件）
- 標準フォーマットへの準拠により、別リポジトリへの転用時にバリデーションが通るようにする

## Test plan
- [x] `npm run lint` パス確認
- [x] `npm test` パス確認
- [ ] `npm run skills:validate` で全スキルのfrontmatterバリデーション通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)