### PR TITLE
fix(review): align silent-catch heuristic severity with skill severity

### DIFF
--- a/src/lib/review-engine.mjs
+++ b/src/lib/review-engine.mjs
@@ -316,7 +316,7 @@ function normalizeHeuristicComments(rawComments) {
             evidence: 'catch 内で return（ログ/再throwなし）',
             impact: '障害調査や失敗検知が困難になる',
             fix: 'ログ+再throw / 上位へ返す / 無視するなら理由コメント+計測を検討する',
-            severity: 'warning',
+            severity: 'nit',
             confidence: 'high',
           }),
         };

--- a/tests/fixtures/review-eval/cases.json
+++ b/tests/fixtures/review-eval/cases.json
@@ -44,7 +44,7 @@
     "phase": "midstream",
     "diffFile": "../planner-dataset/diffs/midstream-observability-silent-catch.diff",
     "planSkills": ["rr-midstream-logging-observability-001"],
-    "mustInclude": ["Evidence:", "catch", "ログ", "再throw", "Severity: warning"],
+    "mustInclude": ["Evidence:", "catch", "ログ", "再throw", "Severity: nit"],
     "maxFindings": 3
   },
   {
@@ -52,7 +52,7 @@
     "phase": "midstream",
     "diffFile": "../planner-dataset/diffs/midstream-observability-silent-catch-return.diff",
     "planSkills": ["rr-midstream-logging-observability-001"],
-    "mustInclude": ["Evidence:", "catch", "Severity: warning"],
+    "mustInclude": ["Evidence:", "catch", "Severity: nit"],
     "maxFindings": 3
   },
   {


### PR DESCRIPTION
## Summary

Unit tests CI failure を修正。heuristic が出力する silent-catch の severity が skill 宣言と不整合のため verifier が reject していた問題。

## Root cause

PR #430 の verifier 統合で \`checkSeverityJustified\` が導入されたが、既存の heuristic 出力と skill severity が整合していなかった:

| 項目 | Value | Verifier 正規化 |
|------|-------|---------------|
| silent-catch heuristic | \`severity: 'warning'\` | \`major\` (rank 2) |
| \`rr-midstream-logging-observability-001\` skill | \`severity: 'minor'\` | \`minor\` (rank 1) |

\`findingRank (2) > skillRank (1)\` なので verifier が reject → comments 0 → テスト失敗。

## Changes

- **src/lib/review-engine.mjs**: silent-catch heuristic の \`severity\` を \`warning\` → \`nit\` (nit → minor) に変更し、skill severity (minor) と整合
- **tests/fixtures/review-eval/cases.json**: 対応する fixture の \`mustInclude\` を \`"Severity: warning"\` → \`"Severity: nit"\` に更新

## Test plan

- [x] \`node --test tests/cli.test.mjs\` — 18/18 pass（4 件の CLI テストが復活）
- [x] \`node --test tests/review-eval.test.mjs\` — 3/3 pass
- [x] \`npm test\` — 331/332 pass（残り 1 件は validateMeta の README version check で、PR #488 で解消）

## Context

main の 3 つの既存 CI failure の 3 件目:

- [x] Meta consistency (PR #488)
- [x] Action dist freshness (PR #491)
- [x] **Unit tests (20.x / 22.x)**（本 PR）

Branch protection 設定 (#483) の前提条件が全て揃います。

🤖 Generated with [Claude Code](https://claude.com/claude-code)