### PR TITLE
[codex] Add agent instructions and learning log

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,196 +1,70 @@
 # AGENTS.md—River Reviewer
 
-この`AGENTS.md`は全AIコーディングエージェント共通のルールである。各ツール固有ファイル（`CLAUDE.md`等）は薄い差分のみを記載する。
+## Scope
 
-**このリポジトリの概要:** Skill Registry駆動のAIコードレビューフレームワーク。`skills/`配下のレビュースキル定義がプロダクトの中核であり、`src/`のランタイム、GitHub Actions、CLIはそのスキルを実行するインターフェイスである。アーキテクチャ詳細は`docs/architecture.md`を参照する。
+- Canonical instructions for all AI coding agents in this repository.
+- Tool-specific files like `CLAUDE.md` stay thin and point here.
 
----
+## Repository Map
 
-## 0. 禁止事項
+- `skills/`: core review skills and registry content.
+- `skills/agent-skills/`: packaged agent skills with `SKILL.md` plus `references/`.
+- `src/`: runtime, CLI, and runner logic.
+- `tests/`: Node.js test suites.
+- `pages/`: public docs; Japanese content is the source of truth.
+- `docs/`: internal notes and runbooks; ask before editing.
+- `runners/node-api/`: separate TypeScript package built with `tsc`.
 
-以下は例外なく禁止する。
+## Package Manager
 
-- `main`ブランチへの直接push（`git push origin main`を実行しない）
-- マージ済みPRブランチへの追加push（修正が必要な場合は新しいブランチと新しいPRを作成する）
-- `.env*`、`secrets/`、`*.pem`、`*.key`の読み取り・コミット（例示にはダミー値を使う）
-- `package-lock.json`の手動編集
-- 外部ネットワークへのアクセス（`curl`、`wget`等）
-- 破壊的コマンド（`rm -rf`、`sudo`等）
-- 外部APIを呼ぶコードでタイムアウト・例外処理を省略すること
+Use **npm**.
 
----
+- Install: `npm install` or `npm ci`
+- Lint: `npm run lint`
+- Test: `npm test`
+- Skills: `npm run skills:validate`
+- Agent skills: `npm run agent-skills:validate`
+- Agent definitions: `npm run agents:validate`
+- Local docs links: `npm run check:links:local`
+- Docs dev server: `npm run dev`
+- Docs build: `npm run build`
+- TypeScript type check: no root `typecheck` script exists; use `npm run build` in `runners/node-api/` when that package changes.
 
-## 1. 自律判断の基準
+## Safety
 
-| 条件                                                    | 行動                               |
-| ------------------------------------------------------- | ---------------------------------- |
-| 変更ファイルが3個以下の見込み、§3「編集対象」のみ       | そのまま実行してよい               |
-| 変更ファイルが4個以上の見込み、または複数領域にまたがる | 実行計画を提示してから着手する     |
-| §3「要確認」パスを含む（`src/`、`docs/`等）             | ユーザーに許可を求めてから編集する |
-| §3「編集禁止」パスを含む                                | 編集しない                         |
-| 判断に迷う場合                                          | ユーザーに確認する。推測で進めない |
+- Do not read or commit `.env*`, `secrets/`, `*.pem`, or `*.key`.
+- Do not access the external network from commands.
+- Do not use destructive commands.
+- Do not hand-edit `package-lock.json`.
+- Do not push directly to `main` or to already-merged PR branches.
+- Do not omit timeout and exception handling in code that calls external APIs.
 
----
+## Edit Scope
 
-## 2. 着手フロー
+- Editable: `pages/`, `skills/`, `schemas/`, `scripts/`, `tests/`, `.github/`, `.claude/`
+- Ask before editing: `docs/`, `assets/`, `src/`
+- Never edit: `package-lock.json`, `LICENSE*`, `CITATION.cff`
 
-タスクを受けたら以下の順で進める。
+## Workflow
 
