### PR TITLE
ci: opt in release workflow to Node 24

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,9 @@ concurrency:
   group: release-please-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What changed
- added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to the Release Please workflow

## Why
- the latest Release Please run no longer shows the archived-action warning or invalid input warning
- the remaining warning is GitHub's Node 20 JavaScript action deprecation notice for `googleapis/release-please-action@v4`
- this opts the workflow into Node 24 ahead of the platform default change

## Validation
- npm test ✅
- npm run lint ✅
- confirmed the latest Release Please run log only had the Node 20 runtime warning left

## Notes
- workflow-only change; no release tag or package version changes