### PR TITLE
feat(review): integrate adr-linker into review pipeline

### DIFF
--- a/runners/core/review-runner.mjs
+++ b/runners/core/review-runner.mjs
@@ -5,6 +5,7 @@ import { inferImpactTags } from '../../src/lib/impact-scope.mjs';
 import { classifyChangedFiles } from '../../src/lib/file-classifier.mjs';
 import { normalizePlannerMode } from '../../src/lib/planner-utils.mjs';
 import { HEURISTIC_SKILL_IDS } from '../../src/lib/heuristic-review.mjs';
+import { findRelatedADRs } from '../../src/lib/adr-linker.mjs';
 
 const MODEL_PRIORITY = {
   cheap: 1,
@@ -187,6 +188,7 @@ export async function buildExecutionPlan(options) {
     diffText,
     dryRun = false,
     llmEnabled = true,
+    repoRoot,
   } = options;
 
   const skills = providedSkills ?? (await loadSkills());
@@ -204,6 +206,7 @@ export async function buildExecutionPlan(options) {
 
   const impactTags = inferImpactTags(changedFiles, { diffText });
   const fileTypes = classifyChangedFiles(changedFiles);
+  const relatedADRs = findRelatedADRs(repoRoot ?? process.cwd(), { changedFiles, keywords: impactTags });
 
   // If planner is provided, try LLM-based planning, fallback to deterministic rank
   const effectivePlannerMode = planner
@@ -235,6 +238,7 @@ export async function buildExecutionPlan(options) {
       ...(fallback ? { plannerError: reasons?.[0]?.reason ?? 'planner fallback' } : {}),
       impactTags,
       fileTypes,
+      relatedADRs,
     };
   }
 
@@ -246,6 +250,7 @@ export async function buildExecutionPlan(options) {
     skipped: selection.skipped,
     impactTags,
     fileTypes,
+    relatedADRs,
   };
 }
 

--- a/src/lib/local-runner.mjs
+++ b/src/lib/local-runner.mjs
@@ -341,6 +341,7 @@ export async function runLocalReview({
     apiKey,
     projectRules: context.projectRules,
     fileTypes: context.plan?.fileTypes,
+    relatedADRs: context.plan?.relatedADRs,
     config: context.config,
   });
 

--- a/src/lib/local-runner.mjs
+++ b/src/lib/local-runner.mjs
@@ -248,6 +248,7 @@ export async function planLocalReview({
     plannerMode: requestedPlannerMode,
     dryRun,
     llmEnabled,
+    repoRoot,
   });
 
   const plannerUsed = planner ? !plan.plannerFallback : false;
@@ -409,6 +410,7 @@ export async function doctorLocalReview({
         preferredModelHint,
         skills,
         llmEnabled,
+        repoRoot,
       })
     : null;
 

--- a/src/lib/review-engine.mjs
+++ b/src/lib/review-engine.mjs
@@ -94,12 +94,23 @@ function buildProjectRulesSection(rulesText) {
   return `\n### Project-specific review rules\n\n以下は、このリポジトリ専用のレビューガイドラインです。必ず考慮してください。\n\n---\n${rulesText}\n---\n`;
 }
 
