### PR TITLE
fix(evals): nightly-audit の stderr 混入と silent failure を修正 (#472)

### DIFF
--- a/.github/workflows/nightly-audit.yml
+++ b/.github/workflows/nightly-audit.yml
@@ -31,15 +31,27 @@ jobs:
       - name: Run unified evaluation
         id: eval
         run: |
+          set +e
           node scripts/evaluate-all.mjs \
             --json \
             --append-ledger \
             --description "nightly-audit $(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            > eval-output.json 2>&1 || true
+            > eval-output.json 2>eval-stderr.log
+          echo "eval_exit=$?" >> $GITHUB_OUTPUT
+          set -e
           cat eval-output.json
 
       - name: Generate audit report
-        run: node scripts/generate-audit-report.mjs eval-output.json
+        run: |
+          if [ ! -s eval-output.json ]; then
+            echo "::error::eval-output.json is empty or missing. Check eval-stderr.log for details."
+            if [ -f eval-stderr.log ]; then
+              echo "=== evaluate-all stderr ==="
+              cat eval-stderr.log
+            fi
+            exit 1
+          fi
+          node scripts/generate-audit-report.mjs eval-output.json
 
       - name: Write GitHub Step Summary
         if: always()
@@ -55,6 +67,7 @@ jobs:
           name: nightly-audit-${{ github.run_number }}
           path: |
             eval-output.json
+            eval-stderr.log
             audit-report.md
             artifacts/evals/results.jsonl
           retention-days: 90


### PR DESCRIPTION
## Summary

PR #465 のレビューで指摘された2件の問題を修正:

### [Critical] stderr が JSON ファイルに混入

**Before**: \`> eval-output.json 2>&1\` により stderr が JSON 出力に混入し、JSON パースが壊れるリスク

**After**: \`> eval-output.json 2>eval-stderr.log\` で stderr を分離

### [Major] silent failure

**Before**: \`|| true\` により evaluate-all のクラッシュがマスクされる

**After**:
- \`set +e\` / \`set -e\` で exit code を \`$GITHUB_OUTPUT\` に保存
- Generate audit report ステップで \`eval-output.json\` の空チェック
- 空の場合は stderr を表示して fail fast

### 追加改善

- アーティファクトに \`eval-stderr.log\` を含め、失敗時のデバッグを容易に

## Changes

- \`.github/workflows/nightly-audit.yml\` — 15行追加、2行削除

## Test plan

- [ ] YAML 構文が valid
- [ ] workflow_dispatch で手動トリガー可能
- [ ] 正常系: eval-output.json が生成され、audit-report.md が出力される
- [ ] 異常系: eval-output.json が空の場合、ワークフローが fail し stderr がログに表示される

Closes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)