-1. 完了条件を確認する。§1の基準で計画提示が必要なら先に提示する
-2. タスク単位でブランチを作成する（`git checkout -b <type>/<description>`）
-3. 編集範囲を§3で確認する
-4. 変更を小さく刻む（1 PRは論理的に1つの目的）
-5. 新規ファイルを作成する場合、同種の既存ファイルのパターンに合わせる
-6. §4の検証コマンドを実行し、全パスを確認する
-7. PRを作成する（§7の手順に従う）
+- Keep each change small and cohesive.
+- If `src/` changes, confirm schema and skill alignment first.
+- Run the required checks before handoff.
+- Prefer existing patterns over new conventions.
 
----
+## Commit Attribution
 
-## 3. 編集範囲
+- AI-authored commits MUST include a `Co-Authored-By:` trailer with the acting model identity.
 
-### 編集対象
+## Project Conventions
 
-- `pages/`: Docusaurusドキュメント（日本語がSSoT）
-- `skills/`: レビュースキル定義（YAMLフロントマター付きMarkdown）
-- `schemas/`: JSON Schema（`skill.schema.json`等）
-- `scripts/`: 検証・ユーティリティスクリプト
-- `tests/`: テストファイル
-- `.github/`: GitHub Actions、エージェント定義
-- `.claude/`: Claude Code設定（agents、commands、hooks、skills）
+- `README.md` is the Japanese source of truth; `README.en.md` is best effort.
+- `skills/` content is the product surface; validate it after edits.
+- Record only durable, reusable repo learnings in `AGENT_LEARNINGS.md`.
+- Use English or Japanese skill searches when locating repo conventions.
 
-### 編集禁止（自動生成・管理外）
+## Local References
 
