### PR TITLE
ci: update release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,10 +19,9 @@ jobs:
     steps:
       - name: Release Please
         id: release
-        uses: google-github-actions/release-please-action@v4
+        uses: googleapis/release-please-action@v4
         with:
           release-type: node
-          package-name: river-reviewer
 
       - name: Checkout (for floating tags)
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
## What changed
- switched the workflow from `google-github-actions/release-please-action@v4` to `googleapis/release-please-action@v4`
- removed the unsupported `package-name` input from the workflow

## Why
- the current workflow emits a deprecation warning for the archived action
- the current workflow also emits an `Unexpected input(s) 'package-name'` warning on every Release Please run

## Validation
- npm test ✅
- npm run lint ✅
- confirmed the latest Release Please run log showed the two warnings this PR removes

## Notes
- this is a workflow-only change; no release tag or package version was changed