### PR TITLE
feat(review): add ADR/spec linker and dependency impact analyzer

### DIFF
--- a/src/lib/adr-linker.mjs
+++ b/src/lib/adr-linker.mjs
@@ -1,0 +1,56 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Scan known ADR/spec directories and find documents relevant to changed files.
+ *
+ * @param {string} repoRoot - Repository root path
+ * @param {{ changedFiles?: string[], keywords?: string[] }} options
+ * @returns {{ path: string, title: string, matchReason: string }[]}
+ */
+export function findRelatedADRs(repoRoot, { changedFiles = [], keywords = [] } = {}) {
+  const adrDirs = ['docs/adr', 'pages/explanation', 'specs'];
+  const results = [];
+
+  for (const dir of adrDirs) {
+    const fullDir = path.join(repoRoot, dir);
+    if (!fs.existsSync(fullDir)) continue;
+
+    const files = fs.readdirSync(fullDir).filter((f) => f.endsWith('.md'));
+    for (const file of files) {
+      const filePath = path.join(dir, file);
+      const content = fs.readFileSync(path.join(fullDir, file), 'utf-8');
+      const title = extractTitle(content) || file;
+
+      // Match by keyword in content
+      for (const kw of keywords) {
+        if (content.toLowerCase().includes(kw.toLowerCase())) {
+          results.push({ path: filePath, title, matchReason: `keyword: ${kw}` });
+          break; // one match per file is enough
+        }
+      }
+
+      // Match by changed file mention in content
+      for (const cf of changedFiles) {
+        const basename = cf.split('/').pop();
+        if (content.includes(cf) || content.includes(basename)) {
+          if (!results.some((r) => r.path === filePath)) {
+            results.push({
+              path: filePath,
+              title,
+              matchReason: `references: ${cf}`,
+            });
+          }
+          break;
+        }
+      }
+    }
+  }
+
+  return results;
+}
+
+function extractTitle(markdown) {
+  const match = /^#\s+(.+)/m.exec(markdown);
+  return match ? match[1].trim() : null;
+}

--- a/src/lib/dependency-impact.mjs
+++ b/src/lib/dependency-impact.mjs
@@ -1,0 +1,50 @@
+/**
+ * Analyze dependency changes from a unified diff of package.json.
+ *
+ * @param {string} diffText - Unified diff text (or just the package.json portion)
+ * @returns {{ added: string[], removed: string[], changed: string[], riskLevel: 'low'|'medium'|'high' }}
+ */
+export function analyzeDependencyImpact(diffText) {
+  const added = [];
+  const removed = [];
+  const changed = [];
+
+  const lines = diffText.split('\n');
+  for (const line of lines) {
+    // Match lines like: +    "lodash": "^4.17.21",  or  -    "lodash": "^4.17.20",
+    const addMatch = /^\+\s+"([^"]+)":\s*"([^"]+)"/.exec(line);
+    const removeMatch = /^-\s+"([^"]+)":\s*"([^"]+)"/.exec(line);
+
+    if (addMatch && !line.startsWith('+++')) {
+      const [, name] = addMatch;
+      // Check if this package also has a removal (= version change)
+      const wasRemoved = removed.findIndex((r) => r === name);
+      if (wasRemoved >= 0) {
+        removed.splice(wasRemoved, 1);
+        changed.push(name);
+      } else {
+        added.push(name);
+      }
+    } else if (removeMatch && !line.startsWith('---')) {
+      const [, name] = removeMatch;
+      // Check if already added (= version change, processed in reverse order)
+      const wasAdded = added.findIndex((a) => a === name);
+      if (wasAdded >= 0) {
+        added.splice(wasAdded, 1);
+        changed.push(name);
+      } else {
+        removed.push(name);
+      }
+    }
+  }
+
+  // Risk assessment
+  let riskLevel = 'low';
+  if (removed.length > 0) riskLevel = 'medium';
+  if (removed.length > 3 || added.length > 5) riskLevel = 'high';
+  // Major version bumps in changed deps are high risk
+  // (simplified: any change counts as medium at minimum)
+  if (changed.length > 0 && riskLevel === 'low') riskLevel = 'medium';
+
+  return { added, removed, changed, riskLevel };
+}

