### PR TITLE
refactor: extract shared helpers and reduce duplication

### DIFF
--- a/src/lib/memory-context.mjs
+++ b/src/lib/memory-context.mjs
@@ -14,14 +14,19 @@ export function loadReviewMemory(repoRoot, { phase, changedFiles } = {}) {
         return related.some((r) => changedFiles.includes(r));
       })
     : allEntries;
-  return {
-    entries: relevant,
-    wontfixes: relevant.filter((e) => e.type === 'wontfix'),
-    patterns: relevant.filter((e) => e.type === 'pattern'),
-    decisions: relevant.filter((e) => e.type === 'decision'),
-    reviews: relevant.filter((e) => e.type === 'review'),
-    suppressions: relevant.filter((e) => e.type === 'suppression'),
+  const buckets = { wontfixes: [], patterns: [], decisions: [], reviews: [], suppressions: [] };
+  const typeMap = {
+    wontfix: 'wontfixes',
+    pattern: 'patterns',
+    decision: 'decisions',
+    review: 'reviews',
+    suppression: 'suppressions',
   };
+  for (const e of relevant) {
+    const bucket = typeMap[e.type];
+    if (bucket) buckets[bucket].push(e);
+  }
+  return { entries: relevant, ...buckets };
 }
 
 export function formatMemoryForPrompt(memoryContext, { maxChars = 1500 } = {}) {
@@ -30,7 +35,8 @@ export function formatMemoryForPrompt(memoryContext, { maxChars = 1500 } = {}) {
   const sections = [];
   if (wontfixes?.length) {
     sections.push('以下の指摘は明示的に受け入れ済みです。再指摘は不要です:');
-    for (const w of wontfixes) sections.push('- [' + w.id + '] ' + (w.title || w.content?.slice(0, 80)));
+    for (const w of wontfixes)
+      sections.push('- [' + w.id + '] ' + (w.title || w.content?.slice(0, 80)));
   }
   if (patterns?.length) {
     sections.push('以下はチーム規約として記録されています:');

--- a/src/lib/regression-eval.mjs
+++ b/src/lib/regression-eval.mjs
@@ -92,40 +92,35 @@ function safeRate(stats) {
   return total > 0 ? stats.pass / total : 1.0;
 }
 
+function arraysEqualSorted(a, b) {
+  const sa = [...a].sort();
+  const sb = [...b].sort();
+  return sa.length === sb.length && sa.every((v, i) => v === sb[i]);
+}
+
 function runMemoryRecallCase(c) {
   const index = { entries: c.memoryEntries };
-  const results = queryMemory(index, c.query);
-  const resultIds = results.map((e) => e.id).sort();
-  const expectedIds = [...c.expectedIds].sort();
-  if (resultIds.length !== expectedIds.length) return false;
-  return resultIds.every((id, i) => id === expectedIds[i]);
+  const resultIds = queryMemory(index, c.query).map((e) => e.id);
+  return arraysEqualSorted(resultIds, c.expectedIds);
 }
 
 function runSuppressionCase(c) {
   const index = { entries: c.memoryEntries };
-  const active = findActiveSuppressions(index, c.changedFiles);
-  const activeIds = active.map((s) => s.id).sort();
-  const expectedIds = [...c.expectedSuppressionIds].sort();
-  if (activeIds.length !== expectedIds.length) return false;
-  return activeIds.every((id, i) => id === expectedIds[i]);
+  const activeIds = findActiveSuppressions(index, c.changedFiles).map((s) => s.id);
+  return arraysEqualSorted(activeIds, c.expectedSuppressionIds);
 }
 
 function runResurfacingCase(c) {
-  const result = shouldResurface(c.suppression, c.changedFiles);
-  return result === c.expectedResurface;
+  return shouldResurface(c.suppression, c.changedFiles) === c.expectedResurface;
 }
 
 function runRiskMapCase(c) {
   const result = evaluateRisk(c.riskMap, c.changedFiles);
   if (result.aggregateAction !== c.expectedAggregateAction) return false;
-  const escalated = [...result.escalatedFiles].sort();
-  const expectedEscalated = [...c.expectedEscalatedFiles].sort();
-  if (escalated.length !== expectedEscalated.length) return false;
-  if (!escalated.every((f, i) => f === expectedEscalated[i])) return false;
-  const human = [...result.humanReviewFiles].sort();
-  const expectedHuman = [...c.expectedHumanReviewFiles].sort();
-  if (human.length !== expectedHuman.length) return false;
-  return human.every((f, i) => f === expectedHuman[i]);
+  return (
+    arraysEqualSorted(result.escalatedFiles, c.expectedEscalatedFiles) &&
+    arraysEqualSorted(result.humanReviewFiles, c.expectedHumanReviewFiles)
+  );
 }
 
 function runMemoryFallbackCase(c) {

--- a/src/lib/resurface.mjs
+++ b/src/lib/resurface.mjs
@@ -1,4 +1,4 @@
-import { findActiveSuppressions, inferSubsystem } from './suppression.mjs';
+import { findActiveSuppressions, matchesScopeFiles, inferSubsystem } from './suppression.mjs';
 
 /**
  * Check for findings that should be resurfaced based on active suppressions.
@@ -34,19 +34,8 @@ export function shouldResurface(suppression, changedFiles) {
   if (expiresAt && expiresAt < new Date().toISOString()) return false;
 
   const related = suppression.metadata?.relatedFiles ?? [];
-  if (!related.length) return false;
-
   const scope = suppression.context?.scope || 'file';
-
-  if (scope === 'global') return true;
-
-  if (scope === 'subsystem') {
-    const suppressionSubs = new Set(related.map(inferSubsystem).filter(Boolean));
-    return changedFiles.some((fp) => suppressionSubs.has(inferSubsystem(fp)));
-  }
-
-  // file scope: exact path match
-  return changedFiles.some((fp) => related.includes(fp));
+  return matchesScopeFiles(scope, related, changedFiles);
 }
 
 /**
@@ -58,21 +47,18 @@ export function shouldResurface(suppression, changedFiles) {
 function buildResurfaceReason(suppression, changedFiles) {
   const related = suppression.metadata?.relatedFiles ?? [];
   const scope = suppression.context?.scope || 'file';
-  const matchedFiles = changedFiles.filter((fp) => {
-    if (scope === 'global') return true;
-    if (scope === 'subsystem') {
-      const subs = new Set(related.map(inferSubsystem).filter(Boolean));
-      return subs.has(inferSubsystem(fp));
-    }
-    return related.includes(fp);
-  });
+  const matchedFiles = changedFiles.filter((fp) => matchesScopeFiles(scope, related, [fp]));
 
   return (
     '[Resurfaced] ' +
     suppression.title +
-    ' (scope: ' + scope +
-    ', matched: ' + matchedFiles.join(', ') +
-    ', original rationale: ' + (suppression.content || 'N/A') + ')'
+    ' (scope: ' +
+    scope +
+    ', matched: ' +
+    matchedFiles.join(', ') +
+    ', original rationale: ' +
+    (suppression.content || 'N/A') +
+    ')'
   );
 }
 
@@ -87,7 +73,8 @@ export function buildResurfaceComments(candidates) {
     file: c.suppression.metadata?.relatedFiles?.[0] || 'unknown',
     line: 0,
     message:
-      'Finding: ' + c.reason +
+      'Finding: ' +
+      c.reason +
       ' Evidence: Previously suppressed finding resurfaced due to related file change.' +
       ' Impact: Review whether the original suppression rationale still applies.' +
       ' Fix: Confirm suppression is still valid or address the finding.' +

--- a/src/lib/suppression.mjs
+++ b/src/lib/suppression.mjs
@@ -74,7 +74,11 @@ export function createSuppression({
  * @param {{ author?: string, reason?: string }} options
  * @returns {object} The resurface entry
  */
-export function revokeSuppression(indexPath, suppressionId, { author = 'river-reviewer', reason = 'revoked' } = {}) {
+export function revokeSuppression(
+  indexPath,
+  suppressionId,
+  { author = 'river-reviewer', reason = 'revoked' } = {}
+) {
   const entry = {
     id: 'resurface-' + suppressionId + '-' + Date.now(),
     type: 'resurface',
@@ -96,6 +100,24 @@ export function revokeSuppression(indexPath, suppressionId, { author = 'river-re
 }
 
 /**
+ * Check if any of the changed files match the suppression's scope.
+ * Shared by findActiveSuppressions and resurface logic.
+ * @param {string} scope - 'global' | 'subsystem' | 'file'
+ * @param {string[]} relatedFiles - Files associated with the suppression
+ * @param {string[]} changedFiles - Files in the current change set
+ * @returns {boolean}
+ */
+export function matchesScopeFiles(scope, relatedFiles, changedFiles) {
+  if (!relatedFiles.length || !changedFiles.length) return false;
+  if (scope === 'global') return true;
+  if (scope === 'subsystem') {
+    const suppressionSubs = new Set(relatedFiles.map(inferSubsystem).filter(Boolean));
+    return changedFiles.some((fp) => suppressionSubs.has(inferSubsystem(fp)));
+  }
+  return changedFiles.some((fp) => relatedFiles.includes(fp));
+}
+
+/**
  * Find active suppressions that overlap with the given file paths.
  * Filters out expired and revoked suppressions.
  * @param {{ entries: object[] }} index - Loaded memory index
@@ -108,7 +130,7 @@ export function findActiveSuppressions(index, filePaths) {
     queryMemory(index, { type: 'resurface' })
       .filter((e) => e.context?.action === 'revoke')
       .map((e) => e.context?.suppressionId)
-      .filter(Boolean),
+      .filter(Boolean)
   );
 
   const now = new Date().toISOString();
@@ -119,17 +141,7 @@ export function findActiveSuppressions(index, filePaths) {
     if (s.context?.expiresAt && s.context.expiresAt < now) return false;
 
     const related = s.metadata?.relatedFiles ?? [];
-    if (!related.length) return false;
-
     const scope = s.context?.scope || 'file';
-    if (scope === 'global') return true;
-
-    if (scope === 'subsystem') {
-      const suppressionSubs = new Set(related.map(inferSubsystem).filter(Boolean));
-      return filePaths.some((fp) => suppressionSubs.has(inferSubsystem(fp)));
-    }
-
-    // default: file scope - exact path match
-    return filePaths.some((fp) => related.includes(fp));
+    return matchesScopeFiles(scope, related, filePaths);
   });
 }


### PR DESCRIPTION
/simplify レビューで検出されたコード品質問題を修正。

**scope-matching ロジックの共通化 (Major)**
suppression.mjs と resurface.mjs に3重複していた global/subsystem/file
スコープ判定ロジックを `matchesScopeFiles()` として抽出・共通化。

**配列比較ヘルパーの抽出 (Minor)**
regression-eval.mjs の4箇所で繰り返されていた sort-then-compare パターンを
`arraysEqualSorted()` に統一。

**memory-context の single-pass 最適化 (Minor)**
5回の `.filter()` による線形スキャンを1回のループによる type 別バケット振り分けに置換。

テスト: 37/37 pass, regression eval 18/18 pass