### PR TITLE
feat(review): integrate verifier into review pipeline

### DIFF
--- a/scripts/evaluate-all.mjs
+++ b/scripts/evaluate-all.mjs
@@ -40,6 +40,7 @@ const RATIO_METRICS = new Set([
   'passRate',
   'falsePositiveRate',
   'evidenceRate',
+  'verifierRejectRate',
 ]);
 
 // --- arg parsing -----------------------------------------------------------

--- a/src/lib/review-engine.mjs
+++ b/src/lib/review-engine.mjs
@@ -510,6 +510,34 @@ export async function generateReview({
     ? { ok: false, invalidCount, samples: formatChecks.filter((c) => !c.ok).slice(0, 3) }
     : { ok: true };
 
+  // Verifier pass: filter findings that fail quality checks
+  const { verifyFinding } = await import('./verifier.mjs');
+  const verifierResults = comments.map((comment) => ({
+    comment,
+    verification: verifyFinding({
+      finding: comment,
+      diff: diff.diffText,
+      skill: plan?.selected?.[0] ?? {},
+    }),
+  }));
+
+  const verified = verifierResults.filter((r) => r.verification.verified).map((r) => r.comment);
+  const rejected = verifierResults.filter((r) => !r.verification.verified);
+
+  debug.verifierRejected = rejected.map((r) => ({
+    file: r.comment.file,
+    line: r.comment.line,
+    reasons: r.verification.reasons,
+  }));
+  debug.verifierStats = {
+    total: comments.length,
+    verified: verified.length,
+    rejected: rejected.length,
+  };
+
+  // Replace comments with verified-only set
+  comments = verified;
+
   return {
     comments,
     prompt: promptInfo.prompt,

--- a/tests/review-engine.test.mjs
+++ b/tests/review-engine.test.mjs
@@ -16,7 +16,9 @@ const diff = {
   files: [
     {
       path: 'src/app.ts',
-      hunks: [{ newStart: 11, addedLines: [11, 12], lines: [], oldStart: 10, oldLines: 0, newLines: 2 }],
+      hunks: [
+        { newStart: 11, addedLines: [11, 12], lines: [], oldStart: 10, oldLines: 0, newLines: 2 },
+      ],
       addedLines: [11, 12],
     },
   ],
@@ -24,14 +26,22 @@ const diff = {
 };
 
 const plan = {
-  selected: [{ metadata: { id: 'skill-1', name: 'Skill One', phase: 'midstream', applyTo: ['src/**'] } }],
+  selected: [
+    { metadata: { id: 'skill-1', name: 'Skill One', phase: 'midstream', applyTo: ['src/**'] } },
+  ],
   skipped: [],
 };
 
 test('generateReview runs heuristics when LLM is skipped', async () => {
   // スキルが選択されている場合、ヒューリスティックが実行される。
   // ヒューリスティックが何も検出しなかった場合、コメントは0件となる（正常な動作）。
-  const result = await generateReview({ diff, plan, phase: 'midstream', dryRun: true, includeFallback: false });
+  const result = await generateReview({
+    diff,
+    plan,
+    phase: 'midstream',
+    dryRun: true,
+    includeFallback: false,
+  });
   assert.equal(result.debug.llmUsed, false);
   assert.ok(result.prompt.includes('River Reviewer'));
   // dry-runモードでもヒューリスティックが実行される
@@ -63,6 +73,22 @@ test('buildPrompt injects project rules when provided', () => {
   });
   assert.match(prompt, /Project-specific review rules/i);
   assert.match(prompt, /Use App Router/);
+});
+
+test('generateReview: verifier stats exist in debug output', async () => {
+  const result = await generateReview({
+    diff: { diffText: '+const x = 1;', files: [], changedFiles: [] },
+    plan: { selected: [] },
+    phase: 'midstream',
+    dryRun: true,
+  });
+  // verifierStats should always be present after the verifier pass
+  assert.ok(result.debug.verifierStats !== undefined, 'verifierStats should exist in debug');
+  assert.equal(typeof result.debug.verifierStats.total, 'number');
+  assert.equal(typeof result.debug.verifierStats.verified, 'number');
+  assert.equal(typeof result.debug.verifierStats.rejected, 'number');
+  // verifierRejected should be an array (possibly empty)
+  assert.ok(Array.isArray(result.debug.verifierRejected), 'verifierRejected should be an array');
 });
 
 test('buildPrompt switches language based on config', () => {


### PR DESCRIPTION
## Summary
- Integrate `verifyFinding` from `src/lib/verifier.mjs` into the `generateReview` pipeline in `src/lib/review-engine.mjs`. All comments now pass through evidence, phase coherence, severity, and actionability checks before emission.
- Rejected findings are logged in `debug.verifierRejected` with reasons; `debug.verifierStats` tracks total/verified/rejected counts.
- Add `verifierRejectRate` to `RATIO_METRICS` in `scripts/evaluate-all.mjs` for future percentage display support.
- Add test verifying `verifierStats` and `verifierRejected` are present in `generateReview` debug output.

## Test plan
- [x] `node --test tests/review-engine.test.mjs` -- 6/6 pass (including new verifier stats test)
- [x] `node --test tests/review-eval.test.mjs` -- 3/3 pass (existing review-eval fixtures unaffected)
- [x] `npx prettier --check` on all changed files passes
- [ ] Manual: run a full review cycle and verify `debug.verifierStats` appears in output
- [ ] Manual: confirm rejected findings are excluded from emitted comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)