### PR TITLE
feat(eval): add failure taxonomy and categorized fixture reports

### DIFF
--- a/schemas/eval-failure.schema.json
+++ b/schemas/eval-failure.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Evaluation Failure Schema",
+  "type": "object",
+  "required": ["category", "caseRef", "description"],
+  "properties": {
+    "category": {
+      "type": "string",
+      "enum": [
+        "routing_miss",
+        "phase_miss",
+        "missing_context",
+        "missing_evidence",
+        "weak_explanation",
+        "false_positive",
+        "severity_mismatch",
+        "verify_gap",
+        "tool_gap"
+      ],
+      "description": "Failure category for systematic tracking."
+    },
+    "caseRef": {
+      "type": "string",
+      "description": "Reference to the test case (e.g., fixture name)."
+    },
+    "evalType": {
+      "type": "string",
+      "enum": ["fixtures", "planner"],
+      "description": "Which evaluation produced this failure."
+    },
+    "severity": {
+      "type": "string",
+      "enum": ["info", "minor", "major", "critical"]
+    },
+    "description": {
+      "type": "string",
+      "description": "Human-readable failure description."
+    }
+  }
+}

--- a/schemas/eval-ledger-entry.schema.json
+++ b/schemas/eval-ledger-entry.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Evaluation Ledger Entry",
+  "type": "object",
+  "required": ["version", "timestamp", "commit", "branch", "scores", "results", "status"],
+  "properties": {
+    "version": { "type": "string" },
+    "timestamp": { "type": "string", "format": "date-time" },
+    "commit": { "type": "string" },
+    "branch": { "type": "string" },
+    "scores": {
+      "type": "object",
+      "additionalProperties": { "type": "number" }
+    },
+    "results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "pass"],
+        "properties": {
+          "name": { "type": "string" },
+          "pass": { "type": "boolean" },
+          "errors": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    },
+    "status": { "type": "string", "enum": ["pass", "fail"] },
+    "description": { "type": "string" },
+    "failures": {
+      "type": "array",
+      "items": { "$ref": "eval-failure.schema.json" }
+    }
+  }
+}

--- a/scripts/evaluate-all.mjs
+++ b/scripts/evaluate-all.mjs
@@ -149,6 +149,7 @@ async function runFixturesEval() {
       evidenceRate: result.summary.evidenceRate,
     },
     errors: result.exitCode === 0 ? [] : ['One or more fixture checks failed'],
+    failuresByCategory: result.summary.failuresByCategory ?? {},
   };
 }
 
@@ -301,6 +302,13 @@ Options:
       if (r.errors.length) {
         for (const e of r.errors) {
           console.log(`       ! ${e}`);
+        }
+      }
+      if (r.failuresByCategory && Object.keys(r.failuresByCategory).length) {
+        const cats = Object.entries(r.failuresByCategory).sort(([, a], [, b]) => b - a);
+        console.log('       top failures:');
+        for (const [cat, count] of cats.slice(0, 3)) {
+          console.log(`         ${cat}: ${count}`);
         }
       }
     }

