### PR TITLE
fix(scripts): respect --check flag and skip markdown table rows

### DIFF
--- a/docs/development/pipeline-params-checklist.md
+++ b/docs/development/pipeline-params-checklist.md
@@ -12,24 +12,24 @@
 
 ### 必須: `generateReview` / `buildPrompt` に新パラメータを追加した場合
 
-- [ ] `src/lib/review-engine.mjs` — 関数シグネチャと内部ロジック
-- [ ] `src/lib/local-runner.mjs` — `runLocalReview` 内の `generateReview` 呼び出し
-- [ ] `src/lib/review-fixtures-eval.mjs` — eval 呼び出し
-- [ ] `tests/review-engine.test.mjs` — 新パラメータ有無のテスト最低2件
-- [ ] `tests/review-eval.test.mjs` — 既存の eval テスト
-- [ ] `tests/finding-format.test.mjs` — フォーマット検証テスト
-- [ ] `tests/integration/local-review.test.mjs` — 統合テスト（関連する場合）
+- [ ] `src/lib/review-engine.mjs`—関数シグネチャと内部ロジック
+- [ ] `src/lib/local-runner.mjs`—`runLocalReview` 内の `generateReview` 呼び出し
+- [ ] `src/lib/review-fixtures-eval.mjs`—eval 呼び出し
+- [ ] `tests/review-engine.test.mjs`—新パラメータ有無のテスト最低2件
+- [ ] `tests/review-eval.test.mjs`—既存の eval テスト
+- [ ] `tests/finding-format.test.mjs`—フォーマット検証テスト
+- [ ] `tests/integration/local-review.test.mjs`—統合テスト（関連する場合）
 
 ### 必須: `verifyFinding` に新パラメータを追加した場合
 
-- [ ] `src/lib/verifier.mjs` — 関数シグネチャと checks オブジェクト
-- [ ] `src/lib/review-engine.mjs` — `generateReview` 内の `verifyFinding` 呼び出し（`await import('./verifier.mjs')` 箇所）
-- [ ] `tests/verifier.test.mjs` — 新チェックの pass/fail/lenient 3パターン
+- [ ] `src/lib/verifier.mjs`—関数シグネチャと checks オブジェクト
+- [ ] `src/lib/review-engine.mjs`—`generateReview` 内の `verifyFinding` 呼び出し（`await import('./verifier.mjs')` 箇所）
+- [ ] `tests/verifier.test.mjs`—新チェックの pass/fail/lenient 3パターン
 
 ### 必須: `buildExecutionPlan` に新パラメータを追加した場合
 
-- [ ] `runners/core/review-runner.mjs` — options destructuring と返却オブジェクト（planner あり/なし両方）
-- [ ] `src/lib/local-runner.mjs` — `planLocalReview` の2箇所（main path + collectLocalContext path）の `buildExecutionPlan` 呼び出し
+- [ ] `runners/core/review-runner.mjs`—options destructuring と返却オブジェクト（planner あり/なし両方）
+- [ ] `src/lib/local-runner.mjs`—`planLocalReview` の2箇所（main path + collectLocalContext path）の `buildExecutionPlan` 呼び出し
 - [ ] plan 経由で下流関数に渡される場合は下流関数のチェックリストも確認
 
 ## 確認方法

--- a/scripts/fix-dashes.mjs
+++ b/scripts/fix-dashes.mjs
@@ -48,7 +48,7 @@ function normalizeTextSegment(line) {
     return { newLine, modified };
 }
 
