### PR TITLE
feat(evals): add risk-map and memory-fallback regression eval fixtures

### DIFF
--- a/scripts/evaluate-regression.mjs
+++ b/scripts/evaluate-regression.mjs
@@ -8,7 +8,14 @@ import url from 'node:url';
 import { evaluateRegression } from '../src/lib/regression-eval.mjs';
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
-const DEFAULT_CASES = path.join(__dirname, '..', 'tests', 'fixtures', 'regression-eval', 'cases.json');
+const DEFAULT_CASES = path.join(
+  __dirname,
+  '..',
+  'tests',
+  'fixtures',
+  'regression-eval',
+  'cases.json'
+);
 
 async function main() {
   const args = process.argv.slice(2);
@@ -25,8 +32,14 @@ async function main() {
   console.log('Fail: ' + result.summary.fail);
   console.log('Policy pass rate: ' + (result.summary.policyPassRate * 100).toFixed(1) + '%');
   console.log('Memory recall rate: ' + (result.summary.memoryRecallRate * 100).toFixed(1) + '%');
-  console.log('Suppression accuracy: ' + (result.summary.suppressionAccuracy * 100).toFixed(1) + '%');
+  console.log(
+    'Suppression accuracy: ' + (result.summary.suppressionAccuracy * 100).toFixed(1) + '%'
+  );
   console.log('Resurface accuracy: ' + (result.summary.resurfaceAccuracy * 100).toFixed(1) + '%');
+  console.log('Escalation accuracy: ' + (result.summary.escalationAccuracy * 100).toFixed(1) + '%');
+  console.log(
+    'Memory fallback rate: ' + (result.summary.memoryFallbackRate * 100).toFixed(1) + '%'
+  );
 
   if (result.summary.fail > 0) {
     console.log('\nFailing cases:');
@@ -38,4 +51,11 @@ async function main() {
   return result.exitCode;
 }
 
-main().then((code) => { process.exitCode = code; }).catch((err) => { console.error(err.message); process.exitCode = 1; });
+main()
+  .then((code) => {
+    process.exitCode = code;
+  })
+  .catch((err) => {
+    console.error(err.message);
+    process.exitCode = 1;
+  });

--- a/src/lib/regression-eval.mjs
+++ b/src/lib/regression-eval.mjs
@@ -1,7 +1,8 @@
 import fs from 'node:fs';
-import { queryMemory } from './riverbed-memory.mjs';
+import { loadMemory, queryMemory } from './riverbed-memory.mjs';
 import { findActiveSuppressions } from './suppression.mjs';
 import { shouldResurface } from './resurface.mjs';
+import { evaluateRisk } from './risk-map.mjs';
 
 /**
  * Run regression evaluation cases.
@@ -35,6 +36,12 @@ export async function evaluateRegression({ casesPath, verbose = false }) {
         case 'resurfacing':
           ok = runResurfacingCase(c);
           break;
+        case 'risk_map':
+          ok = runRiskMapCase(c);
+          break;
+        case 'memory_fallback':
+          ok = runMemoryFallbackCase(c);
+          break;
         default:
           error = 'Unknown category: ' + cat;
       }
@@ -58,6 +65,8 @@ export async function evaluateRegression({ casesPath, verbose = false }) {
   const memoryRecallRate = safeRate(categoryStats.memory_recall);
   const suppressionAccuracy = safeRate(categoryStats.suppression);
   const resurfaceAccuracy = safeRate(categoryStats.resurfacing);
+  const escalationAccuracy = safeRate(categoryStats.risk_map);
+  const memoryFallbackRate = safeRate(categoryStats.memory_fallback);
   const policyPassRate = total > 0 ? pass / total : 0;
 
   return {
@@ -69,9 +78,10 @@ export async function evaluateRegression({ casesPath, verbose = false }) {
       fail,
       policyPassRate,
       memoryRecallRate,
-      escalationAccuracy: 1.0, // placeholder until risk-map eval cases are added
+      escalationAccuracy,
       suppressionAccuracy,
       resurfaceAccuracy,
+      memoryFallbackRate,
     },
   };
 }
@@ -103,4 +113,27 @@ function runSuppressionCase(c) {
 function runResurfacingCase(c) {
   const result = shouldResurface(c.suppression, c.changedFiles);
   return result === c.expectedResurface;
+}
+
+function runRiskMapCase(c) {
+  const result = evaluateRisk(c.riskMap, c.changedFiles);
+  if (result.aggregateAction !== c.expectedAggregateAction) return false;
+  const escalated = [...result.escalatedFiles].sort();
+  const expectedEscalated = [...c.expectedEscalatedFiles].sort();
+  if (escalated.length !== expectedEscalated.length) return false;
+  if (!escalated.every((f, i) => f === expectedEscalated[i])) return false;
+  const human = [...result.humanReviewFiles].sort();
+  const expectedHuman = [...c.expectedHumanReviewFiles].sort();
+  if (human.length !== expectedHuman.length) return false;
+  return human.every((f, i) => f === expectedHuman[i]);
+}
+
+function runMemoryFallbackCase(c) {
+  if (c.memoryPath) {
+    const index = loadMemory(c.memoryPath);
+    return index.entries.length === c.expectedEntryCount;
+  }
+  const index = { entries: c.memoryEntries };
+  const results = queryMemory(index, c.query ?? {});
+  return results.length === c.expectedEntryCount;
 }

--- a/tests/fixtures/regression-eval/cases.json
+++ b/tests/fixtures/regression-eval/cases.json
@@ -3,8 +3,18 @@
     "name": "memory-recall: query by type=wontfix returns matching entries",
     "category": "memory_recall",
     "memoryEntries": [
-      { "id": "wf1", "type": "wontfix", "content": "Accepted verbose logging", "metadata": { "createdAt": "2026-01-01T00:00:00Z", "author": "test" } },
-      { "id": "r1", "type": "review", "content": "Review result", "metadata": { "createdAt": "2026-01-01T00:00:00Z", "author": "test" } }
+      {
+        "id": "wf1",
+        "type": "wontfix",
+        "content": "Accepted verbose logging",
+        "metadata": { "createdAt": "2026-01-01T00:00:00Z", "author": "test" }
+      },
+      {
+        "id": "r1",
+        "type": "review",
+        "content": "Review result",
+        "metadata": { "createdAt": "2026-01-01T00:00:00Z", "author": "test" }
+      }
     ],
     "query": { "type": "wontfix" },
     "expectedIds": ["wf1"]
@@ -13,8 +23,22 @@
     "name": "memory-recall: query by tags filters correctly",
     "category": "memory_recall",
     "memoryEntries": [
-      { "id": "p1", "type": "pattern", "content": "Auth pattern", "metadata": { "createdAt": "2026-01-01T00:00:00Z", "author": "test", "tags": ["security", "auth"] } },
-      { "id": "p2", "type": "pattern", "content": "Perf pattern", "metadata": { "createdAt": "2026-01-01T00:00:00Z", "author": "test", "tags": ["perf"] } }
+      {
+        "id": "p1",
+        "type": "pattern",
+        "content": "Auth pattern",
+        "metadata": {
+          "createdAt": "2026-01-01T00:00:00Z",
+          "author": "test",
+          "tags": ["security", "auth"]
+        }
+      },
+      {
+        "id": "p2",
+        "type": "pattern",
+        "content": "Perf pattern",
+        "metadata": { "createdAt": "2026-01-01T00:00:00Z", "author": "test", "tags": ["perf"] }
+      }
     ],
     "query": { "tags": ["security"] },
     "expectedIds": ["p1"]
@@ -23,8 +47,18 @@
     "name": "memory-recall: query by phase returns correct entries",
     "category": "memory_recall",
     "memoryEntries": [
-      { "id": "u1", "type": "pattern", "content": "Upstream", "metadata": { "createdAt": "2026-01-01T00:00:00Z", "author": "test", "phase": "upstream" } },
-      { "id": "m1", "type": "pattern", "content": "Midstream", "metadata": { "createdAt": "2026-01-01T00:00:00Z", "author": "test", "phase": "midstream" } }
+      {
+        "id": "u1",
+        "type": "pattern",
+        "content": "Upstream",
+        "metadata": { "createdAt": "2026-01-01T00:00:00Z", "author": "test", "phase": "upstream" }
+      },
+      {
+        "id": "m1",
+        "type": "pattern",
+        "content": "Midstream",
+        "metadata": { "createdAt": "2026-01-01T00:00:00Z", "author": "test", "phase": "midstream" }
+      }
     ],
     "query": { "phase": "midstream" },
     "expectedIds": ["m1"]
@@ -33,7 +67,17 @@
     "name": "suppression: active suppression matches by file path",
     "category": "suppression",
     "memoryEntries": [
-      { "id": "s1", "type": "suppression", "content": "Accepted", "metadata": { "createdAt": "2026-01-01T00:00:00Z", "author": "test", "relatedFiles": ["src/auth.ts"] }, "context": { "active": true, "scope": "file" } }
+      {
+        "id": "s1",
+        "type": "suppression",
+        "content": "Accepted",
+        "metadata": {
+          "createdAt": "2026-01-01T00:00:00Z",
+          "author": "test",
+          "relatedFiles": ["src/auth.ts"]
+        },
+        "context": { "active": true, "scope": "file" }
+      }
     ],
     "changedFiles": ["src/auth.ts"],
     "expectedSuppressionIds": ["s1"]
@@ -42,8 +86,24 @@
     "name": "suppression: revoked suppression is excluded",
     "category": "suppression",
     "memoryEntries": [
-      { "id": "s1", "type": "suppression", "content": "Accepted", "metadata": { "createdAt": "2026-01-01T00:00:00Z", "author": "test", "relatedFiles": ["src/auth.ts"] }, "context": { "active": true, "scope": "file" } },
-      { "id": "rev1", "type": "resurface", "content": "Revoked", "metadata": { "createdAt": "2026-01-02T00:00:00Z", "author": "test" }, "context": { "suppressionId": "s1", "action": "revoke" } }
+      {
+        "id": "s1",
+        "type": "suppression",
+        "content": "Accepted",
+        "metadata": {
+          "createdAt": "2026-01-01T00:00:00Z",
+          "author": "test",
+          "relatedFiles": ["src/auth.ts"]
+        },
+        "context": { "active": true, "scope": "file" }
+      },
+      {
+        "id": "rev1",
+        "type": "resurface",
+        "content": "Revoked",
+        "metadata": { "createdAt": "2026-01-02T00:00:00Z", "author": "test" },
+        "context": { "suppressionId": "s1", "action": "revoke" }
+      }
     ],
     "changedFiles": ["src/auth.ts"],
     "expectedSuppressionIds": []
@@ -52,7 +112,17 @@
     "name": "suppression: expired suppression is excluded",
     "category": "suppression",
     "memoryEntries": [
-      { "id": "s1", "type": "suppression", "content": "Temporary", "metadata": { "createdAt": "2024-01-01T00:00:00Z", "author": "test", "relatedFiles": ["src/auth.ts"] }, "context": { "active": true, "scope": "file", "expiresAt": "2025-01-01T00:00:00Z" } }
+      {
+        "id": "s1",
+        "type": "suppression",
+        "content": "Temporary",
+        "metadata": {
+          "createdAt": "2024-01-01T00:00:00Z",
+          "author": "test",
+          "relatedFiles": ["src/auth.ts"]
+        },
+        "context": { "active": true, "scope": "file", "expiresAt": "2025-01-01T00:00:00Z" }
+      }
     ],
     "changedFiles": ["src/auth.ts"],
     "expectedSuppressionIds": []
@@ -61,7 +131,17 @@
     "name": "suppression: subsystem scope matches related path",
     "category": "suppression",
     "memoryEntries": [
-      { "id": "s1", "type": "suppression", "content": "Auth subsystem", "metadata": { "createdAt": "2026-01-01T00:00:00Z", "author": "test", "relatedFiles": ["src/auth/login.ts"] }, "context": { "active": true, "scope": "subsystem" } }
+      {
+        "id": "s1",
+        "type": "suppression",
+        "content": "Auth subsystem",
+        "metadata": {
+          "createdAt": "2026-01-01T00:00:00Z",
+          "author": "test",
+          "relatedFiles": ["src/auth/login.ts"]
+        },
+        "context": { "active": true, "scope": "subsystem" }
+      }
     ],
     "changedFiles": ["src/auth/oauth.ts"],
     "expectedSuppressionIds": ["s1"]
@@ -69,22 +149,174 @@
   {
     "name": "resurfacing: file-scoped suppression resurfaces on same path",
     "category": "resurfacing",
-    "suppression": { "id": "s1", "type": "suppression", "title": "Suppress auth", "content": "ok", "metadata": { "createdAt": "2026-01-01T00:00:00Z", "author": "test", "relatedFiles": ["src/auth.ts"] }, "context": { "active": true, "scope": "file" } },
+    "suppression": {
+      "id": "s1",
+      "type": "suppression",
+      "title": "Suppress auth",
+      "content": "ok",
+      "metadata": {
+        "createdAt": "2026-01-01T00:00:00Z",
+        "author": "test",
+        "relatedFiles": ["src/auth.ts"]
+      },
+      "context": { "active": true, "scope": "file" }
+    },
     "changedFiles": ["src/auth.ts"],
     "expectedResurface": true
   },
   {
     "name": "resurfacing: file-scoped suppression does not resurface on different path",
     "category": "resurfacing",
-    "suppression": { "id": "s1", "type": "suppression", "title": "Suppress auth", "content": "ok", "metadata": { "createdAt": "2026-01-01T00:00:00Z", "author": "test", "relatedFiles": ["src/auth.ts"] }, "context": { "active": true, "scope": "file" } },
+    "suppression": {
+      "id": "s1",
+      "type": "suppression",
+      "title": "Suppress auth",
+      "content": "ok",
+      "metadata": {
+        "createdAt": "2026-01-01T00:00:00Z",
+        "author": "test",
+        "relatedFiles": ["src/auth.ts"]
+      },
+      "context": { "active": true, "scope": "file" }
+    },
     "changedFiles": ["src/billing.ts"],
     "expectedResurface": false
   },
   {
     "name": "resurfacing: inactive suppression does not resurface",
     "category": "resurfacing",
-    "suppression": { "id": "s1", "type": "suppression", "title": "Inactive", "content": "ok", "metadata": { "createdAt": "2026-01-01T00:00:00Z", "author": "test", "relatedFiles": ["src/auth.ts"] }, "context": { "active": false, "scope": "file" } },
+    "suppression": {
+      "id": "s1",
+      "type": "suppression",
+      "title": "Inactive",
+      "content": "ok",
+      "metadata": {
+        "createdAt": "2026-01-01T00:00:00Z",
+        "author": "test",
+        "relatedFiles": ["src/auth.ts"]
+      },
+      "context": { "active": false, "scope": "file" }
+    },
     "changedFiles": ["src/auth.ts"],
     "expectedResurface": false
+  },
+  {
+    "name": "risk-map: docs-only change is comment_only",
+    "category": "risk_map",
+    "riskMap": {
+      "version": "1",
+      "rules": [
+        { "pattern": "db/migrations/**", "action": "require_human_review" },
+        { "pattern": "src/auth/**", "action": "escalate" },
+        { "pattern": "docs/**", "action": "comment_only" }
+      ],
+      "defaults": { "action": "comment_only" }
+    },
+    "changedFiles": ["docs/guide.md", "docs/faq.md"],
+    "expectedAggregateAction": "comment_only",
+    "expectedEscalatedFiles": [],
+    "expectedHumanReviewFiles": []
+  },
+  {
+    "name": "risk-map: auth change triggers escalation",
+    "category": "risk_map",
+    "riskMap": {
+      "version": "1",
+      "rules": [
+        { "pattern": "db/migrations/**", "action": "require_human_review" },
+        { "pattern": "src/auth/**", "action": "escalate" },
+        { "pattern": "docs/**", "action": "comment_only" }
+      ],
+      "defaults": { "action": "comment_only" }
+    },
+    "changedFiles": ["src/auth/login.ts", "src/auth/session.ts"],
+    "expectedAggregateAction": "escalate",
+    "expectedEscalatedFiles": ["src/auth/login.ts", "src/auth/session.ts"],
+    "expectedHumanReviewFiles": []
+  },
+  {
+    "name": "risk-map: db migration requires human review",
+    "category": "risk_map",
+    "riskMap": {
+      "version": "1",
+      "rules": [
+        { "pattern": "db/migrations/**", "action": "require_human_review" },
+        { "pattern": "src/auth/**", "action": "escalate" }
+      ],
+      "defaults": { "action": "comment_only" }
+    },
+    "changedFiles": ["db/migrations/0042_add_column.sql"],
+    "expectedAggregateAction": "require_human_review",
+    "expectedEscalatedFiles": [],
+    "expectedHumanReviewFiles": ["db/migrations/0042_add_column.sql"]
+  },
+  {
+    "name": "risk-map: mixed files aggregate to highest risk",
+    "category": "risk_map",
+    "riskMap": {
+      "version": "1",
+      "rules": [
+        { "pattern": "db/migrations/**", "action": "require_human_review" },
+        { "pattern": "src/auth/**", "action": "escalate" },
+        { "pattern": "docs/**", "action": "comment_only" }
+      ],
+      "defaults": { "action": "comment_only" }
+    },
+    "changedFiles": ["docs/readme.md", "src/auth/login.ts", "db/migrations/001.sql"],
+    "expectedAggregateAction": "require_human_review",
+    "expectedEscalatedFiles": ["src/auth/login.ts"],
+    "expectedHumanReviewFiles": ["db/migrations/001.sql"]
+  },
+  {
+    "name": "risk-map: unmatched files fall back to defaults",
+    "category": "risk_map",
+    "riskMap": {
+      "version": "1",
+      "rules": [{ "pattern": "src/auth/**", "action": "escalate" }],
+      "defaults": { "action": "comment_only" }
+    },
+    "changedFiles": ["src/ui/button.tsx", "src/utils/format.ts"],
+    "expectedAggregateAction": "comment_only",
+    "expectedEscalatedFiles": [],
+    "expectedHumanReviewFiles": []
+  },
+  {
+    "name": "risk-map: empty file list returns default action",
+    "category": "risk_map",
+    "riskMap": {
+      "version": "1",
+      "rules": [{ "pattern": "src/auth/**", "action": "escalate" }],
+      "defaults": { "action": "comment_only" }
+    },
+    "changedFiles": [],
+    "expectedAggregateAction": "comment_only",
+    "expectedEscalatedFiles": [],
+    "expectedHumanReviewFiles": []
+  },
+  {
+    "name": "memory-fallback: missing memory returns empty results",
+    "category": "memory_fallback",
+    "memoryPath": "__nonexistent__/missing.json",
+    "expectedEntryCount": 0
+  },
+  {
+    "name": "memory-fallback: empty query returns all entries",
+    "category": "memory_fallback",
+    "memoryEntries": [
+      {
+        "id": "e1",
+        "type": "wontfix",
+        "content": "ok",
+        "metadata": { "createdAt": "2026-01-01T00:00:00Z", "author": "test" }
+      },
+      {
+        "id": "e2",
+        "type": "review",
+        "content": "ok",
+        "metadata": { "createdAt": "2026-01-01T00:00:00Z", "author": "test" }
+      }
+    ],
+    "query": {},
+    "expectedEntryCount": 2
   }
 ]


### PR DESCRIPTION
リスクマップ分類・エスカレーションルーティング・メモリフォールバック動作の回帰テストを追加し、ガバナンス機能の変更がサイレントに回帰しないことを保証する。

既存10件（memory_recall 3, suppression 4, resurfacing 3）に以下を追加:

**risk_map (6件)**
- docs のみ変更 → comment_only
- auth 変更 → escalate
- DB migration → require_human_review
- 混合ファイル → 最高リスクに集約
- 未マッチファイル → defaults にフォール
- 空ファイルリスト → default action

**memory_fallback (2件)**
- 存在しないメモリファイル → 空結果（stateless fallback）
- 空クエリ → 全エントリ返却

ランナー変更:
- `runRiskMapCase`: `evaluateRisk` を呼び出し、aggregateAction / escalatedFiles / humanReviewFiles を検証
- `runMemoryFallbackCase`: `loadMemory` の ENOENT fallback と `queryMemory` の空フィルタを検証
- `escalationAccuracy` のプレースホルダー (1.0) を実測値に置換
- `memoryFallbackRate` メトリクスを追加
- スクリプト出力に escalation / memory fallback メトリクスを追加

結果: 18/18 pass

Fixes #435