### PR TITLE
refactor: simplify eval tools for performance and consistency

### DIFF
--- a/scripts/evaluate-all.mjs
+++ b/scripts/evaluate-all.mjs
@@ -139,6 +139,13 @@ async function runFixturesEval() {
 
   const result = await evaluateReviewFixtures({ casesPath, verbose: false });
 
+  // Flatten top failure categories into metrics (preserves normalized result shape)
+  const failureCats = result.summary.failuresByCategory ?? {};
+  const topFailureMetrics = {};
+  for (const [cat, count] of Object.entries(failureCats)) {
+    topFailureMetrics[`fail_${cat}`] = count;
+  }
+
   return {
     name: 'fixtures',
     pass: result.exitCode === 0,
@@ -147,9 +154,9 @@ async function runFixturesEval() {
       passRate: result.summary.passRate,
       falsePositiveRate: result.summary.falsePositiveRate,
       evidenceRate: result.summary.evidenceRate,
+      ...topFailureMetrics,
     },
     errors: result.exitCode === 0 ? [] : ['One or more fixture checks failed'],
-    failuresByCategory: result.summary.failuresByCategory ?? {},
   };
 }
 
@@ -211,11 +218,18 @@ Options:
 
   const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf-8'));
 
-  // Run independent evals (planner, meta) in parallel; sequential for fixtures and gate
+  // Run independent evals in parallel; gate depends on --gate-input flag
   const parallel = [];
   if (!parsed.skip.has('planner')) {
     parallel.push(
       runPlannerEval().catch((err) => errorResult('planner', `Planner eval error: ${err.message}`))
+    );
+  }
+  if (!parsed.skip.has('fixtures')) {
+    parallel.push(
+      runFixturesEval().catch((err) =>
+        errorResult('fixtures', `Fixtures eval error: ${err.message}`)
+      )
     );
   }
   if (!parsed.skip.has('meta')) {
@@ -226,19 +240,9 @@ Options:
     );
   }
 
-  const [plannerResult, metaResult] = await Promise.all(parallel);
+  const subResults = await Promise.all(parallel);
 
-  const subResults = [];
-  if (plannerResult) subResults.push(plannerResult);
-
-  if (!parsed.skip.has('fixtures')) {
-    try {
-      subResults.push(await runFixturesEval());
-    } catch (err) {
-      subResults.push(errorResult('fixtures', `Fixtures eval error: ${err.message}`));
-    }
-  }
-
+  // Gate requires --gate-input; handle separately
   if (!parsed.skip.has('gate') && parsed.gateInput) {
     const resolvedGateInput = path.resolve(parsed.gateInput);
     if (!fs.existsSync(resolvedGateInput)) {
@@ -253,8 +257,6 @@ Options:
   } else if (!parsed.skip.has('gate') && !parsed.gateInput) {
     subResults.push(skipResult('gate'));
   }
-
-  if (metaResult) subResults.push(metaResult);
 
   // Build envelope
   const scores = {};
@@ -302,13 +304,6 @@ Options:
       if (r.errors.length) {
         for (const e of r.errors) {
           console.log(`       ! ${e}`);
-        }
-      }
-      if (r.failuresByCategory && Object.keys(r.failuresByCategory).length) {
-        const cats = Object.entries(r.failuresByCategory).sort(([, a], [, b]) => b - a);
-        console.log('       top failures:');
-        for (const [cat, count] of cats.slice(0, 3)) {
-          console.log(`         ${cat}: ${count}`);
         }
       }
     }

