### PR TITLE
feat(memory): add GitHub Artifact persistence for Riverbed Memory

### DIFF
--- a/.github/workflows/riverbed-persist.yml
+++ b/.github/workflows/riverbed-persist.yml
@@ -1,0 +1,31 @@
+name: Riverbed Memory Persist
+
+on:
+  workflow_call:
+    inputs:
+      memory-path:
+        description: 'Path to the memory index file'
+        required: false
+        default: '.river/memory/index.json'
+        type: string
+
+jobs:
+  persist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download previous memory artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: riverbed-memory
+          path: .river/memory
+        continue-on-error: true
+
+      - name: Upload memory artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: riverbed-memory
+          path: ${{ inputs.memory-path }}
+          retention-days: 90
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ artifacts/*
 artifacts/evals/*
 !artifacts/evals/.gitkeep
 
+# Riverbed memory (track directory, ignore data)
+.river/memory/*
+!.river/memory/.gitkeep
+
 # Generated schema/examples backups
 *.schema_*.json
 *_2025*.md

--- a/scripts/evaluate-all.mjs
+++ b/scripts/evaluate-all.mjs
@@ -15,6 +15,7 @@
  *   --description <text>   Optional description for ledger entry
  *   --json                 Print result as JSON instead of human-readable
  *   --skip <name>          Skip a sub-eval (planner|fixtures|gate|meta). Repeatable
+ *   --persist-memory       Write eval result as Riverbed Memory entry
  *   -h, --help             Show help
  */
 
@@ -51,6 +52,7 @@ function parseArgs(argv) {
     description: '',
     json: false,
     skip: new Set(),
+    persistMemory: false,
     help: false,
   };
 
@@ -67,6 +69,8 @@ function parseArgs(argv) {
     } else if (arg === '--skip') {
       const name = args.shift();
       if (name) parsed.skip.add(name);
+    } else if (arg === '--persist-memory') {
+      parsed.persistMemory = true;
     } else if (arg === '-h' || arg === '--help') {
       parsed.help = true;
     }
@@ -211,6 +215,7 @@ Options:
   --description <text>   Optional description for ledger entry
   --json                 Print result as JSON
   --skip <name>          Skip a sub-eval (planner|fixtures|gate|meta). Repeatable
+  --persist-memory       Write eval result as Riverbed Memory entry
   -h, --help             Show help
 `);
     return 0;
@@ -315,6 +320,34 @@ Options:
     appendLedger(envelope);
     if (!parsed.json) {
       console.log(`Ledger entry appended to artifacts/evals/results.jsonl`);
+    }
+  }
+
+  if (parsed.persistMemory) {
+    try {
+      const { appendEntry } = await import('../src/lib/riverbed-memory.mjs');
+      const memoryPath = path.join(ROOT, '.river', 'memory', 'index.json');
+      const entryId = `eval-${envelope.commit}-${Date.now()}`;
+      appendEntry(memoryPath, {
+        id: entryId,
+        type: 'eval_result',
+        title: `Eval run ${envelope.commit}`,
+        content: JSON.stringify(envelope),
+        metadata: {
+          createdAt: envelope.timestamp,
+          author: 'evaluate-all',
+          tags: ['eval', envelope.status],
+          summary: `${envelope.status}: ${Object.keys(envelope.scores).length} metrics`,
+        },
+      });
+      if (!parsed.json) {
+        console.log(`Memory entry ${entryId} persisted to .river/memory/index.json`);
+      }
+    } catch (err) {
+      // Memory persistence is optional; don't fail the eval
+      if (!parsed.json) {
+        console.log(`Warning: failed to persist memory entry: ${err.message}`);
+      }
     }
   }
 

--- a/tests/evaluate-all.test.mjs
+++ b/tests/evaluate-all.test.mjs
@@ -21,6 +21,7 @@ test('parseArgs: defaults', () => {
   assert.equal(result.appendLedger, false);
   assert.equal(result.description, '');
   assert.equal(result.json, false);
+  assert.equal(result.persistMemory, false);
   assert.equal(result.help, false);
   assert.equal(result.skip.size, 0);
 });
@@ -56,6 +57,11 @@ test('parseArgs: -h sets help', () => {
 
 test('parseArgs: --help sets help', () => {
   assert.ok(parseArgs(['--help']).help);
+});
+
+test('parseArgs: --persist-memory flag', () => {
+  const result = parseArgs(['--persist-memory']);
+  assert.equal(result.persistMemory, true);
 });
 
 test('parseArgs: unknown flags are ignored', () => {


### PR DESCRIPTION
## Summary
- Add `.github/workflows/riverbed-persist.yml` reusable workflow for uploading/downloading Riverbed Memory as GitHub Artifacts between CI runs (90-day retention)
- Add `--persist-memory` flag to `scripts/evaluate-all.mjs` that writes eval results as Riverbed Memory entries via `riverbed-memory.mjs` (optional, non-blocking on failure)
- Add `.river/memory/` directory with `.gitkeep` and gitignore rules to track the directory while ignoring data files

## Test plan
- [x] `node --test tests/evaluate-all.test.mjs` -- all 9 tests pass (including new `--persist-memory` flag test and updated defaults test)
- [x] `npx prettier --check` on all modified source files passes
- [x] YAML workflow file validates successfully
- [ ] Verify `--persist-memory` integrates correctly with `riverbed-memory.mjs` once PR-9 merges (dependency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)