### PR TITLE
feat(eval): structured fixture results and multi-axis metrics

### DIFF
--- a/scripts/evaluate-all.mjs
+++ b/scripts/evaluate-all.mjs
@@ -31,7 +31,15 @@ const ROOT = path.join(__dirname, '..');
 const PLANNER_COVERAGE_THRESHOLD = 0.5;
 
 /** Metric keys that represent 0-1 ratios (displayed as percentages). */
-const RATIO_METRICS = new Set(['exactMatch', 'top1Match', 'coverage', 'mrr']);
+const RATIO_METRICS = new Set([
+  'exactMatch',
+  'top1Match',
+  'coverage',
+  'mrr',
+  'passRate',
+  'falsePositiveRate',
+  'evidenceRate',
+]);
 
 // --- arg parsing -----------------------------------------------------------
 
@@ -129,14 +137,18 @@ async function runFixturesEval() {
   const { evaluateReviewFixtures } = await import('../src/lib/review-fixtures-eval.mjs');
   const casesPath = path.join(ROOT, 'tests', 'fixtures', 'review-eval', 'cases.json');
 
-  const exitCode = await evaluateReviewFixtures({ casesPath, verbose: false });
+  const result = await evaluateReviewFixtures({ casesPath, verbose: false });
 
   return {
     name: 'fixtures',
-    pass: exitCode === 0,
+    pass: result.exitCode === 0,
     skipped: false,
-    metrics: { exitCode },
-    errors: exitCode === 0 ? [] : ['One or more fixture checks failed'],
+    metrics: {
+      passRate: result.summary.passRate,
+      falsePositiveRate: result.summary.falsePositiveRate,
+      evidenceRate: result.summary.evidenceRate,
+    },
+    errors: result.exitCode === 0 ? [] : ['One or more fixture checks failed'],
   };
 }
 

--- a/src/lib/review-fixtures-eval.mjs
+++ b/src/lib/review-fixtures-eval.mjs
@@ -24,6 +24,26 @@ function expect(condition, name, message) {
  *   phase?: string | null
  *   verbose?: boolean
  * }} options