--- a/tests/adr-linker.test.mjs
+++ b/tests/adr-linker.test.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { findRelatedADRs } from '../src/lib/adr-linker.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+test('findRelatedADRs matches ADR by keyword', () => {
+  const results = findRelatedADRs(ROOT, { keywords: ['evaluation'] });
+  assert.ok(results.length > 0, 'should find at least one ADR');
+  const adr001 = results.find((r) => r.path.includes('001-eval-driven-improvement-loop'));
+  assert.ok(adr001, 'should find ADR-001');
+  assert.equal(adr001.matchReason, 'keyword: evaluation');
+});
+
+test('findRelatedADRs returns empty for non-existent keyword', () => {
+  const results = findRelatedADRs(ROOT, { keywords: ['xyznonexistent'] });
+  assert.equal(results.length, 0);
+});
+
+test('findRelatedADRs matches by changedFiles when file is referenced in ADR', () => {
+  // ADR-001 mentions artifacts/evals/results.jsonl
+  const results = findRelatedADRs(ROOT, {
+    changedFiles: ['artifacts/evals/results.jsonl'],
+  });
+  assert.ok(results.length > 0, 'should find at least one match');
+  const adr001 = results.find((r) => r.path.includes('001-eval-driven-improvement-loop'));
+  assert.ok(adr001, 'should find ADR-001 via file reference');
+  assert.match(adr001.matchReason, /references:/);
+});
+
+test('findRelatedADRs does not duplicate when both keyword and file match', () => {
+  const results = findRelatedADRs(ROOT, {
+    keywords: ['evaluation'],
+    changedFiles: ['artifacts/evals/results.jsonl'],
+  });
+  const adr001Matches = results.filter((r) => r.path.includes('001-eval-driven-improvement-loop'));
+  // Should appear only once (keyword match takes priority)
+  assert.equal(adr001Matches.length, 1);
+});
+
+test('findRelatedADRs returns empty with no options', () => {
+  const results = findRelatedADRs(ROOT);
+  assert.equal(results.length, 0);
+});
+
+test('findRelatedADRs scans pages/explanation directory', () => {
+  // pages/explanation/ has design-philosophy.md etc.
+  const results = findRelatedADRs(ROOT, { keywords: ['river reviewer'] });
+  const fromExplanation = results.find((r) => r.path.startsWith('pages/explanation/'));
+  assert.ok(fromExplanation, 'should find at least one doc in pages/explanation/');
+});

