### PR TITLE
chore(meta): bump action tag references to v0.12.0

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -76,16 +76,16 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run River Reviewer (midstream)
-        uses: s977043/river-reviewer/runners/github-action@v0.11.0
+        uses: s977043/river-reviewer/runners/github-action@v0.12.0
         with:
           phase: midstream # upstream|midstream|downstream|all (future-ready)
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 ```
 
-Pin to a release tag such as `@v0.11.0` for stability. Optionally, you can maintain a floating alias tag like `@v0`.
+Pin to a release tag such as `@v0.12.0` for stability. Optionally, you can maintain a floating alias tag like `@v0`.
 
-Latest release: [v0.11.0](https://github.com/s977043/river-reviewer/releases/tag/v0.11.0)
+Latest release: [v0.12.0](https://github.com/s977043/river-reviewer/releases/tag/v0.12.0)
 
 > **ℹ️ Upgrading from v0.1.x:** v0.2.0 and later use the new GitHub Action path `runners/github-action` instead of `.github/actions/river-reviewer`. See [Migration Guide](docs/migration/runners-architecture-guide.md) and [DEPRECATED.md](docs/deprecated.md) for details.
 

--- a/README.md
+++ b/README.md
@@ -86,16 +86,16 @@ jobs:
         with:
           fetch-depth: 0 # merge-base を安定取得
       - name: Run River Reviewer (midstream)
-        uses: s977043/river-reviewer/runners/github-action@v0.11.0
+        uses: s977043/river-reviewer/runners/github-action@v0.12.0
         with:
           phase: midstream # upstream|midstream|downstream|all (future-ready)
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 ```
 
-タグは `@v0.11.0` などのリリースタグにピン留めしてください。浮動タグを使う場合は `@v0` のようなエイリアスタグを用意して運用します（任意）。
+タグは `@v0.12.0` などのリリースタグにピン留めしてください。浮動タグを使う場合は `@v0` のようなエイリアスタグを用意して運用します（任意）。
 
