### PR TITLE
feat(review): add rule-based finding verifier

### DIFF
--- a/src/lib/verifier.mjs
+++ b/src/lib/verifier.mjs
@@ -1,0 +1,128 @@
+/**
+ * Verify individual review findings before emission.
+ *
+ * Rule-based checks only (no LLM calls). Returns verification result
+ * with per-check details. Rejected findings should be logged but not emitted.
+ */
+
+/**
+ * Severity hierarchy for comparison (higher number = more severe).
+ * Internal vocabulary is mapped to output schema equivalents.
+ * @see .claude/rules/review-core.md for the canonical mapping
+ */
+const SEVERITY_RANK = /** @type {const} */ ({
+  info: 0,
+  minor: 1,
+  major: 2,
+  critical: 3,
+});
+
+/**
+ * Map internal vocabulary to output schema severity.
+ * blocker → critical, warning → major, nit → minor.
+ * Unknown values fall back to "major" (fail-safe per review-core.md).
+ * @param {string} raw
+ * @returns {keyof typeof SEVERITY_RANK}
+ */
+function normalizeSeverity(raw) {
+  const lower = String(raw ?? '')
+    .toLowerCase()
+    .trim();
+  if (lower === 'blocker') return 'critical';
+  if (lower === 'warning') return 'major';
+  if (lower === 'nit') return 'minor';
+  if (lower in SEVERITY_RANK) return /** @type {keyof typeof SEVERITY_RANK} */ (lower);
+  return 'major'; // fail-safe
+}
+
+/**
+ * Check that the finding message contains "Evidence:" followed by
+ * at least 5 non-whitespace characters of content.
+ * @param {{ message?: string }} finding
+ * @returns {boolean}
+ */
+function checkEvidenceExists(finding) {
+  const text = String(finding?.message ?? '');
+  const match = /Evidence:\s*(\S.{4,})/.exec(text);
+  return match !== null;
+}
+
+/**
+ * Check that the finding's phase matches the skill's declared phase.
+ * Lenient: returns true when either side is missing phase information.
+ * @param {{ phase?: string }} finding
+ * @param {{ metadata?: { phase?: string } }} skill
+ * @returns {boolean}
+ */
+function checkPhaseCoherent(finding, skill) {
+  const findingPhase = finding?.phase;
+  const skillPhase = skill?.metadata?.phase;
+  if (!findingPhase || !skillPhase) return true;
+  return findingPhase === skillPhase;
+}
+
+/**
+ * Check that the finding severity does not exceed the skill's declared
+ * severity level. Uses the internal vocabulary mapping from review-core.md.
+ * Lenient: returns true when severity cannot be determined from either side.
+ * @param {{ message?: string }} finding
+ * @param {{ metadata?: { severity?: string } }} skill
+ * @returns {boolean}
+ */
+function checkSeverityJustified(finding, skill) {
+  const text = String(finding?.message ?? '');
+  const sevMatch = /Severity:\s*(\w+)/.exec(text);
+  if (!sevMatch) return true;
+
+  const skillSeverity = skill?.metadata?.severity;
+  if (!skillSeverity) return true;
+
+  const findingNormalized = normalizeSeverity(sevMatch[1]);
+  const skillNormalized = normalizeSeverity(skillSeverity);
+
+  const findingRank = SEVERITY_RANK[findingNormalized] ?? SEVERITY_RANK.major;
+  const skillRank = SEVERITY_RANK[skillNormalized] ?? SEVERITY_RANK.major;
+
+  return findingRank <= skillRank;
+}
+
+/**
+ * Check that the finding message contains "Fix:" or "Suggestion:" followed
+ * by at least 10 characters of actionable content.
+ * @param {{ message?: string }} finding
+ * @returns {boolean}
+ */
+function checkSuggestionActionable(finding) {
+  const text = String(finding?.message ?? '');
+  const match = /(?:Fix|Suggestion):\s*(.{10,})/.exec(text);
+  return match !== null;
+}
+
+/**
+ * @param {{ finding: object, diff: string, skill: object }} params
+ * @returns {{ verified: boolean, reasons: string[], checks: object }}
+ */
+export function verifyFinding({ finding, diff, skill }) {
+  const checks = {
+    evidenceExists: checkEvidenceExists(finding),
+    phaseCoherent: checkPhaseCoherent(finding, skill),
+    severityJustified: checkSeverityJustified(finding, skill),
+    suggestionActionable: checkSuggestionActionable(finding),
+  };
+
+  const reasons = [];
+  if (!checks.evidenceExists) reasons.push('No evidence provided in finding');
+  if (!checks.phaseCoherent)
+    reasons.push(
+      `Phase mismatch: finding phase does not match skill phase "${skill?.metadata?.phase}"`
+    );
+  if (!checks.severityJustified)
+    reasons.push('Severity exceeds skill severity without justification');
+  if (!checks.suggestionActionable) reasons.push('Fix/suggestion is missing or too brief');
+
+  return {
+    verified: reasons.length === 0,
+    reasons,
+    checks,
+  };
+}

