### PR TITLE
feat(review): add diff cross-validation to verifier

### DIFF
--- a/src/lib/verifier.mjs
+++ b/src/lib/verifier.mjs
@@ -14,6 +14,7 @@
 const RE_EVIDENCE = /Evidence:\s*(\S.{4,})/;
 const RE_SEVERITY = /Severity:\s*(\w+)/;
 const RE_ACTIONABLE = /(?:Fix|Suggestion):\s*(.{10,})/;
+const RE_FILE_REF = /[\w./-]+\.\w{1,10}/g;
 
 const SEVERITY_RANK = /** @type {const} */ ({
   info: 0,
@@ -104,12 +105,34 @@ function checkSuggestionActionable(finding) {
 }
 
 /**
+ * Check that file names referenced in the Evidence text actually appear
+ * in the diff. Lenient: returns true when no file references are found
+ * in the evidence (to avoid false negatives on prose-only evidence).
+ * @param {{ message?: string }} finding
+ * @param {string} diffText
+ * @returns {boolean}
+ */
+function checkEvidenceInDiff(finding, diffText) {
+  const text = String(finding?.message ?? '');
+  const evidenceMatch = RE_EVIDENCE.exec(text);
+  if (!evidenceMatch) return true;
+
+  const evidenceText = evidenceMatch[1];
+  const fileRefs = evidenceText.match(RE_FILE_REF);
+  if (!fileRefs || fileRefs.length === 0) return true;
+
+  const diff = String(diffText ?? '');
+  return fileRefs.some((ref) => diff.includes(ref));
+}
+
+/**
  * @param {{ finding: object, diff: string, skill: object }} params
  * @returns {{ verified: boolean, reasons: string[], checks: object }}
  */
 export function verifyFinding({ finding, diff, skill }) {
   const checks = {
     evidenceExists: checkEvidenceExists(finding),
+    evidenceInDiff: checkEvidenceInDiff(finding, diff),
     phaseCoherent: checkPhaseCoherent(finding, skill),
     severityJustified: checkSeverityJustified(finding, skill),
     suggestionActionable: checkSuggestionActionable(finding),
@@ -117,6 +140,7 @@ export function verifyFinding({ finding, diff, skill }) {
 
   const reasons = [];
   if (!checks.evidenceExists) reasons.push('No evidence provided in finding');
+  if (!checks.evidenceInDiff) reasons.push('Evidence references file not found in diff');
   if (!checks.phaseCoherent)
     reasons.push(
       `Phase mismatch: finding phase does not match skill phase "${skill?.metadata?.phase}"`

--- a/src/lib/verifier.mjs
+++ b/src/lib/verifier.mjs
@@ -14,7 +14,7 @@
 const RE_EVIDENCE = /Evidence:\s*(\S.{4,})/;
 const RE_SEVERITY = /Severity:\s*(\w+)/;
 const RE_ACTIONABLE = /(?:Fix|Suggestion):\s*(.{10,})/;
-const RE_FILE_REF = /[\w./-]+\.\w{1,10}/g;
+const RE_FILE_REF = /[\w/-]+(?:\.[\w]+)+/g;
 
 const SEVERITY_RANK = /** @type {const} */ ({
   info: 0,

--- a/tests/verifier.test.mjs
+++ b/tests/verifier.test.mjs
@@ -166,3 +166,40 @@ test('verifyFinding: multiple failures are all reported', () => {
   assert.equal(result.checks.phaseCoherent, false);
   assert.equal(result.checks.suggestionActionable, false);
 });
+
+test('verifyFinding: evidenceInDiff passes when file is in diff', () => {
+  const result = verifyFinding({
+    finding: {
+      message:
+        'Finding:\nEvidence: hardcoded secret in src/config/auth.ts\nSeverity: warning\nFix: Move the secret to environment variables',
+    },
+    diff: 'diff --git a/src/config/auth.ts b/src/config/auth.ts\n+const secret = "abc";',
+    skill: { metadata: { severity: 'major' } },
+  });
+  assert.equal(result.checks.evidenceInDiff, true);
+});
+
+test('verifyFinding: evidenceInDiff fails when file is not in diff', () => {
+  const result = verifyFinding({
+    finding: {
+      message:
+        'Finding:\nEvidence: hardcoded secret in src/config/auth.ts\nSeverity: warning\nFix: Move the secret to environment variables',
+    },
+    diff: 'diff --git a/src/index.mjs b/src/index.mjs\n+console.log("hello");',
+    skill: { metadata: { severity: 'major' } },
+  });
+  assert.equal(result.checks.evidenceInDiff, false);
+  assert.ok(result.reasons.some((r) => r.includes('file not found in diff')));
+});
+
+test('verifyFinding: evidenceInDiff lenient when no file reference', () => {
+  const result = verifyFinding({
+    finding: {
+      message:
+        'Finding:\nEvidence: the code uses an outdated pattern\nSeverity: warning\nFix: Migrate to the newer API for better performance',
+    },
+    diff: 'diff --git a/src/index.mjs b/src/index.mjs\n+console.log("hello");',
+    skill: { metadata: { severity: 'major' } },
+  });
+  assert.equal(result.checks.evidenceInDiff, true);
+});


### PR DESCRIPTION
verifier の Evidence チェックを強化し、Evidence テキストが参照するファイルが実際に diff 内に存在するかを検証する。

既存の `checkEvidenceExists` は `Evidence:` ラベルの有無しか見ておらず、「Evidence: src/config/auth.ts にハードコード」と書かれていても、そのファイルが diff に含まれない場合でも pass していた。これにより diff 外のコードへの推測に基づく指摘がフィルタされずに出力される問題があった。

実装:
- `checkEvidenceInDiff(finding, diffText)` を追加
- `RE_FILE_REF` regex でファイル名参照を抽出し、diff 内の存在を検証
- ファイル参照なしの Evidence は lenient pass（prose-only evidence の false negative 回避）
- テスト3パターン追加（file in diff / file not in diff / no file ref）

設計判断:
- `fileRefs.some()` で少なくとも1つのファイルが diff にあれば pass（全一致を要求しない）
- `RE_FILE_REF` は `/g` フラグ付きだが `String.match()` で使用するため stateful 問題なし

Fixes #441