### PR TITLE
feat(eval): add unified evaluation runner and experiment ledger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,11 @@ node_modules
 build/
 .docusaurus/
 
-# Runner outputs
-artifacts/
+# Runner outputs (track evals directory for ledger)
+artifacts/*
+!artifacts/evals/
+artifacts/evals/*
+!artifacts/evals/.gitkeep
 
 # Generated schema/examples backups
 *.schema_*.json

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "planner:eval:dataset": "node scripts/evaluate-planner-dataset.mjs",
     "eval:fixtures": "node scripts/evaluate-review-fixtures.mjs",
     "meta:validate": "node scripts/validate-meta-consistency.mjs",
+    "eval:all": "node scripts/evaluate-all.mjs",
     "check:bilingual": "node scripts/check-bilingual-pairs.mjs",
     "check:doc-placement": "node scripts/check-doc-placement.mjs",
     "check:docs": "npm run check:bilingual && npm run check:doc-placement",

--- a/scripts/evaluate-all.mjs
+++ b/scripts/evaluate-all.mjs
@@ -1,0 +1,313 @@
+#!/usr/bin/env node
+/**
+ * Unified evaluation runner for River Reviewer.
+ *
+ * Bundles planner:eval, eval:fixtures, severity gate, and meta-consistency
+ * into a single invocation. Outputs a JSON envelope and optionally appends
+ * to the experiment ledger at artifacts/evals/results.jsonl.
+ *
+ * Usage:
+ *   node scripts/evaluate-all.mjs [options]
+ *
+ * Options:
+ *   --gate-input <path>    Path to River Reviewer JSON output for gate eval
+ *   --append-ledger        Append result to artifacts/evals/results.jsonl
+ *   --description <text>   Optional description for ledger entry
+ *   --json                 Print result as JSON instead of human-readable
+ *   --skip <name>          Skip a sub-eval (planner|fixtures|gate|meta). Repeatable
+ *   -h, --help             Show help
+ */
+
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import url from 'node:url';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const ROOT = path.join(__dirname, '..');
+
+// --- arg parsing -----------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = [...argv];
+  const parsed = {
+    gateInput: null,
+    appendLedger: false,
+    description: '',
+    json: false,
+    skip: new Set(),
+    help: false,
+  };
+
+  while (args.length) {
+    const arg = args.shift();
+    if (arg === '--gate-input') {
+      parsed.gateInput = args.shift() ?? null;
+    } else if (arg === '--append-ledger') {
+      parsed.appendLedger = true;
+    } else if (arg === '--description') {
+      parsed.description = args.shift() ?? '';
+    } else if (arg === '--json') {
+      parsed.json = true;
+    } else if (arg === '--skip') {
+      const name = args.shift();
+      if (name) parsed.skip.add(name);
+    } else if (arg === '-h' || arg === '--help') {
+      parsed.help = true;
+    }
+  }
+
+  return parsed;
+}
+
+// --- git helpers ------------------------------------------------------------
+
+function gitCommit() {
+  try {
+    return execSync('git rev-parse --short HEAD', { cwd: ROOT, encoding: 'utf8' }).trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+function gitBranch() {
+  try {
+    return execSync('git rev-parse --abbrev-ref HEAD', { cwd: ROOT, encoding: 'utf8' }).trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+// --- sub-eval runners -------------------------------------------------------
+
+async function runPlannerEval() {
+  const { evaluatePlanner } = await import('../src/lib/planner-eval.mjs');
+  const fixturePath = path.join(ROOT, 'tests', 'fixtures', 'planner-eval-cases.json');
+  const data = JSON.parse(fs.readFileSync(fixturePath, 'utf-8'));
+  const cases = data.map((c) => ({
+    ...c,
+    llmPlan: async () => c.llmPlan ?? c.plan ?? c.expectedOrder.map((id) => ({ id })),
+    skills: c.skills,
+    context: c.context,
+  }));
+
+  const { summary } = await evaluatePlanner(cases);
+
+  return {
+    name: 'planner',
+    pass: summary.coverage >= 0.5,
+    metrics: {
+      exactMatch: summary.exactMatch,
+      top1Match: summary.top1Match,
+      coverage: summary.coverage,
+      mrr: summary.mrr,
+    },
+    errors: [],
+  };
+}
+
+async function runFixturesEval() {
+  const { evaluateReviewFixtures } = await import('../src/lib/review-fixtures-eval.mjs');
+  const casesPath = path.join(ROOT, 'tests', 'fixtures', 'review-eval', 'cases.json');
+
+  const exitCode = await evaluateReviewFixtures({ casesPath, verbose: false });
+
+  return {
+    name: 'fixtures',
+    pass: exitCode === 0,
+    metrics: {
+      exitCode,
+    },
+    errors: exitCode === 0 ? [] : ['One or more fixture checks failed'],
+  };
+}
+
+async function runGateEval(inputPath) {
+  const { evaluateGate } = await import('./evaluate-review-gate.mjs');
+  const result = await evaluateGate({ input: inputPath });
+
+  return {
+    name: 'gate',
+    pass: result.pass,
+    metrics: {},
+    errors: result.pass ? [] : [result.summary],
+  };
+}
+
+async function runMetaValidation() {
+  const { validateMeta } = await import('./validate-meta-consistency.mjs');
+  const errors = await validateMeta();
+
+  return {
+    name: 'meta',
+    pass: errors.length === 0,
+    metrics: {
+      errorCount: errors.length,
+    },
+    errors,
+  };
+}
+
+// --- ledger -----------------------------------------------------------------
+
+function appendLedger(entry) {
+  const ledgerPath = path.join(ROOT, 'artifacts', 'evals', 'results.jsonl');
+  const dir = path.dirname(ledgerPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  fs.appendFileSync(ledgerPath, JSON.stringify(entry) + '\n');
+}
+
+// --- main -------------------------------------------------------------------
+
+async function main() {
+  const parsed = parseArgs(process.argv.slice(2));
+
+  if (parsed.help) {
+    console.log(`Usage: node scripts/evaluate-all.mjs [options]
+
+Options:
+  --gate-input <path>    Path to River Reviewer JSON output for gate eval
+  --append-ledger        Append result to artifacts/evals/results.jsonl
+  --description <text>   Optional description for ledger entry
+  --json                 Print result as JSON
+  --skip <name>          Skip a sub-eval (planner|fixtures|gate|meta). Repeatable
+  -h, --help             Show help
+`);
+    return 0;
+  }
+
+  const subResults = [];
+
+  if (!parsed.skip.has('planner')) {
+    try {
+      subResults.push(await runPlannerEval());
+    } catch (err) {
+      subResults.push({
+        name: 'planner',
+        pass: false,
+        metrics: {},
+        errors: [`Planner eval error: ${err.message}`],
+      });
+    }
+  }
+
+  if (!parsed.skip.has('fixtures')) {
+    try {
+      subResults.push(await runFixturesEval());
+    } catch (err) {
+      subResults.push({
+        name: 'fixtures',
+        pass: false,
+        metrics: {},
+        errors: [`Fixtures eval error: ${err.message}`],
+      });
+    }
+  }
+
+  if (!parsed.skip.has('gate') && parsed.gateInput) {
+    try {
+      subResults.push(await runGateEval(path.resolve(parsed.gateInput)));
+    } catch (err) {
+      subResults.push({
+        name: 'gate',
+        pass: false,
+        metrics: {},
+        errors: [`Gate eval error: ${err.message}`],
+      });
+    }
+  }
+
+  if (!parsed.skip.has('meta')) {
+    try {
+      subResults.push(await runMetaValidation());
+    } catch (err) {
+      subResults.push({
+        name: 'meta',
+        pass: false,
+        metrics: {},
+        errors: [`Meta validation error: ${err.message}`],
+      });
+    }
+  }
+
+  // Build envelope
+  const allPass = subResults.every((r) => r.pass);
+  const scores = {};
+  for (const r of subResults) {
+    for (const [k, v] of Object.entries(r.metrics)) {
+      scores[`${r.name}_${k}`] = v;
+    }
+  }
+
+  const envelope = {
+    timestamp: new Date().toISOString(),
+    commit: gitCommit(),
+    branch: gitBranch(),
+    scores,
+    results: subResults.map((r) => ({
+      name: r.name,
+      pass: r.pass,
+      errors: r.errors,
+    })),
+    status: allPass ? 'pass' : 'fail',
+    description: parsed.description || undefined,
+  };
+
+  if (parsed.json) {
+    console.log(JSON.stringify(envelope, null, 2));
+  } else {
+    console.log(`\n=== River Reviewer Unified Evaluation ===`);
+    console.log(`Commit: ${envelope.commit} (${envelope.branch})`);
+    console.log(`Time:   ${envelope.timestamp}`);
+    console.log(`Status: ${envelope.status.toUpperCase()}\n`);
+
+    for (const r of subResults) {
+      const icon = r.pass ? 'PASS' : 'FAIL';
+      console.log(`[${icon}] ${r.name}`);
+      if (Object.keys(r.metrics).length) {
+        for (const [k, v] of Object.entries(r.metrics)) {
+          const display = typeof v === 'number' && v <= 1 && v >= 0 ? `${(v * 100).toFixed(1)}%` : v;
+          console.log(`       ${k}: ${display}`);
+        }
+      }
+      if (r.errors.length) {
+        for (const e of r.errors) {
+          console.log(`       ! ${e}`);
+        }
+      }
+    }
+
+    console.log('');
+  }
+
+  if (parsed.appendLedger) {
+    appendLedger(envelope);
+    if (!parsed.json) {
+      console.log(`Ledger entry appended to artifacts/evals/results.jsonl`);
+    }
+  }
+
+  return allPass ? 0 : 1;
+}
+
+export { main as evaluateAll };
+
+const isDirectRun =
+  process.argv[1] &&
+  (process.argv[1].endsWith('evaluate-all.mjs') || process.argv[1].endsWith('evaluate-all'));
+
+if (isDirectRun) {
+  main()
+    .then((code) => {
+      if (typeof code === 'number' && code !== 0) {
+        process.exitCode = code;
+      }
+    })
+    .catch((err) => {
+      console.error(`Unified eval error: ${err.message}`);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/evaluate-all.mjs
+++ b/scripts/evaluate-all.mjs
@@ -85,6 +85,16 @@ function gitBranch() {
   }
 }
 
+// --- result helpers ---------------------------------------------------------
+
+function errorResult(name, message) {
+  return { name, pass: false, skipped: false, metrics: {}, errors: [message] };
+}
+
+function skipResult(name) {
+  return { name, pass: true, skipped: true, metrics: {}, errors: [] };
+}
+
 // --- sub-eval runners -------------------------------------------------------
 
 async function runPlannerEval() {
@@ -104,6 +114,7 @@ async function runPlannerEval() {
   return {
     name: 'planner',
     pass: summary.coverage >= PLANNER_COVERAGE_THRESHOLD,
+    skipped: false,
     metrics: {
       exactMatch: summary.exactMatch,
       top1Match: summary.top1Match,
@@ -123,9 +134,8 @@ async function runFixturesEval() {
   return {
     name: 'fixtures',
     pass: exitCode === 0,
-    metrics: {
-      exitCode,
-    },
+    skipped: false,
+    metrics: { exitCode },
     errors: exitCode === 0 ? [] : ['One or more fixture checks failed'],
   };
 }
@@ -137,6 +147,7 @@ async function runGateEval(inputPath) {
   return {
     name: 'gate',
     pass: result.pass,
+    skipped: false,
     metrics: {},
     errors: result.pass ? [] : [result.summary],
   };
@@ -149,9 +160,8 @@ async function runMetaValidation() {
   return {
     name: 'meta',
     pass: errors.length === 0,
-    metrics: {
-      errorCount: errors.length,
-    },
+    skipped: false,
+    metrics: { errorCount: errors.length },
     errors,
   };
 }
@@ -171,7 +181,6 @@ function appendLedger(entry) {
 
 async function main() {
   const parsed = parseArgs(process.argv.slice(2));
-  const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf-8'));
 
   if (parsed.help) {
     console.log(`Usage: node scripts/evaluate-all.mjs [options]
@@ -187,80 +196,54 @@ Options:
     return 0;
   }
 
-  const subResults = [];
+  const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf-8'));
 
+  // Run independent evals (planner, meta) in parallel; sequential for fixtures and gate
+  const parallel = [];
   if (!parsed.skip.has('planner')) {
-    try {
-      subResults.push(await runPlannerEval());
-    } catch (err) {
-      subResults.push({
-        name: 'planner',
-        pass: false,
-        metrics: {},
-        errors: [`Planner eval error: ${err.message}`],
-      });
-    }
+    parallel.push(
+      runPlannerEval().catch((err) => errorResult('planner', `Planner eval error: ${err.message}`))
+    );
   }
+  if (!parsed.skip.has('meta')) {
+    parallel.push(
+      runMetaValidation().catch((err) =>
+        errorResult('meta', `Meta validation error: ${err.message}`)
+      )
+    );
+  }
+
+  const [plannerResult, metaResult] = await Promise.all(parallel);
+
+  const subResults = [];
+  if (plannerResult) subResults.push(plannerResult);
 
   if (!parsed.skip.has('fixtures')) {
     try {
       subResults.push(await runFixturesEval());
     } catch (err) {
-      subResults.push({
-        name: 'fixtures',
-        pass: false,
-        metrics: {},
-        errors: [`Fixtures eval error: ${err.message}`],
-      });
+      subResults.push(errorResult('fixtures', `Fixtures eval error: ${err.message}`));
     }
   }
 
   if (!parsed.skip.has('gate') && parsed.gateInput) {
     const resolvedGateInput = path.resolve(parsed.gateInput);
     if (!fs.existsSync(resolvedGateInput)) {
-      subResults.push({
-        name: 'gate',
-        pass: false,
-        metrics: {},
-        errors: [`Gate input file not found: ${parsed.gateInput}`],
-      });
+      subResults.push(errorResult('gate', `Gate input file not found: ${parsed.gateInput}`));
     } else {
       try {
         subResults.push(await runGateEval(resolvedGateInput));
       } catch (err) {
-        subResults.push({
-          name: 'gate',
-          pass: false,
-          metrics: {},
-          errors: [`Gate eval error: ${err.message}`],
-        });
+        subResults.push(errorResult('gate', `Gate eval error: ${err.message}`));
       }
     }
   } else if (!parsed.skip.has('gate') && !parsed.gateInput) {
-    subResults.push({
-      name: 'gate',
-      pass: true,
-      metrics: {},
-      errors: [],
-      skipped: true,
-    });
+    subResults.push(skipResult('gate'));
   }
 
-  if (!parsed.skip.has('meta')) {
-    try {
-      subResults.push(await runMetaValidation());
-    } catch (err) {
-      subResults.push({
-        name: 'meta',
-        pass: false,
-        metrics: {},
-        errors: [`Meta validation error: ${err.message}`],
-      });
-    }
-  }
+  if (metaResult) subResults.push(metaResult);
 
   // Build envelope
-  const allPass = subResults.every((r) => r.pass);
   const scores = {};
   for (const r of subResults) {
     for (const [k, v] of Object.entries(r.metrics)) {
@@ -281,7 +264,7 @@ Options:
         pass: r.pass,
         errors: r.errors,
       })),
-    status: allPass ? 'pass' : 'fail',
+    status: subResults.every((r) => r.pass) ? 'pass' : 'fail',
     description: parsed.description || undefined,
   };
 
@@ -320,7 +303,7 @@ Options:
     }
   }
 
-  return allPass ? 0 : 1;
+  return envelope.status === 'pass' ? 0 : 1;
 }
 
 export { main as evaluateAll, parseArgs, appendLedger };

--- a/scripts/evaluate-all.mjs
+++ b/scripts/evaluate-all.mjs
@@ -27,6 +27,12 @@ import url from 'node:url';
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const ROOT = path.join(__dirname, '..');
 
+/** Minimum planner coverage to pass. Conservative initial baseline. */
+const PLANNER_COVERAGE_THRESHOLD = 0.5;
+
+/** Metric keys that represent 0-1 ratios (displayed as percentages). */
+const RATIO_METRICS = new Set(['exactMatch', 'top1Match', 'coverage', 'mrr']);
+
 // --- arg parsing -----------------------------------------------------------
 
 function parseArgs(argv) {
@@ -96,7 +102,7 @@ async function runPlannerEval() {
 
   return {
     name: 'planner',
-    pass: summary.coverage >= 0.5,
+    pass: summary.coverage >= PLANNER_COVERAGE_THRESHOLD,
     metrics: {
       exactMatch: summary.exactMatch,
       top1Match: summary.top1Match,
@@ -164,6 +170,7 @@ function appendLedger(entry) {
 
 async function main() {
   const parsed = parseArgs(process.argv.slice(2));
+  const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf-8'));
 
   if (parsed.help) {
     console.log(`Usage: node scripts/evaluate-all.mjs [options]
@@ -208,16 +215,34 @@ Options:
   }
 
   if (!parsed.skip.has('gate') && parsed.gateInput) {
-    try {
-      subResults.push(await runGateEval(path.resolve(parsed.gateInput)));
-    } catch (err) {
+    const resolvedGateInput = path.resolve(parsed.gateInput);
+    if (!fs.existsSync(resolvedGateInput)) {
       subResults.push({
         name: 'gate',
         pass: false,
         metrics: {},
-        errors: [`Gate eval error: ${err.message}`],
+        errors: [`Gate input file not found: ${parsed.gateInput}`],
       });
+    } else {
+      try {
+        subResults.push(await runGateEval(resolvedGateInput));
+      } catch (err) {
+        subResults.push({
+          name: 'gate',
+          pass: false,
+          metrics: {},
+          errors: [`Gate eval error: ${err.message}`],
+        });
+      }
     }
+  } else if (!parsed.skip.has('gate') && !parsed.gateInput) {
+    subResults.push({
+      name: 'gate',
+      pass: true,
+      metrics: {},
+      errors: [],
+      skipped: true,
+    });
   }
 
   if (!parsed.skip.has('meta')) {
@@ -243,15 +268,18 @@ Options:
   }
 
   const envelope = {
+    version: pkg.version,
     timestamp: new Date().toISOString(),
     commit: gitCommit(),
     branch: gitBranch(),
     scores,
-    results: subResults.map((r) => ({
-      name: r.name,
-      pass: r.pass,
-      errors: r.errors,
-    })),
+    results: subResults
+      .filter((r) => !r.skipped)
+      .map((r) => ({
+        name: r.name,
+        pass: r.pass,
+        errors: r.errors,
+      })),
     status: allPass ? 'pass' : 'fail',
     description: parsed.description || undefined,
   };
@@ -265,11 +293,12 @@ Options:
     console.log(`Status: ${envelope.status.toUpperCase()}\n`);
 
     for (const r of subResults) {
-      const icon = r.pass ? 'PASS' : 'FAIL';
+      const icon = r.skipped ? 'SKIP' : r.pass ? 'PASS' : 'FAIL';
       console.log(`[${icon}] ${r.name}`);
       if (Object.keys(r.metrics).length) {
         for (const [k, v] of Object.entries(r.metrics)) {
-          const display = typeof v === 'number' && v <= 1 && v >= 0 ? `${(v * 100).toFixed(1)}%` : v;
+          const display =
+            typeof v === 'number' && RATIO_METRICS.has(k) ? `${(v * 100).toFixed(1)}%` : v;
           console.log(`       ${k}: ${display}`);
         }
       }
@@ -293,7 +322,7 @@ Options:
   return allPass ? 0 : 1;
 }
 
-export { main as evaluateAll };
+export { main as evaluateAll, parseArgs, appendLedger };
 
 const isDirectRun =
   process.argv[1] &&

--- a/scripts/evaluate-all.mjs
+++ b/scripts/evaluate-all.mjs
@@ -93,7 +93,8 @@ async function runPlannerEval() {
   const data = JSON.parse(fs.readFileSync(fixturePath, 'utf-8'));
   const cases = data.map((c) => ({
     ...c,
-    llmPlan: async () => c.llmPlan ?? c.plan ?? c.expectedOrder.map((id) => ({ id })),
+    llmPlan: async ({ skills, context }) =>
+      c.llmPlan ?? c.plan ?? c.expectedOrder.map((id) => ({ id })),
     skills: c.skills,
     context: c.context,
   }));

--- a/tests/evaluate-all.test.mjs
+++ b/tests/evaluate-all.test.mjs
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+test('evaluate-all: parseArgs handles all flags', async () => {
+  // Import the module to verify it loads without errors.
+  // The main function is exported as evaluateAll.
+  const mod = await import('../scripts/evaluate-all.mjs');
+  assert.ok(typeof mod.evaluateAll === 'function', 'evaluateAll should be exported');
+});
+
+test('evaluate-all: appendLedger creates file and appends JSONL', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rr-ledger-'));
+  const ledgerPath = path.join(tmpDir, 'results.jsonl');
+
+  const entry1 = { timestamp: '2024-01-01T00:00:00Z', status: 'pass' };
+  const entry2 = { timestamp: '2024-01-02T00:00:00Z', status: 'fail' };
+
+  fs.appendFileSync(ledgerPath, JSON.stringify(entry1) + '\n');
+  fs.appendFileSync(ledgerPath, JSON.stringify(entry2) + '\n');
+
+  const lines = fs.readFileSync(ledgerPath, 'utf8').trim().split('\n');
+  assert.equal(lines.length, 2);
+  assert.deepEqual(JSON.parse(lines[0]), entry1);
+  assert.deepEqual(JSON.parse(lines[1]), entry2);
+
+  fs.rmSync(tmpDir, { recursive: true });
+});
+
+test('evaluate-all: envelope structure is valid', () => {
+  // Simulate building an envelope from sub-results
+  const subResults = [
+    { name: 'planner', pass: true, metrics: { coverage: 0.85 }, errors: [] },
+    { name: 'meta', pass: true, metrics: { errorCount: 0 }, errors: [] },
+  ];
+
+  const allPass = subResults.every((r) => r.pass);
+  const scores = {};
+  for (const r of subResults) {
+    for (const [k, v] of Object.entries(r.metrics)) {
+      scores[`${r.name}_${k}`] = v;
+    }
+  }
+
+  const envelope = {
+    timestamp: new Date().toISOString(),
+    commit: 'abc1234',
+    branch: 'main',
+    scores,
+    results: subResults.map((r) => ({ name: r.name, pass: r.pass, errors: r.errors })),
+    status: allPass ? 'pass' : 'fail',
+  };
+
+  assert.equal(envelope.status, 'pass');
+  assert.equal(envelope.scores.planner_coverage, 0.85);
+  assert.equal(envelope.scores.meta_errorCount, 0);
+  assert.equal(envelope.results.length, 2);
+  assert.ok(envelope.timestamp);
+});
+
+test('evaluate-all: envelope status is fail when any sub-eval fails', () => {
+  const subResults = [
+    { name: 'planner', pass: true, metrics: {}, errors: [] },
+    { name: 'fixtures', pass: false, metrics: {}, errors: ['check failed'] },
+  ];
+
+  const allPass = subResults.every((r) => r.pass);
+  const status = allPass ? 'pass' : 'fail';
+
+  assert.equal(status, 'fail');
+});

--- a/tests/evaluate-all.test.mjs
+++ b/tests/evaluate-all.test.mjs
@@ -1,73 +1,82 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
+import url from 'node:url';
 
-test('evaluate-all: parseArgs handles all flags', async () => {
-  // Import the module to verify it loads without errors.
-  // The main function is exported as evaluateAll.
-  const mod = await import('../scripts/evaluate-all.mjs');
-  assert.ok(typeof mod.evaluateAll === 'function', 'evaluateAll should be exported');
+import { appendLedger, evaluateAll, parseArgs } from '../scripts/evaluate-all.mjs';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const ROOT = path.join(__dirname, '..');
+
+test('exports: evaluateAll, parseArgs, appendLedger are functions', () => {
+  assert.equal(typeof evaluateAll, 'function');
+  assert.equal(typeof parseArgs, 'function');
+  assert.equal(typeof appendLedger, 'function');
 });
 
-test('evaluate-all: appendLedger creates file and appends JSONL', () => {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rr-ledger-'));
-  const ledgerPath = path.join(tmpDir, 'results.jsonl');
-
-  const entry1 = { timestamp: '2024-01-01T00:00:00Z', status: 'pass' };
-  const entry2 = { timestamp: '2024-01-02T00:00:00Z', status: 'fail' };
-
-  fs.appendFileSync(ledgerPath, JSON.stringify(entry1) + '\n');
-  fs.appendFileSync(ledgerPath, JSON.stringify(entry2) + '\n');
-
-  const lines = fs.readFileSync(ledgerPath, 'utf8').trim().split('\n');
-  assert.equal(lines.length, 2);
-  assert.deepEqual(JSON.parse(lines[0]), entry1);
-  assert.deepEqual(JSON.parse(lines[1]), entry2);
-
-  fs.rmSync(tmpDir, { recursive: true });
+test('parseArgs: defaults', () => {
+  const result = parseArgs([]);
+  assert.equal(result.gateInput, null);
+  assert.equal(result.appendLedger, false);
+  assert.equal(result.description, '');
+  assert.equal(result.json, false);
+  assert.equal(result.help, false);
+  assert.equal(result.skip.size, 0);
 });
 
-test('evaluate-all: envelope structure is valid', () => {
-  // Simulate building an envelope from sub-results
-  const subResults = [
-    { name: 'planner', pass: true, metrics: { coverage: 0.85 }, errors: [] },
-    { name: 'meta', pass: true, metrics: { errorCount: 0 }, errors: [] },
-  ];
+test('parseArgs: --skip collects multiple values', () => {
+  const result = parseArgs(['--skip', 'planner', '--skip', 'gate']);
+  assert.ok(result.skip.has('planner'));
+  assert.ok(result.skip.has('gate'));
+  assert.equal(result.skip.size, 2);
+});
 
-  const allPass = subResults.every((r) => r.pass);
-  const scores = {};
-  for (const r of subResults) {
-    for (const [k, v] of Object.entries(r.metrics)) {
-      scores[`${r.name}_${k}`] = v;
-    }
+test('parseArgs: all flags combined', () => {
+  const result = parseArgs([
+    '--gate-input',
+    '/tmp/out.json',
+    '--append-ledger',
+    '--description',
+    'test run',
+    '--json',
+    '--skip',
+    'meta',
+  ]);
+  assert.equal(result.gateInput, '/tmp/out.json');
+  assert.equal(result.appendLedger, true);
+  assert.equal(result.description, 'test run');
+  assert.equal(result.json, true);
+  assert.ok(result.skip.has('meta'));
+});
+
+test('parseArgs: -h sets help', () => {
+  assert.ok(parseArgs(['-h']).help);
+});
+
+test('parseArgs: --help sets help', () => {
+  assert.ok(parseArgs(['--help']).help);
+});
+
+test('parseArgs: unknown flags are ignored', () => {
+  const result = parseArgs(['--unknown', 'value']);
+  assert.equal(result.help, false);
+  assert.equal(result.gateInput, null);
+});
+
+test('appendLedger: writes valid JSONL entry', () => {
+  const ledgerPath = path.join(ROOT, 'artifacts', 'evals', 'results.jsonl');
+  const before = fs.existsSync(ledgerPath) ? fs.readFileSync(ledgerPath, 'utf8') : '';
+
+  try {
+    const marker = `__test_${Date.now()}`;
+    appendLedger({ marker, timestamp: new Date().toISOString() });
+
+    const content = fs.readFileSync(ledgerPath, 'utf8');
+    const lastLine = content.trim().split('\n').pop();
+    const parsed = JSON.parse(lastLine);
+    assert.equal(parsed.marker, marker);
+  } finally {
+    fs.writeFileSync(ledgerPath, before);
   }
-
-  const envelope = {
-    timestamp: new Date().toISOString(),
-    commit: 'abc1234',
-    branch: 'main',
-    scores,
-    results: subResults.map((r) => ({ name: r.name, pass: r.pass, errors: r.errors })),
-    status: allPass ? 'pass' : 'fail',
-  };
-
-  assert.equal(envelope.status, 'pass');
-  assert.equal(envelope.scores.planner_coverage, 0.85);
-  assert.equal(envelope.scores.meta_errorCount, 0);
-  assert.equal(envelope.results.length, 2);
-  assert.ok(envelope.timestamp);
-});
-
-test('evaluate-all: envelope status is fail when any sub-eval fails', () => {
-  const subResults = [
-    { name: 'planner', pass: true, metrics: {}, errors: [] },
-    { name: 'fixtures', pass: false, metrics: {}, errors: ['check failed'] },
-  ];
-
-  const allPass = subResults.every((r) => r.pass);
-  const status = allPass ? 'pass' : 'fail';
-
-  assert.equal(status, 'fail');
 });


### PR DESCRIPTION
## Summary

- `npm run eval:all` を追加 — planner:eval, eval:fixtures, severity gate, meta-consistency を一括実行する統合 eval runner
- `artifacts/evals/` ディレクトリを追加 — 実験結果を `results.jsonl` (JSONL) に記録する ledger の基盤
- `--append-ledger` フラグで baseline/candidate 比較データを蓄積可能
- `--json`, `--skip <name>`, `--gate-input <path>` 等のオプションに対応

### 背景

[Evaluation-Driven Reviewer Improvement Loop 導入計画](https://github.com/s977043/river-reviewer/blob/feat/eval-unified-runner-and-ledger/.claude/plans/enchanted-petting-finch.md) の PR-1。autoagent の evaluation loop を参考に、River Reviewer の改善を感覚ベースから evaluation-driven に移行するための最小基盤。

### 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `scripts/evaluate-all.mjs` | 統合 eval runner (新規) |
| `tests/evaluate-all.test.mjs` | テスト 4 件 (新規) |
| `artifacts/evals/.gitkeep` | ledger ディレクトリ (新規) |
| `package.json` | `eval:all` スクリプト追加 |
| `.gitignore` | `artifacts/evals/.gitkeep` を追跡対象に |

## Test plan

- [ ] `node --test tests/evaluate-all.test.mjs` が 4/4 pass
- [ ] `npm run eval:all -- --skip fixtures --skip gate` で planner + meta が実行される
- [ ] `npm run eval:all -- --skip fixtures --skip gate --json` で JSON envelope が出力される
- [ ] `npm run eval:all -- --skip fixtures --skip gate --append-ledger` で `artifacts/evals/results.jsonl` にエントリ追記
- [ ] `npm run format:check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)