### PR TITLE
feat(review): add test impact analyzer and config risk detector

### DIFF
--- a/src/lib/config-risk.mjs
+++ b/src/lib/config-risk.mjs
@@ -1,0 +1,75 @@
+/**
+ * Detect high-risk patterns in configuration file changes.
+ *
+ * @param {{ file: string, diff: string }[]} configChanges - Array of config file diffs
+ * @returns {{ risks: { file: string, pattern: string, severity: 'info'|'warning'|'critical' }[], riskLevel: 'low'|'medium'|'high' }}
+ */
+export function detectConfigRisks(configChanges) {
+  const risks = [];
+
+  for (const { file, diff } of configChanges) {
+    const lines = diff.split('\n');
+    const basename = file.split('/').pop() ?? '';
+
+    for (const line of lines) {
+      // Removed environment variables
+      if (line.startsWith('-') && /[A-Z_]{2,}=/.test(line) && !line.startsWith('---')) {
+        risks.push({ file, pattern: 'Removed environment variable', severity: 'warning' });
+      }
+
+      // Secrets/tokens in added lines
+      if (line.startsWith('+') && !line.startsWith('+++')) {
+        if (/(?:secret|token|password|api_?key|private_?key)/i.test(line)) {
+          // Only flag if it looks like an actual value, not a variable reference
+          if (!line.includes('process.env') && !line.includes('${') && !line.includes('EXAMPLE')) {
+            risks.push({ file, pattern: 'Possible secret in config', severity: 'critical' });
+          }
+        }
+      }
+
+      // Port changes
+      if (line.startsWith('+') && /\bport\b/i.test(line) && /\d{4,5}/.test(line)) {
+        risks.push({ file, pattern: 'Port configuration changed', severity: 'info' });
+      }
+    }
+
+    // CI workflow changes are inherently risky
+    if (file.startsWith('.github/workflows/')) {
+      // Check for permission changes
+      if (diff.includes('permissions:')) {
+        risks.push({ file, pattern: 'CI workflow permissions changed', severity: 'warning' });
+      }
+      // Check for new secret usage
+      if (/^\+.*secrets\./m.test(diff)) {
+        risks.push({ file, pattern: 'New secret reference in CI', severity: 'warning' });
+      }
+    }
+
+    // Docker changes
+    if (basename.startsWith('Dockerfile') || basename.startsWith('docker-compose')) {
+      if (/^\+.*(?:EXPOSE|ports:)/m.test(diff)) {
+        risks.push({ file, pattern: 'Container port exposure changed', severity: 'info' });
+      }
+      if (/^\+.*(?:privileged|cap_add)/m.test(diff)) {
+        risks.push({ file, pattern: 'Container privilege escalation', severity: 'critical' });
+      }
+    }
+  }
+
+  // Deduplicate
+  const unique = [];
+  const seen = new Set();
+  for (const risk of risks) {
+    const key = `${risk.file}:${risk.pattern}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      unique.push(risk);
+    }
+  }
+
+  const hasCritical = unique.some((r) => r.severity === 'critical');
+  const hasWarning = unique.some((r) => r.severity === 'warning');
+  const riskLevel = hasCritical ? 'high' : hasWarning ? 'medium' : 'low';
+
+  return { risks: unique, riskLevel };
+}

--- a/src/lib/test-impact.mjs
+++ b/src/lib/test-impact.mjs
@@ -1,0 +1,41 @@
+import { classifyChangedFiles } from './file-classifier.mjs';
+
+/**
+ * Analyze test coverage gaps based on changed file classification.
+ *
+ * @param {string[]} changedFiles - Array of changed file paths
+ * @returns {{ appFilesChanged: number, testFilesChanged: number, gapFiles: string[], coverageRatio: number, riskLevel: 'low'|'medium'|'high' }}
+ */
+export function analyzeTestImpact(changedFiles) {
+  const classified = classifyChangedFiles(changedFiles);
+
+  const appFiles = classified.app;
+  const testFiles = classified.test;
+
+  // Files in app that likely need corresponding tests
+  const gapFiles = appFiles.filter((appFile) => {
+    const basename =
+      appFile
+        .split('/')
+        .pop()
+        ?.replace(/\.[^.]+$/, '') ?? '';
+    // Check if any test file references this app file's basename
+    return !testFiles.some((testFile) => testFile.includes(basename));
+  });
+
+  const appCount = appFiles.length;
+  const testCount = testFiles.length;
+  const coverageRatio = appCount === 0 ? 1 : testCount / appCount;
+
+  let riskLevel = 'low';
+  if (appCount > 0 && testCount === 0) riskLevel = 'high';
+  else if (appCount > 0 && gapFiles.length >= appCount / 2) riskLevel = 'medium';
+
+  return {
+    appFilesChanged: appCount,
+    testFilesChanged: testCount,
+    gapFiles,
+    coverageRatio: Math.min(coverageRatio, 1), // cap at 1
+    riskLevel,
+  };
+}

--- a/tests/config-risk.test.mjs
+++ b/tests/config-risk.test.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { detectConfigRisks } from '../src/lib/config-risk.mjs';
+
+test('detectConfigRisks: clean config change is low risk', () => {
+  const result = detectConfigRisks([
+    {
+      file: 'package.json',
+      diff: '+    "new-dep": "^1.0.0"',
+    },
+  ]);
+  assert.equal(result.riskLevel, 'low');
+});
+
+test('detectConfigRisks: removed env var is warning', () => {
+  const result = detectConfigRisks([
+    {
+      file: '.env.example',
+      diff: '-DATABASE_URL=postgres://localhost/dev',
+    },
+  ]);
+  assert.equal(result.riskLevel, 'medium');
+  assert.ok(result.risks.some((r) => r.pattern.includes('environment variable')));
+});
+
+test('detectConfigRisks: secret in config is critical', () => {
+  const result = detectConfigRisks([
+    {
+      file: 'config.json',
+      diff: '+  "api_key": "sk-abc123"',
+    },
+  ]);
+  assert.equal(result.riskLevel, 'high');
+});
+
+test('detectConfigRisks: CI permission change is warning', () => {
+  const result = detectConfigRisks([
+    {
+      file: '.github/workflows/deploy.yml',
+      diff: '+permissions:\n+  contents: write',
+    },
+  ]);
+  assert.ok(result.risks.some((r) => r.pattern.includes('permissions')));
+});
+
+test('detectConfigRisks: empty changes is low risk', () => {
+  const result = detectConfigRisks([]);
+  assert.equal(result.riskLevel, 'low');
+  assert.equal(result.risks.length, 0);
+});
+
+test('detectConfigRisks: container privilege escalation is critical', () => {
+  const result = detectConfigRisks([
+    {
+      file: 'docker-compose.yml',
+      diff: '+    privileged: true',
+    },
+  ]);
+  assert.equal(result.riskLevel, 'high');
+});

--- a/tests/test-impact.test.mjs
+++ b/tests/test-impact.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { analyzeTestImpact } from '../src/lib/test-impact.mjs';
+
+test('analyzeTestImpact: no app changes is low risk', () => {
+  const result = analyzeTestImpact(['docs/readme.md']);
+  assert.equal(result.riskLevel, 'low');
+  assert.equal(result.appFilesChanged, 0);
+});
+
+test('analyzeTestImpact: app changes with tests is low risk', () => {
+  const result = analyzeTestImpact(['src/lib/verifier.mjs', 'tests/verifier.test.mjs']);
+  assert.equal(result.riskLevel, 'low');
+  assert.equal(result.gapFiles.length, 0);
+});
+
+test('analyzeTestImpact: app changes without tests is high risk', () => {
+  const result = analyzeTestImpact(['src/lib/review-engine.mjs', 'src/lib/diff.mjs']);
+  assert.equal(result.riskLevel, 'high');
+  assert.equal(result.gapFiles.length, 2);
+});
+
+test('analyzeTestImpact: partial test coverage is medium risk', () => {
+  const result = analyzeTestImpact([
+    'src/lib/verifier.mjs',
+    'src/lib/review-engine.mjs',
+    'tests/verifier.test.mjs',
+  ]);
+  assert.equal(result.riskLevel, 'medium');
+});


### PR DESCRIPTION
## Summary
- Add `analyzeTestImpact()` in `src/lib/test-impact.mjs` — uses file-classifier results to report test coverage gaps and assign risk levels (low/medium/high) based on app-to-test file ratios
- Add `detectConfigRisks()` in `src/lib/config-risk.mjs` — scans config file diffs for dangerous patterns: secret leaks, env var removal, CI permission changes, container privilege escalation
- Add 10 tests covering both modules (4 for test-impact, 6 for config-risk)

## Test plan
- [x] `node --test tests/test-impact.test.mjs tests/config-risk.test.mjs` — 10/10 pass
- [x] `npm test` — full suite 226/226 pass
- [x] `npm run format:check` — all new files pass prettier

🤖 Generated with [Claude Code](https://claude.com/claude-code)