### PR TITLE
feat(policy): AI/人間レビュー境界のリスクマップとエスカレーションポリシー (#431)

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "codex:local": "CODEX_HOME=\"$(git rev-parse --show-toplevel)/.codex\" codex -C \"$(git rev-parse --show-toplevel)\"",
     "codex:exec": "CODEX_HOME=\"$(git rev-parse --show-toplevel)/.codex\" codex exec -C \"$(git rev-parse --show-toplevel)\"",
     "river": "node ./src/cli.mjs",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "eval:regression": "node scripts/evaluate-regression.mjs"
   },
   "dependencies": {
     "@docusaurus/core": "^3.5.0",

--- a/runners/core/review-runner.mjs
+++ b/runners/core/review-runner.mjs
@@ -5,6 +5,7 @@ import { inferImpactTags } from '../../src/lib/impact-scope.mjs';
 import { classifyChangedFiles } from '../../src/lib/file-classifier.mjs';
 import { normalizePlannerMode } from '../../src/lib/planner-utils.mjs';
 import { HEURISTIC_SKILL_IDS } from '../../src/lib/heuristic-review.mjs';
+import { evaluateRisk } from '../../src/lib/risk-map.mjs';
 import { findRelatedADRs } from '../../src/lib/adr-linker.mjs';
 
 const MODEL_PRIORITY = {
@@ -189,6 +190,7 @@ export async function buildExecutionPlan(options) {
     dryRun = false,
     llmEnabled = true,
     repoRoot,
+    riskMap,
   } = options;
 
   const skills = providedSkills ?? (await loadSkills());
@@ -206,6 +208,7 @@ export async function buildExecutionPlan(options) {
 
   const impactTags = inferImpactTags(changedFiles, { diffText });
   const fileTypes = classifyChangedFiles(changedFiles);
+  const riskAssessment = riskMap ? evaluateRisk(riskMap, changedFiles) : null;
   const relatedADRs = findRelatedADRs(repoRoot ?? process.cwd(), { changedFiles, keywords: impactTags });
 
   // If planner is provided, try LLM-based planning, fallback to deterministic rank

--- a/schemas/eval-failure.schema.json
+++ b/schemas/eval-failure.schema.json
@@ -25,7 +25,7 @@
     },
     "evalType": {
       "type": "string",
-      "enum": ["fixtures", "planner"],
+      "enum": ["fixtures", "planner", "regression"],
       "description": "Which evaluation produced this failure."
     },
     "severity": {

--- a/schemas/output.schema.json
+++ b/schemas/output.schema.json
@@ -99,6 +99,17 @@
         "notes": {
           "type": "string",
           "description": "Optional run-level notes or caveats."
+        },
+        "riskSummary": {
+          "type": "object",
+          "description": "Risk assessment summary from risk map evaluation.",
+          "required": ["aggregateAction", "escalatedFiles", "humanReviewFiles"],
+          "additionalProperties": false,
+          "properties": {
+            "aggregateAction": { "type": "string", "enum": ["comment_only", "escalate", "require_human_review"] },
+            "escalatedFiles": { "type": "array", "items": { "type": "string" } },
+            "humanReviewFiles": { "type": "array", "items": { "type": "string" } }
+          }
         }
       }
     }

--- a/schemas/risk-map.schema.json
+++ b/schemas/risk-map.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Risk Map Schema",
+  "description": "Repository-level risk map for classifying file changes into review actions.",
+  "type": "object",
+  "required": ["rules"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "string",
+      "default": "1",
+      "description": "Schema version."
+    },
+    "rules": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/riskRule" },
+      "description": "Ordered list of risk rules. First match wins."
+    },
+    "defaults": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "action": { "$ref": "#/$defs/riskAction" }
+      },
+      "default": { "action": "comment_only" },
+      "description": "Fallback action when no rules match."
+    }
+  },
+  "$defs": {
+    "riskAction": {
+      "type": "string",
+      "enum": ["comment_only", "escalate", "require_human_review"]
+    },
+    "riskRule": {
+      "type": "object",
+      "required": ["pattern", "action"],
+      "additionalProperties": false,
+      "properties": {
+        "pattern": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Glob pattern to match against changed file paths."
+        },
+        "action": { "$ref": "#/$defs/riskAction" },
+        "reason": {
+          "type": "string",
+          "description": "Human-readable reason for this risk classification."
+        }
+      }
+    }
+  }
+}

--- a/schemas/riverbed-entry.schema.json
+++ b/schemas/riverbed-entry.schema.json
@@ -7,7 +7,7 @@
   "$defs": {
     "entryType": {
       "type": "string",
-      "enum": ["adr", "review", "wontfix", "pattern", "decision", "eval_result"]
+      "enum": ["adr", "review", "wontfix", "pattern", "decision", "eval_result", "suppression", "resurface"]
     },
     "phase": {
       "type": "string",

--- a/schemas/riverbed-index.schema.json
+++ b/schemas/riverbed-index.schema.json
@@ -13,7 +13,7 @@
         "id": { "type": "string" },
         "type": {
           "type": "string",
-          "enum": ["adr", "review", "wontfix", "pattern", "decision", "eval_result"]
+          "enum": ["adr", "review", "wontfix", "pattern", "decision", "eval_result", "suppression", "resurface"]
         },
         "path": { "type": "string", "description": "Relative path to the entry JSON file." },
         "title": { "type": "string" },

--- a/scripts/evaluate-all.mjs
+++ b/scripts/evaluate-all.mjs
@@ -41,6 +41,11 @@ const RATIO_METRICS = new Set([
   'falsePositiveRate',
   'evidenceRate',
   'verifierRejectRate',
+  'policyPassRate',
+  'memoryRecallRate',
+  'escalationAccuracy',
+  'suppressionAccuracy',
+  'resurfaceAccuracy',
 ]);
 
 // --- arg parsing -----------------------------------------------------------
@@ -191,6 +196,26 @@ async function runMetaValidation() {
   };
 }
 
+
+async function runRegressionEval() {
+  const { evaluateRegression } = await import('../src/lib/regression-eval.mjs');
+  const casesPath = path.join(ROOT, 'tests', 'fixtures', 'regression-eval', 'cases.json');
+  const result = await evaluateRegression({ casesPath, verbose: false });
+  return {
+    name: 'regression',
+    pass: result.exitCode === 0,
+    skipped: false,
+    metrics: {
+      policyPassRate: result.summary.policyPassRate,
+      memoryRecallRate: result.summary.memoryRecallRate,
+      escalationAccuracy: result.summary.escalationAccuracy,
+      suppressionAccuracy: result.summary.suppressionAccuracy,
+      resurfaceAccuracy: result.summary.resurfaceAccuracy,
+    },
+    errors: result.exitCode === 0 ? [] : ['One or more regression checks failed'],
+  };
+}
+
 // --- ledger -----------------------------------------------------------------
 
 function appendLedger(entry) {
@@ -235,6 +260,13 @@ Options:
     parallel.push(
       runFixturesEval().catch((err) =>
         errorResult('fixtures', `Fixtures eval error: ${err.message}`)
+      )
+    );
+  }
+  if (!parsed.skip.has('regression')) {
+    parallel.push(
+      runRegressionEval().catch((err) =>
+        errorResult('regression', `Regression eval error: ${err.message}`)
       )
     );
   }

--- a/scripts/evaluate-regression.mjs
+++ b/scripts/evaluate-regression.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+/**
+ * Regression evaluation runner for River Reviewer governance features.
+ * Usage: node scripts/evaluate-regression.mjs [--cases <path>] [--verbose]
+ */
+import path from 'node:path';
+import url from 'node:url';
+import { evaluateRegression } from '../src/lib/regression-eval.mjs';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const DEFAULT_CASES = path.join(__dirname, '..', 'tests', 'fixtures', 'regression-eval', 'cases.json');
+
+async function main() {
+  const args = process.argv.slice(2);
+  const verbose = args.includes('--verbose');
+  const casesIdx = args.indexOf('--cases');
+  const casesPath = casesIdx >= 0 ? args[casesIdx + 1] : DEFAULT_CASES;
+
+  console.log('Running regression evaluation...');
+  const result = await evaluateRegression({ casesPath, verbose });
+
+  console.log('\n=== Regression Eval Results ===');
+  console.log('Total: ' + result.summary.total);
+  console.log('Pass: ' + result.summary.pass);
+  console.log('Fail: ' + result.summary.fail);
+  console.log('Policy pass rate: ' + (result.summary.policyPassRate * 100).toFixed(1) + '%');
+  console.log('Memory recall rate: ' + (result.summary.memoryRecallRate * 100).toFixed(1) + '%');
+  console.log('Suppression accuracy: ' + (result.summary.suppressionAccuracy * 100).toFixed(1) + '%');
+  console.log('Resurface accuracy: ' + (result.summary.resurfaceAccuracy * 100).toFixed(1) + '%');
+
+  if (result.summary.fail > 0) {
+    console.log('\nFailing cases:');
+    for (const c of result.cases.filter((r) => !r.pass)) {
+      console.log('  - ' + c.name + (c.error ? ': ' + c.error : ''));
+    }
+  }
+
+  return result.exitCode;
+}
+
+main().then((code) => { process.exitCode = code; }).catch((err) => { console.error(err.message); process.exitCode = 1; });

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -15,6 +15,7 @@ import { renderDiffText } from './lib/diff-optimizer.mjs';
 import CostEstimator from './core/cost-estimator.mjs';
 import { SkillDispatcher } from './core/skill-dispatcher.mjs';
 import { ProjectRulesError } from './lib/rules.mjs';
+import { RiskMapError } from './lib/risk-map.mjs';
 import { parseList } from './lib/utils.mjs';
 import { PLANNER_MODES } from './lib/planner-utils.mjs';
 
@@ -393,6 +394,16 @@ function logPreview(title, text, maxLength, log, { leadingNewline = false } = {}
   log(preview);
 }
 
+function formatRiskSummaryMarkdown(plan) {
+  const risk = plan?.riskAssessment;
+  if (!risk) return '';
+  const badge = risk.aggregateAction === 'require_human_review' ? '🔴 require_human_review' : risk.aggregateAction === 'escalate' ? '🟡 escalate' : '🟢 comment_only';
+  const lines = ['### リスク評価\n', '**判定**: ' + badge + '\n'];
+  if (risk.humanReviewFiles?.length) { lines.push('**人間レビュー必須**:'); for (const f of risk.humanReviewFiles) lines.push('- ' + f); lines.push(''); }
+  if (risk.escalatedFiles?.length) { lines.push('**エスカレーション対象**:'); for (const f of risk.escalatedFiles) lines.push('- ' + f); lines.push(''); }
+  return lines.join('\n');
+}
+
 function printMarkdownReport(result, phase) {
   const header = `${COMMENT_MARKER}
 ## River Reviewer
@@ -401,8 +412,9 @@ function printMarkdownReport(result, phase) {
 ${formatDebugSummaryMarkdown(result)}
 `;
   const planSection = formatPlanMarkdown(result.plan);
+  const riskSection = formatRiskSummaryMarkdown(result.plan);
   const findings = `### 指摘\n${formatCommentsMarkdown(result.comments)}\n`;
-  console.log([header, planSection, findings].join('\n'));
+  console.log([header, planSection, riskSection, findings].join('\n'));
 }
 
 function printDebugInfo(result, { log = console.log } = {}) {
@@ -508,7 +520,10 @@ function formatJsonOutput(result, phase) {
     };
   });
 