+ * @returns {Promise<{
+ *   exitCode: number,
+ *   cases: Array<{
+ *     name: string,
+ *     pass: boolean,
+ *     findingCount: number,
+ *     mustIncludeHits: string[],
+ *     mustIncludeMisses: string[],
+ *     isGuardCase: boolean,
+ *     guardViolated: boolean,
+ *   }>,
+ *   summary: {
+ *     total: number,
+ *     passed: number,
+ *     failed: number,
+ *     passRate: number,
+ *     falsePositiveRate: number,
+ *     evidenceRate: number,
+ *   }
+ * }>}
  */
 export async function evaluateReviewFixtures({ casesPath, phase = null, verbose = false }) {
   const resolvedCasesPath = path.resolve(casesPath);
@@ -31,6 +51,12 @@ export async function evaluateReviewFixtures({ casesPath, phase = null, verbose 
   const cases = JSON.parse(fs.readFileSync(resolvedCasesPath, 'utf8'));
 
   const failures = [];
+  const caseResults = [];
+  let guardCaseCount = 0;
+  let falsePositiveCount = 0;
+  let totalFindingCount = 0;
+  let evidenceHitCount = 0;
+
   for (const c of cases) {
     const name = c.name ?? '(unnamed case)';
     const diffPath = path.resolve(fixturesDir, c.diffFile);
@@ -56,8 +82,30 @@ export async function evaluateReviewFixtures({ casesPath, phase = null, verbose 
 
     const merged = result.comments.map(x => x.message).join('\n');
     const expectNoFindings = Boolean(c.expectNoFindings);
+    const isGuardCase = expectNoFindings;
     const minFindings = Number.isFinite(c.minFindings) ? c.minFindings : expectNoFindings ? 0 : 1;
     const maxFindings = Number.isFinite(c.maxFindings) ? c.maxFindings : null;
+
+    // Track guard case metrics
+    if (isGuardCase) {
+      guardCaseCount++;
+      if (result.comments.length > 0) {
+        falsePositiveCount++;
+      }
+    }
+
+    // Track evidence metrics across all findings
+    totalFindingCount += result.comments.length;
+    for (const comment of result.comments) {
+      if (comment.message.includes('Evidence:')) {
+        evidenceHitCount++;
+      }
+    }
+
+    // Track mustInclude hits and misses
+    const mustIncludeTokens = c.mustInclude ?? [];
+    const mustIncludeHits = mustIncludeTokens.filter(token => merged.includes(token));
+    const mustIncludeMisses = mustIncludeTokens.filter(token => !merged.includes(token));
 
     const checks = [
       expect(
@@ -75,12 +123,23 @@ export async function evaluateReviewFixtures({ casesPath, phase = null, verbose 
         : expect(result.comments.length <= maxFindings, name, `too many findings: ${result.comments.length}`),
     ].filter(Boolean);
 
-    for (const token of c.mustInclude ?? []) {
+    for (const token of mustIncludeTokens) {
       checks.push(expect(merged.includes(token), name, `missing token: ${token}`));
     }
 
     const caseFailures = checks.filter(Boolean);
+    const casePassed = caseFailures.length === 0;
     failures.push(...caseFailures);
+
+    caseResults.push({
+      name,
+      pass: casePassed,
+      findingCount: result.comments.length,
+      mustIncludeHits,
+      mustIncludeMisses,
+      isGuardCase,
+      guardViolated: isGuardCase && result.comments.length > 0,
+    });
 
     if (verbose) {
       console.log(caseFailures.length ? formatFailure(name, `${caseFailures.length} checks failed`) : formatSuccess(name));
@@ -92,11 +151,24 @@ export async function evaluateReviewFixtures({ casesPath, phase = null, verbose 
     }
   }
 
+  const failedCaseCount = caseResults.filter(r => !r.pass).length;
+
   if (failures.length) {
     console.error(`\n${failures.length} fixture checks failed.`);
-    return 1;
+  } else {
+    console.log('\nAll review fixtures passed.');
   }
 
-  console.log('\nAll review fixtures passed.');
-  return 0;
+  return {
+    exitCode: failures.length ? 1 : 0,
+    cases: caseResults,
+    summary: {
+      total: cases.length,
+      passed: cases.length - failedCaseCount,
+      failed: failedCaseCount,
+      passRate: cases.length > 0 ? (cases.length - failedCaseCount) / cases.length : 0,
+      falsePositiveRate: guardCaseCount > 0 ? falsePositiveCount / guardCaseCount : 0,
+      evidenceRate: totalFindingCount > 0 ? evidenceHitCount / totalFindingCount : 0,
+    },
+  };
 }

--- a/tests/review-eval.test.mjs
+++ b/tests/review-eval.test.mjs
@@ -6,6 +6,7 @@ import url from 'node:url';
 
 import { parseUnifiedDiff } from '../src/lib/diff.mjs';
 import { generateReview } from '../src/lib/review-engine.mjs';
+import { evaluateReviewFixtures } from '../src/lib/review-fixtures-eval.mjs';
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
@@ -52,4 +53,63 @@ test('review eval fixtures keep must-include signals (heuristic path)', async ()
       assert.ok(merged.includes(token), `[${c.name}] missing token: ${token}`);
     }
   }
+});
+
+test('evaluateReviewFixtures returns structured result with exitCode, cases, and summary', async () => {
+  const casesPath = path.join(__dirname, 'fixtures', 'review-eval', 'cases.json');
+  const result = await evaluateReviewFixtures({ casesPath, verbose: false });
+
+  // Top-level shape
+  assert.equal(typeof result, 'object', 'result should be an object');
+  assert.equal(typeof result.exitCode, 'number', 'exitCode should be a number');
+  assert.ok(Array.isArray(result.cases), 'cases should be an array');
+  assert.equal(typeof result.summary, 'object', 'summary should be an object');
+
+  // Backward compatibility: exitCode is 0 or 1
+  assert.ok(result.exitCode === 0 || result.exitCode === 1, 'exitCode should be 0 or 1');
+
+  // Summary fields
+  assert.equal(typeof result.summary.total, 'number');
+  assert.equal(typeof result.summary.passed, 'number');
+  assert.equal(typeof result.summary.failed, 'number');
+  assert.equal(typeof result.summary.passRate, 'number');
+  assert.equal(typeof result.summary.falsePositiveRate, 'number');
+  assert.equal(typeof result.summary.evidenceRate, 'number');
+
+  // passRate is between 0 and 1
+  assert.ok(result.summary.passRate >= 0 && result.summary.passRate <= 1, 'passRate should be 0-1');
+  assert.ok(
+    result.summary.falsePositiveRate >= 0 && result.summary.falsePositiveRate <= 1,
+    'falsePositiveRate should be 0-1',
+  );
+  assert.ok(result.summary.evidenceRate >= 0 && result.summary.evidenceRate <= 1, 'evidenceRate should be 0-1');
+
+  // total = passed + failed
+  assert.equal(result.summary.total, result.summary.passed + result.summary.failed);
+
+  // cases array matches total
+  assert.equal(result.cases.length, result.summary.total, 'cases length should match summary total');
+});
+
+test('evaluateReviewFixtures case results have correct shape', async () => {
+  const casesPath = path.join(__dirname, 'fixtures', 'review-eval', 'cases.json');
+  const result = await evaluateReviewFixtures({ casesPath, verbose: false });
+
+  for (const c of result.cases) {
+    assert.equal(typeof c.name, 'string', 'case name should be a string');
+    assert.equal(typeof c.pass, 'boolean', 'case pass should be a boolean');
+    assert.equal(typeof c.findingCount, 'number', 'findingCount should be a number');
+    assert.ok(Array.isArray(c.mustIncludeHits), 'mustIncludeHits should be an array');
+    assert.ok(Array.isArray(c.mustIncludeMisses), 'mustIncludeMisses should be an array');
+    assert.equal(typeof c.isGuardCase, 'boolean', 'isGuardCase should be a boolean');
+    assert.equal(typeof c.guardViolated, 'boolean', 'guardViolated should be a boolean');
+  }
+
+  // Guard cases should exist (we know the fixture data has some)
+  const guardCases = result.cases.filter(c => c.isGuardCase);
+  assert.ok(guardCases.length > 0, 'should have at least one guard case');
+
+  // Non-guard cases should exist too
+  const nonGuardCases = result.cases.filter(c => !c.isGuardCase);
+  assert.ok(nonGuardCases.length > 0, 'should have at least one non-guard case');
 });


### PR DESCRIPTION
## Summary
- **`evaluateReviewFixtures`** now returns a structured object (`{ exitCode, cases, summary }`) instead of just an exit code, while preserving backward-compatible console output
- Each case result includes `name`, `pass`, `findingCount`, `mustIncludeHits`, `mustIncludeMisses`, `isGuardCase`, and `guardViolated`
- `summary` provides multi-axis metrics: `passRate`, `falsePositiveRate` (guard cases that incorrectly produced findings), and `evidenceRate` (findings containing `Evidence:`)
- **`evaluate-all.mjs`** updated to consume structured return value and expose `passRate`, `falsePositiveRate`, `evidenceRate` as percentage metrics
- New tests verify structured return shape, field types, and backward compatibility

## Test plan
- [x] `node --test tests/review-eval.test.mjs` passes (3 tests including 2 new)
- [x] `node --test tests/evaluate-all.test.mjs` passes (8 tests)
- [x] `npm test` passes (183 tests)
- [x] `npm run lint` passes
- [x] `npm run format:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)