-- `package-lock.json`: `npm ci`で再生成する
-- `LICENSE*`、`CITATION.cff`: ライセンス・引用情報
-
-### 要確認（ユーザーの許可を得てから編集）
-
-- `docs/`: 内部資料。公開コンテンツは`pages/`で管理する
-- `assets/`: 各種アセット
-- `src/`: ランタイムソースコード。仕様変更前に`schemas/*.json`と既存`skills/`の整合を確認する
-
----
-
-## 4. 検証コマンド
-
-### 全PR共通（必須）
-
-```bash
-npm run lint     # Prettier + markdownlint + textlint
-npm test         # Node.js test runner
-```
-
-### 変更内容に応じた追加（該当時は必須）
-
-| 変更対象                             | コマンド                        |
-| ------------------------------------ | ------------------------------- |
-| `skills/**/*.md`                     | `npm run skills:validate`       |
-| `skills/agent-skills/**/*.md`        | `npm run agent-skills:validate` |
-| `.github/agents/`、`.claude/agents/` | `npm run agents:validate`       |
-| `pages/**/*.md`                      | `npm run check:links:local`     |
-
-### 任意
-
-| コマンド                 | 用途                           |
-| ------------------------ | ------------------------------ |
-| `npm run check:links`    | 全リンク検証（外部含む、低速） |
-| `npm run trace:validate` | OpenTelemetryトレース検証      |
-| `npm run planner:eval`   | Planner品質ベンチマーク        |
-
-### セットアップ
-
-- 依存導入: `npm ci`（CI/再現性重視）または`npm install`（ローカル開発）
-- ドキュメント開発サーバー: `npm run dev`（Docusaurus）
-- ドキュメントビルド: `npm run build`
-- リンクチェックには別途lycheeが必要: `brew install lychee`（macOS）
-
----
-
-## 5. 技術スタックとスタイル
-
-- **Runtime**: Node.js 20+、npm（lockfile: `package-lock.json`）
-- **Test Runner**: `node --test`（built-in）
-- **Documentation**: Docusaurus 3（`pages/`配下）
-- **Linting**: `prettier`、`eslint`（`.eslintrc.js`）、`markdownlint`（`.markdownlint.json`）、`textlint`（日本語文法）、`vale`（英語prose）
-- **フォーマット**: Prettier（`**/*.{js,json,md,yml,yaml}`、設定は`.prettierrc.json`）
-- **JavaScript/Node**: ESM
-- **ドキュメント言語**: 日本語（`*.md`）がSSoT。英語版は`*.en.md`。差分がある場合は日本語を優先する
-
----
-
-## 6. スキルとエージェント定義
-
-### スキル定義（`skills/`）
-
-- 形式: YAMLフロントマター付きMarkdown
-- 主なフィールド: `id`、`name`、`description`、`category`（`core`/`upstream`/`midstream`/`downstream`）、`applyTo`、`inputContext`、`outputKind`、`modelHint`、`severity`、`tags`
-- 新規作成時は`skills/_template.md`と同カテゴリーの既存スキルを参照する
-- 検証: §4の表を参照
-
-### Agent Skillsパッケージ（`skills/agent-skills/`）
-
-- 形式: `SKILL.md` + `references/`を基本とするフォルダー単位
-
-### Claude Codeスキル（`.claude/skills/`）
-
-- 形式: Claude Code Agent Skills仕様に準拠（`SKILL.md` + `references/` + `assets/`）
-- 主なフィールド: `name`、`description`、`allowed-tools`、`disable-model-invocation`
-- 用途: 開発支援ワークフロー（スキル作成・改善・運用計画等）。`skills/`のレビュースキルとは別体系
-- 検証: `npm run lint`（Prettier + markdownlint）
-
-### エージェント定義
-
-- `.claude/agents/`（Claude Code用）、`.github/agents/`（Copilot用）
-- 検証: §4の表を参照
-
----
-
-## 7. コミット/PRルール
-
-詳細は`CONTRIBUTING.md`を参照する。
-
-- コミット前に§4の必須検証を実行する
-- PR本文に目的・変更内容・影響範囲・実行コマンドと結果を記載する
-- コミットメッセージはConventional Commits（`feat:`、`fix:`等）に従う
-- PR作成手順:
-
-```bash
-git checkout -b <type>/<description>
-git add <files>
-git commit -m "<type>: <description>"
-git push -u origin <type>/<description>
-gh pr create --title "<type>: <description>" --body "..."
-```
-
----
-
-## 8. スキル検索
-
-スキルは日本語で記述されているが、英語プロンプトでも活用できる。
-
-- 英語と日本語の両方のキーワードで`skills/`を検索する
-- 英語検索で見つからない場合、主要な用語を日本語に翻訳して再検索する
-- ファイル名や`id`フィールドには英語ヒントを含むことが多い
-- 検索コマンド例: `rg -i "keyword" skills/`または`fd skill.md skills/`
-
----
-
-## 9. AI実装メモ
-
-- このリポジトリはAIレビューエージェントそのものの定義・スキルを含む。`src/`を変更する場合は§3「要確認」に従う
-- **LLM有効判定の共通化**: LLM機能を実装・変更する際は`src/lib/utils.mjs`の`isLlmEnabled()`を使用する。OpenAI（`OPENAI_API_KEY`、`RIVER_OPENAI_API_KEY`）およびGoogle Gemini（`GOOGLE_API_KEY`）の両方のキーをチェックする
-- 不明な場合はREADMEと`docs/architecture.md`を参照する
-- 並行タスクにはGit Worktreeを使用する。手順は`docs/runbook/dev.md`を参照する
-
----
-
-## 10. AIプロバイダー別設定
-
-| プロバイダー   | 設定ファイル                      | カスタムコマンド          | エージェント      |
-| -------------- | --------------------------------- | ------------------------- | ----------------- |
-| GitHub Copilot | `.github/copilot-instructions.md` | `/skill`、`/review`       | `@river-reviewer` |
-| Claude Code    | `CLAUDE.md`、`.claude/`           | `/skill`、`/review-local` | `river-reviewer`  |
-| Google Gemini  | `GEMINI.md`                       | -                         | Gemini CLI/Chat   |
-| OpenAI Codex   | `.codex/`                         | -                         | -                 |
-
-各プロバイダー固有ファイルはこの`AGENTS.md`を前提にツール固有の差分だけを薄く記載する（ドリフト防止）。`AGENTS.md`内のセクションを参照する場合は、セクション番号ではなく見出しアンカー（例: `#10-aiプロバイダー別設定`）でリンクすること。
+- Core repository architecture: `docs/architecture.md`
+- Development runbook: `docs/runbook/dev.md`
+- Skill structure: `skills/README.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@
 - `tests/`: Node.js test suites.
 - `pages/`: public docs; Japanese content is the source of truth.
 - `docs/`: internal notes and runbooks; ask before editing.
+- `runners/github-action/`: GitHub Action runner implementation.
 - `runners/node-api/`: separate TypeScript package built with `tsc`.
 
 ## Package Manager
@@ -41,8 +42,8 @@ Use **npm**.
 
 ## Edit Scope
 
-- Editable: `pages/`, `skills/`, `schemas/`, `scripts/`, `tests/`, `.github/`, `.claude/`
-- Ask before editing: `docs/`, `assets/`, `src/`
+- Editable: `pages/`, `skills/`, `schemas/`, `scripts/`, `tests/`, `.github/`, `.claude/`, `AGENT_LEARNINGS.md`
+- Ask before editing: `docs/`, `assets/`, `src/`, `runners/`, `README.md`, `README.en.md`, `AGENTS.md`
 - Never edit: `package-lock.json`, `LICENSE*`, `CITATION.cff`
 
 ## Workflow

--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -1,0 +1,31 @@
+# AGENT_LEARNINGS.md — River Reviewer
+
+## Purpose
+
+- Store durable, reusable repo-specific learnings for future agents.
+- Keep this file focused on facts that help across branches and sessions.
+
+## Write Rules
+
+- Add only stable observations that have been verified in the repository.
+- Capture one learning per bullet with enough context to reuse it.
+- Record secrets, personal data, transient debugging notes, and branch-specific TODOs nowhere in this file.
+- Prefer facts that change slowly: command shapes, package boundaries, validation rules, source-of-truth files, and recurring pitfalls.
+
+## Entry Format
+
+- `YYYY-MM-DD`: short learning statement.
+- `Applies to`: where the learning matters.
+- `Evidence`: file or command that confirmed it.
+
+## Current Learnings
+
+- `2026-04-03`: `README.md` is the Japanese source of truth, and `README.en.md` is best effort only.
+  - `Applies to`: docs updates, content parity checks, and agent instructions.
+  - `Evidence`: repository README files and existing project guidance.
+- `2026-04-03`: The root package uses `npm`; validation is `npm run lint` and `npm test`, while the root has no `typecheck` script.
+  - `Applies to`: routine verification and agent planning.
+  - `Evidence`: root `package.json`.
+- `2026-04-03`: `runners/node-api/` is a separate TypeScript package and its compile check is `npm run build` (`tsc`) inside that directory.
+  - `Applies to`: changes to the Node API runner or its published types.
+  - `Evidence`: `runners/node-api/package.json`.

--- a/README.en.md
+++ b/README.en.md
@@ -76,16 +76,16 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run River Reviewer (midstream)
-        uses: s977043/river-reviewer/runners/github-action@v0.10.0
+        uses: s977043/river-reviewer/runners/github-action@v0.11.0
         with:
           phase: midstream # upstream|midstream|downstream|all (future-ready)
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 ```
 
