### PR TITLE
refactor: add planner failure taxonomy and fix riverbed-index schema

### DIFF
--- a/schemas/riverbed-index.schema.json
+++ b/schemas/riverbed-index.schema.json
@@ -13,7 +13,7 @@
         "id": { "type": "string" },
         "type": {
           "type": "string",
-          "enum": ["adr", "review", "wontfix", "pattern", "decision"]
+          "enum": ["adr", "review", "wontfix", "pattern", "decision", "eval_result"]
         },
         "path": { "type": "string", "description": "Relative path to the entry JSON file." },
         "title": { "type": "string" },

--- a/src/lib/planner-dataset-eval.mjs
+++ b/src/lib/planner-dataset-eval.mjs
@@ -60,6 +60,26 @@ export async function evaluatePlannerDataset({
       const top1Match = expectedTop1.length ? (expectedTop1.includes(top1) ? 1 : 0) : null;
       const missingExpected = expectedAny.filter((id) => !selectedIds.includes(id));
 
+      const failures = [];
+      if (missingExpected.length > 0) {
+        for (const skillId of missingExpected) {
+          failures.push({
+            category: 'routing_miss',
+            caseRef: c.name,
+            evalType: 'planner',
+            description: `Expected skill ${skillId} not selected`,
+          });
+        }
+      }
+      if (top1Match === 0 && expectedTop1.length > 0) {
+        failures.push({
+          category: 'phase_miss',
+          caseRef: c.name,
+          evalType: 'planner',
+          description: `Top-1 mismatch: got ${top1}, expected one of ${expectedTop1.join(', ')}`,
+        });
+      }
+
       return {
         name: c.name,
         phase: c.phase,
@@ -74,6 +94,7 @@ export async function evaluatePlannerDataset({
         coverage,
         top1Match,
         missingExpected,
+        failures,
         skipped: plan.skipped.map((s) => ({
           id: getMeta(s.skill).id,
           reasons: s.reasons,
@@ -83,12 +104,18 @@ export async function evaluatePlannerDataset({
   );
 
   const definedTop1 = results.map((r) => r.top1Match).filter((v) => v != null);
+  const allFailures = results.flatMap((r) => r.failures ?? []);
+  const failuresByCategory = {};
+  for (const f of allFailures) {
+    failuresByCategory[f.category] = (failuresByCategory[f.category] ?? 0) + 1;
+  }
   return {
     summary: {
       cases: results.length,
       coverage: average(results.map((r) => r.coverage)),
       top1Match: definedTop1.length ? average(definedTop1) : 0,
       top1MatchCases: definedTop1.length,
+      failuresByCategory,
     },
     cases: results,
   };

--- a/tests/planner-dataset-eval.test.mjs
+++ b/tests/planner-dataset-eval.test.mjs
@@ -11,7 +11,7 @@ test('evaluatePlannerDataset loads fixture cases', async () => {
   const { summary, cases } = await evaluatePlannerDataset({ datasetDir });
   assert.ok(summary.cases >= 10);
   assert.strictEqual(cases.length, summary.cases);
-  assert.ok(cases.every(c => typeof c.name === 'string' && c.name.length > 0));
+  assert.ok(cases.every((c) => typeof c.name === 'string' && c.name.length > 0));
 });
 
 test('evaluatePlannerDataset keeps stable baseline metrics (coverage/top1Match)', async () => {
@@ -24,5 +24,21 @@ test('evaluatePlannerDataset keeps stable baseline metrics (coverage/top1Match)'
   // top1Match is defined only for cases that set expectedTop1.
   if (summary.top1MatchCases > 0) {
     assert.ok(summary.top1Match >= 0.9);
+  }
+});
+
+test('evaluatePlannerDataset: results include failures array', async () => {
+  const datasetDir = path.join(__dirname, 'fixtures', 'planner-dataset');
+
+  try {
+    const result = await evaluatePlannerDataset({ datasetDir });
+    for (const c of result.cases) {
+      assert.ok(Array.isArray(c.failures), `case ${c.name} should have failures array`);
+    }
+    assert.ok(result.summary.failuresByCategory !== undefined);
+  } catch (err) {
+    // Skip if dataset not available
+    if (err.code === 'ENOENT') return;
+    throw err;
   }
 });


### PR DESCRIPTION
## Summary
- Add failure taxonomy (`routing_miss` / `phase_miss`) to `evaluatePlannerDataset` results, with per-case `failures` array and `failuresByCategory` summary aggregate
- Add `eval_result` to `riverbed-index.schema.json` entryType enum for consistency with `riverbed-entry.schema.json`
- Add test verifying `failures` array and `failuresByCategory` are present in evaluation output

## Test plan
- [x] All 3 planner-dataset-eval tests pass (`node --test tests/planner-dataset-eval.test.mjs`)
- [x] Prettier formatting check passes
- [ ] Verify CI passes on remote

🤖 Generated with [Claude Code](https://claude.com/claude-code)