--- a/src/lib/file-classifier.mjs
+++ b/src/lib/file-classifier.mjs
@@ -1,3 +1,23 @@
+// Pre-compiled regexes for classification (avoid per-call compilation)
+const RE_TEST_EXT = /\.(?:test|spec)\.(?:[jt]sx?|mjs)$/;
+const RE_SCHEMA_EXT = /\.schema\.[jt]s$/;
+const RE_MIGRATION = /(?:^|\/)migrations?\//;
+const RE_MIGRATE = /(?:^|\/)migrate/;
+const RE_CONFIG_EXT = /\.config\.(?:[jt]sx?|mjs)$/;
+const RE_RC_FILE = /^\.[a-z]+rc(?:\.[a-z]+)?$/;
+const RE_TSCONFIG = /^tsconfig.*\.json$/;
+const RE_DOCKERFILE = /^Dockerfile/;
+const RE_DOCKER_COMPOSE = /^docker-compose/;
+
+const CONFIG_NAMES = new Set([
+  'package.json',
+  '.river-reviewer.json',
+  '.lychee.toml',
+  '.markdownlint.json',
+  '.markdownlint-cli2.yaml',
+  '.textlintrc.json',
+]);
+
 /**
  * Classify changed files by type for routing and evidence collection.
  * Complementary to impact-scope.mjs which classifies by quality domain.
@@ -26,66 +46,47 @@ export function classifyChangedFiles(files) {
 
 // Priority: test > schema > migration > config > infra > docs > app > unknown
 function classifyFile(file) {
-  const normalized = file.replaceAll('\\', '/');
-  const basename = normalized.split('/').pop() ?? '';
+  const basename = file.split(/[/\\]/).pop() ?? '';
 
-  if (isTest(normalized, basename)) return 'test';
-  if (isSchema(normalized, basename)) return 'schema';
-  if (isMigration(normalized)) return 'migration';
-  if (isConfig(normalized, basename)) return 'config';
-  if (isInfra(normalized)) return 'infra';
-  if (isDocs(normalized, basename)) return 'docs';
-  if (isApp(normalized)) return 'app';
+  if (isTest(file, basename)) return 'test';
+  if (isSchema(file, basename)) return 'schema';
+  if (isMigration(file)) return 'migration';
+  if (isConfig(file, basename)) return 'config';
+  if (isInfra(file, basename)) return 'infra';
+  if (isDocs(file, basename)) return 'docs';
+  if (isApp(file)) return 'app';
   return 'unknown';
 }
 
 function isTest(file, basename) {
-  return (
-    file.startsWith('tests/') ||
-    file.includes('/__tests__/') ||
-    /\.(?:test|spec)\.[jt]sx?$/.test(basename) ||
-    /\.(?:test|spec)\.mjs$/.test(basename)
-  );
+  return file.startsWith('tests/') || file.includes('/__tests__/') || RE_TEST_EXT.test(basename);
 }
 
 function isSchema(file, basename) {
   return (
-    file.startsWith('schemas/') ||
-    /\.schema\.[jt]s$/.test(basename) ||
-    basename.endsWith('.schema.json')
+    file.startsWith('schemas/') || RE_SCHEMA_EXT.test(basename) || basename.endsWith('.schema.json')
   );
 }
 
 function isMigration(file) {
-  return (
-    /(?:^|\/)migrations?\//.test(file) || /(?:^|\/)migrate/.test(file) || file.startsWith('db/')
-  );
+  return RE_MIGRATION.test(file) || RE_MIGRATE.test(file) || file.startsWith('db/');
 }
 
 function isConfig(file, basename) {
-  if (/\.config\.[jt]sx?$/.test(basename) || /\.config\.mjs$/.test(basename)) return true;
-  if (/^\.[a-z]+rc(?:\.[a-z]+)?$/.test(basename)) return true;
-  const configNames = [
-    'package.json',
-    '.env',
-    '.river-reviewer.json',
-    '.lychee.toml',
-    '.markdownlint.json',
-    '.markdownlint-cli2.yaml',
-    '.textlintrc.json',
-  ];
-  if (configNames.some((c) => basename === c || basename.startsWith('.env'))) return true;
-  if (/^tsconfig.*\.json$/.test(basename)) return true;
+  if (RE_CONFIG_EXT.test(basename)) return true;
+  if (RE_RC_FILE.test(basename)) return true;
+  if (CONFIG_NAMES.has(basename) || basename.startsWith('.env')) return true;
+  if (RE_TSCONFIG.test(basename)) return true;
   return false;
 }
 
-function isInfra(file) {
+function isInfra(file, basename) {
   return (
     file.startsWith('.github/') ||
     file.startsWith('.husky/') ||
     file.startsWith('scripts/') ||
-    /^Dockerfile/.test(file.split('/').pop() ?? '') ||
-    /^docker-compose/.test(file.split('/').pop() ?? '')
+    RE_DOCKERFILE.test(basename) ||
+    RE_DOCKER_COMPOSE.test(basename)
   );
 }
 

--- a/src/lib/verifier.mjs
+++ b/src/lib/verifier.mjs
@@ -10,6 +10,11 @@
  * Internal vocabulary is mapped to output schema equivalents.
  * @see .claude/rules/review-core.md for the canonical mapping
  */
+// Pre-compiled patterns for finding message parsing
+const RE_EVIDENCE = /Evidence:\s*(\S.{4,})/;
+const RE_SEVERITY = /Severity:\s*(\w+)/;
+const RE_ACTIONABLE = /(?:Fix|Suggestion):\s*(.{10,})/;
+
 const SEVERITY_RANK = /** @type {const} */ ({
   info: 0,
   minor: 1,
@@ -43,7 +48,7 @@ function normalizeSeverity(raw) {
  */
 function checkEvidenceExists(finding) {
   const text = String(finding?.message ?? '');
-  const match = /Evidence:\s*(\S.{4,})/.exec(text);
+  const match = RE_EVIDENCE.exec(text);
   return match !== null;
 }
 
@@ -71,7 +76,7 @@ function checkPhaseCoherent(finding, skill) {
  */
 function checkSeverityJustified(finding, skill) {
   const text = String(finding?.message ?? '');
-  const sevMatch = /Severity:\s*(\w+)/.exec(text);
+  const sevMatch = RE_SEVERITY.exec(text);
   if (!sevMatch) return true;
 
   const skillSeverity = skill?.metadata?.severity;
@@ -94,7 +99,7 @@ function checkSeverityJustified(finding, skill) {
  */
 function checkSuggestionActionable(finding) {
   const text = String(finding?.message ?? '');
-  const match = /(?:Fix|Suggestion):\s*(.{10,})/.exec(text);
+  const match = RE_ACTIONABLE.exec(text);
   return match !== null;
 }
 


### PR DESCRIPTION
## Summary

- `file-classifier.mjs`: 10+ regex を module scope に移動、`configNames` 配列を `Set` に変更 (100 ファイルで 500+ の不要な regex コンパイルを削減)
- `verifier.mjs`: 3 regex を module scope に移動 (一貫性)
- `evaluate-all.mjs`: `failuresByCategory` を metrics に統合 (result shape の正規化)、planner+fixtures+meta を `Promise.all` で完全並列化

## Test plan

- [x] `node --test tests/evaluate-all.test.mjs tests/verifier.test.mjs tests/file-classifier.test.mjs` — 29/29 pass
- [x] `npm run eval:all -- --skip fixtures --skip gate --json` — 正常出力

🤖 Generated with [Claude Code](https://claude.com/claude-code)