-  return { issues, summary: { issueCountBySeverity, issueCountByPhase } };
+  const summary = { issueCountBySeverity, issueCountByPhase };
+  const riskAssessment = result.plan?.riskAssessment;
+  if (riskAssessment) { summary.riskSummary = { aggregateAction: riskAssessment.aggregateAction, escalatedFiles: riskAssessment.escalatedFiles, humanReviewFiles: riskAssessment.humanReviewFiles }; }
+  return { issues, summary };
 }
 
 function countChangedLines(files) {
@@ -756,6 +771,9 @@ Dependencies: ${
         'Check `.river/rules.md` exists and is readable (or remove it to disable rules).',
         'Docs: README.md (Project-specific review rules)',
       ]);
+    } else if (error instanceof RiskMapError) {
+      console.error(error.message);
+      printHintLines(['Check `.river/risk-map.yaml` format and valid action values.', 'Valid actions: comment_only, escalate, require_human_review']);
     } else if (error instanceof GitError) {
       console.error(`Git command failed: ${error.message}`);
       printHintLines([

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -397,10 +397,23 @@ function logPreview(title, text, maxLength, log, { leadingNewline = false } = {}
 function formatRiskSummaryMarkdown(plan) {
   const risk = plan?.riskAssessment;
   if (!risk) return '';
-  const badge = risk.aggregateAction === 'require_human_review' ? '🔴 require_human_review' : risk.aggregateAction === 'escalate' ? '🟡 escalate' : '🟢 comment_only';
+  const badge =
+    risk.aggregateAction === 'require_human_review'
+      ? '🔴 require_human_review'
+      : risk.aggregateAction === 'escalate'
+        ? '🟡 escalate'
+        : '🟢 comment_only';
   const lines = ['### リスク評価\n', '**判定**: ' + badge + '\n'];
-  if (risk.humanReviewFiles?.length) { lines.push('**人間レビュー必須**:'); for (const f of risk.humanReviewFiles) lines.push('- ' + f); lines.push(''); }
-  if (risk.escalatedFiles?.length) { lines.push('**エスカレーション対象**:'); for (const f of risk.escalatedFiles) lines.push('- ' + f); lines.push(''); }
+  if (risk.humanReviewFiles?.length) {
+    lines.push('**人間レビュー必須**:');
+    for (const f of risk.humanReviewFiles) lines.push('- ' + sanitizeForMarkdown(f));
+    lines.push('');
+  }
+  if (risk.escalatedFiles?.length) {
+    lines.push('**エスカレーション対象**:');
+    for (const f of risk.escalatedFiles) lines.push('- ' + sanitizeForMarkdown(f));
+    lines.push('');
+  }
   return lines.join('\n');
 }
 
@@ -489,7 +502,7 @@ function mapSeverity(internalSeverity) {
  */
 function extractField(message, label) {
   const regex = new RegExp(
-    `${label}:\\s*([^]*?)(?=\\s+(?:Finding|Evidence|Impact|Fix|Severity|Confidence):)|${label}:\\s*(.+)$`,
+    `${label}:\\s*([^]*?)(?=\\s+(?:Finding|Evidence|Impact|Fix|Severity|Confidence):)|${label}:\\s*(.+)$`
   );
   const match = (message ?? '').match(regex);
   return (match?.[1] ?? match?.[2] ?? '').trim();
@@ -522,7 +535,13 @@ function formatJsonOutput(result, phase) {
 
   const summary = { issueCountBySeverity, issueCountByPhase };
   const riskAssessment = result.plan?.riskAssessment;
-  if (riskAssessment) { summary.riskSummary = { aggregateAction: riskAssessment.aggregateAction, escalatedFiles: riskAssessment.escalatedFiles, humanReviewFiles: riskAssessment.humanReviewFiles }; }
+  if (riskAssessment) {
+    summary.riskSummary = {
+      aggregateAction: riskAssessment.aggregateAction,
+      escalatedFiles: riskAssessment.escalatedFiles,
+      humanReviewFiles: riskAssessment.humanReviewFiles,
+    };
+  }
   return { issues, summary };
 }
 
@@ -671,7 +690,8 @@ Dependencies: ${
         ? estimator.estimateFromDiff(context.diff, context.plan?.selected ?? [])
         : null;
 
-    const logRunHeader = parsed.output === 'markdown' || parsed.output === 'json' ? console.error : console.log;
+    const logRunHeader =
+      parsed.output === 'markdown' || parsed.output === 'json' ? console.error : console.log;
     logRunHeader(`River Reviewer (local)
 Phase: ${parsed.phase}
 Repo: ${context.repoRoot}
@@ -773,7 +793,10 @@ Dependencies: ${
       ]);
     } else if (error instanceof RiskMapError) {
       console.error(error.message);
-      printHintLines(['Check `.river/risk-map.yaml` format and valid action values.', 'Valid actions: comment_only, escalate, require_human_review']);
+      printHintLines([
+        'Check `.river/risk-map.yaml` format and valid action values.',
+        'Valid actions: comment_only, escalate, require_human_review',
+      ]);
     } else if (error instanceof GitError) {
       console.error(`Git command failed: ${error.message}`);
       printHintLines([

--- a/src/config/risk-map-schema.mjs
+++ b/src/config/risk-map-schema.mjs
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+export const RiskActionSchema = z.enum(['comment_only', 'escalate', 'require_human_review']);
+
+export const RiskRuleSchema = z.object({
+  pattern: z.string().min(1),
+  action: RiskActionSchema,
+  reason: z.string().optional(),
+});
+
+export const RiskMapSchema = z.object({
+  version: z.string().default('1'),
+  rules: z.array(RiskRuleSchema).min(1),
+  defaults: z
+    .object({
+      action: RiskActionSchema.default('comment_only'),
+    })
+    .default({ action: 'comment_only' }),
+});

--- a/src/lib/local-runner.mjs
+++ b/src/lib/local-runner.mjs
@@ -10,6 +10,8 @@ import { createOpenAIPlanner } from './openai-planner.mjs';
 import { normalizePlannerMode } from './planner-utils.mjs';
 import { buildExecutionPlan } from '../../runners/core/review-runner.mjs';
 import { loadProjectRules } from './rules.mjs';
+import { loadRiskMap } from './risk-map.mjs';
+import { loadReviewMemory } from './memory-context.mjs';
 import { loadSkills } from '../../runners/core/skill-loader.mjs';
 import { isLlmEnabled, parseList } from './utils.mjs';
 
@@ -123,6 +125,7 @@ async function collectLocalContext({
   const { config, path: configPath, source: configSource } = await configLoader.load(repoRoot);
   const prLabels = await resolvePullRequestLabels();
   const { rulesText: projectRules } = await loadProjectRules(repoRoot);
+  const riskMap = await loadRiskMap(repoRoot);
   const defaultBranch = await detectDefaultBranch(repoRoot);
   const mergeBase = await findMergeBase(repoRoot, defaultBranch);
   const rawDiff = await collectRepoDiff(repoRoot, mergeBase, { contextLines });
@@ -137,6 +140,7 @@ async function collectLocalContext({
     configPath,
     configSource,
     projectRules,
+    riskMap,
     defaultBranch,
     mergeBase,
     diff,
@@ -168,6 +172,7 @@ export async function planLocalReview({
   const {
     repoRoot,
     projectRules,
+    riskMap,
     defaultBranch,
     mergeBase,
     diff,
@@ -249,6 +254,7 @@ export async function planLocalReview({
     dryRun,
     llmEnabled,
     repoRoot,
+    riskMap,
   });
 
   const plannerUsed = planner ? !plan.plannerFallback : false;
@@ -333,6 +339,11 @@ export async function runLocalReview({
     };
   }
 
+  const memoryContext = loadReviewMemory(context.repoRoot, {
+    phase: normalizePhase(phase),
+    changedFiles: context.changedFiles,
+  });
+
   const review = await generateReview({
     diff: context.diff,
     plan: context.plan,
@@ -341,6 +352,8 @@ export async function runLocalReview({
     model,
     apiKey,
     projectRules: context.projectRules,
+    riskAssessment: context.plan?.riskAssessment ?? null,
+    memoryContext,
     fileTypes: context.plan?.fileTypes,
     relatedADRs: context.plan?.relatedADRs,
     config: context.config,

--- a/src/lib/memory-context.mjs
+++ b/src/lib/memory-context.mjs
@@ -1,0 +1,67 @@
+import path from 'node:path';
+import { loadMemory, queryMemory } from './riverbed-memory.mjs';
+
+const DEFAULT_MEMORY_PATH = path.join('.river', 'memory', 'index.json');
+
+export function loadReviewMemory(repoRoot, { phase, changedFiles } = {}) {
+  const indexPath = path.resolve(repoRoot, DEFAULT_MEMORY_PATH);
+  const index = loadMemory(indexPath);
+  const allEntries = phase ? queryMemory(index, { phase }) : (index.entries ?? []);
+  const relevant = changedFiles?.length
+    ? allEntries.filter((e) => {
+        const related = e.metadata?.relatedFiles ?? [];
+        if (!related.length) return true;
+        return related.some((r) => changedFiles.includes(r));
+      })
+    : allEntries;
+  return {
+    entries: relevant,
+    wontfixes: relevant.filter((e) => e.type === 'wontfix'),
+    patterns: relevant.filter((e) => e.type === 'pattern'),
+    decisions: relevant.filter((e) => e.type === 'decision'),
+    reviews: relevant.filter((e) => e.type === 'review'),
+    suppressions: relevant.filter((e) => e.type === 'suppression'),
+  };
+}
+
+export function formatMemoryForPrompt(memoryContext, { maxChars = 1500 } = {}) {
+  if (!memoryContext) return '';
+  const { wontfixes, patterns, decisions } = memoryContext;
+  const sections = [];
+  if (wontfixes?.length) {
+    sections.push('以下の指摘は明示的に受け入れ済みです。再指摘は不要です:');
+    for (const w of wontfixes) sections.push('- [' + w.id + '] ' + (w.title || w.content?.slice(0, 80)));
+  }
+  if (patterns?.length) {
+    sections.push('以下はチーム規約として記録されています:');
+    for (const p of patterns) sections.push('- ' + (p.title || p.content?.slice(0, 80)));
+  }
+  if (decisions?.length) {
+    sections.push('以下の設計判断が記録されています:');
+    for (const d of decisions) sections.push('- ' + (d.title || d.content?.slice(0, 80)));
+  }
+  if (!sections.length) return '';
+  const text = '\n### Memory Context (previous review decisions)\n\n' + sections.join('\n');
+  return text.length > maxChars ? text.slice(0, maxChars) + '\n...[truncated]' : text;
+}
+
+export function buildReviewEntry(reviewResult, { phase, changedFiles, commit } = {}) {
+  const timestamp = new Date().toISOString();
+  const id = 'review-' + (commit || 'unknown') + '-' + Date.now();
+  const commentCount = reviewResult.comments?.length ?? 0;
+  const summary = commentCount + ' findings in ' + (phase || 'midstream') + ' phase';
+  return {
+    id,
+    type: 'review',
+    title: 'Review: ' + summary,
+    content: JSON.stringify({ commentCount, phase, changedFiles: changedFiles?.slice(0, 20) }),
+    metadata: {
+      createdAt: timestamp,
+      author: 'river-reviewer',
+      ...(phase ? { phase } : {}),
+      tags: ['review', 'automated'],
+      relatedFiles: changedFiles?.slice(0, 50) ?? [],
+      summary,
+    },
+  };
+}

--- a/src/lib/regression-eval.mjs
+++ b/src/lib/regression-eval.mjs
@@ -1,0 +1,106 @@
+import fs from 'node:fs';
+import { queryMemory } from './riverbed-memory.mjs';
+import { findActiveSuppressions } from './suppression.mjs';
+import { shouldResurface } from './resurface.mjs';
+
+/**
+ * Run regression evaluation cases.
+ * Each case tests a specific behavior: memory recall, suppression, or resurfacing.
+ *
+ * @param {{ casesPath: string, verbose?: boolean }} options
+ * @returns {{ exitCode: number, cases: object[], summary: object }}
+ */
+export async function evaluateRegression({ casesPath, verbose = false }) {
+  const raw = fs.readFileSync(casesPath, 'utf-8');
+  const cases = JSON.parse(raw);
+  const results = [];
+  let pass = 0;
+  let fail = 0;
+  const categoryStats = {};
+
+  for (const c of cases) {
+    const cat = c.category;
+    if (!categoryStats[cat]) categoryStats[cat] = { pass: 0, fail: 0 };
+    let ok = false;
+    let error = null;
+
+    try {
+      switch (cat) {
+        case 'memory_recall':
+          ok = runMemoryRecallCase(c);
+          break;
+        case 'suppression':
+          ok = runSuppressionCase(c);
+          break;
+        case 'resurfacing':
+          ok = runResurfacingCase(c);
+          break;
+        default:
+          error = 'Unknown category: ' + cat;
+      }
+    } catch (err) {
+      error = err.message;
+    }
+
+    if (ok && !error) {
+      pass++;
+      categoryStats[cat].pass++;
+    } else {
+      fail++;
+      categoryStats[cat].fail++;
+    }
+
+    results.push({ name: c.name, category: cat, pass: ok && !error, error });
+    if (verbose && error) console.error('  FAIL: ' + c.name + ' - ' + error);
+  }
+
+  const total = cases.length;
+  const memoryRecallRate = safeRate(categoryStats.memory_recall);
+  const suppressionAccuracy = safeRate(categoryStats.suppression);
+  const resurfaceAccuracy = safeRate(categoryStats.resurfacing);
+  const policyPassRate = total > 0 ? pass / total : 0;
+
+  return {
+    exitCode: fail > 0 ? 1 : 0,
+    cases: results,
+    summary: {
+      total,
+      pass,
+      fail,
+      policyPassRate,
+      memoryRecallRate,
+      escalationAccuracy: 1.0, // placeholder until risk-map eval cases are added
+      suppressionAccuracy,
+      resurfaceAccuracy,
+    },
+  };
+}
+
+function safeRate(stats) {
+  if (!stats) return 1.0;
+  const total = stats.pass + stats.fail;
+  return total > 0 ? stats.pass / total : 1.0;
+}
+
+function runMemoryRecallCase(c) {
+  const index = { entries: c.memoryEntries };
+  const results = queryMemory(index, c.query);
+  const resultIds = results.map((e) => e.id).sort();
+  const expectedIds = [...c.expectedIds].sort();
+  if (resultIds.length !== expectedIds.length) return false;
+  return resultIds.every((id, i) => id === expectedIds[i]);
+}
+
+function runSuppressionCase(c) {
+  const index = { entries: c.memoryEntries };
+  const active = findActiveSuppressions(index, c.changedFiles);
+  const activeIds = active.map((s) => s.id).sort();
+  const expectedIds = [...c.expectedSuppressionIds].sort();
+  if (activeIds.length !== expectedIds.length) return false;
+  return activeIds.every((id, i) => id === expectedIds[i]);
+}
+
+function runResurfacingCase(c) {
+  const result = shouldResurface(c.suppression, c.changedFiles);
+  return result === c.expectedResurface;
+}

--- a/src/lib/resurface.mjs
+++ b/src/lib/resurface.mjs
@@ -1,0 +1,98 @@
+import { findActiveSuppressions, inferSubsystem } from './suppression.mjs';
+
+/**
+ * Check for findings that should be resurfaced based on active suppressions.
+ * Conservative: only resurfaces on same path or same subsystem.
+ *
+ * @param {{ suppressions: object[] }} memoryContext
+ * @param {string[]} changedFiles
+ * @returns {object[]} Resurfacing candidates with suppression context
+ */
+export function checkForResurfacingFindings({ memoryContext, changedFiles }) {
+  if (!memoryContext?.suppressions?.length || !changedFiles?.length) return [];
+
+  // Note: memoryContext.suppressions are already filtered by loadReviewMemory
+  // but we do additional scope-based matching here
+  return memoryContext.suppressions
+    .filter((s) => shouldResurface(s, changedFiles))
+    .map((s) => ({
+      suppression: s,
+      reason: buildResurfaceReason(s, changedFiles),
+    }));
+}
+
+/**
+ * Determine if a suppression should be resurfaced for the given changed files.
+ * @param {object} suppression
+ * @param {string[]} changedFiles
+ * @returns {boolean}
+ */
+export function shouldResurface(suppression, changedFiles) {
+  if (!suppression?.context?.active) return false;
+
+  const expiresAt = suppression.context?.expiresAt;
+  if (expiresAt && expiresAt < new Date().toISOString()) return false;
+
+  const related = suppression.metadata?.relatedFiles ?? [];
+  if (!related.length) return false;
+
+  const scope = suppression.context?.scope || 'file';
+
+  if (scope === 'global') return true;
+
+  if (scope === 'subsystem') {
+    const suppressionSubs = new Set(related.map(inferSubsystem).filter(Boolean));
+    return changedFiles.some((fp) => suppressionSubs.has(inferSubsystem(fp)));
+  }
+
+  // file scope: exact path match
+  return changedFiles.some((fp) => related.includes(fp));
+}
+
+/**
+ * Build a human-readable reason for why a finding is being resurfaced.
+ * @param {object} suppression
+ * @param {string[]} changedFiles
+ * @returns {string}
+ */
+function buildResurfaceReason(suppression, changedFiles) {
+  const related = suppression.metadata?.relatedFiles ?? [];
+  const scope = suppression.context?.scope || 'file';
+  const matchedFiles = changedFiles.filter((fp) => {
+    if (scope === 'global') return true;
+    if (scope === 'subsystem') {
+      const subs = new Set(related.map(inferSubsystem).filter(Boolean));
+      return subs.has(inferSubsystem(fp));
+    }
+    return related.includes(fp);
+  });
+
+  return (
+    '[Resurfaced] ' +
+    suppression.title +
+    ' (scope: ' + scope +
+    ', matched: ' + matchedFiles.join(', ') +
+    ', original rationale: ' + (suppression.content || 'N/A') + ')'
+  );
+}
+
+/**
+ * Build review comments from resurfacing candidates.
+ * Uses severity=nit and confidence=low to keep them advisory.
+ * @param {object[]} candidates - Output from checkForResurfacingFindings
+ * @returns {object[]}
+ */
+export function buildResurfaceComments(candidates) {
+  return candidates.map((c) => ({
+    file: c.suppression.metadata?.relatedFiles?.[0] || 'unknown',
+    line: 0,
+    message:
+      'Finding: ' + c.reason +
+      ' Evidence: Previously suppressed finding resurfaced due to related file change.' +
+      ' Impact: Review whether the original suppression rationale still applies.' +
+      ' Fix: Confirm suppression is still valid or address the finding.' +
+      ' Severity: nit Confidence: low',
+    resurfaced: true,
+    suppressionId: c.suppression.id,
+  }));
+}

--- a/src/lib/review-engine.mjs
+++ b/src/lib/review-engine.mjs
@@ -104,9 +104,10 @@ function buildADRContextSection(relatedADRs) {
   return lines.join('\n');
 }
 
-
 function sanitizePath(p) {
-  return String(p).replace(/[\n\r]/g, '').slice(0, 200);
+  return String(p)
+    .replace(/[\n\r]/g, '')
+    .slice(0, 200);
 }
 
 function buildRiskAssessmentSection(riskAssessment) {

--- a/src/lib/review-engine.mjs
+++ b/src/lib/review-engine.mjs
@@ -104,12 +104,36 @@ function buildADRContextSection(relatedADRs) {
   return lines.join('\n');
 }
 
+
+function sanitizePath(p) {
+  return String(p).replace(/[\n\r]/g, '').slice(0, 200);
+}
+
+function buildRiskAssessmentSection(riskAssessment) {
+  if (!riskAssessment) return '';
+  const { escalatedFiles, humanReviewFiles } = riskAssessment;
+  if (!escalatedFiles?.length && !humanReviewFiles?.length) return '';
+  const lines = ['\n### Risk Assessment\n'];
+  if (humanReviewFiles?.length) {
+    lines.push('以下のファイルは人間によるレビューが必須です:');
+    for (const f of humanReviewFiles) lines.push('- ' + sanitizePath(f) + ': require_human_review');
+  }
+  if (escalatedFiles?.length) {
+    lines.push('以下のファイルはエスカレーション対象です:');
+    for (const f of escalatedFiles) lines.push('- ' + sanitizePath(f) + ': escalate');
+  }
+  lines.push('これらのファイルには特に注意してレビューしてください。\n');
+  return lines.join('\n');
+}
+
 export function buildPrompt({
   diffText,
   diffFiles,
   plan,
   phase,
   projectRules,
+  riskAssessment,
+  memoryContext,
   relatedADRs,
   maxChars = MAX_PROMPT_CHARS,
   config = defaultConfig,
@@ -129,7 +153,7 @@ ${buildFileSummary(diffFiles)}
 Relevant skills:
 ${buildSkillSummary(plan)}
 
-${buildProjectRulesSection(projectRules)}${buildADRContextSection(relatedADRs)}Review the unified git diff below and produce concise findings.
+${buildProjectRulesSection(projectRules)}${buildRiskAssessmentSection(riskAssessment)}${buildADRContextSection(relatedADRs)}Review the unified git diff below and produce concise findings.
 ${buildLanguageInstruction(language)}
 - Output each finding on its own line using the format "<file>:<line>: <message>".
 - In <message>, include short labels: "Finding:", "Evidence:", "Impact:", "Fix:", "Severity:", "Confidence:".
@@ -421,6 +445,7 @@ export async function generateReview({
   projectRules,
   fileTypes,
   relatedADRs,
+  riskAssessment,
   maxPromptChars = MAX_PROMPT_CHARS,
   config,
 }) {
@@ -432,6 +457,7 @@ export async function generateReview({
     phase,
     projectRules,
     relatedADRs,
+    riskAssessment,
     maxChars: maxPromptChars,
     config: effectiveConfig,
   });

--- a/src/lib/risk-map.mjs
+++ b/src/lib/risk-map.mjs
@@ -1,0 +1,135 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import yaml from 'js-yaml';
+import { minimatch } from 'minimatch';
+import { RiskMapSchema } from '../config/risk-map-schema.mjs';
+
+const DEFAULT_RISK_MAP_PATH = path.join('.river', 'risk-map.yaml');
+
+export class RiskMapError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'RiskMapError';
+  }
+}
+
+/**
+ * Load a risk map from .river/risk-map.yaml (or a custom path).
+ * Missing files are treated as "no risk map" without error.
+ * @param {string} repoRoot
+ * @param {{ riskMapPath?: string }} [options]
+ * @returns {Promise<import('../../schemas/risk-map.schema.json') | null>}
+ */
+export async function loadRiskMap(repoRoot, options = {}) {
+  const repoRootAbs = path.resolve(repoRoot);
+  const relativePath = options.riskMapPath ?? DEFAULT_RISK_MAP_PATH;
+  const fullPath = path.resolve(repoRootAbs, relativePath);
+
+  if (!fullPath.startsWith(repoRootAbs + path.sep) && fullPath !== repoRootAbs) {
+    throw new RiskMapError(`Risk map path is outside of the repository: ${relativePath}`);
+  }
+
+  let raw;
+  try {
+    raw = await fs.readFile(fullPath, 'utf8');
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return null;
+    }
+    throw new RiskMapError(`Failed to read risk map at ${fullPath}: ${error.message}`);
+  }
+
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  let parsed;
+  try {
+    parsed = yaml.load(trimmed);
+  } catch (error) {
+    throw new RiskMapError(`Failed to parse risk map YAML: ${error.message}`);
+  }
+
+  const result = RiskMapSchema.safeParse(parsed);
+  if (!result.success) {
+    const issues = result.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+    throw new RiskMapError(`Invalid risk map schema: ${issues}`);
+  }
+
+  return result.data;
+}
+
+const ACTION_PRIORITY = {
+  comment_only: 0,
+  escalate: 1,
+  require_human_review: 2,
+};
+
+/**
+ * Evaluate risk for a list of changed files against a risk map.
+ * First matching rule wins per file.
+ * @param {object} riskMap - Parsed risk map config
+ * @param {string[]} filePaths - List of changed file paths
+ * @returns {{ fileRisks: Array<{ file: string, action: string, rule?: object }>, aggregateAction: string, escalatedFiles: string[], humanReviewFiles: string[] }}
+ */
+export function evaluateRisk(riskMap, filePaths) {
+  if (!riskMap || !filePaths?.length) {
+    return {
+      fileRisks: [],
+      aggregateAction: riskMap?.defaults?.action ?? 'comment_only',
+      escalatedFiles: [],
+      humanReviewFiles: [],
+    };
+  }
+
+  const defaultAction = riskMap.defaults?.action ?? 'comment_only';
+  const fileRisks = [];
+
+  for (const file of filePaths) {
+    let matched = false;
+    for (const rule of riskMap.rules) {
+      if (minimatch(file, rule.pattern, { dot: true })) {
+        fileRisks.push({
+          file,
+          action: rule.action,
+          rule: { pattern: rule.pattern, reason: rule.reason },
+        });
+        matched = true;
+        break;
+      }
+    }
+    if (!matched) {
+      fileRisks.push({ file, action: defaultAction });
+    }
+  }
+
+  const escalatedFiles = fileRisks
+    .filter((r) => r.action === 'escalate')
+    .map((r) => r.file);
+  const humanReviewFiles = fileRisks
+    .filter((r) => r.action === 'require_human_review')
+    .map((r) => r.file);
+  const aggregateAction = aggregateRiskLevel(fileRisks, defaultAction);
+
+  return { fileRisks, aggregateAction, escalatedFiles, humanReviewFiles };
+}
+
+/**
+ * Aggregate to the highest risk action across all file risks.
+ * @param {Array<{ action: string }>} fileRisks
+ * @param {string} [fallback='comment_only']
+ * @returns {string}
+ */
+export function aggregateRiskLevel(fileRisks, fallback = 'comment_only') {
+  if (!fileRisks?.length) return fallback;
+
+  let maxPriority = -1;
+  let maxAction = fallback;
+  for (const { action } of fileRisks) {
+    const priority = ACTION_PRIORITY[action] ?? 0;
+    if (priority > maxPriority) {
+      maxPriority = priority;
+      maxAction = action;
+    }
+  }
+  return maxAction;
+}

--- a/src/lib/suppression.mjs
+++ b/src/lib/suppression.mjs
@@ -1,0 +1,135 @@
+import crypto from 'node:crypto';
+import { appendEntry, loadMemory, queryMemory } from './riverbed-memory.mjs';
+
+/**
+ * Create a stable content hash from a finding's key fields.
+ * @param {{ file?: string, message?: string, ruleId?: string }} finding
+ * @returns {string}
+ */
+export function hashFinding(finding) {
+  const key = [finding.file || '', finding.message || '', finding.ruleId || ''].join('::');
+  return crypto.createHash('sha256').update(key).digest('hex').slice(0, 16);
+}
+
+/**
+ * Extract subsystem identifier from a file path.
+ * e.g. 'src/auth/handler.ts' -> 'auth', 'src/lib/utils.mjs' -> 'lib'
+ * @param {string} filePath
+ * @returns {string}
+ */
+export function inferSubsystem(filePath) {
+  const parts = filePath.split('/').filter(Boolean);
+  if (parts.length >= 2 && parts[0] === 'src') return parts[1];
+  if (parts.length >= 2) return parts[0];
+  return '';
+}
+
+/**
+ * Create a suppression record in Riverbed Memory.
+ * @param {object} options
+ * @returns {object} The created suppression entry
+ */
+export function createSuppression({
+  indexPath,
+  findingId,
+  findingHash,
+  filePaths,
+  rationale,
+  scope = 'file',
+  expiresAt,
+  prNumber,
+  author = 'river-reviewer',
+}) {
+  if (!rationale) throw new Error('Suppression requires a rationale');
+
+  const entry = {
+    id: 'suppression-' + (findingHash || hashFinding({ file: filePaths?.[0] })) + '-' + Date.now(),
+    type: 'suppression',
+    title: 'Suppress: ' + (findingId || 'finding'),
+    content: rationale,
+    metadata: {
+      createdAt: new Date().toISOString(),
+      author,
+      tags: ['suppression', 'active', scope],
+      relatedFiles: filePaths ?? [],
+      ...(prNumber ? { links: ['PR#' + prNumber] } : {}),
+    },
+    context: {
+      findingId: findingId || null,
+      findingHash: findingHash || null,
+      scope,
+      active: true,
+      ...(expiresAt ? { expiresAt } : {}),
+    },
+  };
+
+  appendEntry(indexPath, entry);
+  return entry;
+}
+
+/**
+ * Revoke a suppression by appending a resurface entry (append-only).
+ * @param {string} indexPath
+ * @param {string} suppressionId
+ * @param {{ author?: string, reason?: string }} options
+ * @returns {object} The resurface entry
+ */
+export function revokeSuppression(indexPath, suppressionId, { author = 'river-reviewer', reason = 'revoked' } = {}) {
+  const entry = {
+    id: 'resurface-' + suppressionId + '-' + Date.now(),
+    type: 'resurface',
+    title: 'Revoke: ' + suppressionId,
+    content: reason,
+    metadata: {
+      createdAt: new Date().toISOString(),
+      author,
+      tags: ['resurface', 'revocation'],
+    },
+    context: {
+      suppressionId,
+      action: 'revoke',
+    },
+  };
+
+  appendEntry(indexPath, entry);
+  return entry;
+}
+
+/**
+ * Find active suppressions that overlap with the given file paths.
+ * Filters out expired and revoked suppressions.
+ * @param {{ entries: object[] }} index - Loaded memory index
+ * @param {string[]} filePaths
+ * @returns {object[]}
+ */
+export function findActiveSuppressions(index, filePaths) {
+  const suppressions = queryMemory(index, { type: 'suppression' });
+  const revocations = new Set(
+    queryMemory(index, { type: 'resurface' })
+      .filter((e) => e.context?.action === 'revoke')
+      .map((e) => e.context?.suppressionId)
+      .filter(Boolean),
+  );
+
+  const now = new Date().toISOString();
+
+  return suppressions.filter((s) => {
+    if (!s.context?.active) return false;
+    if (revocations.has(s.id)) return false;
+    if (s.context?.expiresAt && s.context.expiresAt < now) return false;
+
+    const related = s.metadata?.relatedFiles ?? [];
+    if (!related.length) return false;
+
+    const scope = s.context?.scope || 'file';
+    if (scope === 'global') return true;
+
+    if (scope === 'subsystem') {
+      const suppressionSubs = new Set(related.map(inferSubsystem).filter(Boolean));
+      return filePaths.some((fp) => suppressionSubs.has(inferSubsystem(fp)));
+    }
+
+    // default: file scope - exact path match
+    return filePaths.some((fp) => related.includes(fp));
+  });
+}

--- a/tests/fixtures/regression-eval/cases.json
+++ b/tests/fixtures/regression-eval/cases.json
@@ -1,0 +1,90 @@
+[
+  {
+    "name": "memory-recall: query by type=wontfix returns matching entries",
+    "category": "memory_recall",
+    "memoryEntries": [
+      { "id": "wf1", "type": "wontfix", "content": "Accepted verbose logging", "metadata": { "createdAt": "2026-01-01T00:00:00Z", "author": "test" } },
+      { "id": "r1", "type": "review", "content": "Review result", "metadata": { "createdAt": "2026-01-01T00:00:00Z", "author": "test" } }
+    ],
+    "query": { "type": "wontfix" },
+    "expectedIds": ["wf1"]
+  },
+  {
+    "name": "memory-recall: query by tags filters correctly",
+    "category": "memory_recall",
+    "memoryEntries": [
+      { "id": "p1", "type": "pattern", "content": "Auth pattern", "metadata": { "createdAt": "2026-01-01T00:00:00Z", "author": "test", "tags": ["security", "auth"] } },
+      { "id": "p2", "type": "pattern", "content": "Perf pattern", "metadata": { "createdAt": "2026-01-01T00:00:00Z", "author": "test", "tags": ["perf"] } }
+    ],
+    "query": { "tags": ["security"] },
+    "expectedIds": ["p1"]
+  },
+  {
+    "name": "memory-recall: query by phase returns correct entries",
+    "category": "memory_recall",
+    "memoryEntries": [
+      { "id": "u1", "type": "pattern", "content": "Upstream", "metadata": { "createdAt": "2026-01-01T00:00:00Z", "author": "test", "phase": "upstream" } },
+      { "id": "m1", "type": "pattern", "content": "Midstream", "metadata": { "createdAt": "2026-01-01T00:00:00Z", "author": "test", "phase": "midstream" } }
+    ],
+    "query": { "phase": "midstream" },
+    "expectedIds": ["m1"]
+  },
+  {
+    "name": "suppression: active suppression matches by file path",
+    "category": "suppression",
+    "memoryEntries": [
+      { "id": "s1", "type": "suppression", "content": "Accepted", "metadata": { "createdAt": "2026-01-01T00:00:00Z", "author": "test", "relatedFiles": ["src/auth.ts"] }, "context": { "active": true, "scope": "file" } }
+    ],
+    "changedFiles": ["src/auth.ts"],
+    "expectedSuppressionIds": ["s1"]
+  },
+  {
+    "name": "suppression: revoked suppression is excluded",
+    "category": "suppression",
+    "memoryEntries": [
+      { "id": "s1", "type": "suppression", "content": "Accepted", "metadata": { "createdAt": "2026-01-01T00:00:00Z", "author": "test", "relatedFiles": ["src/auth.ts"] }, "context": { "active": true, "scope": "file" } },
+      { "id": "rev1", "type": "resurface", "content": "Revoked", "metadata": { "createdAt": "2026-01-02T00:00:00Z", "author": "test" }, "context": { "suppressionId": "s1", "action": "revoke" } }
+    ],
+    "changedFiles": ["src/auth.ts"],
+    "expectedSuppressionIds": []
+  },
+  {
+    "name": "suppression: expired suppression is excluded",
+    "category": "suppression",
+    "memoryEntries": [
+      { "id": "s1", "type": "suppression", "content": "Temporary", "metadata": { "createdAt": "2024-01-01T00:00:00Z", "author": "test", "relatedFiles": ["src/auth.ts"] }, "context": { "active": true, "scope": "file", "expiresAt": "2025-01-01T00:00:00Z" } }
+    ],
+    "changedFiles": ["src/auth.ts"],
+    "expectedSuppressionIds": []
+  },
+  {
+    "name": "suppression: subsystem scope matches related path",
+    "category": "suppression",
+    "memoryEntries": [
+      { "id": "s1", "type": "suppression", "content": "Auth subsystem", "metadata": { "createdAt": "2026-01-01T00:00:00Z", "author": "test", "relatedFiles": ["src/auth/login.ts"] }, "context": { "active": true, "scope": "subsystem" } }
+    ],
+    "changedFiles": ["src/auth/oauth.ts"],
+    "expectedSuppressionIds": ["s1"]
+  },
+  {
+    "name": "resurfacing: file-scoped suppression resurfaces on same path",
+    "category": "resurfacing",
+    "suppression": { "id": "s1", "type": "suppression", "title": "Suppress auth", "content": "ok", "metadata": { "createdAt": "2026-01-01T00:00:00Z", "author": "test", "relatedFiles": ["src/auth.ts"] }, "context": { "active": true, "scope": "file" } },
+    "changedFiles": ["src/auth.ts"],
+    "expectedResurface": true
+  },
+  {
+    "name": "resurfacing: file-scoped suppression does not resurface on different path",
+    "category": "resurfacing",
+    "suppression": { "id": "s1", "type": "suppression", "title": "Suppress auth", "content": "ok", "metadata": { "createdAt": "2026-01-01T00:00:00Z", "author": "test", "relatedFiles": ["src/auth.ts"] }, "context": { "active": true, "scope": "file" } },
+    "changedFiles": ["src/billing.ts"],
+    "expectedResurface": false
+  },
+  {
+    "name": "resurfacing: inactive suppression does not resurface",
+    "category": "resurfacing",
+    "suppression": { "id": "s1", "type": "suppression", "title": "Inactive", "content": "ok", "metadata": { "createdAt": "2026-01-01T00:00:00Z", "author": "test", "relatedFiles": ["src/auth.ts"] }, "context": { "active": false, "scope": "file" } },
+    "changedFiles": ["src/auth.ts"],
+    "expectedResurface": false
+  }
+]

--- a/tests/memory-context.test.mjs
+++ b/tests/memory-context.test.mjs
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { mkdtempSync } from 'node:fs';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import test from 'node:test';
+import { loadReviewMemory, formatMemoryForPrompt, buildReviewEntry } from '../src/lib/memory-context.mjs';
+
+function createTempDir() { return mkdtempSync(path.join(tmpdir(), 'river-mem-ctx-')); }
+function writeIndex(dir, entries) {
+  const memDir = path.join(dir, '.river', 'memory');
+  fs.mkdirSync(memDir, { recursive: true });
+  fs.writeFileSync(path.join(memDir, 'index.json'), JSON.stringify({ entries, version: '1' }, null, 2));
+}
+function makeEntry(overrides = {}) {
+  return { id: 'test-' + Date.now() + '-' + Math.random().toString(36).slice(2,6), type: 'review', content: 'test', metadata: { createdAt: new Date().toISOString(), author: 'test' }, ...overrides };
+}
+
+test('loadReviewMemory returns empty buckets when index missing', () => {
+  const dir = createTempDir();
+  try {
+    const ctx = loadReviewMemory(dir);
+    assert.deepEqual(ctx.entries, []);
+    assert.deepEqual(ctx.wontfixes, []);
+    assert.deepEqual(ctx.patterns, []);
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('loadReviewMemory buckets entries by type', () => {
+  const dir = createTempDir();
+  try {
+    writeIndex(dir, [makeEntry({id:'w1',type:'wontfix'}), makeEntry({id:'p1',type:'pattern'}), makeEntry({id:'d1',type:'decision'}), makeEntry({id:'r1',type:'review'})]);
+    const ctx = loadReviewMemory(dir);
+    assert.equal(ctx.entries.length, 4);
+    assert.equal(ctx.wontfixes.length, 1);
+    assert.equal(ctx.patterns.length, 1);
+    assert.equal(ctx.decisions.length, 1);
+    assert.equal(ctx.reviews.length, 1);
+    assert.equal(ctx.suppressions.length, 0);
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('loadReviewMemory filters by phase', () => {
+  const dir = createTempDir();
+  try {
+    writeIndex(dir, [
+      makeEntry({id:'u1',type:'pattern',metadata:{createdAt:'2026-01-01T00:00:00Z',author:'t',phase:'upstream'}}),
+      makeEntry({id:'m1',type:'pattern',metadata:{createdAt:'2026-01-01T00:00:00Z',author:'t',phase:'midstream'}}),
+    ]);
+    const ctx = loadReviewMemory(dir, { phase: 'midstream' });
+    assert.equal(ctx.entries.length, 1);
+    assert.equal(ctx.entries[0].id, 'm1');
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('loadReviewMemory filters by relatedFiles overlap', () => {
+  const dir = createTempDir();
+  try {
+    writeIndex(dir, [
+      makeEntry({id:'a1',type:'wontfix',metadata:{createdAt:'2026-01-01T00:00:00Z',author:'t',relatedFiles:['src/auth.ts']}}),
+      makeEntry({id:'b1',type:'wontfix',metadata:{createdAt:'2026-01-01T00:00:00Z',author:'t',relatedFiles:['src/billing.ts']}}),
+    ]);
+    const ctx = loadReviewMemory(dir, { changedFiles: ['src/auth.ts'] });
+    assert.equal(ctx.wontfixes.length, 1);
+    assert.equal(ctx.wontfixes[0].id, 'a1');
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('loadReviewMemory includes entries without relatedFiles', () => {
+  const dir = createTempDir();
+  try {
+    writeIndex(dir, [
+      makeEntry({id:'nr1',type:'pattern',metadata:{createdAt:'2026-01-01T00:00:00Z',author:'t'}}),
+      makeEntry({id:'r1',type:'pattern',metadata:{createdAt:'2026-01-01T00:00:00Z',author:'t',relatedFiles:['unrelated.ts']}}),
+    ]);
+    const ctx = loadReviewMemory(dir, { changedFiles: ['src/app.ts'] });
+    assert.equal(ctx.patterns.length, 1);
+    assert.equal(ctx.patterns[0].id, 'nr1');
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('formatMemoryForPrompt returns empty string for empty context', () => {
+  assert.equal(formatMemoryForPrompt({ entries:[], wontfixes:[], patterns:[], decisions:[], reviews:[], suppressions:[] }), '');
+});
+
+test('formatMemoryForPrompt returns empty string for null', () => {
+  assert.equal(formatMemoryForPrompt(null), '');
+});
+
+test('formatMemoryForPrompt formats wontfix entries', () => {
+  const text = formatMemoryForPrompt({ wontfixes:[{id:'wf1',title:'Accepted logging',content:''}], patterns:[], decisions:[] });
+  assert.ok(text.includes('受け入れ済み'));
+  assert.ok(text.includes('wf1'));
+});
+
+test('formatMemoryForPrompt formats pattern entries', () => {
+  const text = formatMemoryForPrompt({ wontfixes:[], patterns:[{id:'p1',title:'Use pure functions',content:''}], decisions:[] });
+  assert.ok(text.includes('チーム規約'));
+  assert.ok(text.includes('Use pure functions'));
+});
+
+test('formatMemoryForPrompt truncates to maxChars', () => {
+  const ctx = { wontfixes: Array.from({length:50},(_,i)=>({id:'wf'+i,title:'Long entry '+i+' padding text here',content:''})), patterns:[], decisions:[] };
+  const text = formatMemoryForPrompt(ctx, { maxChars: 200 });
+  assert.ok(text.length <= 215);
+  assert.ok(text.includes('[truncated]'));
+});
+
+test('buildReviewEntry returns valid entry structure', () => {
+  const entry = buildReviewEntry({ comments:[{file:'a.ts',line:1,message:'test'}] }, { phase:'midstream', changedFiles:['a.ts'], commit:'abc123' });
+  assert.equal(entry.type, 'review');
+  assert.ok(entry.id.startsWith('review-abc123-'));
+  assert.equal(entry.metadata.author, 'river-reviewer');
+  assert.equal(entry.metadata.phase, 'midstream');
+  assert.deepEqual(entry.metadata.relatedFiles, ['a.ts']);
+});
+
+test('buildReviewEntry uses unknown when no commit', () => {
+  const entry = buildReviewEntry({ comments:[] }, {});
+  assert.ok(entry.id.startsWith('review-unknown-'));
+});

--- a/tests/regression-eval.test.mjs
+++ b/tests/regression-eval.test.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import url from 'node:url';
+import test from 'node:test';
+import { evaluateRegression } from '../src/lib/regression-eval.mjs';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const CASES_PATH = path.join(__dirname, 'fixtures', 'regression-eval', 'cases.json');
+
+test('evaluateRegression loads and runs all fixture cases', async () => {
+  const result = await evaluateRegression({ casesPath: CASES_PATH });
+  assert.ok(result.summary.total >= 8, 'Expected at least 8 cases');
+  assert.equal(result.cases.length, result.summary.total);
+});
+
+test('evaluateRegression returns structured result shape', async () => {
+  const result = await evaluateRegression({ casesPath: CASES_PATH });
+  assert.equal(typeof result.exitCode, 'number');
+  assert.ok(Array.isArray(result.cases));
+  assert.equal(typeof result.summary.policyPassRate, 'number');
+  assert.equal(typeof result.summary.memoryRecallRate, 'number');
+  assert.equal(typeof result.summary.suppressionAccuracy, 'number');
+  assert.equal(typeof result.summary.resurfaceAccuracy, 'number');
+});
+
+test('evaluateRegression: all current cases pass', async () => {
+  const result = await evaluateRegression({ casesPath: CASES_PATH });
+  assert.equal(result.exitCode, 0, 'Expected all cases to pass. Failures: ' +
+    result.cases.filter(c => !c.pass).map(c => c.name).join(', '));
+  assert.equal(result.summary.policyPassRate, 1.0);
+});
+
+test('evaluateRegression: memory_recall cases work', async () => {
+  const result = await evaluateRegression({ casesPath: CASES_PATH });
+  const memoryCases = result.cases.filter(c => c.category === 'memory_recall');
+  assert.ok(memoryCases.length >= 3);
+  assert.ok(memoryCases.every(c => c.pass));
+});
+
+test('evaluateRegression: suppression cases work', async () => {
+  const result = await evaluateRegression({ casesPath: CASES_PATH });
+  const suppCases = result.cases.filter(c => c.category === 'suppression');
+  assert.ok(suppCases.length >= 4);
+  assert.ok(suppCases.every(c => c.pass));
+});
+
+test('evaluateRegression: resurfacing cases work', async () => {
+  const result = await evaluateRegression({ casesPath: CASES_PATH });
+  const resCases = result.cases.filter(c => c.category === 'resurfacing');
+  assert.ok(resCases.length >= 3);
+  assert.ok(resCases.every(c => c.pass));
+});

--- a/tests/resurface.test.mjs
+++ b/tests/resurface.test.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { checkForResurfacingFindings, shouldResurface, buildResurfaceComments } from '../src/lib/resurface.mjs';
+
+function makeSuppression(overrides = {}) {
+  return {
+    id: 's1',
+    type: 'suppression',
+    title: 'Suppress finding',
+    content: 'Accepted for now',
+    metadata: { createdAt: '2026-01-01T00:00:00Z', author: 't', relatedFiles: ['src/auth.ts'] },
+    context: { active: true, scope: 'file', findingId: 'f1' },
+    ...overrides,
+  };
+}
+
+test('checkForResurfacingFindings returns empty for no suppressions', () => {
+  const result = checkForResurfacingFindings({ memoryContext: { suppressions: [] }, changedFiles: ['a.ts'] });
+  assert.deepEqual(result, []);
+});
+
+test('checkForResurfacingFindings returns empty for null memoryContext', () => {
+  const result = checkForResurfacingFindings({ memoryContext: null, changedFiles: ['a.ts'] });
+  assert.deepEqual(result, []);
+});
+
+test('checkForResurfacingFindings matches file-scoped suppression', () => {
+  const ctx = { suppressions: [makeSuppression()] };
+  const result = checkForResurfacingFindings({ memoryContext: ctx, changedFiles: ['src/auth.ts'] });
+  assert.equal(result.length, 1);
+  assert.ok(result[0].reason.includes('Resurfaced'));
+});
+
+test('checkForResurfacingFindings skips unrelated files', () => {
+  const ctx = { suppressions: [makeSuppression()] };
+  const result = checkForResurfacingFindings({ memoryContext: ctx, changedFiles: ['src/billing.ts'] });
+  assert.equal(result.length, 0);
+});
+
+test('shouldResurface matches subsystem scope', () => {
+  const s = makeSuppression({ context: { active: true, scope: 'subsystem' }, metadata: { createdAt: '2026-01-01T00:00:00Z', author: 't', relatedFiles: ['src/auth/login.ts'] } });
+  assert.equal(shouldResurface(s, ['src/auth/oauth.ts']), true);
+  assert.equal(shouldResurface(s, ['src/billing/charge.ts']), false);
+});
+
+test('shouldResurface returns false for inactive suppression', () => {
+  const s = makeSuppression({ context: { active: false, scope: 'file' } });
+  assert.equal(shouldResurface(s, ['src/auth.ts']), false);
+});
+
+test('shouldResurface returns false for expired suppression', () => {
+  const s = makeSuppression({ context: { active: true, scope: 'file', expiresAt: '2025-01-01T00:00:00Z' } });
+  assert.equal(shouldResurface(s, ['src/auth.ts']), false);
+});
+
+test('shouldResurface returns true for global scope', () => {
+  const s = makeSuppression({ context: { active: true, scope: 'global' } });
+  assert.equal(shouldResurface(s, ['any/file.ts']), true);
+});
+
+test('buildResurfaceComments creates valid comments', () => {
+  const candidates = [{ suppression: makeSuppression(), reason: '[Resurfaced] test' }];
+  const comments = buildResurfaceComments(candidates);
+  assert.equal(comments.length, 1);
+  assert.equal(comments[0].resurfaced, true);
+  assert.equal(comments[0].file, 'src/auth.ts');
+  assert.ok(comments[0].message.includes('Severity: nit'));
+  assert.ok(comments[0].message.includes('Confidence: low'));
+});

--- a/tests/risk-map.test.mjs
+++ b/tests/risk-map.test.mjs
@@ -1,0 +1,220 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdir, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import test from 'node:test';
+import { loadRiskMap, evaluateRisk, aggregateRiskLevel } from '../src/lib/risk-map.mjs';
+
+function createTempDir() {
+  return mkdtempSync(path.join(tmpdir(), 'river-risk-map-'));
+}
+
+async function writeRiskMap(dir, content) {
+  const riverDir = path.join(dir, '.river');
+  await mkdir(riverDir, { recursive: true });
+  writeFileSync(path.join(riverDir, 'risk-map.yaml'), content);
+}
+
+// --- loadRiskMap ---
+
+test('loadRiskMap returns null when file is absent', async () => {
+  const dir = createTempDir();
+  try {
+    const result = await loadRiskMap(dir);
+    assert.equal(result, null);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('loadRiskMap returns null when file is empty', async () => {
+  const dir = createTempDir();
+  try {
+    await writeRiskMap(dir, '   \n  ');
+    const result = await loadRiskMap(dir);
+    assert.equal(result, null);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('loadRiskMap parses valid YAML', async () => {
+  const dir = createTempDir();
+  try {
+    await writeRiskMap(
+      dir,
+      `
+rules:
+  - pattern: "src/auth/**"
+    action: require_human_review
+    reason: "Security critical"
+  - pattern: "docs/**"
+    action: comment_only
+defaults:
+  action: escalate
+`,
+    );
+    const result = await loadRiskMap(dir);
+    assert.equal(result.rules.length, 2);
+    assert.equal(result.rules[0].action, 'require_human_review');
+    assert.equal(result.rules[0].reason, 'Security critical');
+    assert.equal(result.defaults.action, 'escalate');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('loadRiskMap applies defaults when defaults section is absent', async () => {
+  const dir = createTempDir();
+  try {
+    await writeRiskMap(
+      dir,
+      `
+rules:
+  - pattern: "**/*.sql"
+    action: escalate
+`,
+    );
+    const result = await loadRiskMap(dir);
+    assert.equal(result.defaults.action, 'comment_only');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('loadRiskMap rejects invalid action value', async () => {
+  const dir = createTempDir();
+  try {
+    await writeRiskMap(
+      dir,
+      `
+rules:
+  - pattern: "**/*"
+    action: auto_merge
+`,
+    );
+    await assert.rejects(() => loadRiskMap(dir), { name: 'RiskMapError' });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('loadRiskMap rejects empty rules array', async () => {
+  const dir = createTempDir();
+  try {
+    await writeRiskMap(dir, 'rules: []');
+    await assert.rejects(() => loadRiskMap(dir), { name: 'RiskMapError' });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('loadRiskMap rejects path outside repository', async () => {
+  const dir = createTempDir();
+  try {
+    await assert.rejects(() => loadRiskMap(dir, { riskMapPath: '../../etc/passwd' }), {
+      name: 'RiskMapError',
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+
+test('loadRiskMap rejects malformed YAML', async () => {
+  const dir = createTempDir();
+  try {
+    await writeRiskMap(dir, '{ bad yaml ::: }');
+    await assert.rejects(() => loadRiskMap(dir), { name: 'RiskMapError' });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// --- evaluateRisk ---
+
+test('evaluateRisk: first matching rule wins', () => {
+  const riskMap = {
+    rules: [
+      { pattern: 'src/auth/**', action: 'require_human_review', reason: 'Auth' },
+      { pattern: 'src/**', action: 'comment_only' },
+    ],
+    defaults: { action: 'comment_only' },
+  };
+  const result = evaluateRisk(riskMap, ['src/auth/handler.ts', 'src/utils.ts']);
+  assert.equal(result.fileRisks[0].action, 'require_human_review');
+  assert.equal(result.fileRisks[0].rule.reason, 'Auth');
+  assert.equal(result.fileRisks[1].action, 'comment_only');
+});
+
+test('evaluateRisk: falls back to defaults when no rules match', () => {
+  const riskMap = {
+    rules: [{ pattern: 'src/auth/**', action: 'require_human_review' }],
+    defaults: { action: 'escalate' },
+  };
+  const result = evaluateRisk(riskMap, ['docs/readme.md']);
+  assert.equal(result.fileRisks[0].action, 'escalate');
+  assert.equal(result.fileRisks[0].rule, undefined);
+});
+
+test('evaluateRisk: aggregates to highest risk level', () => {
+  const riskMap = {
+    rules: [
+      { pattern: 'db/migrations/**', action: 'require_human_review' },
+      { pattern: 'src/**', action: 'escalate' },
+      { pattern: 'docs/**', action: 'comment_only' },
+    ],
+    defaults: { action: 'comment_only' },
+  };
+  const result = evaluateRisk(riskMap, [
+    'docs/readme.md',
+    'src/app.ts',
+    'db/migrations/001.sql',
+  ]);
+  assert.equal(result.aggregateAction, 'require_human_review');
+  assert.deepEqual(result.escalatedFiles, ['src/app.ts']);
+  assert.deepEqual(result.humanReviewFiles, ['db/migrations/001.sql']);
+});
+
+test('evaluateRisk: handles empty file list', () => {
+  const riskMap = {
+    rules: [{ pattern: '**/*', action: 'escalate' }],
+    defaults: { action: 'comment_only' },
+  };
+  const result = evaluateRisk(riskMap, []);
+  assert.deepEqual(result.fileRisks, []);
+  assert.equal(result.aggregateAction, 'comment_only');
+});
+
+test('evaluateRisk: returns default action when riskMap is null', () => {
+  const result = evaluateRisk(null, ['src/app.ts']);
+  assert.equal(result.aggregateAction, 'comment_only');
+  assert.deepEqual(result.fileRisks, []);
+});
+
+test('evaluateRisk: glob patterns match dot files', () => {
+  const riskMap = {
+    rules: [{ pattern: '.github/workflows/**', action: 'escalate', reason: 'CI config' }],
+    defaults: { action: 'comment_only' },
+  };
+  const result = evaluateRisk(riskMap, ['.github/workflows/deploy.yml']);
+  assert.equal(result.fileRisks[0].action, 'escalate');
+  assert.equal(result.escalatedFiles.length, 1);
+});
+
+// --- aggregateRiskLevel ---
+
+test('aggregateRiskLevel: returns fallback for empty array', () => {
+  assert.equal(aggregateRiskLevel([], 'escalate'), 'escalate');
+  assert.equal(aggregateRiskLevel(null), 'comment_only');
+});
+
+test('aggregateRiskLevel: picks highest priority', () => {
+  const risks = [
+    { action: 'comment_only' },
+    { action: 'escalate' },
+    { action: 'comment_only' },
+  ];
+  assert.equal(aggregateRiskLevel(risks), 'escalate');
+});

--- a/tests/suppression.test.mjs
+++ b/tests/suppression.test.mjs
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { mkdtempSync } from 'node:fs';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import test from 'node:test';
+import { hashFinding, inferSubsystem, createSuppression, revokeSuppression, findActiveSuppressions } from '../src/lib/suppression.mjs';
+import { loadMemory } from '../src/lib/riverbed-memory.mjs';
+
+function tmpIndex() {
+  const dir = mkdtempSync(path.join(tmpdir(), 'river-supp-'));
+  const memDir = path.join(dir, '.river', 'memory');
+  fs.mkdirSync(memDir, { recursive: true });
+  return { dir, indexPath: path.join(memDir, 'index.json') };
+}
+
+test('hashFinding produces stable hash for same input', () => {
+  const h1 = hashFinding({ file: 'a.ts', message: 'test', ruleId: 'r1' });
+  const h2 = hashFinding({ file: 'a.ts', message: 'test', ruleId: 'r1' });
+  assert.equal(h1, h2);
+  assert.equal(h1.length, 16);
+});
+
+test('hashFinding produces different hash for different input', () => {
+  const h1 = hashFinding({ file: 'a.ts', message: 'test' });
+  const h2 = hashFinding({ file: 'b.ts', message: 'test' });
+  assert.notEqual(h1, h2);
+});
+
+test('inferSubsystem extracts correct subsystem', () => {
+  assert.equal(inferSubsystem('src/auth/handler.ts'), 'auth');
+  assert.equal(inferSubsystem('src/lib/utils.mjs'), 'lib');
+  assert.equal(inferSubsystem('runners/core/loader.mjs'), 'runners');
+  assert.equal(inferSubsystem('file.ts'), '');
+});
+
+test('createSuppression creates valid entry', () => {
+  const { dir, indexPath } = tmpIndex();
+  try {
+    const entry = createSuppression({
+      indexPath,
+      findingId: 'f1',
+      findingHash: 'abc123',
+      filePaths: ['src/auth.ts'],
+      rationale: 'Accepted for now',
+      scope: 'file',
+      author: 'tester',
+    });
+    assert.equal(entry.type, 'suppression');
+    assert.ok(entry.id.startsWith('suppression-abc123-'));
+    assert.equal(entry.content, 'Accepted for now');
+    assert.ok(entry.metadata.tags.includes('active'));
+    assert.ok(entry.context.active);
+    const index = loadMemory(indexPath);
+    assert.equal(index.entries.length, 1);
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('createSuppression rejects missing rationale', () => {
+  const { dir, indexPath } = tmpIndex();
+  try {
+    assert.throws(() => createSuppression({ indexPath, filePaths: ['a.ts'] }), /rationale/);
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('revokeSuppression appends resurface entry', () => {
+  const { dir, indexPath } = tmpIndex();
+  try {
+    createSuppression({ indexPath, findingId: 'f1', findingHash: 'h1', filePaths: ['a.ts'], rationale: 'ok' });
+    const entry = revokeSuppression(indexPath, 'suppression-h1-123', { reason: 'no longer valid' });
+    assert.equal(entry.type, 'resurface');
+    assert.equal(entry.context.action, 'revoke');
+    const index = loadMemory(indexPath);
+    assert.equal(index.entries.length, 2);
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('findActiveSuppressions matches by file path', () => {
+  const index = {
+    entries: [
+      { id: 's1', type: 'suppression', content: 'ok', metadata: { createdAt: '2026-01-01T00:00:00Z', author: 't', relatedFiles: ['src/auth.ts'] }, context: { active: true, scope: 'file' } },
+      { id: 's2', type: 'suppression', content: 'ok', metadata: { createdAt: '2026-01-01T00:00:00Z', author: 't', relatedFiles: ['src/billing.ts'] }, context: { active: true, scope: 'file' } },
+    ],
+  };
+  const result = findActiveSuppressions(index, ['src/auth.ts']);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].id, 's1');
+});
+
+test('findActiveSuppressions excludes revoked suppressions', () => {
+  const index = {
+    entries: [
+      { id: 's1', type: 'suppression', content: 'ok', metadata: { createdAt: '2026-01-01T00:00:00Z', author: 't', relatedFiles: ['src/auth.ts'] }, context: { active: true, scope: 'file' } },
+      { id: 'r1', type: 'resurface', content: 'revoked', metadata: { createdAt: '2026-01-02T00:00:00Z', author: 't' }, context: { suppressionId: 's1', action: 'revoke' } },
+    ],
+  };
+  const result = findActiveSuppressions(index, ['src/auth.ts']);
+  assert.equal(result.length, 0);
+});
+
+test('findActiveSuppressions excludes expired suppressions', () => {
+  const index = {
+    entries: [
+      { id: 's1', type: 'suppression', content: 'ok', metadata: { createdAt: '2024-01-01T00:00:00Z', author: 't', relatedFiles: ['src/auth.ts'] }, context: { active: true, scope: 'file', expiresAt: '2025-01-01T00:00:00Z' } },
+    ],
+  };
+  const result = findActiveSuppressions(index, ['src/auth.ts']);
+  assert.equal(result.length, 0);
+});
+
+test('findActiveSuppressions matches subsystem scope', () => {
+  const index = {
+    entries: [
+      { id: 's1', type: 'suppression', content: 'ok', metadata: { createdAt: '2026-01-01T00:00:00Z', author: 't', relatedFiles: ['src/auth/login.ts'] }, context: { active: true, scope: 'subsystem' } },
+    ],
+  };
+  const result = findActiveSuppressions(index, ['src/auth/oauth.ts']);
+  assert.equal(result.length, 1);
+});


### PR DESCRIPTION
## Summary

- `.river/risk-map.yaml` によるファイルリスク分類（comment_only / escalate / require_human_review）
- 決定論的なポリシー評価をレビューパイプラインに統合
- JSON/Markdown 出力にリスクサマリーを追加

## Changes

| ファイル | 目的 |
|---------|------|
| `schemas/risk-map.schema.json` | リスクマップ設定の JSON Schema |
| `src/config/risk-map-schema.mjs` | Zod バリデーション |
| `src/lib/risk-map.mjs` | ローダー・評価器（loadRiskMap, evaluateRisk, aggregateRiskLevel） |
| `tests/risk-map.test.mjs` | 16テスト |
| `runners/core/review-runner.mjs` | buildExecutionPlan に riskAssessment 追加 |
| `src/lib/review-engine.mjs` | プロンプトにリスク評価セクション注入 |
| `src/cli.mjs` | RiskMapError ハンドリング、出力にリスクサマリー |
| `schemas/output.schema.json` | riskSummary フィールド追加 |

## Test plan

- [ ] `node --test tests/risk-map.test.mjs` — 16/16 通過
- [ ] `npm test` — 既存テストに回帰なし
- [ ] `.river/risk-map.yaml` 無しで既存動作に影響なし（null 安全）

🤖 Generated with [Claude Code](https://claude.com/claude-code)