### PR TITLE
docs(commands): add preflight step to /plan-merge-order

### DIFF
--- a/.claude/commands/plan-merge-order.md
+++ b/.claude/commands/plan-merge-order.md
@@ -1,12 +1,40 @@
 ---
 description: 複数 PR のマージ順序を事前計画してリベースコストを最小化する
 argument-hint: '[PR numbers or branch names]'
-allowed-tools: Bash(gh pr list:*), Bash(gh pr view:*), Bash(gh pr diff:*), Bash(git log:*)
+allowed-tools: Bash(gh pr list:*), Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh api:*), Bash(git log:*), Bash(git fetch:*)
 ---
 
 複数の PR を作成・マージする際の順序を事前計画してください。対象: $ARGUMENTS
 
 ## 手順
+
+### 0. Preflight 検証 (前提)
+
+マージ順序を計算する前に、**対象 PR が本当にマージ対象かを検証**する。`/preflight $ARGUMENTS` を先に実行するか、以下を直接実行する:
+
+```bash
+git fetch origin main
+git log origin/main --oneline -15                                    # main に関連コミットが既にあるか目視
+
+# 対象 PR ごとに REST API で state を直接取得 (gh pr view の GraphQL はキャッシュ遅延あり)
+for pr in <PR numbers>; do
+  gh api repos/OWNER/REPO/pulls/$pr --jq '{number, state, merged, merged_at, mergeable_state}'
+done
+
+# 類似キーワードで並行 in-flight PR を検索
+gh pr list --state open --search "<keyword>" --json number,title,headRefName,author
+
+# 直近 close 済 PR も確認 (並行作業の痕跡)
+gh pr list --state closed --search "<keyword>" --limit 5 --json number,title,mergedAt
+```
+
+判定基準:
+
+- **対象 PR に merged=true が含まれる** → その PR を対象から除外してユーザーに報告
+- **類似 keyword の別 open PR が存在** → 並行作業あり、続行前にユーザー確認
+- **main に同内容のコミット既に存在** → タスク obsolete の可能性、続行前にユーザー確認
+
+この Step を飛ばして依存グラフ作成に進んではならない。`gh pr list` のキャッシュ遅延で closed PR を OPEN と誤判定し、**重複作業・force-push 計画・stale commits 分析に時間を費やした事例が複数回発生している** (2026-04-11 セッションで 4 重複 PR)。
 
 ### 1. 対象 PR の収集
 
@@ -79,6 +107,8 @@ git log --format= --name-only --since=6.months | sort | uniq -c | sort -rn | hea
 
 ## 禁止事項
 
+- **Step 0 の Preflight 検証を省略して Step 1 以降に進んではならない**
 - 依存関係を調べずにマージ順序を決めてはならない
 - Hot file の複数 PR 同時マージを推奨してはならない
 - 「順序は適当で大丈夫」と断定してはならない
+- `gh pr list` / `gh pr view` の GraphQL 結果のみで state を信頼してはならない (必ず `gh api repos/.../pulls/{N}` で裏取り)


### PR DESCRIPTION
## Summary

\`/plan-merge-order\` に新しい **Step 0: Preflight 検証** を追加。依存グラフ作成・マージ順序決定の前に、対象 PR が本当にマージ対象かを検証するフェーズを強制する。

\`/preflight\` (#501) と同じ検証を chain として実行する形で、多 PR 引き継ぎ作業の入口を二重ガードする。

## Problem

2026-04-11 のセッションで、\`/plan-merge-order\` を 5 PR (#453, #459, #460, #470, #474) に対して実行したが、検証前は以下の判断ミスが発生していた:

- **#459, #460, #470 は既にマージ済**だったが \`gh pr list\` の GraphQL キャッシュが OPEN と返していた
- **#453 は #478 で同内容が並行マージ済**だったが conflict 分析・force-push 計画に時間を費やした
- これらに気付くまでの数ターンが stale data 前提の無駄作業になった

\`/preflight\` を #501 で codify したが、**既存の \`/plan-merge-order\` を呼ぶタイミングで \`/preflight\` を実行する強制がない**ため、planner が単体で起動されると依然として同じ問題が起きる。

## Change

### \`.claude/commands/plan-merge-order.md\`

- **新規 Step 0**: Preflight 検証フェーズ
  - \`git fetch origin main\` + \`git log origin/main --oneline -15\`
  - 対象 PR ごとに \`gh api repos/.../pulls/{N}\` で REST 直叩き (GraphQL キャッシュ回避)
  - \`gh pr list --state open --search\` で並行 PR 検索
  - \`gh pr list --state closed --search\` で直近 close PR 検索
  - 判定基準 3 種: merged 混在 / 類似 open PR 存在 / main に同内容コミット
- **禁止事項追加**:
  - "Step 0 の Preflight 検証を省略して Step 1 以降に進んではならない"
  - "\`gh pr list\` / \`gh pr view\` の GraphQL 結果のみで state を信頼してはならない"
- **frontmatter 拡張**: \`allowed-tools\` に \`gh api\`, \`git fetch\` を追加

## Design Decisions

### なぜ \`/preflight\` を inline 化せず参照にしたか

\`/preflight\` (#501) を丸ごとコピーすると重複保守コストが発生する。本 PR では Step 0 の冒頭で "\`/preflight $ARGUMENTS\` を先に実行するか、以下を直接実行する" と明記し、両経路 (slash command chain / inline コマンド実行) を許容している。

### なぜ禁止事項を "Step 0 を省略するな" と明示したか

\`/preflight\` (#501) 実装時に "memory 保存だけでは runtime 参照されない" という学びがあった。\`/plan-merge-order\` は既存コマンドであり、読み手 (エージェント) が Step 1 から読み始めて Step 0 を skip する可能性がある。禁止事項の冒頭に置くことで skip 抑止力を上げる。

## Test plan

- [x] \`npm run lint\` pass (prettier / markdownlint / textlint / check:dashes)
- [x] diff は \`.claude/commands/plan-merge-order.md\` の 1 ファイルのみ
- [x] fix-dashes.mjs の副作用 (\`docs/agent-layers.md\`, \`docs/development/pipeline-params-checklist.md\`) は revert 済
- [ ] CI green
- [ ] 次回の multi-PR 引き継ぎで Step 0 が実行されること

## Out of scope

- **fix-dashes.mjs \`--check\` フラグのバグ修正**: 別 PR として separate (reference_fix_dashes_check_flag memory で追跡中)
- **\`/preflight\` 自動 chain (pre-hook 的な強制)**: Claude Code の hook 機構で実装可能だが、この PR のスコープでは "禁止事項" で宣言するに留める

## 関連

- #501 (/preflight skill 新規追加)
- \`feedback_verify_task_still_needed.md\` memory (4 重複事例)

🤖 Generated with [Claude Code](https://claude.com/claude-code)