-Pin to a release tag such as `@v0.10.0` for stability. Optionally, you can maintain a floating alias tag like `@v0`.
+Pin to a release tag such as `@v0.11.0` for stability. Optionally, you can maintain a floating alias tag like `@v0`.
 
-Latest release: [v0.10.0](https://github.com/s977043/river-reviewer/releases/tag/v0.10.0)
+Latest release: [v0.11.0](https://github.com/s977043/river-reviewer/releases/tag/v0.11.0)
 
 > **ℹ️ Upgrading from v0.1.x:** v0.2.0 and later use the new GitHub Action path `runners/github-action` instead of `.github/actions/river-reviewer`. See [Migration Guide](docs/migration/runners-architecture-guide.md) and [DEPRECATED.md](docs/deprecated.md) for details.
 

--- a/README.md
+++ b/README.md
@@ -86,16 +86,16 @@ jobs:
         with:
           fetch-depth: 0 # merge-base を安定取得
       - name: Run River Reviewer (midstream)
-        uses: s977043/river-reviewer/runners/github-action@v0.10.0
+        uses: s977043/river-reviewer/runners/github-action@v0.11.0
         with:
           phase: midstream # upstream|midstream|downstream|all (future-ready)
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 ```
 
-タグは `@v0.10.0` などのリリースタグにピン留めしてください。浮動タグを使う場合は `@v0` のようなエイリアスタグを用意して運用します（任意）。
+タグは `@v0.11.0` などのリリースタグにピン留めしてください。浮動タグを使う場合は `@v0` のようなエイリアスタグを用意して運用します（任意）。
 
-最新リリース: [v0.10.0](https://github.com/s977043/river-reviewer/releases/tag/v0.10.0)
+最新リリース: [v0.11.0](https://github.com/s977043/river-reviewer/releases/tag/v0.11.0)
 
 > **ℹ️ v0.1.x からのアップグレード:** v0.2.0以降では、GitHub Actionのパスが `.github/actions/river-reviewer` から `runners/github-action` に変更されています。詳細は[移行ガイド](docs/migration/runners-architecture-guide.md)と[DEPRECATED.md](docs/deprecated.md)をご確認ください。
 
@@ -110,7 +110,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.10.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
         with: { phase: upstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 
@@ -119,7 +119,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.10.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
         with: { phase: midstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 
@@ -128,7 +128,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.10.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
         with: { phase: downstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 ```
@@ -142,7 +142,7 @@ review:
   steps:
     - uses: actions/checkout@v6
       with: { fetch-depth: 0 }
-    - uses: s977043/river-reviewer/runners/github-action@v0.10.0
+    - uses: s977043/river-reviewer/runners/github-action@v0.11.0
       with:
         phase: midstream
         estimate: true # コスト見積もりのみ
@@ -160,7 +160,7 @@ review:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.10.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
         with:
           phase: midstream
           dry_run: true            # Draft はドライランでプロンプト確認のみ
@@ -173,7 +173,7 @@ review:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.10.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
         with:
           phase: midstream
           dry_run: false           # Ready ではフルレビュー

--- a/README.md
+++ b/README.md
@@ -220,6 +220,12 @@ exclude:
 7. Review fixtures 評価（任意）: `npm run eval:fixtures`（must_include 方式）
 8. ドキュメント開発（任意）: `npm run dev`（Docusaurus）
 
+## AI エージェント運用
+
+- ルートの `AGENTS.md` が AI コーディングエージェント向けの SSOT です。
+- `AGENT_LEARNINGS.md` には、再利用できる確定済みの学びだけを追加します。
+- 秘密情報、個人情報、一時的なメモはどちらにも書きません。
+
 ### Codex を project-local config で使う
 
 Codex 用の project-local config は [`.codex/config.toml`](./.codex/config.toml) にあり、**opt-in** です。通常の Codex 利用には影響しません。このリポジトリ設定を使うときだけ、以下のいずれかで起動します。

--- a/docs/use-cases/github-actions.md
+++ b/docs/use-cases/github-actions.md
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0 # Required for git diff
 
       - name: Run River Reviewer
-        uses: s977043/river-reviewer/runners/github-action@v0.10.0
+        uses: s977043/river-reviewer/runners/github-action@v0.11.0
         with:
           phase: midstream
         env:
@@ -67,7 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.10.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
         with: { phase: upstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 
@@ -81,7 +81,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.10.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
         with: { phase: midstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 
@@ -95,7 +95,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.10.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
         with: { phase: downstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 ```
@@ -122,7 +122,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.10.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
         with: { phase: ${{ matrix.phase }} }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 ```
@@ -140,7 +140,7 @@ jobs:
 ### Example: Custom Skills Directory
 
 ```yaml
-- uses: s977043/river-reviewer/runners/github-action@v0.10.0
+- uses: s977043/river-reviewer/runners/github-action@v0.11.0
   with:
     phase: midstream
     skills-dir: custom-skills # Use custom skill location
@@ -149,7 +149,7 @@ jobs:
 ### Example: JSON Output
 
 ```yaml
-- uses: s977043/river-reviewer/runners/github-action@v0.10.0
+- uses: s977043/river-reviewer/runners/github-action@v0.11.0
   with:
     phase: midstream
     output-format: json
@@ -224,7 +224,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.10.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
         with: { phase: midstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 ```
@@ -249,7 +249,7 @@ jobs:
           repository: your-org/shared-skills
           path: shared-skills
 
-      - uses: s977043/river-reviewer/runners/github-action@v0.10.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
         with:
           phase: midstream
           skills-dir: shared-skills
@@ -268,7 +268,7 @@ jobs:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
 
-      - uses: s977043/river-reviewer/runners/github-action@v0.10.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
         with:
           phase: midstream
         env:
@@ -309,7 +309,7 @@ jobs:
           ref: refs/pull/${{ inputs.pr_number }}/head
           fetch-depth: 0
 
-      - uses: s977043/river-reviewer/runners/github-action@v0.10.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
         with:
           phase: ${{ inputs.phase }}
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
@@ -333,7 +333,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.10.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
         with: { phase: midstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 ```
@@ -445,7 +445,7 @@ Line 15: ...
 ## Best Practices
 
 1. **Use Specific Phases** - Run only relevant skills to save time and costs
-2. **Pin Action Versions** - Use `@v0.10.0` instead of `@main` for stability
+2. **Pin Action Versions** - Use `@v0.11.0` instead of `@main` for stability
 3. **Set Permissions Explicitly** - Define minimum required permissions
 4. **Monitor API Usage** - Track LLM API costs and set budgets
 5. **Test Locally First** - Validate skills work before running in CI
@@ -473,7 +473,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.10.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
         with: { phase: midstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 
@@ -485,7 +485,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.10.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
         with: { phase: downstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 ```
@@ -518,7 +518,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.10.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
         with: { phase: ${{ matrix.phase }} }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 ```

--- a/scripts/check-doc-placement.mjs
+++ b/scripts/check-doc-placement.mjs
@@ -9,6 +9,7 @@ const repoRoot = path.resolve(__dirname, '..');
 
 const ROOT_ALLOWLIST = new Set([
   'AGENTS.md',
+  'AGENT_LEARNINGS.md',
   'CHANGELOG.md',
   'CLAUDE.md',
   'CODE_OF_CONDUCT.md',


### PR DESCRIPTION
## What changed
- Added a repository-root AGENTS.md for AI coding agents.
- Added AGENT_LEARNINGS.md to store reusable repo knowledge only.
- Added a short README note explaining the role split.

## Why
- To make agent behavior consistent, reduce duplicate instructions, and keep durable repo knowledge separate from transient notes.

## Validation
- npm run lint ✅
- npm test ⚠️ failed due an existing metadata mismatch in the repository (package.json version 0.11.0 vs README/docs references to v0.10.0).

## Notes
- No secrets, personal data, or temporary debugging notes were added.
- The change is limited to documentation and operational guidance.