-最新リリース: [v0.11.0](https://github.com/s977043/river-reviewer/releases/tag/v0.11.0)
+最新リリース: [v0.12.0](https://github.com/s977043/river-reviewer/releases/tag/v0.12.0)
 
 > **ℹ️ v0.1.x からのアップグレード:** v0.2.0以降では、GitHub Actionのパスが `.github/actions/river-reviewer` から `runners/github-action` に変更されています。詳細は[移行ガイド](docs/migration/runners-architecture-guide.md)と[DEPRECATED.md](docs/deprecated.md)をご確認ください。
 
@@ -110,7 +110,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
         with: { phase: upstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 
@@ -119,7 +119,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
         with: { phase: midstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 
@@ -128,7 +128,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
         with: { phase: downstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 ```
@@ -142,7 +142,7 @@ review:
   steps:
     - uses: actions/checkout@v6
       with: { fetch-depth: 0 }
-    - uses: s977043/river-reviewer/runners/github-action@v0.11.0
+    - uses: s977043/river-reviewer/runners/github-action@v0.12.0
       with:
         phase: midstream
         estimate: true # コスト見積もりのみ
@@ -160,7 +160,7 @@ review:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
         with:
           phase: midstream
           dry_run: true            # Draft はドライランでプロンプト確認のみ
@@ -173,7 +173,7 @@ review:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
         with:
           phase: midstream
           dry_run: false           # Ready ではフルレビュー

--- a/docs/use-cases/github-actions.md
+++ b/docs/use-cases/github-actions.md
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0 # Required for git diff
 
       - name: Run River Reviewer
-        uses: s977043/river-reviewer/runners/github-action@v0.11.0
+        uses: s977043/river-reviewer/runners/github-action@v0.12.0
         with:
           phase: midstream
         env:
@@ -67,7 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
         with: { phase: upstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 
@@ -81,7 +81,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
         with: { phase: midstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 
@@ -95,7 +95,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
         with: { phase: downstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 ```
@@ -122,7 +122,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
         with: { phase: ${{ matrix.phase }} }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 ```
@@ -140,7 +140,7 @@ jobs:
 ### Example: Custom Skills Directory
 
 ```yaml
-- uses: s977043/river-reviewer/runners/github-action@v0.11.0
+- uses: s977043/river-reviewer/runners/github-action@v0.12.0
   with:
     phase: midstream
     skills-dir: custom-skills # Use custom skill location
@@ -149,7 +149,7 @@ jobs:
 ### Example: JSON Output
 
 ```yaml
-- uses: s977043/river-reviewer/runners/github-action@v0.11.0
+- uses: s977043/river-reviewer/runners/github-action@v0.12.0
   with:
     phase: midstream
     output-format: json
@@ -224,7 +224,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
         with: { phase: midstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 ```
@@ -249,7 +249,7 @@ jobs:
           repository: your-org/shared-skills
           path: shared-skills
 
-      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
         with:
           phase: midstream
           skills-dir: shared-skills
@@ -268,7 +268,7 @@ jobs:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
 
-      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
         with:
           phase: midstream
         env:
@@ -309,7 +309,7 @@ jobs:
           ref: refs/pull/${{ inputs.pr_number }}/head
           fetch-depth: 0
 
-      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
         with:
           phase: ${{ inputs.phase }}
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
@@ -333,7 +333,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
         with: { phase: midstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 ```
@@ -445,7 +445,7 @@ Line 15: ...
 ## Best Practices
 
 1. **Use Specific Phases** - Run only relevant skills to save time and costs
-2. **Pin Action Versions** - Use `@v0.11.0` instead of `@main` for stability
+2. **Pin Action Versions** - Use `@v0.12.0` instead of `@main` for stability
 3. **Set Permissions Explicitly** - Define minimum required permissions
 4. **Monitor API Usage** - Track LLM API costs and set budgets
 5. **Test Locally First** - Validate skills work before running in CI
@@ -473,7 +473,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
         with: { phase: midstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 
@@ -485,7 +485,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
         with: { phase: downstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 ```
@@ -518,7 +518,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.11.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
         with: { phase: ${{ matrix.phase }} }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 ```


### PR DESCRIPTION
## Summary

main の CI "Meta consistency" check が 5 エラーで赤の状態 (pre-existing)。`package.json` は `0.12.0` なのに README/docs が `@v0.11.0` を参照していたため、`scripts/validate-meta-consistency.mjs` と `tests/validate-meta-consistency.test.mjs` が失敗していた。

本 PR で 3 ファイルの version reference を一括更新。

## 修正内容

| File | 変更箇所 |
| ---- | -------- |
| `README.md` | 9 箇所 (action tag 8, Latest release 1) |
| `README.en.md` | 3 箇所 (action tag 2, Latest release 1) |
| `docs/use-cases/github-actions.md` | 16 箇所 (全て action tag) |

いずれも \`s977043/river-reviewer/runners/github-action@v0.12.0\` への pin 変更。prose や例のセマンティクスは変わらない。

## 影響範囲

- Meta consistency CI check: 5 errors → 0 errors
- \`tests/validate-meta-consistency.test.mjs\` の \`validateMeta passes on current repo state\` が pass する (Unit tests 失敗の 1 件を解消)

## 経緯

#487 (husky chmod) の CI 確認中に pre-existing 失敗として検出。#484 "Verify CI green before merge" ガードを尊重し、#487 merge 前に main の baseline を green に戻すための 3 連続 PR の 1 件目:

1. **本 PR**: Meta consistency (version bump)
2. 後続 PR: Action dist freshness (\`runners/github-action/dist/\` 再生成)
3. 後続 PR: Unit tests (LLM dry-run 期待値 — 残存する場合)

## Test plan

- [x] \`npm run meta:validate\` — 0 errors
- [x] \`node --test tests/validate-meta-consistency.test.mjs\` — 7/7 pass
- [x] \`npm run lint\` — pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)