### PR TITLE
feat(ci): add nightly eval workflow for review quality monitoring

### DIFF
--- a/.github/workflows/nightly-eval.yml
+++ b/.github/workflows/nightly-eval.yml
@@ -1,0 +1,64 @@
+name: Nightly Eval
+
+on:
+  schedule:
+    # Run daily at 04:00 JST (19:00 UTC previous day)
+    - cron: '0 19 * * *'
+  workflow_dispatch:
+    inputs:
+      description:
+        description: 'Optional description for the ledger entry'
+        required: false
+        default: ''
+
+concurrency:
+  group: nightly-eval
+  cancel-in-progress: true
+
+jobs:
+  eval:
+    name: Unified evaluation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unified evaluation
+        run: |
+          DESC="${{ github.event.inputs.description || format('nightly-{0}', github.run_id) }}"
+          npm run eval:all -- --json --append-ledger --description "$DESC" > eval-output.json
+          cat eval-output.json
+
+      - name: Generate summary
+        if: always()
+        run: |
+          node -e "
+            const r = JSON.parse(require('fs').readFileSync('eval-output.json','utf8'));
+            const lines = ['## Nightly Eval Summary', '',
+              '| Metric | Value |', '| --- | --- |'];
+            for (const [k,v] of Object.entries(r.scores)) {
+              const display = typeof v === 'number' && v <= 1 ? (v*100).toFixed(1)+'%' : v;
+              lines.push('| ' + k + ' | ' + display + ' |');
+            }
+            lines.push('', 'Status: **' + r.status.toUpperCase() + '**');
+            require('fs').writeFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join('\n'));
+          "
+
+      - name: Upload eval artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-eval-${{ github.run_id }}
+          path: |
+            eval-output.json
+            artifacts/evals/results.jsonl
+          retention-days: 90

--- a/.github/workflows/nightly-eval.yml
+++ b/.github/workflows/nightly-eval.yml
@@ -42,7 +42,9 @@ jobs:
         if: always()
         run: |
           node -e "
-            const r = JSON.parse(require('fs').readFileSync('eval-output.json','utf8'));
+            const fs = require('fs');
+            if (!fs.existsSync('eval-output.json')) { console.log('No eval output found'); process.exit(0); }
+            const r = JSON.parse(fs.readFileSync('eval-output.json','utf8'));
             const lines = ['## Nightly Eval Summary', '',
               '| Metric | Value |', '| --- | --- |'];
             for (const [k,v] of Object.entries(r.scores)) {
@@ -50,7 +52,7 @@ jobs:
               lines.push('| ' + k + ' | ' + display + ' |');
             }
             lines.push('', 'Status: **' + r.status.toUpperCase() + '**');
-            require('fs').writeFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join('\n'));
+            fs.writeFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join('\n'));
           "
 
       - name: Upload eval artifacts

--- a/.github/workflows/nightly-eval.yml
+++ b/.github/workflows/nightly-eval.yml
@@ -33,8 +33,9 @@ jobs:
         run: npm ci
 
       - name: Run unified evaluation
+        env:
+          DESC: ${{ github.event.inputs.description || format('nightly-{0}', github.run_id) }}
         run: |
-          DESC="${{ github.event.inputs.description || format('nightly-{0}', github.run_id) }}"
           npm run eval:all -- --json --append-ledger --description "$DESC" > eval-output.json
           cat eval-output.json
 


### PR DESCRIPTION
レビュー品質シグナルを定期計測する夜間 GitHub Actions ワークフローを追加する。

eval:all は既に統合ランナーとして稼働可能だが、定期的に実行してメトリクスを蓄積する仕組みがなかった。改善の採否判断（keep/discard policy）を機能させるには、継続的な baseline 蓄積が必要。

ワークフロー仕様:
- 毎日 04:00 JST (19:00 UTC) にスケジュール実行
- `npm run eval:all -- --json --append-ledger` で全 eval を実行
- GitHub Step Summary にメトリクステーブルを出力
- eval-output.json と results.jsonl を artifact として保存（90日 retention）
- workflow_dispatch で手動実行にも対応
- concurrency group で重複実行を防止

eval 失敗時の安全策:
- eval-output.json が存在しない場合、summary ステップは graceful に終了
- artifact upload は `if: always()` で eval 失敗時も保存

Fixes #433