### PR TITLE
feat(review): add changed-files classifier

### DIFF
--- a/src/lib/file-classifier.mjs
+++ b/src/lib/file-classifier.mjs
@@ -1,0 +1,100 @@
+/**
+ * Classify changed files by type for routing and evidence collection.
+ * Complementary to impact-scope.mjs which classifies by quality domain.
+ *
+ * @param {string[]} files - Array of file paths (relative to repo root)
+ * @returns {{ config: string[], schema: string[], migration: string[], app: string[], test: string[], infra: string[], docs: string[], unknown: string[] }}
+ */
+export function classifyChangedFiles(files) {
+  const result = {
+    config: [],
+    schema: [],
+    migration: [],
+    app: [],
+    test: [],
+    infra: [],
+    docs: [],
+    unknown: [],
+  };
+
+  for (const file of files) {
+    result[classifyFile(file)].push(file);
+  }
+
+  return result;
+}
+
+// Priority: test > schema > migration > config > infra > docs > app > unknown
+function classifyFile(file) {
+  const normalized = file.replaceAll('\\', '/');
+  const basename = normalized.split('/').pop() ?? '';
+
+  if (isTest(normalized, basename)) return 'test';
+  if (isSchema(normalized, basename)) return 'schema';
+  if (isMigration(normalized)) return 'migration';
+  if (isConfig(normalized, basename)) return 'config';
+  if (isInfra(normalized)) return 'infra';
+  if (isDocs(normalized, basename)) return 'docs';
+  if (isApp(normalized)) return 'app';
+  return 'unknown';
+}
+
+function isTest(file, basename) {
+  return (
+    file.startsWith('tests/') ||
+    file.includes('/__tests__/') ||
+    /\.(?:test|spec)\.[jt]sx?$/.test(basename) ||
+    /\.(?:test|spec)\.mjs$/.test(basename)
+  );
+}
+
+function isSchema(file, basename) {
+  return (
+    file.startsWith('schemas/') ||
+    /\.schema\.[jt]s$/.test(basename) ||
+    basename.endsWith('.schema.json')
+  );
+}
+
+function isMigration(file) {
+  return (
+    /(?:^|\/)migrations?\//.test(file) || /(?:^|\/)migrate/.test(file) || file.startsWith('db/')
+  );
+}
+
+function isConfig(file, basename) {
+  if (/\.config\.[jt]sx?$/.test(basename) || /\.config\.mjs$/.test(basename)) return true;
+  if (/^\.[a-z]+rc(?:\.[a-z]+)?$/.test(basename)) return true;
+  const configNames = [
+    'package.json',
+    '.env',
+    '.river-reviewer.json',
+    '.lychee.toml',
+    '.markdownlint.json',
+    '.markdownlint-cli2.yaml',
+    '.textlintrc.json',
+  ];
+  if (configNames.some((c) => basename === c || basename.startsWith('.env'))) return true;
+  if (/^tsconfig.*\.json$/.test(basename)) return true;
+  return false;
+}
+
+function isInfra(file) {
+  return (
+    file.startsWith('.github/') ||
+    file.startsWith('.husky/') ||
+    file.startsWith('scripts/') ||
+    /^Dockerfile/.test(file.split('/').pop() ?? '') ||
+    /^docker-compose/.test(file.split('/').pop() ?? '')
+  );
+}
+
+function isDocs(file, basename) {
+  if (basename.endsWith('.md') || basename.endsWith('.mdx')) return true;
+  if (file.startsWith('docs/') || file.startsWith('pages/')) return true;
+  return false;
+}
+
+function isApp(file) {
+  return file.startsWith('src/') || file.startsWith('runners/');
+}

--- a/tests/file-classifier.test.mjs
+++ b/tests/file-classifier.test.mjs
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { classifyChangedFiles } from '../src/lib/file-classifier.mjs';
+
+test('classifyChangedFiles: categorizes mixed file set', () => {
+  const result = classifyChangedFiles([
+    'src/lib/review-engine.mjs',
+    'tests/verifier.test.mjs',
+    'schemas/skill.schema.json',
+    '.github/workflows/test.yml',
+    'package.json',
+    'docs/architecture.md',
+    'pages/reference/eval-keep-discard-policy.md',
+    'db/migrations/001_init.sql',
+    'unknown-file.xyz',
+  ]);
+
+  assert.deepEqual(result.app, ['src/lib/review-engine.mjs']);
+  assert.deepEqual(result.test, ['tests/verifier.test.mjs']);
+  assert.deepEqual(result.schema, ['schemas/skill.schema.json']);
+  assert.deepEqual(result.infra, ['.github/workflows/test.yml']);
+  assert.deepEqual(result.config, ['package.json']);
+  assert.deepEqual(result.docs, [
+    'docs/architecture.md',
+    'pages/reference/eval-keep-discard-policy.md',
+  ]);
+  assert.deepEqual(result.migration, ['db/migrations/001_init.sql']);
+  assert.deepEqual(result.unknown, ['unknown-file.xyz']);
+});
+
+test('classifyChangedFiles: test files take priority over app', () => {
+  const result = classifyChangedFiles(['src/lib/__tests__/foo.test.mjs']);
+  assert.deepEqual(result.test, ['src/lib/__tests__/foo.test.mjs']);
+  assert.deepEqual(result.app, []);
+});
+
+test('classifyChangedFiles: empty input returns empty categories', () => {
+  const result = classifyChangedFiles([]);
+  assert.equal(Object.values(result).flat().length, 0);
+});
+
+test('classifyChangedFiles: config patterns', () => {
+  const result = classifyChangedFiles([
+    'tsconfig.json',
+    '.eslintrc.json',
+    '.env.example',
+    'jest.config.js',
+    '.river-reviewer.json',
+  ]);
+  assert.equal(result.config.length, 5);
+});
+
+test('classifyChangedFiles: schema files', () => {
+  const result = classifyChangedFiles([
+    'schemas/eval-failure.schema.json',
+    'schemas/output.schema.json',
+  ]);
+  assert.equal(result.schema.length, 2);
+});
+
+test('classifyChangedFiles: infra patterns', () => {
+  const result = classifyChangedFiles([
+    '.github/workflows/deploy.yml',
+    'Dockerfile',
+    '.husky/pre-commit',
+    'scripts/setup.sh',
+  ]);
+  assert.equal(result.infra.length, 4);
+});
+
+test('classifyChangedFiles: docs from various locations', () => {
+  const result = classifyChangedFiles([
+    'README.md',
+    'docs/adr/001-eval-driven-improvement-loop.md',
+    'AGENTS.md',
+  ]);
+  assert.equal(result.docs.length, 3);
+});
+
+test('classifyChangedFiles: migration patterns', () => {
+  const result = classifyChangedFiles([
+    'db/migrations/001_init.sql',
+    'src/migrations/20240101_add_users.ts',
+  ]);
+  assert.equal(result.migration.length, 2);
+});


### PR DESCRIPTION
## Summary

- `src/lib/file-classifier.mjs` — 変更ファイルを種別 (config, schema, migration, app, test, infra, docs) に分類
- `impact-scope.mjs` の品質ドメインタグ (security, performance 等) と相補的
- 将来 `review-runner.mjs` の `buildExecutionPlan` で routing context として使用

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `src/lib/file-classifier.mjs` | `classifyChangedFiles(files)` を export (新規) |
| `tests/file-classifier.test.mjs` | テスト 8 件 (新規) |

## Test plan

- [x] `node --test tests/file-classifier.test.mjs` 8/8 pass
- [x] `npx prettier --check src/lib/file-classifier.mjs tests/file-classifier.test.mjs` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)