### PR TITLE
feat(memory): add Riverbed Memory v1 runtime

### DIFF
--- a/schemas/riverbed-entry.schema.json
+++ b/schemas/riverbed-entry.schema.json
@@ -7,7 +7,7 @@
   "$defs": {
     "entryType": {
       "type": "string",
-      "enum": ["adr", "review", "wontfix", "pattern", "decision"]
+      "enum": ["adr", "review", "wontfix", "pattern", "decision", "eval_result"]
     },
     "phase": {
       "type": "string",

--- a/src/lib/riverbed-memory.mjs
+++ b/src/lib/riverbed-memory.mjs
@@ -1,0 +1,70 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Load the Riverbed Memory index from disk.
+ * Returns empty structure if file doesn't exist (stateless fallback).
+ *
+ * @param {string} indexPath - Path to the index.json file
+ * @returns {{ entries: object[], version: string }}
+ */
+export function loadMemory(indexPath) {
+  try {
+    const raw = fs.readFileSync(indexPath, 'utf-8');
+    return JSON.parse(raw);
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return { entries: [], version: '1' };
+    }
+    throw err;
+  }
+}
+
+/**
+ * Append a memory entry to the index.
+ * Creates the directory and file if they don't exist.
+ *
+ * @param {string} indexPath - Path to the index.json file
+ * @param {object} entry - Entry conforming to riverbed-entry.schema.json
+ */
+export function appendEntry(indexPath, entry) {
+  const index = loadMemory(indexPath);
+
+  // Validate required fields
+  if (!entry.id || !entry.type || !entry.content || !entry.metadata) {
+    throw new Error('Entry must have id, type, content, and metadata fields');
+  }
+
+  // Prevent duplicate IDs
+  if (index.entries.some((e) => e.id === entry.id)) {
+    throw new Error(`Duplicate entry ID: ${entry.id}`);
+  }
+
+  index.entries.push(entry);
+
+  const dir = path.dirname(indexPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  fs.writeFileSync(indexPath, JSON.stringify(index, null, 2) + '\n');
+}
+
+/**
+ * Query memory entries by filter criteria.
+ * All filter fields are optional; entries must match ALL provided criteria.
+ *
+ * @param {{ entries: object[] }} index - Loaded memory index
+ * @param {{ type?: string, tags?: string[], phase?: string }} filter
+ * @returns {object[]}
+ */
+export function queryMemory(index, { type, tags, phase } = {}) {
+  return index.entries.filter((entry) => {
+    if (type && entry.type !== type) return false;
+    if (phase && entry.metadata?.phase !== phase) return false;
+    if (tags && tags.length > 0) {
+      const entryTags = entry.metadata?.tags ?? [];
+      if (!tags.every((t) => entryTags.includes(t))) return false;
+    }
+    return true;
+  });
+}

--- a/tests/riverbed-memory.test.mjs
+++ b/tests/riverbed-memory.test.mjs
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { loadMemory, appendEntry, queryMemory } from '../src/lib/riverbed-memory.mjs';
+
+function tmpIndex() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rr-memory-'));
+  return { dir, indexPath: path.join(dir, 'index.json') };
+}
+
+function cleanup(dir) {
+  fs.rmSync(dir, { recursive: true });
+}
+
+function makeEntry(overrides = {}) {
+  return {
+    id: `test-${Date.now()}`,
+    type: 'review',
+    content: 'Test content',
+    metadata: { createdAt: new Date().toISOString(), author: 'test' },
+    ...overrides,
+  };
+}
+
+test('loadMemory: returns empty structure for missing file', () => {
+  const { dir, indexPath } = tmpIndex();
+  const mem = loadMemory(indexPath);
+  assert.deepEqual(mem.entries, []);
+  assert.equal(mem.version, '1');
+  cleanup(dir);
+});
+
+test('loadMemory: reads existing index', () => {
+  const { dir, indexPath } = tmpIndex();
+  const data = { entries: [makeEntry()], version: '1' };
+  fs.writeFileSync(indexPath, JSON.stringify(data));
+  const mem = loadMemory(indexPath);
+  assert.equal(mem.entries.length, 1);
+  cleanup(dir);
+});
+
+test('appendEntry: creates file and adds entry', () => {
+  const { dir, indexPath } = tmpIndex();
+  const entry = makeEntry({ id: 'e1' });
+  appendEntry(indexPath, entry);
+  const mem = loadMemory(indexPath);
+  assert.equal(mem.entries.length, 1);
+  assert.equal(mem.entries[0].id, 'e1');
+  cleanup(dir);
+});
+
+test('appendEntry: rejects duplicate ID', () => {
+  const { dir, indexPath } = tmpIndex();
+  appendEntry(indexPath, makeEntry({ id: 'dup' }));
+  assert.throws(() => appendEntry(indexPath, makeEntry({ id: 'dup' })), /Duplicate/);
+  cleanup(dir);
+});
+
+test('appendEntry: rejects entry without required fields', () => {
+  const { dir, indexPath } = tmpIndex();
+  assert.throws(() => appendEntry(indexPath, { id: 'x' }), /must have/);
+  cleanup(dir);
+});
+
+test('queryMemory: filters by type', () => {
+  const entries = [
+    makeEntry({ id: 'a', type: 'adr' }),
+    makeEntry({ id: 'b', type: 'review' }),
+    makeEntry({ id: 'c', type: 'adr' }),
+  ];
+  const result = queryMemory({ entries }, { type: 'adr' });
+  assert.equal(result.length, 2);
+});
+
+test('queryMemory: filters by phase', () => {
+  const entries = [
+    makeEntry({ id: 'a', metadata: { createdAt: '', author: '', phase: 'upstream' } }),
+    makeEntry({ id: 'b', metadata: { createdAt: '', author: '', phase: 'midstream' } }),
+  ];
+  const result = queryMemory({ entries }, { phase: 'upstream' });
+  assert.equal(result.length, 1);
+  assert.equal(result[0].id, 'a');
+});
+
+test('queryMemory: filters by tags', () => {
+  const entries = [
+    makeEntry({ id: 'a', metadata: { createdAt: '', author: '', tags: ['security', 'auth'] } }),
+    makeEntry({ id: 'b', metadata: { createdAt: '', author: '', tags: ['perf'] } }),
+  ];
+  const result = queryMemory({ entries }, { tags: ['security'] });
+  assert.equal(result.length, 1);
+  assert.equal(result[0].id, 'a');
+});
+
+test('queryMemory: empty filter returns all', () => {
+  const entries = [makeEntry({ id: 'a' }), makeEntry({ id: 'b' })];
+  const result = queryMemory({ entries });
+  assert.equal(result.length, 2);
+});
+
+test('queryMemory: combined filters are AND', () => {
+  const entries = [
+    makeEntry({
+      id: 'a',
+      type: 'adr',
+      metadata: { createdAt: '', author: '', phase: 'upstream' },
+    }),
+    makeEntry({
+      id: 'b',
+      type: 'adr',
+      metadata: { createdAt: '', author: '', phase: 'midstream' },
+    }),
+    makeEntry({
+      id: 'c',
+      type: 'review',
+      metadata: { createdAt: '', author: '', phase: 'upstream' },
+    }),
+  ];
+  const result = queryMemory({ entries }, { type: 'adr', phase: 'upstream' });
+  assert.equal(result.length, 1);
+  assert.equal(result[0].id, 'a');
+});


### PR DESCRIPTION
## Summary
- Add `eval_result` to the `entryType` enum in `schemas/riverbed-entry.schema.json`
- Create `src/lib/riverbed-memory.mjs` with `loadMemory`, `appendEntry`, and `queryMemory` functions for file-based memory persistence (stateless fallback when no index file exists)
- Add comprehensive test suite in `tests/riverbed-memory.test.mjs` (10 tests covering load, append, query, validation, and edge cases)

## Test plan
- [x] `node --test tests/riverbed-memory.test.mjs` — all 10 tests pass
- [x] `npx prettier --check` — formatting verified on all changed files
- [ ] Verify schema change does not break existing `skills:validate` or `agents:validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)