--- a/src/lib/review-fixtures-eval.mjs
+++ b/src/lib/review-fixtures-eval.mjs
@@ -18,6 +18,45 @@ function expect(condition, name, message) {
 }
 
 /**
+ * Categorize a fixture failure based on the check context.
+ * @param {{ token?: string, isGuardCase?: boolean, findingCount?: number, minFindings?: number, maxFindings?: number | null }} ctx
+ * @returns {{ category: string, description: string }}
+ */
+function categorizeFailure(ctx) {
+  // Guard case produced findings → false positive
+  if (ctx.isGuardCase && ctx.findingCount > 0) {
+    return { category: 'false_positive', description: 'guard case produced findings' };
+  }
+
+  // No findings when some were expected → routing miss
+  if (ctx.findingCount === 0 && ctx.minFindings > 0) {
+    return {
+      category: 'routing_miss',
+      description: `expected at least ${ctx.minFindings} findings, got 0`,
+    };
+  }
+
+  // Too many findings → weak explanation
+  if (ctx.maxFindings != null && ctx.findingCount > ctx.maxFindings) {
+    return { category: 'weak_explanation', description: `too many findings: ${ctx.findingCount}` };
+  }
+
+  // Missing mustInclude token categorization
+  if (ctx.token != null) {
+    if (ctx.token === 'Evidence:') {
+      return { category: 'missing_evidence', description: `missing token: ${ctx.token}` };
+    }
+    if (ctx.token.includes('Severity:')) {
+      return { category: 'severity_mismatch', description: `missing token: ${ctx.token}` };
+    }
+    return { category: 'missing_context', description: `missing token: ${ctx.token}` };
+  }
+
+  // Fallback
+  return { category: 'missing_context', description: 'unclassified failure' };
+}
+
+/**
  * Evaluate review fixtures (must_include checks).
  * @param {{
  *   casesPath: string
@@ -34,6 +73,7 @@ function expect(condition, name, message) {
  *     mustIncludeMisses: string[],
  *     isGuardCase: boolean,
  *     guardViolated: boolean,
+ *     failures: Array<{ category: string, description: string }>,
  *   }>,
  *   summary: {
  *     total: number,
@@ -42,6 +82,7 @@ function expect(condition, name, message) {
  *     passRate: number,
  *     falsePositiveRate: number,
  *     evidenceRate: number,
+ *     failuresByCategory: Record<string, number>,
  *   }
  * }>}
  */
