### PR TITLE
feat(review): integrate file-classifier into verifier with debug output

### DIFF
--- a/src/lib/local-runner.mjs
+++ b/src/lib/local-runner.mjs
@@ -20,26 +20,40 @@ function normalizePhase(phase) {
 }
 
 // NOTE: Keep this list in sync with schemas/skill.schema.json dependencies enum.
-const dependencyStubs = ['code_search', 'test_runner', 'coverage_report', 'adr_lookup', 'repo_metadata', 'tracing'];
+const dependencyStubs = [
+  'code_search',
+  'test_runner',
+  'coverage_report',
+  'adr_lookup',
+  'repo_metadata',
+  'tracing',
+];
 
 const configLoader = new ConfigLoader();
 
 function shouldExclude(filePath, patterns = []) {
-  return patterns.some(pattern => minimatch(filePath, pattern, { dot: true }));
+  return patterns.some((pattern) => minimatch(filePath, pattern, { dot: true }));
 }
 
 function applyFileExclusions(diff, patterns = []) {
   if (!patterns.length) return diff;
 
-  const changedFiles = (diff.changedFiles ?? []).filter(filePath => !shouldExclude(filePath, patterns));
-  const rawFiles = (diff.files ?? []).filter(file => !shouldExclude(file.path, patterns));
-  const optimizedFiles = (diff.filesForReview ?? diff.files ?? []).filter(file => !shouldExclude(file.path, patterns));
+  const changedFiles = (diff.changedFiles ?? []).filter(
+    (filePath) => !shouldExclude(filePath, patterns)
+  );
+  const rawFiles = (diff.files ?? []).filter((file) => !shouldExclude(file.path, patterns));
+  const optimizedFiles = (diff.filesForReview ?? diff.files ?? []).filter(
+    (file) => !shouldExclude(file.path, patterns)
+  );
 
   const rawDiffText = renderDiffText(rawFiles);
   const diffText = renderDiffText(optimizedFiles);
   const rawTokenEstimate = Math.ceil(rawDiffText.length / 4);
   const tokenEstimate = Math.ceil(diffText.length / 4);
-  const reduction = rawTokenEstimate === 0 ? 0 : Math.max(0, Math.round(((rawTokenEstimate - tokenEstimate) / rawTokenEstimate) * 100));
+  const reduction =
+    rawTokenEstimate === 0
+      ? 0
+      : Math.max(0, Math.round(((rawTokenEstimate - tokenEstimate) / rawTokenEstimate) * 100));
 
   return {
     ...diff,
@@ -65,7 +79,7 @@ async function resolvePullRequestLabels() {
     const raw = await fs.readFile(eventPath, 'utf8');
     const event = JSON.parse(raw);
     const pullRequestLabels = event?.pull_request?.labels ?? event?.labels ?? [];
-    return pullRequestLabels.map(label => label?.name).filter(Boolean);
+    return pullRequestLabels.map((label) => label?.name).filter(Boolean);
   } catch {
     return [];
   }
@@ -73,10 +87,10 @@ async function resolvePullRequestLabels() {
 
 function shouldSkipByLabel(prLabels = [], ignorePatterns = []) {
   if (!prLabels.length || !ignorePatterns.length) return { matched: [], shouldSkip: false };
-  const normalizedLabels = prLabels.map(label => label.toLowerCase());
-  const matched = ignorePatterns.filter(pattern => {
+  const normalizedLabels = prLabels.map((label) => label.toLowerCase());
+  const matched = ignorePatterns.filter((pattern) => {
     const needle = pattern.toLowerCase();
-    return normalizedLabels.some(label => label.includes(needle));
+    return normalizedLabels.some((label) => label.includes(needle));
   });
   return { matched, shouldSkip: matched.length > 0 };
 }
@@ -113,7 +127,7 @@ async function collectLocalContext({
   const mergeBase = await findMergeBase(repoRoot, defaultBranch);
   const rawDiff = await collectRepoDiff(repoRoot, mergeBase, { contextLines });
   const diff = applyFileExclusions(rawDiff, config.exclude?.files ?? []);
-  const reviewFiles = diff.filesForReview?.map(file => file.path) ?? diff.changedFiles;
+  const reviewFiles = diff.filesForReview?.map((file) => file.path) ?? diff.changedFiles;
   const contexts = resolveAvailableContexts(availableContexts);
   const dependencies = resolveAvailableDependencies(availableDependencies);
 
@@ -172,7 +186,7 @@ export async function planLocalReview({
 
   const { matched: ignoredLabels, shouldSkip } = shouldSkipByLabel(
     prLabels,
-    config.exclude?.prLabelsToIgnore ?? [],
+    config.exclude?.prLabelsToIgnore ?? []
   );
 
   if (shouldSkip) {
@@ -263,21 +277,19 @@ export async function planLocalReview({
   };
 }
 
-export async function runLocalReview(
-  {
-    cwd = process.cwd(),
-    phase = 'midstream',
-    dryRun = false,
-    debug = false,
-    preferredModelHint = 'balanced',
-    model,
-    apiKey,
-    context: providedContext,
-    availableContexts,
-    availableDependencies,
-    plannerMode,
-  } = {},
-) {
+export async function runLocalReview({
+  cwd = process.cwd(),
+  phase = 'midstream',
+  dryRun = false,
+  debug = false,
+  preferredModelHint = 'balanced',
+  model,
+  apiKey,
+  context: providedContext,
+  availableContexts,
+  availableDependencies,
+  plannerMode,
+} = {}) {
   const context =
     providedContext ??
     (await planLocalReview({
@@ -328,6 +340,7 @@ export async function runLocalReview(
     model,
     apiKey,
     projectRules: context.projectRules,
+    fileTypes: context.plan?.fileTypes,
     config: context.config,
   });
 
@@ -372,8 +385,16 @@ export async function doctorLocalReview({
     availableContexts,
     availableDependencies,
   });
-  const { repoRoot, projectRules, defaultBranch, mergeBase, diff, reviewFiles, availableContexts: contexts, availableDependencies: dependencies } =
-    base;
+  const {
+    repoRoot,
+    projectRules,
+    defaultBranch,
+    mergeBase,
+    diff,
+    reviewFiles,
+    availableContexts: contexts,
+    availableDependencies: dependencies,
+  } = base;
 
   const llmEnabled = isLlmEnabled();
 

--- a/src/lib/review-engine.mjs
+++ b/src/lib/review-engine.mjs
@@ -408,6 +408,7 @@ export async function generateReview({
   model,
   apiKey,
   projectRules,
+  fileTypes,
   maxPromptChars = MAX_PROMPT_CHARS,
   config,
 }) {
@@ -510,6 +511,8 @@ export async function generateReview({
     ? { ok: false, invalidCount, samples: formatChecks.filter((c) => !c.ok).slice(0, 3) }
     : { ok: true };
 
+  debug.fileClassification = fileTypes ?? null;
+
   // Verifier pass: filter findings that fail quality checks
   const { verifyFinding } = await import('./verifier.mjs');
   const verifierResults = comments.map((comment) => ({
@@ -518,6 +521,7 @@ export async function generateReview({
       finding: comment,
       diff: diff.diffText,
       skill: plan?.selected?.[0] ?? {},
+      fileTypes,
     }),
   }));
 

--- a/src/lib/verifier.mjs
+++ b/src/lib/verifier.mjs
@@ -14,7 +14,7 @@
 const RE_EVIDENCE = /Evidence:\s*(\S.{4,})/;
 const RE_SEVERITY = /Severity:\s*(\w+)/;
 const RE_ACTIONABLE = /(?:Fix|Suggestion):\s*(.{10,})/;
-const RE_FILE_REF = /[\w./-]+\.\w{1,10}/g;
+const RE_FILE_REF = /[\w/-]+(?:\.[\w]+)+/g;
 
 const SEVERITY_RANK = /** @type {const} */ ({
   info: 0,
@@ -131,7 +131,7 @@ function checkEvidenceInDiff(finding, diffText) {
  */
 const FILE_TYPE_PHASE_MAP = {
   test: ['downstream'],
-  docs: ['upstream'],
+  docs: ['upstream', 'midstream'],
   schema: ['upstream', 'midstream'],
   migration: ['upstream', 'midstream'],
 };

--- a/src/lib/verifier.mjs
+++ b/src/lib/verifier.mjs
@@ -126,14 +126,45 @@ function checkEvidenceInDiff(finding, diffText) {
 }
 
 /**
- * @param {{ finding: object, diff: string, skill: object }} params
+ * Expected phase(s) for each file type category from file-classifier.
+ * Lenient: categories not listed here are not checked.
+ */
+const FILE_TYPE_PHASE_MAP = {
+  test: ['downstream'],
+  docs: ['upstream'],
+  schema: ['upstream', 'midstream'],
+  migration: ['upstream', 'midstream'],
+};
+
+/**
+ * Check that the finding's file category is coherent with the finding's phase.
+ * Uses file-classifier output to map file → category → expected phases.
+ * Lenient: returns true when information is insufficient.
+ * @param {{ file?: string, phase?: string }} finding
+ * @param {Record<string, string[]> | null | undefined} fileTypes
+ * @returns {boolean}
+ */
+function checkFilePhaseCoherent(finding, fileTypes) {
+  if (!fileTypes || !finding?.file || !finding?.phase) return true;
+  const fileCategory = Object.entries(fileTypes).find(([, files]) =>
+    files.includes(finding.file)
+  )?.[0];
+  if (!fileCategory) return true;
+  const expectedPhases = FILE_TYPE_PHASE_MAP[fileCategory];
+  if (!expectedPhases) return true;
+  return expectedPhases.includes(finding.phase);
+}
+
+/**
+ * @param {{ finding: object, diff: string, skill: object, fileTypes?: object }} params
  * @returns {{ verified: boolean, reasons: string[], checks: object }}
  */
-export function verifyFinding({ finding, diff, skill }) {
+export function verifyFinding({ finding, diff, skill, fileTypes }) {
   const checks = {
     evidenceExists: checkEvidenceExists(finding),
     evidenceInDiff: checkEvidenceInDiff(finding, diff),
     phaseCoherent: checkPhaseCoherent(finding, skill),
+    filePhaseCoherent: checkFilePhaseCoherent(finding, fileTypes),
     severityJustified: checkSeverityJustified(finding, skill),
     suggestionActionable: checkSuggestionActionable(finding),
   };
@@ -141,6 +172,7 @@ export function verifyFinding({ finding, diff, skill }) {
   const reasons = [];
   if (!checks.evidenceExists) reasons.push('No evidence provided in finding');
   if (!checks.evidenceInDiff) reasons.push('Evidence references file not found in diff');
+  if (!checks.filePhaseCoherent) reasons.push('File type does not match finding phase');
   if (!checks.phaseCoherent)
     reasons.push(
       `Phase mismatch: finding phase does not match skill phase "${skill?.metadata?.phase}"`

--- a/src/lib/verifier.mjs
+++ b/src/lib/verifier.mjs
@@ -14,6 +14,7 @@
 const RE_EVIDENCE = /Evidence:\s*(\S.{4,})/;
 const RE_SEVERITY = /Severity:\s*(\w+)/;
 const RE_ACTIONABLE = /(?:Fix|Suggestion):\s*(.{10,})/;
+const RE_FILE_REF = /[\w./-]+\.\w{1,10}/g;
 
 const SEVERITY_RANK = /** @type {const} */ ({
   info: 0,
@@ -104,12 +105,34 @@ function checkSuggestionActionable(finding) {
 }
 
 /**
+ * Check that file names referenced in the Evidence text actually appear
+ * in the diff. Lenient: returns true when no file references are found
+ * in the evidence (to avoid false negatives on prose-only evidence).
+ * @param {{ message?: string }} finding
+ * @param {string} diffText
+ * @returns {boolean}
+ */
+function checkEvidenceInDiff(finding, diffText) {
+  const text = String(finding?.message ?? '');
+  const evidenceMatch = RE_EVIDENCE.exec(text);
+  if (!evidenceMatch) return true;
+
+  const evidenceText = evidenceMatch[1];
+  const fileRefs = evidenceText.match(RE_FILE_REF);
+  if (!fileRefs || fileRefs.length === 0) return true;
+
+  const diff = String(diffText ?? '');
+  return fileRefs.some((ref) => diff.includes(ref));
+}
+
+/**
  * @param {{ finding: object, diff: string, skill: object }} params
  * @returns {{ verified: boolean, reasons: string[], checks: object }}
  */
 export function verifyFinding({ finding, diff, skill }) {
   const checks = {
     evidenceExists: checkEvidenceExists(finding),
+    evidenceInDiff: checkEvidenceInDiff(finding, diff),
     phaseCoherent: checkPhaseCoherent(finding, skill),
     severityJustified: checkSeverityJustified(finding, skill),
     suggestionActionable: checkSuggestionActionable(finding),
@@ -117,6 +140,7 @@ export function verifyFinding({ finding, diff, skill }) {
 
   const reasons = [];
   if (!checks.evidenceExists) reasons.push('No evidence provided in finding');
+  if (!checks.evidenceInDiff) reasons.push('Evidence references file not found in diff');
   if (!checks.phaseCoherent)
     reasons.push(
       `Phase mismatch: finding phase does not match skill phase "${skill?.metadata?.phase}"`

--- a/tests/verifier.test.mjs
+++ b/tests/verifier.test.mjs
@@ -166,3 +166,40 @@ test('verifyFinding: multiple failures are all reported', () => {
   assert.equal(result.checks.phaseCoherent, false);
   assert.equal(result.checks.suggestionActionable, false);
 });
+
+test('verifyFinding: evidenceInDiff passes when file is in diff', () => {
+  const result = verifyFinding({
+    finding: {
+      message:
+        'Finding:\nEvidence: hardcoded secret in src/config/auth.ts\nSeverity: warning\nFix: Move the secret to environment variables',
+    },
+    diff: 'diff --git a/src/config/auth.ts b/src/config/auth.ts\n+const secret = "abc";',
+    skill: { metadata: { severity: 'major' } },
+  });
+  assert.equal(result.checks.evidenceInDiff, true);
+});
+
+test('verifyFinding: evidenceInDiff fails when file is not in diff', () => {
+  const result = verifyFinding({
+    finding: {
+      message:
+        'Finding:\nEvidence: hardcoded secret in src/config/auth.ts\nSeverity: warning\nFix: Move the secret to environment variables',
+    },
+    diff: 'diff --git a/src/index.mjs b/src/index.mjs\n+console.log("hello");',
+    skill: { metadata: { severity: 'major' } },
+  });
+  assert.equal(result.checks.evidenceInDiff, false);
+  assert.ok(result.reasons.some((r) => r.includes('file not found in diff')));
+});
+
+test('verifyFinding: evidenceInDiff lenient when no file reference', () => {
+  const result = verifyFinding({
+    finding: {
+      message:
+        'Finding:\nEvidence: the code uses an outdated pattern\nSeverity: warning\nFix: Migrate to the newer API for better performance',
+    },
+    diff: 'diff --git a/src/index.mjs b/src/index.mjs\n+console.log("hello");',
+    skill: { metadata: { severity: 'major' } },
+  });
+  assert.equal(result.checks.evidenceInDiff, true);
+});

--- a/tests/verifier.test.mjs
+++ b/tests/verifier.test.mjs
@@ -203,3 +203,48 @@ test('verifyFinding: evidenceInDiff lenient when no file reference', () => {
   });
   assert.equal(result.checks.evidenceInDiff, true);
 });
+
+test('verifyFinding: filePhaseCoherent passes when file type matches phase', () => {
+  const result = verifyFinding({
+    finding: {
+      file: 'tests/foo.test.mjs',
+      phase: 'downstream',
+      message:
+        'Finding:\nEvidence: test is incomplete\nSeverity: nit\nFix: Add assertion for edge case',
+    },
+    diff: 'diff --git a/tests/foo.test.mjs\n+test()',
+    skill: { metadata: { severity: 'minor' } },
+    fileTypes: { test: ['tests/foo.test.mjs'], app: ['src/index.mjs'] },
+  });
+  assert.equal(result.checks.filePhaseCoherent, true);
+});
+
+test('verifyFinding: filePhaseCoherent rejects when file type mismatches phase', () => {
+  const result = verifyFinding({
+    finding: {
+      file: 'tests/foo.test.mjs',
+      phase: 'upstream',
+      message:
+        'Finding:\nEvidence: test is incomplete\nSeverity: nit\nFix: Add assertion for edge case',
+    },
+    diff: 'diff --git a/tests/foo.test.mjs\n+test()',
+    skill: { metadata: { severity: 'minor' } },
+    fileTypes: { test: ['tests/foo.test.mjs'], app: ['src/index.mjs'] },
+  });
+  assert.equal(result.checks.filePhaseCoherent, false);
+  assert.ok(result.reasons.some((r) => r.includes('File type does not match')));
+});
+
+test('verifyFinding: filePhaseCoherent lenient when fileTypes not provided', () => {
+  const result = verifyFinding({
+    finding: {
+      file: 'tests/foo.test.mjs',
+      phase: 'upstream',
+      message:
+        'Finding:\nEvidence: test is incomplete\nSeverity: nit\nFix: Add assertion for edge case',
+    },
+    diff: 'diff --git a/tests/foo.test.mjs\n+test()',
+    skill: { metadata: { severity: 'minor' } },
+  });
+  assert.equal(result.checks.filePhaseCoherent, true);
+});


### PR DESCRIPTION
file-classifier の分類結果を verifier の phase coherence チェックに活用し、debug 出力に含める。

file-classifier（#427 で統合済み）は8カテゴリの分類を出力するが、verifier には渡されておらず、「test ファイルに upstream phase の指摘」のようなミスマッチがフィルタされなかった。また classifier 結果が debug に含まれないため、分類の妥当性を検証する手段がなかった。

変更内容:

**src/lib/verifier.mjs**
- `FILE_TYPE_PHASE_MAP` を定義（test→downstream, docs→upstream, schema→upstream/midstream, migration→upstream/midstream）
- `checkFilePhaseCoherent(finding, fileTypes)` を追加
- `verifyFinding` の引数に `fileTypes` を追加（optional、後方互換）
- app / config / infra は全 phase で出現しうるため意図的にマッピングから除外（lenient pass）

**src/lib/review-engine.mjs**
- `generateReview` に `fileTypes` パラメータを追加
- `debug.fileClassification` に分類結果を出力
- verifier 呼び出しに `fileTypes` を転送

**tests/verifier.test.mjs**
- file-phase coherence テスト3件追加（match / mismatch / not provided）

注意: このブランチは #441（diff cross-validation）の変更を含む。#441 との統合順序に注意。

Fixes #443