### PR TITLE
feat(eval): add eval ledger section to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -53,6 +53,19 @@ npm run agents:validate
 npm test
 ```
 
+## Eval Ledger（skill / planner / routing 変更時）
+
+> skill、planner、routing、output policy に影響する変更では、[採否基準](../pages/reference/eval-keep-discard-policy.md)に基づいて keep/discard を判断してください。
+
+- [ ] 変更前: `npm run eval:all -- --append-ledger --description "baseline"`
+- [ ] 変更後: `npm run eval:all -- --append-ledger --description "candidate: <変更内容>"`
+- [ ] `artifacts/evals/results.jsonl` の直近 2 エントリを比較
+- [ ] keep/discard 判定根拠:
+
+```text
+（ここに比較結果を貼付）
+```
+
 ## Checklist / チェックリスト
 
 - [ ] Added or updated tests related to the changes.（変更内容に関連するテストを追加・修正しました。）


### PR DESCRIPTION
PR テンプレートの「Validation & Evidence」セクションと「Checklist」セクションの間に、eval ledger の記載欄を追加する。

skill / planner / routing / output policy に影響する変更では、`pages/reference/eval-keep-discard-policy.md` で定義された採否基準に基づいて baseline と candidate を比較し、keep/discard を判断するフローが必要。これまでこの手順が PR テンプレートに組み込まれておらず、運用が属人的だった。

変更内容:
- `npm run eval:all -- --append-ledger` の baseline / candidate 実行手順をチェックリスト化
- 比較結果の貼付欄（`text` コードブロック）を追加
- 採否基準ドキュメントへのリンクを追加

Fixes #438