@@ -63,13 +104,13 @@ export async function evaluateReviewFixtures({ casesPath, phase = null, verbose 
     const diffText = fs.readFileSync(diffPath, 'utf8');
     const parsedDiff = parseUnifiedDiff(diffText);
     const plan = {
-      selected: (c.planSkills ?? []).map(id => ({ metadata: { id } })),
+      selected: (c.planSkills ?? []).map((id) => ({ metadata: { id } })),
       skipped: [],
     };
     const diff = {
       diffText,
       files: parsedDiff.files,
-      changedFiles: parsedDiff.files.map(f => f.path).filter(Boolean),
+      changedFiles: parsedDiff.files.map((f) => f.path).filter(Boolean),
     };
 
     const result = await generateReview({
@@ -80,7 +121,7 @@ export async function evaluateReviewFixtures({ casesPath, phase = null, verbose 
       includeFallback: false,
     });
 
-    const merged = result.comments.map(x => x.message).join('\n');
+    const merged = result.comments.map((x) => x.message).join('\n');
     const expectNoFindings = Boolean(c.expectNoFindings);
     const isGuardCase = expectNoFindings;
     const minFindings = Number.isFinite(c.minFindings) ? c.minFindings : expectNoFindings ? 0 : 1;
@@ -104,23 +145,27 @@ export async function evaluateReviewFixtures({ casesPath, phase = null, verbose 
 
     // Track mustInclude hits and misses
     const mustIncludeTokens = c.mustInclude ?? [];
-    const mustIncludeHits = mustIncludeTokens.filter(token => merged.includes(token));
-    const mustIncludeMisses = mustIncludeTokens.filter(token => !merged.includes(token));
+    const mustIncludeHits = mustIncludeTokens.filter((token) => merged.includes(token));
+    const mustIncludeMisses = mustIncludeTokens.filter((token) => !merged.includes(token));
 
     const checks = [
       expect(
         result.debug?.findingFormat?.ok !== false,
         name,
-        'skill output format is invalid (missing labels or invalid Severity/Confidence)',
+        'skill output format is invalid (missing labels or invalid Severity/Confidence)'
       ),
       expect(
         result.comments.length >= minFindings,
         name,
-        `expected at least ${minFindings} findings, got ${result.comments.length}`,
+        `expected at least ${minFindings} findings, got ${result.comments.length}`
       ),
       maxFindings == null
         ? null
-        : expect(result.comments.length <= maxFindings, name, `too many findings: ${result.comments.length}`),
+        : expect(
+            result.comments.length <= maxFindings,
+            name,
+            `too many findings: ${result.comments.length}`
+          ),
     ].filter(Boolean);
 
     for (const token of mustIncludeTokens) {
@@ -131,6 +176,31 @@ export async function evaluateReviewFixtures({ casesPath, phase = null, verbose 
     const casePassed = caseFailures.length === 0;
     failures.push(...caseFailures);
 
+    // Categorize failures for this case
+    const categorizedFailures = [];
+    if (!casePassed) {
+      // Guard case false positive
+      if (isGuardCase && result.comments.length > 0) {
+        categorizedFailures.push(
+          categorizeFailure({ isGuardCase: true, findingCount: result.comments.length })
+        );
+      }
+      // No findings when expected
+      if (result.comments.length === 0 && minFindings > 0) {
+        categorizedFailures.push(categorizeFailure({ findingCount: 0, minFindings }));
+      }
+      // Too many findings
+      if (maxFindings != null && result.comments.length > maxFindings && !isGuardCase) {
+        categorizedFailures.push(
+          categorizeFailure({ findingCount: result.comments.length, maxFindings })
+        );
+      }
+      // Missing mustInclude tokens
+      for (const token of mustIncludeMisses) {
+        categorizedFailures.push(categorizeFailure({ token }));
+      }
+    }
+
     caseResults.push({
       name,
       pass: casePassed,
@@ -139,19 +209,32 @@ export async function evaluateReviewFixtures({ casesPath, phase = null, verbose 
       mustIncludeMisses,
       isGuardCase,
       guardViolated: isGuardCase && result.comments.length > 0,
+      failures: categorizedFailures,
     });
 
     if (verbose) {
-      console.log(caseFailures.length ? formatFailure(name, `${caseFailures.length} checks failed`) : formatSuccess(name));
+      console.log(
+        caseFailures.length
+          ? formatFailure(name, `${caseFailures.length} checks failed`)
+          : formatSuccess(name)
+      );
       if (caseFailures.length) {
-        caseFailures.forEach(line => console.log(`  ${line}`));
+        caseFailures.forEach((line) => console.log(`  ${line}`));
       }
     } else {
       console.log(caseFailures.length ? formatFailure(name, caseFailures[0]) : formatSuccess(name));
     }
   }
 
-  const failedCaseCount = caseResults.filter(r => !r.pass).length;
+  const failedCaseCount = caseResults.filter((r) => !r.pass).length;
+
+  // Aggregate failure categories
+  const failuresByCategory = {};
+  for (const cr of caseResults) {
+    for (const f of cr.failures) {
+      failuresByCategory[f.category] = (failuresByCategory[f.category] ?? 0) + 1;
+    }
+  }
 
   if (failures.length) {
     console.error(`\n${failures.length} fixture checks failed.`);
@@ -169,6 +252,9 @@ export async function evaluateReviewFixtures({ casesPath, phase = null, verbose 
       passRate: cases.length > 0 ? (cases.length - failedCaseCount) / cases.length : 0,
       falsePositiveRate: guardCaseCount > 0 ? falsePositiveCount / guardCaseCount : 0,
       evidenceRate: totalFindingCount > 0 ? evidenceHitCount / totalFindingCount : 0,
+      failuresByCategory,
     },
   };
 }
+
+export { categorizeFailure };

--- a/tests/eval-failure-categorization.test.mjs
+++ b/tests/eval-failure-categorization.test.mjs
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { categorizeFailure } from '../src/lib/review-fixtures-eval.mjs';
+
+test('categorizeFailure: missing "Evidence:" token → missing_evidence', () => {
+  const result = categorizeFailure({ token: 'Evidence:' });
+  assert.equal(result.category, 'missing_evidence');
+  assert.match(result.description, /Evidence:/);
+});
+
+test('categorizeFailure: missing "Severity: blocker" token → severity_mismatch', () => {
+  const result = categorizeFailure({ token: 'Severity: blocker' });
+  assert.equal(result.category, 'severity_mismatch');
+  assert.match(result.description, /Severity: blocker/);
+});
+
+test('categorizeFailure: missing "Severity: warning" token → severity_mismatch', () => {
+  const result = categorizeFailure({ token: 'Severity: warning' });
+  assert.equal(result.category, 'severity_mismatch');
+  assert.match(result.description, /Severity: warning/);
+});
+
+test('categorizeFailure: guard case with findings → false_positive', () => {
+  const result = categorizeFailure({ isGuardCase: true, findingCount: 2 });
+  assert.equal(result.category, 'false_positive');
+  assert.match(result.description, /guard case/);
+});
+
+test('categorizeFailure: zero findings when expected → routing_miss', () => {
+  const result = categorizeFailure({ findingCount: 0, minFindings: 1 });
+  assert.equal(result.category, 'routing_miss');
+  assert.match(result.description, /expected at least 1/);
+});
+
+test('categorizeFailure: too many findings → weak_explanation', () => {
+  const result = categorizeFailure({ findingCount: 5, maxFindings: 3 });
+  assert.equal(result.category, 'weak_explanation');
+  assert.match(result.description, /too many findings/);
+});
+
+test('categorizeFailure: other missing token → missing_context', () => {
+  const result = categorizeFailure({ token: 'Fix:' });
+  assert.equal(result.category, 'missing_context');
+  assert.match(result.description, /Fix:/);
+});
+
+test('categorizeFailure: generic token "GitHub Secrets" → missing_context', () => {
+  const result = categorizeFailure({ token: 'GitHub Secrets' });
+  assert.equal(result.category, 'missing_context');
+  assert.match(result.description, /GitHub Secrets/);
+});
+
+test('categorizeFailure: no context → missing_context fallback', () => {
+  const result = categorizeFailure({});
+  assert.equal(result.category, 'missing_context');
+  assert.match(result.description, /unclassified/);
+});
+
+test('categorizeFailure: guard case priority over token check', () => {
+  // When guard case is violated, the guard check fires first
+  const result = categorizeFailure({ isGuardCase: true, findingCount: 1 });
+  assert.equal(result.category, 'false_positive');
+});
+
+test('categorizeFailure: routing_miss with higher minFindings', () => {
+  const result = categorizeFailure({ findingCount: 0, minFindings: 3 });
+  assert.equal(result.category, 'routing_miss');
+  assert.match(result.description, /expected at least 3/);
+});


### PR DESCRIPTION
## Summary
- Add `eval-failure.schema.json` defining 9 failure categories (routing_miss, missing_evidence, false_positive, severity_mismatch, etc.) for systematic tracking of fixture evaluation failures
- Add `eval-ledger-entry.schema.json` formalizing the JSONL ledger entry format with optional failures array
- Extend `review-fixtures-eval.mjs` with `categorizeFailure()` that classifies each failed case by analyzing token patterns, guard violations, and finding counts
- Update `evaluate-all.mjs` to display top 3 failure categories in the human-readable unified eval output

## Test plan
- [x] `node --test tests/eval-failure-categorization.test.mjs` -- 11 tests covering all category mappings (missing_evidence, severity_mismatch, false_positive, routing_miss, weak_explanation, missing_context, fallback)
- [x] `node --test tests/review-eval.test.mjs` -- 3 existing tests pass (backward-compatible: new `failures` field and `failuresByCategory` added without breaking existing shape)
- [x] `node --test tests/evaluate-all.test.mjs` -- 8 existing tests pass
- [x] `npm run format:check` -- all changed files pass Prettier

🤖 Generated with [Claude Code](https://claude.com/claude-code)