--- a/tests/dependency-impact.test.mjs
+++ b/tests/dependency-impact.test.mjs
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { analyzeDependencyImpact } from '../src/lib/dependency-impact.mjs';
+
+test('analyzeDependencyImpact detects added dependency', () => {
+  const diff = `
+--- a/package.json
++++ b/package.json
+@@ -10,6 +10,7 @@
+     "express": "^4.18.0",
++    "lodash": "^4.17.21",
+     "react": "^18.2.0"
+`;
+  const result = analyzeDependencyImpact(diff);
+  assert.deepEqual(result.added, ['lodash']);
+  assert.deepEqual(result.removed, []);
+  assert.deepEqual(result.changed, []);
+});
+
+test('analyzeDependencyImpact detects removed dependency', () => {
+  const diff = `
+--- a/package.json
++++ b/package.json
+@@ -10,7 +10,6 @@
+     "express": "^4.18.0",
+-    "lodash": "^4.17.21",
+     "react": "^18.2.0"
+`;
+  const result = analyzeDependencyImpact(diff);
+  assert.deepEqual(result.added, []);
+  assert.deepEqual(result.removed, ['lodash']);
+  assert.deepEqual(result.changed, []);
+});
+
+test('analyzeDependencyImpact detects version change (remove then add)', () => {
+  const diff = `
+--- a/package.json
++++ b/package.json
+@@ -10,7 +10,7 @@
+     "express": "^4.18.0",
+-    "lodash": "^4.17.20",
++    "lodash": "^4.17.21",
+     "react": "^18.2.0"
+`;
+  const result = analyzeDependencyImpact(diff);
+  assert.deepEqual(result.added, []);
+  assert.deepEqual(result.removed, []);
+  assert.deepEqual(result.changed, ['lodash']);
+});
+
+test('analyzeDependencyImpact detects version change (add then remove order)', () => {
+  // Some diffs might show the add before the remove
+  const diff = `
+--- a/package.json
++++ b/package.json
+@@ -10,7 +10,7 @@
+     "express": "^4.18.0",
++    "axios": "^1.6.0",
+-    "axios": "^1.5.0",
+     "react": "^18.2.0"
+`;
+  const result = analyzeDependencyImpact(diff);
+  assert.deepEqual(result.added, []);
+  assert.deepEqual(result.removed, []);
+  assert.deepEqual(result.changed, ['axios']);
+});
+
+test('analyzeDependencyImpact returns empty for empty diff', () => {
+  const result = analyzeDependencyImpact('');
+  assert.deepEqual(result.added, []);
+  assert.deepEqual(result.removed, []);
+  assert.deepEqual(result.changed, []);
+  assert.equal(result.riskLevel, 'low');
+});
+
+test('analyzeDependencyImpact risk level: low for adds only (few)', () => {
+  const diff = `
++    "lodash": "^4.17.21",
++    "axios": "^1.6.0",
+`;
+  const result = analyzeDependencyImpact(diff);
+  assert.equal(result.riskLevel, 'low');
+  assert.equal(result.added.length, 2);
+});
+
+test('analyzeDependencyImpact risk level: medium for removals', () => {
+  const diff = `
+-    "lodash": "^4.17.21",
+`;
+  const result = analyzeDependencyImpact(diff);
+  assert.equal(result.riskLevel, 'medium');
+});
+
+test('analyzeDependencyImpact risk level: medium for version changes', () => {
+  const diff = `
+-    "lodash": "^4.17.20",
++    "lodash": "^4.17.21",
+`;
+  const result = analyzeDependencyImpact(diff);
+  assert.equal(result.riskLevel, 'medium');
+  assert.deepEqual(result.changed, ['lodash']);
+});
+
+test('analyzeDependencyImpact risk level: high for many removals', () => {
+  const diff = `
+-    "a": "^1.0.0",
+-    "b": "^1.0.0",
+-    "c": "^1.0.0",
+-    "d": "^1.0.0",
+`;
+  const result = analyzeDependencyImpact(diff);
+  assert.equal(result.riskLevel, 'high');
+});
+
+test('analyzeDependencyImpact risk level: high for many additions', () => {
+  const diff = `
++    "a": "^1.0.0",
++    "b": "^1.0.0",
++    "c": "^1.0.0",
++    "d": "^1.0.0",
++    "e": "^1.0.0",
++    "f": "^1.0.0",
+`;
+  const result = analyzeDependencyImpact(diff);
+  assert.equal(result.riskLevel, 'high');
+  assert.equal(result.added.length, 6);
+});
+
+test('analyzeDependencyImpact ignores +++ and --- header lines', () => {
+  const diff = `--- a/package.json
++++ b/package.json
+@@ -1,5 +1,5 @@
++    "new-pkg": "^1.0.0",
+`;
+  const result = analyzeDependencyImpact(diff);
+  assert.deepEqual(result.added, ['new-pkg']);
+  assert.deepEqual(result.removed, []);
+});


### PR DESCRIPTION
## Summary
- Add `findRelatedADRs()` in `src/lib/adr-linker.mjs` to scan `docs/adr/`, `pages/explanation/`, `specs/` for design documents relevant to changed files or keywords
- Add `analyzeDependencyImpact()` in `src/lib/dependency-impact.mjs` to detect added/removed/changed dependencies from package.json diffs with risk level assessment
- Add 17 tests covering keyword matching, file reference matching, deduplication, dependency detection, version changes, and risk levels

## Test plan
- [x] `node --test tests/adr-linker.test.mjs tests/dependency-impact.test.mjs` — 17/17 pass
- [x] `npm test` — full suite 232/232 pass
- [x] `prettier --check` passes on all new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)