--- a/tests/verifier.test.mjs
+++ b/tests/verifier.test.mjs
@@ -1,0 +1,168 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { verifyFinding } from '../src/lib/verifier.mjs';
+
+test('verifyFinding: passes for well-formed finding', () => {
+  const result = verifyFinding({
+    finding: {
+      message:
+        'Finding:\nEvidence: The diff shows X\nSeverity: warning\nConfidence: high\nFix: Use Y instead of Z for better performance',
+    },
+    diff: '...',
+    skill: { metadata: { phase: 'midstream', severity: 'major' } },
+  });
+  assert.ok(result.verified);
+  assert.equal(result.reasons.length, 0);
+});
+
+test('verifyFinding: rejects finding without evidence', () => {
+  const result = verifyFinding({
+    finding: {
+      message: 'Finding:\nSeverity: warning\nFix: Do something about this',
+    },
+    diff: '...',
+    skill: { metadata: { phase: 'midstream' } },
+  });
+  assert.ok(!result.verified);
+  assert.ok(result.reasons.some((r) => r.includes('evidence')));
+  assert.equal(result.checks.evidenceExists, false);
+});
+
+test('verifyFinding: rejects finding without actionable fix', () => {
+  const result = verifyFinding({
+    finding: {
+      message: 'Finding:\nEvidence: code at line 5\nSeverity: warning\nFix: fix it',
+    },
+    diff: '...',
+    skill: { metadata: { phase: 'midstream' } },
+  });
+  assert.ok(!result.verified);
+  assert.equal(result.checks.suggestionActionable, false);
+});
+
+test('verifyFinding: accepts finding with no phase info (lenient)', () => {
+  const result = verifyFinding({
+    finding: {
+      message:
+        'Finding:\nEvidence: some evidence here\nSeverity: warning\nFix: Replace the old API call with the new versioned endpoint',
+    },
+    diff: '...',
+    skill: { metadata: {} },
+  });
+  assert.ok(result.checks.phaseCoherent);
+});
+
+test('verifyFinding: severity blocker maps to critical', () => {
+  const result = verifyFinding({
+    finding: {
+      message:
+        'Finding:\nEvidence: hardcoded secret\nSeverity: blocker\nFix: Move to environment variable and use GitHub Secrets',
+    },
+    diff: '...',
+    skill: { metadata: { phase: 'midstream', severity: 'critical' } },
+  });
+  assert.ok(result.checks.severityJustified);
+});
+
+test('verifyFinding: rejects blocker severity when skill is minor', () => {
+  const result = verifyFinding({
+    finding: {
+      message:
+        'Finding:\nEvidence: minor style issue\nSeverity: blocker\nFix: Rename the variable to follow naming convention guidelines',
+    },
+    diff: '...',
+    skill: { metadata: { phase: 'midstream', severity: 'minor' } },
+  });
+  assert.equal(result.checks.severityJustified, false);
+});
+
+test('verifyFinding: severity nit maps to minor', () => {
+  const result = verifyFinding({
+    finding: {
+      message:
+        'Finding:\nEvidence: trailing whitespace\nSeverity: nit\nFix: Remove the trailing whitespace on lines 5 and 12',
+    },
+    diff: '...',
+    skill: { metadata: { severity: 'minor' } },
+  });
+  assert.ok(result.checks.severityJustified);
+});
+
+test('verifyFinding: nit severity rejected when skill is info', () => {
+  const result = verifyFinding({
+    finding: {
+      message:
+        'Finding:\nEvidence: minor whitespace\nSeverity: nit\nFix: Clean up trailing whitespace in the file',
+    },
+    diff: '...',
+    skill: { metadata: { severity: 'info' } },
+  });
+  assert.equal(result.checks.severityJustified, false);
+});
+
+test('verifyFinding: lenient when finding has no severity', () => {
+  const result = verifyFinding({
+    finding: {
+      message:
+        'Finding:\nEvidence: some evidence here\nFix: Replace the old API call with the new versioned endpoint',
+    },
+    diff: '...',
+    skill: { metadata: { severity: 'minor' } },
+  });
+  assert.ok(result.checks.severityJustified);
+});
+
+test('verifyFinding: lenient when skill has no severity', () => {
+  const result = verifyFinding({
+    finding: {
+      message:
+        'Finding:\nEvidence: some evidence here\nSeverity: blocker\nFix: Replace the old API call with the new versioned endpoint',
+    },
+    diff: '...',
+    skill: { metadata: {} },
+  });
+  assert.ok(result.checks.severityJustified);
+});
+
+test('verifyFinding: Suggestion label is accepted as actionable', () => {
+  const result = verifyFinding({
+    finding: {
+      message:
+        'Finding:\nEvidence: duplicated logic\nSeverity: warning\nSuggestion: Extract the shared logic into a utility function',
+    },
+    diff: '...',
+    skill: { metadata: { severity: 'major' } },
+  });
+  assert.ok(result.checks.suggestionActionable);
+});
+
+test('verifyFinding: phase mismatch is rejected', () => {
+  const result = verifyFinding({
+    finding: {
+      phase: 'upstream',
+      message:
+        'Finding:\nEvidence: some evidence here\nSeverity: warning\nFix: Replace the old API call with the new versioned endpoint',
+    },
+    diff: '...',
+    skill: { metadata: { phase: 'midstream', severity: 'major' } },
+  });
+  assert.equal(result.checks.phaseCoherent, false);
+  assert.ok(result.reasons.some((r) => r.includes('Phase mismatch')));
+});
+
+test('verifyFinding: multiple failures are all reported', () => {
+  const result = verifyFinding({
+    finding: {
+      phase: 'upstream',
+      message: 'No structured labels at all',
+    },
+    diff: '...',
+    skill: { metadata: { phase: 'midstream', severity: 'minor' } },
+  });
+  assert.ok(!result.verified);
+  assert.ok(result.reasons.length >= 3);
+  assert.equal(result.checks.evidenceExists, false);
+  assert.equal(result.checks.phaseCoherent, false);
+  assert.equal(result.checks.suggestionActionable, false);
+});


### PR DESCRIPTION
## Summary
- Add `src/lib/verifier.mjs` with four rule-based checks for finding verification: evidence exists, phase coherent, severity justified, and suggestion actionable
- Add `tests/verifier.test.mjs` with 13 test cases covering all check functions, severity vocabulary mapping, lenient fallbacks, and multi-failure scenarios
- Standalone module (no changes to review-engine.mjs); integration will come in a follow-up PR

## Test plan
- [x] `node --test tests/verifier.test.mjs` — 13/13 pass
- [x] `npm test` — full suite 196/196 pass
- [x] `prettier --check` passes on both new files
- [ ] Verify CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)