### PR TITLE
fix(docs): deduplicate AGENT_LEARNINGS.md and fix broken GEMINI.md reference

### DIFF
--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -27,4 +27,4 @@
   - `Evidence`: `src/lib/utils.mjs`, `src/lib/local-runner.mjs`, `src/core/skill-dispatcher.mjs`.
 - `2026-04-03`: Use Git Worktrees for parallel agent tasks. Setup and teardown steps are documented in `docs/runbook/dev.md` § 並行タスク。
   - `Applies to`: concurrent branch work and multi-agent workflows.
-  - `Evidence`: `docs/runbook/dev.md` lines 32-45.
+  - `Evidence`: `docs/runbook/dev.md`「並行タスク（Git Worktree）」セクション。

--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -11,6 +11,8 @@
 - Capture one learning per bullet with enough context to reuse it.
 - Record secrets, personal data, transient debugging notes, and branch-specific TODOs nowhere in this file.
 - Prefer facts that change slowly: command shapes, package boundaries, validation rules, source-of-truth files, and recurring pitfalls.
+- Do not duplicate facts already stated in `AGENTS.md`. Only record what is not obvious from the canonical instructions.
+- Remove or update entries when the underlying fact changes. Review during major refactors.
 
 ## Entry Format
 
@@ -20,12 +22,9 @@
 
 ## Current Learnings
 
-- `2026-04-03`: `README.md` is the Japanese source of truth, and `README.en.md` is best effort only.
-  - `Applies to`: docs updates, content parity checks, and agent instructions.
-  - `Evidence`: repository README files and existing project guidance.
-- `2026-04-03`: The root package uses `npm`; validation is `npm run lint` and `npm test`, while the root has no `typecheck` script.
-  - `Applies to`: routine verification and agent planning.
-  - `Evidence`: root `package.json`.
-- `2026-04-03`: `runners/node-api/` is a separate TypeScript package and its compile check is `npm run build` (`tsc`) inside that directory.
-  - `Applies to`: changes to the Node API runner or its published types.
-  - `Evidence`: `runners/node-api/package.json`.
+- `2026-04-03`: LLM feature guards use `isLlmEnabled()` from `src/lib/utils.mjs`. It checks both OpenAI (`OPENAI_API_KEY`, `RIVER_OPENAI_API_KEY`) and Google Gemini (`GOOGLE_API_KEY`) keys.
+  - `Applies to`: any code that conditionally enables LLM-powered features.
+  - `Evidence`: `src/lib/utils.mjs`, `src/lib/local-runner.mjs`, `src/core/skill-dispatcher.mjs`.
+- `2026-04-03`: Use Git Worktrees for parallel agent tasks. Setup and teardown steps are documented in `docs/runbook/dev.md` § 並行タスク。
+  - `Applies to`: concurrent branch work and multi-agent workflows.
+  - `Evidence`: `docs/runbook/dev.md` lines 32-45.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -18,6 +18,6 @@
 
 ### Development Tips
 
-開発上のヒントについては、[AGENTS.md](./AGENTS.md) の「9. AI実装メモ」を参照してください。
+開発上のヒントについては、[AGENTS.md](./AGENTS.md) の「Local References」セクションと [AGENT_LEARNINGS.md](./AGENT_LEARNINGS.md) を参照してください。
 
 > ルール変更や運用メモは `AGENTS.md` に集約し、このファイルは最小限に保ってください。


### PR DESCRIPTION
## Summary

- **AGENT_LEARNINGS.md**: 3つのシードエントリが `AGENTS.md` の内容と完全重複していたため、真に追加価値のある学び（`isLlmEnabled()` ユーティリティ、Git Worktree ワークフロー）に置き換え
- **AGENT_LEARNINGS.md**: 重複禁止ルールと陳腐化時の削除・更新ルールを Write Rules に追加
- **GEMINI.md**: 削除済みセクション「9. AI実装メモ」への壊れた参照を「Local References」セクションと `AGENT_LEARNINGS.md` への参照に修正

## Motivation

PR #410 で `AGENTS.md` を簡素化した際に:
1. `AGENT_LEARNINGS.md` のシードエントリが `AGENTS.md` と同じ事実を繰り返しており、エージェントのコンテキストウィンドウのトークンを無駄にしていた
2. 旧AGENTS.mdの「9. AI実装メモ」に記載されていた `isLlmEnabled()` と Git Worktree の知見が失われていた
3. `GEMINI.md` のクロスリファレンスが壊れたまま残っていた

## Test plan

- [x] `npm run lint` パス
- [x] `npm test` 全177テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)