### PR TITLE
docs(guards): add git discipline and output verification rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,8 @@ If a check fails, show the failure output and proposed fix before applying.
 - **Research before proposing**: Do not create GitHub issues without first confirming the feature is not already implemented. See `/propose-issue`.
 - **Propagate signatures**: When adding parameters to pipeline functions (`generateReview`, `verifyFinding`, `buildExecutionPlan`), consult `docs/development/pipeline-params-checklist.md` to avoid call-site gaps.
 - **Plan merge order**: When creating multiple PRs that touch overlapping files, run `/plan-merge-order` before merging to minimize rebase cost.
+- **Commit before risky git ops**: Before `git stash`, `git checkout`, `git reset --hard`, or any branch switch with uncommitted work, create a WIP commit on a dedicated branch. Stash + checkout + rebase chains have repeatedly lost work in this repo.
+- **Read command output fully**: Always parse git/gh command output for branch name, commit hash, and status line. Silent branch drift has caused commits to land on the wrong branch more than once. Do not chain to the next step until the current output is verified.
 
 ## Tooling
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,8 +39,8 @@ If a check fails, show the failure output and proposed fix before applying.
 - **Research before proposing**: Do not create GitHub issues without first confirming the feature is not already implemented. See `/propose-issue`.
 - **Propagate signatures**: When adding parameters to pipeline functions (`generateReview`, `verifyFinding`, `buildExecutionPlan`), consult `docs/development/pipeline-params-checklist.md` to avoid call-site gaps.
 - **Plan merge order**: When creating multiple PRs that touch overlapping files, run `/plan-merge-order` before merging to minimize rebase cost.
-- **Commit before risky git ops**: Before `git stash`, `git checkout`, `git reset --hard`, or any branch switch with uncommitted work, create a WIP commit on a dedicated branch. Stash + checkout + rebase chains have repeatedly lost work in this repo.
-- **Read command output fully**: Always parse git/gh command output for branch name, commit hash, and status line. Silent branch drift has caused commits to land on the wrong branch more than once. Do not chain to the next step until the current output is verified.
+- **Commit before branch switches**: Before `git checkout`/`git switch` with uncommitted work, create a throwaway safety commit on a new branch: `git switch -c wip/<topic> && git add -A && git commit -m "wip" --no-verify`. Stash-then-switch chains have lost work when combined with the lint-staged auto-stash. Does not authorize `git stash drop`, `git reset --hard`, or `git push --force` — those remain prohibited per AGENTS.md Safety.
+- **Verify git output before chaining**: Extends **Run before claiming**. After `git commit`, `git push`, `git switch`, and `gh pr merge`, read the branch name, commit hash, and status line in the output and confirm they match the intended target before running the next command. Verify with `git status -sb` or `git rev-parse --abbrev-ref HEAD` if the output is ambiguous.
 
 ## Tooling
 


### PR DESCRIPTION
直近セッションで再発した git 操作の事故を AI Misoperation Guards に codify する。

**追加ルール (CLAUDE.md)**

1. **Commit before branch switches** — `git checkout`/`git switch` 前に `git switch -c wip/<topic> && git add -A && git commit -m "wip" --no-verify` で作業を保護。lint-staged の auto-stash と組み合わさると work が失われる事故を防ぐ。destructive ops (`git stash drop`, `reset --hard`, `push --force`) は引き続き AGENTS.md で禁止。

2. **Verify git output before chaining** — "Run before claiming" の延長。`git commit`, `git push`, `git switch`, `gh pr merge` の後、出力の branch 名・コミットハッシュ・status 行を必ず確認してから次のコマンドに進む。曖昧な場合は `git status -sb` / `git rev-parse --abbrev-ref HEAD` で検証。

**動機**

2セッション連続で以下の事故が発生:
- 作業中ファイルを stash/checkout chain で2回失い、全ファイル再作成が必要になった
- コミット出力の branch 名を読み飛ばし、意図と異なるブランチ3回に commit がランディング

**レビュー対応**

セルフレビュー + 3エージェント並列レビュー (Quality, Reuse, Efficiency) を実施し、以下の指摘を反映済み:

- Major: 元の rule が `git reset --hard`/`git stash` を含み、AGENTS.md Safety の禁止条項と矛盾 → 非破壊的な checkout/switch のみに scope を絞り、destructive ops は引き続き禁止と明記
- Minor: "WIP commit on a dedicated branch" が曖昧 → 具体コマンドを併記
- Minor: "Read command output fully" が既存の "Run before claiming" と部分重複 → "Extends **Run before claiming**" で明示
- Minor: トリガーが広すぎ → 対象コマンドを明示 (`commit`, `push`, `switch`, `gh pr merge`)
- Minor: falsifiable check がない → `git status -sb` / `git rev-parse` を verification 手段として併記

**関連メモリ** (git 管理外、ユーザー auto-memory):

- `feedback_git_wip_commit.md`
- `feedback_read_command_output.md`