+function buildADRContextSection(relatedADRs) {
+  if (!relatedADRs?.length) return '';
+  const lines = ['\n### Related ADRs/Specs\n'];
+  for (const adr of relatedADRs.slice(0, 5)) {
+    lines.push(`- ${adr.title} (${adr.path}) — ${adr.matchReason}`);
+  }
+  lines.push('\nこれらの設計文書との整合性を考慮してレビューしてください。\n');
+  return lines.join('\n');
+}
+
 export function buildPrompt({
   diffText,
   diffFiles,
   plan,
   phase,
   projectRules,
+  relatedADRs,
   maxChars = MAX_PROMPT_CHARS,
   config = defaultConfig,
 }) {
@@ -118,7 +129,7 @@ ${buildFileSummary(diffFiles)}
 Relevant skills:
 ${buildSkillSummary(plan)}
 
-${buildProjectRulesSection(projectRules)}Review the unified git diff below and produce concise findings.
+${buildProjectRulesSection(projectRules)}${buildADRContextSection(relatedADRs)}Review the unified git diff below and produce concise findings.
 ${buildLanguageInstruction(language)}
 - Output each finding on its own line using the format "<file>:<line>: <message>".
 - In <message>, include short labels: "Finding:", "Evidence:", "Impact:", "Fix:", "Severity:", "Confidence:".
@@ -409,6 +420,7 @@ export async function generateReview({
   apiKey,
   projectRules,
   fileTypes,
+  relatedADRs,
   maxPromptChars = MAX_PROMPT_CHARS,
   config,
 }) {
@@ -419,6 +431,7 @@ export async function generateReview({
     plan,
     phase,
     projectRules,
+    relatedADRs,
     maxChars: maxPromptChars,
     config: effectiveConfig,
   });

--- a/tests/review-engine.test.mjs
+++ b/tests/review-engine.test.mjs
@@ -91,6 +91,48 @@ test('generateReview: verifier stats exist in debug output', async () => {
   assert.ok(Array.isArray(result.debug.verifierRejected), 'verifierRejected should be an array');
 });
 
+test('buildPrompt includes ADR context section when relatedADRs provided', () => {
+  const relatedADRs = [
+    { title: 'ADR-001 Eval Loop', path: 'docs/adr/001-eval.md', matchReason: 'keyword: evaluation' },
+    { title: 'ADR-002 Scoring', path: 'docs/adr/002-scoring.md', matchReason: 'references: src/app.ts' },
+  ];
+  const { prompt } = buildPrompt({
+    diffText,
+    diffFiles: diff.files,
+    plan,
+    phase: 'midstream',
+    projectRules: null,
+    relatedADRs,
+  });
+  assert.match(prompt, /Related ADRs\/Specs/);
+  assert.match(prompt, /ADR-001 Eval Loop/);
+  assert.match(prompt, /ADR-002 Scoring/);
+  assert.match(prompt, /設計文書との整合性/);
+});
+
+test('buildPrompt omits ADR context section when relatedADRs is empty', () => {
+  const { prompt } = buildPrompt({
+    diffText,
+    diffFiles: diff.files,
+    plan,
+    phase: 'midstream',
+    projectRules: null,
+    relatedADRs: [],
+  });
+  assert.ok(!prompt.includes('Related ADRs/Specs'));
+});
+
+test('buildPrompt omits ADR context section when relatedADRs is undefined', () => {
+  const { prompt } = buildPrompt({
+    diffText,
+    diffFiles: diff.files,
+    plan,
+    phase: 'midstream',
+    projectRules: null,
+  });
+  assert.ok(!prompt.includes('Related ADRs/Specs'));
+});
+
 test('buildPrompt switches language based on config', () => {
   const { prompt, language } = buildPrompt({
     diffText,


### PR DESCRIPTION
既存の adr-linker ライブラリ（`src/lib/adr-linker.mjs`）をレビューパイプラインに統合し、レビュー時に関連する ADR/spec を自動参照可能にする。

`findRelatedADRs` は実装・テスト済みだったが、パイプラインに接続されておらず、レビュー実行時に ADR コンテキストが注入されていなかった。upstream / midstream の phase 間で「設計意図不明」となる指摘を減らすために、ADR 参照をプロンプトに含める。

変更内容:

**runners/core/review-runner.mjs**
- `findRelatedADRs` の import と呼び出しを追加
- `buildExecutionPlan` の options に `repoRoot` を追加（未指定時は `process.cwd()` にフォールバック）
- plan 返却オブジェクトに `relatedADRs` を追加（planner あり/なし両パス）

**src/lib/review-engine.mjs**
- `buildADRContextSection(relatedADRs)` を追加（`buildProjectRulesSection` と同パターン）
- `buildPrompt` / `generateReview` に `relatedADRs` パラメータを追加
- 最大5件に制限（プロンプト肥大化防止）

**tests/review-engine.test.mjs**
- ADR context テスト3件追加（provided / empty / undefined）

Fixes #444