-function processMarkdownFile(filePath) {
+function processMarkdownFile(filePath, { check = false } = {}) {
     const content = fs.readFileSync(filePath, 'utf8');
     const lines = content.split(/\r?\n/);
     let inCodeFence = false;
@@ -96,6 +96,15 @@ function processMarkdownFile(filePath) {
             continue;
         }
 
+        // Skip markdown table rows. Table cells often use `—` as a placeholder
+        // with padding whitespace for alignment, which the dash regex would
+        // otherwise collapse. Prettier then reintroduces the padding, causing
+        // fix-dashes and prettier to fight in an infinite loop.
+        if (/^\s*\|/.test(line)) {
+            newLines.push(line);
+            continue;
+        }
+
         // Headings: lines starting with # (one or more)
         if (/^#+\s+/.test(line)) {
             const prefix = line.match(/^#+\s+/)[0];
@@ -121,7 +130,7 @@ function processMarkdownFile(filePath) {
         newLines.push(line);
     }
 
-    if (changed) {
+    if (changed && !check) {
         fs.writeFileSync(filePath, newLines.join('\n'), 'utf8');
     }
     return changed;
@@ -143,11 +152,12 @@ function collectTargetFiles() {
 function listAdd(arr, set) { for (const a of arr) set.add(a); }
 
 function main() {
+    const check = process.argv.includes('--check');
     const files = collectTargetFiles();
     const modifiedFiles = [];
     for (const file of files) {
         try {
-            const changed = processMarkdownFile(file);
+            const changed = processMarkdownFile(file, { check });
             if (changed) modifiedFiles.push(file);
         } catch (err) {
             console.error(`Error processing ${file}:`, err.message);
@@ -156,6 +166,11 @@ function main() {
     if (modifiedFiles.length === 0) {
         console.log('No heading/title dash normalizations needed.');
         process.exit(0);
+    }
+    if (check) {
+        console.error('Files need dash normalization (run `node scripts/fix-dashes.mjs` to fix):');
+        for (const f of modifiedFiles) console.error(' -', f);
+        process.exit(1);
     }
     console.log('Modified files:');
     for (const f of modifiedFiles) console.log(' -', f);


### PR DESCRIPTION
## Summary

\`scripts/fix-dashes.mjs\` の 2 つのバグを修正:

1. **\`--check\` フラグが完全に無視されていた** — 常に書き込み + exit 0 のため、\`npm run check:dashes\` が drift を CI でガードできていなかった
2. **markdown table 内の padding em-dash を collapse** — テーブル整列を壊し、prettier との無限ループを引き起こしていた (docs/agent-layers.md で特に顕著)

この 2 件が組み合わさり、main に docs の dash drift が silent に蓄積していた。

## Problem

### Bug 1: --check フラグ無視

\`package.json\`:

\`\`\`json
"check:dashes": "node scripts/fix-dashes.mjs --check"
\`\`\`

だが \`scripts/fix-dashes.mjs\` は \`process.argv\` を見ず、常に \`fs.writeFileSync\` で書き換えて exit 0 していた。結果:

- CI の \`npm run lint\` が \`check:dashes\` ステップで drift を検出しても exit 0 で通過
- CI は ephemeral なのでファイル変更は破棄され、main のコミット済み drift はそのまま
- ローカルで \`npm run lint\` を走らせた人だけが "Modified files" 出力に気付く
- 結果: main が恒常的に "stale drift" 状態で、PR 作成のたびに関係ない docs/* が変更される (本セッションで 5 回以上 revert した)

### Bug 2: markdown table の padding dash を collapse

現行の regex:

\`\`\`js
const dashRegex = /\s([\u2013\u2014])\s/g;  // <space><en/em-dash><space>
\`\`\`

は \`| architect | — | \`.github/agents/\` | ...\` のような table cell の em-dash を \`|—|\` に collapse する。これによりテーブル整列が壊れ、prettier が padding を戻す → fix-dashes が再度 collapse → ... と無限ループ。

### 影響

\`docs/agent-layers.md\` と \`docs/development/pipeline-params-checklist.md\` が毎回 CI で書き換えられるが、drift 状態のまま commit され続けていた。本セッションで \`npm run lint\` 実行時に 5 回以上 \`git checkout -- docs/...\` で revert した。

## Change

### \`scripts/fix-dashes.mjs\`

\`\`\`js
function processMarkdownFile(filePath, { check = false } = {}) {
  // ...
  // Skip markdown table rows
  if (/^\s*\|/.test(line)) {
    newLines.push(line);
    continue;
  }
  // ...
  if (changed && !check) {
    fs.writeFileSync(filePath, newLines.join('\n'), 'utf8');
  }
  return changed;
}

function main() {
  const check = process.argv.includes('--check');
  // ...
  if (check) {
    console.error('Files need dash normalization (run ...)');
    for (const f of modifiedFiles) console.error(' -', f);
    process.exit(1);
  }
}
\`\`\`

- processMarkdownFile に \`{ check = false }\` オプション追加
- main() で \`--check\` を parse し、drift 検出時に stderr + exit 1
- table row (\`^\s*\|\`) を skip するガード追加

### \`docs/development/pipeline-params-checklist.md\`

- 新しい fix-dashes を write モードで一度だけ実行し、**正当な** dash drift (table row ではない散文内の \` – \` → \`—\`) を normalize してコミット
- これにより baseline が green に戻り、新しい \`--check\` ガードが即 fail しない

## Why bundled into one PR

script fix と drift 修復は意図的にセットにしている:

- **gate のみ先 merge** → main CI が即 red、全 open PR が red
- **drift 修復のみ先 merge** → gate がないので次の drift で同じ状態に戻る

両方を含めることで、merge と同時に "green baseline + 以降のガード" を提供する。

## Test plan

- [x] \`node scripts/fix-dashes.mjs --check\` on clean main — pipeline-params-checklist.md を検出して exit 1
- [x] \`node scripts/fix-dashes.mjs\` — 該当ファイルを修正して exit 0
- [x] \`node scripts/fix-dashes.mjs --check\` after fix — 無出力、exit 0
- [x] \`npm run lint\` — prettier / check:dashes / markdownlint / textlint の 4 全 pass
- [x] \`docs/agent-layers.md\` が script で変更されなくなった (table skip が効いている)
- [ ] CI green
- [ ] 次回の docs 修正 PR で drift が新たに発生した場合、CI がそれを検出して PR を block する

## Follow-ups / 影響

- **#499 (bot \`auto-fix dash spacing\`)** は \`pipeline-params-checklist.md\` の同じ drift を並行修正中。本 PR が先に merge されれば #499 は conflict or redundant として close できる
- **bot workflow の見直し**: \`auto/fix-dashes-automation\` branch の bot は write モードで drift を PR 化しているが、本 PR 後はその役割が不要 (CI gate が drift を直接 block する)

## 関連

- \`reference_fix_dashes_check_flag.md\` memory (本セッションで記録した技術的負債)
- \`feedback_formatter_hook_workflow.md\` memory (formatter hook の branch 越境問題)

🤖 Generated with [Claude Code](https://claude.com/claude-code)