### PR TITLE
docs: add keep/discard policy and eval-driven improvement ADR

### DIFF
--- a/docs/adr/001-eval-driven-improvement-loop.md
+++ b/docs/adr/001-eval-driven-improvement-loop.md
@@ -1,0 +1,55 @@
+# ADR-001: Evaluation-Driven Reviewer Improvement Loop を導入する
+
+## Status
+
+Accepted
+
+## Context
+
+River Reviewer は phase-aware な review framework として、Upstream / Midstream / Downstream の流れ、schema-driven な skill 管理、evidence-based なフィードバックを重視している。現在の repo には planner:eval、eval:fixtures、agent-skills:validate、Agent Skills runtime loading、SKILL.md bridge、routing skills、review severity gate evaluator、meta-consistency validation が存在し、改善のための構成要素は揃っている。
+
+一方で、改善の採否を一貫して記録し、baseline と比較し、keep/discard を判断する統一ループはまだ前面化されていない。[autoagent](https://github.com/kevinrgu/autoagent) は baseline-first、ledger、failure grouping、specialized tools、verification sub-agent、keep/discard rule を明示しており、この運用原理は River Reviewer の改善プロセスに転用できる。
+
+## Decision
+
+River Reviewer に、production runtime の自己改変ではなく、review framework 自体の改善運用としての Evaluation-Driven Improvement Loop を導入する。
+
+導入範囲:
+
+1. planner:eval / eval:fixtures / severity / meta-consistency を束ねる統合 eval runner（`npm run eval:all`）
+2. 実験 ledger（`artifacts/evals/results.jsonl`）
+3. failure taxonomy（eval 結果の構造化分類）
+4. reviewer → verifier の二段構成
+5. Riverbed Memory v1 への接続点となる artifact 出力
+
+## Non-Goals
+
+- production reviewer の自律自己改変
+- single-file harness 化
+- passed だけを最適化する単一指標運用
+- phase / schema / evidence-based 原則の弱体化
+
+## Consequences
+
+### Positive
+
+- 改善の採否が説明可能になる
+- false positive と evidence 欠落を系統的に減らせる
+- Riverbed Memory v1 に接続しやすくなる
+- skill 改善と tool 改善を分けて議論できる
+
+### Negative
+
+- eval 運用コストが増える
+- fixture 整備が先に必要になる
+- 指標設計を誤ると局所最適化が起きる
+
+## Rollout Plan
+
+1. 統合 eval runner + ledger（PR-1: merged）
+2. 構造化 eval 結果 + multi-axis metrics（PR-2）
+3. keep/discard policy（PR-3: this document）
+4. failure taxonomy（PR-4）
+5. verifier layer（PR-5）
+6. reviewer-specific tools（PR-6+）
+7. Riverbed Memory v1（PR-9-10）

--- a/pages/reference/_meta.json
+++ b/pages/reference/_meta.json
@@ -11,5 +11,6 @@
   "stable-interfaces": "安定インターフェース（CLI / GitHub Actions）",
   "runner-cli-reference": "Runner CLI リファレンス",
   "evaluation-fixture-format": "評価フィクスチャ形式",
-  "glossary": "用語集"
+  "glossary": "用語集",
+  "eval-keep-discard-policy": "評価ベースの採否基準"
 }

--- a/pages/reference/eval-keep-discard-policy.md
+++ b/pages/reference/eval-keep-discard-policy.md
@@ -1,0 +1,61 @@
+---
+sidebar_label: 評価ベースの採否基準
+---
+
+# 評価ベースの採否基準（Keep/Discard Policy）
+
+## 概要
+
+River Reviewer の skill / planner / routing / output policy の変更は、必ず評価結果に基づいて採否を判断する。「改善したつもり」を排除し、ledger に記録された baseline と candidate の比較で意思決定する。
+
+## 評価指標
+
+| 指標 | 説明 | 計測元 |
+|---|---|---|
+| planner coverage | 期待スキルが選択される割合 | `npm run planner:eval` |
+| planner top1Match | 最優先スキルの一致率 | `npm run planner:eval` |
+| must_include recall | fixture で期待トークンが出力に含まれる割合 | `npm run eval:fixtures` |
+| false positive rate | guard case (expectNoFindings) で誤検出した割合 | `npm run eval:fixtures` |
+| evidence attachment rate | findings に `Evidence:` が含まれる割合 | `npm run eval:fixtures` |
+| severity consistency | severity が rubric と整合する割合 | 将来追加 |
+| meta consistency | version/tag の整合性 | `npm run meta:validate` |
+
+## 採否ルール
+
+### Keep（採用）する条件
+
+以下のいずれかを満たす場合、変更を keep とする:
+
+1. **must_include recall が改善**し、他の指標が悪化していない
+2. **recall が同等**で、false positive rate が減少
+3. **recall が同等**で、実装が単純化されている（行数削減、依存削減）
+4. **planner coverage が改善**し、他の指標が悪化していない
+
+### Discard（棄却）する条件
+
+以下のいずれかに該当する場合、変更を discard とする:
+
+1. **evidence_rate が悪化**（根拠なき指摘の増加）
+2. **planner coverage が 5% を超えて低下**
+3. **must_include recall が低下**
+4. **npm test または npm run lint が失敗**
+5. **crash（実行時エラー）が発生**
+
+### 判断が分かれる場合
+
+- 複数の指標が相反する場合は、**evidence_rate > recall > false_positive_rate** の優先順で判断する
+- 小規模な変動（±2% 以内）は統計的に有意でない可能性があるため、2 回以上の実行で確認する
+
+## 運用手順
+
+1. 変更前に `npm run eval:all -- --append-ledger --description "baseline"` を実行
+2. 変更を実施
+3. 変更後に `npm run eval:all -- --append-ledger --description "candidate: <変更内容>"` を実行
+4. `artifacts/evals/results.jsonl` の直近 2 エントリを比較
+5. 上記ルールに基づいて keep/discard を判断
+6. PR に判断根拠を記載
+
+## 参考
+
+- [autoagent](https://github.com/kevinrgu/autoagent) の keep/discard ルールを River Reviewer 向けに翻訳
+- 単一指標（passed count）の最適化ではなく、多軸評価を採用


### PR DESCRIPTION
## Summary
- `pages/reference/eval-keep-discard-policy.md` — 評価ベースの採否基準を明文化
- `docs/adr/001-eval-driven-improvement-loop.md` — ADR-001: Evaluation-Driven Improvement Loop

## Test plan
- [ ] `npm run lint:md` pass
- [ ] `npm run build` pass (Docusaurus)
- [ ] Keep/discard ルールが明確で、PR テンプレートからリンク可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)