### PR TITLE
fix(skills): 5パターン診断に基づくスキル改善

### DIFF
--- a/.claude/skills/skill-creator/SKILL.md
+++ b/.claude/skills/skill-creator/SKILL.md
@@ -133,6 +133,8 @@ Move heavy references, examples, and templates into separate files.
 
 Use `${CLAUDE_SKILL_ROOT}/assets/basic-skill-template.md` as the starting skeleton.
 
+The generated SKILL.md must include a Pattern declaration section at the top with primary pattern, secondary patterns, and Why fields matching the choice from Phase 0.5.
+
 ## Phase 4: Eval design
 
 Create an initial eval plan with:

--- a/.claude/skills/skill-ops-planner/SKILL.md
+++ b/.claude/skills/skill-ops-planner/SKILL.md
@@ -8,8 +8,8 @@ allowed-tools: Read, Grep, Glob, Bash
 ## Pattern declaration
 
 Primary pattern: Pipeline
-Secondary patterns: Reviewer
-Why: portfolio planning requires strict phase order (inventory → classify → policy → metrics → roadmap) with review checkpoints at each stage.
+Secondary patterns: Reviewer, Inversion
+Why: portfolio planning requires strict phase order (inventory → classify → policy → metrics → roadmap) with review checkpoints at each stage. Inversion is needed at Phase 0 to block progress when inventory data is insufficient.
 
 ## Purpose
 
@@ -37,10 +37,11 @@ Before planning, identify:
 - current storage layout
 - current evaluation maturity
 
-If the current inventory is missing:
+If any of the above cannot be determined:
 
-- create an inventory-first plan
-- do not pretend portfolio governance already exists
+- stop and ask the user for the missing information
+- do not proceed to Phase 1 until at least active skills and current storage layout are confirmed
+- if no inventory exists at all, output an inventory-first plan and stop
 
 ## Phase 1: Inventory and pattern segmentation
 
@@ -55,7 +56,21 @@ For each skill, record:
 - current eval maturity
 - review requirement
 
-Group the portfolio by:
+Output each skill as a structured record:
+
+```text
+skill: <name>
+owner: <person or team>
+purpose: <one line>
+invocation: auto | manual
+risk: low | medium | high
+primary_pattern: <pattern>
+secondary_patterns: <patterns or none>
+eval_maturity: none | basic | comprehensive
+review: <cadence>
+```
+
+Then group the portfolio by:
 
 - responsibility type (knowledge / workflow / investigation / review / operational)
 - risk type

--- a/.claude/skills/skill-optimizer/SKILL.md
+++ b/.claude/skills/skill-optimizer/SKILL.md
@@ -91,7 +91,7 @@ Classify failures into:
 
 ## Phase 2.5: Pattern mismatch diagnosis
 
-Before proposing wording or structure fixes, check whether the failure is caused by the wrong pattern or a missing secondary pattern.
+Before proposing wording or structure fixes, you must check whether the failure is caused by the wrong pattern or a missing secondary pattern. Do not skip this phase.
 
 Check:
 
@@ -105,6 +105,8 @@ If pattern mismatch exists:
 
 - recommend the smallest structural correction first
 - do not jump to wording tweaks before resolving the pattern issue
+
+Do not proceed to Phase 3 until pattern mismatch has been evaluated and documented.
 
 ## Phase 3: Optimization proposal
 


### PR DESCRIPTION
## 概要

skill-optimizerのPhase 2.5（パターンミスマッチ診断）手法を3スキル自身に適用し、診断で発見された構造的問題を修正。

## 診断結果と対応

| スキル | 診断前 | 課題 | 対応 |
|--------|--------|------|------|
| skill-ops-planner | 75% | Generator不足・Inversion未明示 | Phase 1に構造化レコードフォーマット追加、Phase 0にstopルール明示、Pattern declarationにInversion追加 |
| skill-creator | 85% | Generator暗黙的 | Phase 3にPattern declaration出力要件を追加 |
| skill-optimizer | 90% | Phase 2.5の強制性が弱い | Phase 2.5を助言形→必須checkpointに強化 |

## 変更ファイル（3ファイル、+26/-7行）

- `.claude/skills/skill-ops-planner/SKILL.md` — Inversion stopルール、構造化inventory format
- `.claude/skills/skill-creator/SKILL.md` — Phase 3にPattern declaration出力要件
- `.claude/skills/skill-optimizer/SKILL.md` — Phase 2.5を必須checkpoint化

## テスト計画

- [x] `npm run lint` 通過
- [x] `npm test`（162テスト）通過


🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>