### PR TITLE
refactor(tests): extract shared helpers and accelerate cli tests (phase 1)

### DIFF
--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
+import { realpathSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import {
   GitError,
   GitRepoNotFoundError,
@@ -813,9 +815,34 @@ Dependencies: ${
 
 export { parseArgs, main };
 
-// この CLI が直接起動されたときのみ main() を実行する。
-// import された場合（テストなど）は副作用を起こさない。
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * この CLI が直接起動されたときのみ `main()` を実行する。
+ *
+ * `import.meta.url === \`file://${process.argv[1]}\`` という素朴な比較は、
+ * 以下のケースで偽になり自動起動が走らない:
+ *
+ *   1. npm `bin` 経由（`npm install -g`）: `process.argv[1]` が symlink の
+ *      `.../node_modules/.bin/river` のままで、`import.meta.url` は実体の
+ *      `.../src/cli.mjs` を指す。
+ *   2. macOS の `/tmp` → `/private/tmp` など、プラットフォーム固有の
+ *      canonical path 展開。
+ *   3. Windows のバックスラッシュ区切り path（`file:///C:/...` 形式でない）。
+ *
+ * そのため `realpathSync` で symlink を解決し、`pathToFileURL` で URL に
+ * 変換した上で比較する。比較に失敗してもアプリは落とさない（import-only
+ * シナリオを壊さない）。
+ */
+function isDirectInvocation() {
+  if (!process.argv[1]) return false;
+  try {
+    const real = realpathSync(process.argv[1]);
+    return fileURLToPath(import.meta.url) === real || import.meta.url === pathToFileURL(real).href;
+  } catch {
+    return false;
+  }
+}
+
+if (isDirectInvocation()) {
   main().then((code) => {
     if (typeof code === 'number' && code !== 0) {
       process.exitCode = code;

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -555,8 +555,8 @@ function countChangedLines(files) {
   return lines;
 }
 
-async function main() {
-  const parsed = parseArgs(process.argv.slice(2));
+async function main(argv = process.argv.slice(2)) {
+  const parsed = parseArgs(argv);
   if (parsed.command === 'help' || !parsed.command) {
     printHelp();
     return 0;
@@ -811,8 +811,14 @@ Dependencies: ${
   }
 }
 
-main().then((code) => {
-  if (typeof code === 'number' && code !== 0) {
-    process.exitCode = code;
-  }
-});
+export { parseArgs, main };
+
+// この CLI が直接起動されたときのみ main() を実行する。
+// import された場合（テストなど）は副作用を起こさない。
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    if (typeof code === 'number' && code !== 0) {
+      process.exitCode = code;
+    }
+  });
+}

--- a/tests/cli-parse-args.test.mjs
+++ b/tests/cli-parse-args.test.mjs
@@ -1,0 +1,245 @@
+// tests/cli-parse-args.test.mjs
+//
+// parseArgs の純粋関数テスト。
+// 子プロセスを起動せず、同期的に parse 結果を検証することで高速化する。
+// 各テストは < 50ms で完走する想定。
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { parseArgs } from '../src/cli.mjs';
+
+// parseArgs は process.env を参照してデフォルト値を決めるため、
+// 環境変数がテスト結果に影響しないよう一時的にクリアする。
+function withCleanEnv(fn) {
+  const keys = ['RIVER_PHASE', 'RIVER_PLANNER_MODE'];
+  const backup = {};
+  for (const key of keys) {
+    backup[key] = process.env[key];
+    delete process.env[key];
+  }
+  try {
+    return fn();
+  } finally {
+    for (const key of keys) {
+      if (backup[key] === undefined) delete process.env[key];
+      else process.env[key] = backup[key];
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Defaults and commands
+// -----------------------------------------------------------------------------
+
+test('parseArgs: empty argv leaves command null and defaults applied', () => {
+  withCleanEnv(() => {
+    const parsed = parseArgs([]);
+    assert.equal(parsed.command, null);
+    assert.equal(parsed.target, '.');
+    assert.equal(parsed.phase, 'midstream');
+    assert.equal(parsed.plannerMode, 'off');
+    assert.equal(parsed.dryRun, false);
+    assert.equal(parsed.debug, false);
+    assert.equal(parsed.estimate, false);
+    assert.equal(parsed.maxCost, null);
+    assert.equal(parsed.output, 'text');
+  });
+});
+
+test('parseArgs: run command with default target', () => {
+  const parsed = parseArgs(['run']);
+  assert.equal(parsed.command, 'run');
+  assert.equal(parsed.target, '.');
+});
+
+test('parseArgs: run command with explicit target path', () => {
+  const parsed = parseArgs(['run', '/tmp/myrepo']);
+  assert.equal(parsed.command, 'run');
+  assert.equal(parsed.target, '/tmp/myrepo');
+});
+
+test('parseArgs: doctor command', () => {
+  const parsed = parseArgs(['doctor', '.']);
+  assert.equal(parsed.command, 'doctor');
+  assert.equal(parsed.target, '.');
+});
+
+test('parseArgs: eval command sets command without target', () => {
+  const parsed = parseArgs(['eval']);
+  assert.equal(parsed.command, 'eval');
+});
+
+test('parseArgs: skills list subcommand', () => {
+  const parsed = parseArgs(['skills', 'list']);
+  assert.equal(parsed.command, 'skills');
+  assert.equal(parsed.skillsSubcommand, 'list');
+});
+
+test('parseArgs: skills import subcommand with --from', () => {
+  const parsed = parseArgs(['skills', 'import', '--from', '/some/path']);
+  assert.equal(parsed.command, 'skills');
+  assert.equal(parsed.skillsSubcommand, 'import');
+  assert.equal(parsed.fromPath, '/some/path');
+});
+
+test('parseArgs: skills export subcommand with --to and --include-assets', () => {
+  const parsed = parseArgs(['skills', 'export', '--to', '/out', '--include-assets']);
+  assert.equal(parsed.skillsSubcommand, 'export');
+  assert.equal(parsed.toPath, '/out');
+  assert.equal(parsed.includeAssets, true);
+});
+
+// -----------------------------------------------------------------------------
+// Boolean flags
+// -----------------------------------------------------------------------------
+
+test('parseArgs: --dry-run sets dryRun true', () => {
+  const parsed = parseArgs(['run', '.', '--dry-run']);
+  assert.equal(parsed.dryRun, true);
+});
+
+test('parseArgs: --debug sets debug true', () => {
+  const parsed = parseArgs(['run', '.', '--debug']);
+  assert.equal(parsed.debug, true);
+});
+
+test('parseArgs: --estimate sets estimate true', () => {
+  const parsed = parseArgs(['run', '.', '--estimate']);
+  assert.equal(parsed.estimate, true);
+});
+
+test('parseArgs: --verbose sets verbose true', () => {
+  const parsed = parseArgs(['eval', '--verbose']);
+  assert.equal(parsed.verbose, true);
+});
+
+// -----------------------------------------------------------------------------
+// Options with values
+// -----------------------------------------------------------------------------
+
+test('parseArgs: --phase downstream', () => {
+  const parsed = parseArgs(['run', '.', '--phase', 'downstream']);
+  assert.equal(parsed.phase, 'downstream');
+});
+
+test('parseArgs: --phase without value falls back to help', () => {
+  const parsed = parseArgs(['run', '.', '--phase']);
+  assert.equal(parsed.command, 'help');
+});
+
+test('parseArgs: --planner order', () => {
+  const parsed = parseArgs(['run', '.', '--planner', 'order']);
+  assert.equal(parsed.plannerMode, 'order');
+});
+
+test('parseArgs: --planner invalid value falls back to help', () => {
+  const parsed = parseArgs(['run', '.', '--planner', 'bogus']);
+  assert.equal(parsed.command, 'help');
+});
+
+test('parseArgs: --output markdown', () => {
+  const parsed = parseArgs(['run', '.', '--output', 'markdown']);
+  assert.equal(parsed.output, 'markdown');
+});
+
+test('parseArgs: --output invalid value falls back to help', () => {
+  const parsed = parseArgs(['run', '.', '--output', 'xml']);
+  assert.equal(parsed.command, 'help');
+});
+
+test('parseArgs: --max-cost accepts positive decimal', () => {
+  const parsed = parseArgs(['run', '.', '--max-cost', '0.25']);
+  assert.equal(parsed.maxCost, 0.25);
+});
+
+test('parseArgs: --max-cost rejects negative value', () => {
+  const parsed = parseArgs(['run', '.', '--max-cost', '-1']);
+  assert.equal(parsed.command, 'help');
+});
+
+test('parseArgs: --max-cost rejects non-numeric value', () => {
+  const parsed = parseArgs(['run', '.', '--max-cost', 'free']);
+  assert.equal(parsed.command, 'help');
+});
+
+test('parseArgs: --context comma list', () => {
+  const parsed = parseArgs(['run', '.', '--context', 'diff,fullFile,tests']);
+  assert.deepEqual(parsed.availableContexts, ['diff', 'fullFile', 'tests']);
+});
+
+test('parseArgs: --dependency comma list', () => {
+  const parsed = parseArgs(['run', '.', '--dependency', 'code_search,test_runner']);
+  assert.deepEqual(parsed.availableDependencies, ['code_search', 'test_runner']);
+});
+
+test('parseArgs: --cases path for eval', () => {
+  const parsed = parseArgs(['eval', '--cases', 'custom-cases.json']);
+  assert.equal(parsed.fixturesCasesPath, 'custom-cases.json');
+});
+
+// -----------------------------------------------------------------------------
+// skills import options
+// -----------------------------------------------------------------------------
+
+test('parseArgs: --strict sets validationMode strict', () => {
+  const parsed = parseArgs(['skills', 'import', '--strict']);
+  assert.equal(parsed.validationMode, 'strict');
+});
+
+test('parseArgs: --loose sets validationMode loose', () => {
+  const parsed = parseArgs(['skills', 'import', '--loose']);
+  assert.equal(parsed.validationMode, 'loose');
+});
+
+test('parseArgs: --source rr', () => {
+  const parsed = parseArgs(['skills', 'list', '--source', 'rr']);
+  assert.equal(parsed.listSource, 'rr');
+});
+
+test('parseArgs: --source invalid value falls back to help', () => {
+  const parsed = parseArgs(['skills', 'list', '--source', 'wrong']);
+  assert.equal(parsed.command, 'help');
+});
+
+// -----------------------------------------------------------------------------
+// Help flag
+// -----------------------------------------------------------------------------
+
+test('parseArgs: -h triggers help command', () => {
+  const parsed = parseArgs(['-h']);
+  assert.equal(parsed.command, 'help');
+});
+
+test('parseArgs: --help triggers help command', () => {
+  const parsed = parseArgs(['--help']);
+  assert.equal(parsed.command, 'help');
+});
+
+// -----------------------------------------------------------------------------
+// Environment variable defaults
+// -----------------------------------------------------------------------------
+
+test('parseArgs: RIVER_PHASE env overrides default phase', () => {
+  const backup = process.env.RIVER_PHASE;
+  process.env.RIVER_PHASE = 'upstream';
+  try {
+    const parsed = parseArgs([]);
+    assert.equal(parsed.phase, 'upstream');
+  } finally {
+    if (backup === undefined) delete process.env.RIVER_PHASE;
+    else process.env.RIVER_PHASE = backup;
+  }
+});
+
+test('parseArgs: explicit --phase overrides RIVER_PHASE env', () => {
+  const backup = process.env.RIVER_PHASE;
+  process.env.RIVER_PHASE = 'upstream';
+  try {
+    const parsed = parseArgs(['run', '.', '--phase', 'downstream']);
+    assert.equal(parsed.phase, 'downstream');
+  } finally {
+    if (backup === undefined) delete process.env.RIVER_PHASE;
+    else process.env.RIVER_PHASE = backup;
+  }
+});

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -1,66 +1,43 @@
+// tests/cli.test.mjs
+//
+// river CLI の end-to-end テスト。
+// 通常は runCliInProcess() で in-process 実行し、subprocess 経由が必要な
+// テスト（process.exitCode の厳密検証）だけ runCliAsSubprocess() を使う。
+//
+// グルーピング:
+//   - river run - dry-run outputs
+//   - river run - markdown output
+//   - river run - guards & error paths
+//   - river doctor
+//   - river skills subcommands
+//
+// 重複していた createRepoWithChange / runCli / runGit は
+// tests/helpers/ に統合済み。
+
 import assert from 'node:assert';
-import { execFile } from 'node:child_process';
-import { mkdtempSync, writeFileSync } from 'node:fs';
-import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
-import { tmpdir } from 'node:os';
-import { promisify } from 'node:util';
-import test from 'node:test';
+import test, { describe } from 'node:test';
 
-const execFileAsync = promisify(execFile);
-const CLI_PATH = resolve('src/cli.mjs');
+import { runCliAsSubprocess, runCliInProcess } from './helpers/cli.mjs';
+import {
+  createTempGitRepo,
+  createRepoWithSilentCatchChange,
+  runGit,
+} from './helpers/temp-repo.mjs';
+import { createTempDir, cleanupTempDirAsync } from './helpers/temp-dir.mjs';
 
-async function runCli(args, cwd, env = {}) {
-  try {
-    const { stdout, stderr } = await execFileAsync('node', [CLI_PATH, ...args], {
-      cwd,
-      env: { ...process.env, ...env },
-    });
-    return { code: 0, stdout: stdout.toString(), stderr: stderr?.toString() ?? '' };
-  } catch (error) {
-    return {
-      code: error.code ?? 1,
-      stdout: error.stdout?.toString() ?? '',
-      stderr: error.stderr?.toString() ?? '',
-    };
-  }
-}
+// -----------------------------------------------------------------------------
+// river run - dry-run outputs
+// -----------------------------------------------------------------------------
 
-async function runGit(args, cwd) {
-  return execFileAsync('git', args, { cwd });
-}
+describe('river run - dry-run outputs', () => {
+  test('emits review comments in dry-run mode', async (t) => {
+    const { dir, cleanup } = await createRepoWithSilentCatchChange();
+    t.after(cleanup);
 
-async function createRepoWithChange() {
-  const dir = mkdtempSync(join(tmpdir(), 'river-cli-'));
-  await runGit(['init', '-b', 'main'], dir);
-  await runGit(['config', 'user.email', 'cli@example.com'], dir);
-  await runGit(['config', 'user.name', 'CLI Tester'], dir);
-
-  const srcDir = join(dir, 'src');
-  await mkdir(srcDir, { recursive: true });
-  const app = join(srcDir, 'app.js');
-  writeFileSync(app, 'export const value = 1;\n');
-  await runGit(['add', '.'], dir);
-  await runGit(['commit', '-m', 'init'], dir);
-
-  // ヒューリスティックが検出するパターンを含める（silent catch）
-  writeFileSync(app, `export const value = 2;
-export function test() {
-  try {
-    run();
-  } catch(e) {
-    return;
-  }
-}
-`);
-
-  return { dir, app };
-}
-
-test('river run emits review comments in dry-run mode', async () => {
-  const { dir } = await createRepoWithChange();
-  try {
-    const result = await runCli(['run', '.', '--dry-run', '--debug'], dir);
+    const result = await runCliInProcess(['run', '.', '--dry-run', '--debug'], { cwd: dir });
 
     assert.strictEqual(result.code, 0, result.stderr);
     assert.match(result.stdout, /River Reviewer/);
@@ -68,229 +45,238 @@ test('river run emits review comments in dry-run mode', async () => {
     assert.match(result.stdout, /src\/app.js:/);
     assert.match(result.stdout, /LLM:/);
     assert.match(result.stdout, /Changed files/);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
-});
+  });
 
-test('river run supports markdown output for PR comments', async () => {
-  const { dir } = await createRepoWithChange();
-  try {
-    const result = await runCli(['run', '.', '--dry-run', '--output', 'markdown'], dir);
-    assert.strictEqual(result.code, 0, result.stderr);
-    assert.match(result.stdout, /^<!-- river-reviewer -->/);
-    assert.match(result.stdout, /## River Reviewer/);
-    assert.match(result.stdout, /### 指摘/);
-    // Verify skill grouping header is present (skillId is sanitized, so hyphens are escaped)
-    assert.match(result.stdout, /#### 🔍 rr\\-midstream\\-logging\\-observability\\-001/);
-    assert.doesNotMatch(result.stdout, /--- diff preview ---/);
-    assert.match(result.stderr, /River Reviewer \(local\)/);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
-});
+  test('falls back gracefully without API key', async (t) => {
+    const { dir, cleanup } = await createRepoWithSilentCatchChange();
+    t.after(cleanup);
 
-test('river run writes debug output to stderr when markdown output is selected', async () => {
-  const { dir } = await createRepoWithChange();
-  try {
-    const result = await runCli(['run', '.', '--dry-run', '--output', 'markdown', '--debug'], dir);
-    assert.strictEqual(result.code, 0, result.stderr);
-    assert.doesNotMatch(result.stdout, /--- diff preview ---/);
-    assert.match(result.stderr, /--- diff preview ---/);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
-});
-
-test('river run reports when there are no changes', async () => {
-  const { dir } = await createRepoWithChange();
-  try {
-    await runGit(['add', '.'], dir);
-    await runGit(['commit', '-m', 'apply change'], dir);
-
-    const result = await runCli(['run', '.'], dir);
-    assert.strictEqual(result.code, 0, result.stderr);
-    assert.match(result.stdout, /No changes to review/);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
-});
-
-test('river run skips when PR labels match exclude list', async () => {
-  const { dir } = await createRepoWithChange();
-  try {
-    const configPath = join(dir, '.river-reviewer.json');
-    writeFileSync(
-      configPath,
-      JSON.stringify({ exclude: { prLabelsToIgnore: ['skip-review'] } }, null, 2),
-      'utf8',
-    );
-
-    const result = await runCli(['run', '.'], dir, { RIVER_PR_LABELS: 'skip-review' });
-
-    assert.strictEqual(result.code, 0, result.stderr);
-    assert.match(result.stdout, /Review skipped: PR labels matched exclude patterns/);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
-});
-
-test('river run falls back gracefully without API key', async () => {
-  const { dir } = await createRepoWithChange();
-  try {
-    const result = await runCli(['run', '.', '--debug'], dir);
+    const result = await runCliInProcess(['run', '.', '--debug'], { cwd: dir });
     assert.strictEqual(result.code, 0, result.stderr);
     assert.match(result.stdout, /River Reviewer/);
     assert.match(result.stdout, /LLM: OPENAI_API_KEY/i);
     assert.match(result.stdout, /Planner: off/i);
     assert.match(result.stdout, /Review comments/);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
-});
+  });
 
-test('river run reports planner skip reason when requested without API key', async () => {
-  const { dir } = await createRepoWithChange();
-  try {
-    const result = await runCli(['run', '.', '--planner', 'order', '--debug'], dir);
+  test('reports planner skip reason when requested without API key', async (t) => {
+    const { dir, cleanup } = await createRepoWithSilentCatchChange();
+    t.after(cleanup);
+
+    const result = await runCliInProcess(['run', '.', '--planner', 'order', '--debug'], {
+      cwd: dir,
+    });
     assert.strictEqual(result.code, 0, result.stderr);
     assert.match(result.stdout, /Planner: order skipped/i);
     assert.match(result.stdout, /OPENAI_API_KEY/i);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
-});
+  });
 
-test('river run injects project rules into prompt when present', async () => {
-  const { dir } = await createRepoWithChange();
-  try {
+  test('injects project rules into prompt when present', async (t) => {
+    const { dir, cleanup } = await createRepoWithSilentCatchChange();
+    t.after(cleanup);
+
     const rulesDir = join(dir, '.river');
-    await mkdir(rulesDir, { recursive: true });
+    mkdirSync(rulesDir, { recursive: true });
     writeFileSync(join(rulesDir, 'rules.md'), '- Use App Router\n- Prefer server components');
 
-    const result = await runCli(['run', '.', '--dry-run', '--debug'], dir);
+    const result = await runCliInProcess(['run', '.', '--dry-run', '--debug'], { cwd: dir });
     assert.strictEqual(result.code, 0, result.stderr);
     assert.match(result.stdout, /Project rules: present/);
     assert.match(result.stdout, /Project-specific review rules/i);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
-});
+  });
 
-test('river run supports cost estimation only', async () => {
-  const { dir } = await createRepoWithChange();
-  try {
-    const result = await runCli(['run', '.', '--estimate'], dir);
-    assert.strictEqual(result.code, 0, result.stderr);
-    assert.match(result.stdout, /Cost Estimate/);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
-});
+  test('reports when there are no changes', async (t) => {
+    const { dir, cleanup } = await createRepoWithSilentCatchChange();
+    t.after(cleanup);
 
-test('river run aborts when max-cost is exceeded', async () => {
-  const { dir } = await createRepoWithChange();
-  try {
-    const result = await runCli(['run', '.', '--max-cost', '0.0001'], dir);
-    assert.notStrictEqual(result.code, 0);
-    assert.match(result.stdout + result.stderr, /exceeds max-cost/i);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
-});
-
-test('river run rejects negative max-cost value', async () => {
-  const { dir } = await createRepoWithChange();
-  try {
-    const result = await runCli(['run', '.', '--max-cost', '-1'], dir);
-    assert.strictEqual(result.code, 0);
-    assert.match(result.stderr, /requires a non-negative numeric value/i);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
-});
-
-test('river run skips markdown-only changes after optimization', async () => {
-  const dir = mkdtempSync(join(tmpdir(), 'river-cli-md-'));
-  try {
-    await runGit(['init', '-b', 'main'], dir);
-    await runGit(['config', 'user.email', 'cli@example.com'], dir);
-    await runGit(['config', 'user.name', 'CLI Tester'], dir);
-    const doc = join(dir, 'README.md');
-    writeFileSync(doc, '# first\n');
     await runGit(['add', '.'], dir);
-    await runGit(['commit', '-m', 'init'], dir);
-    writeFileSync(doc, '# second\n');
+    await runGit(['commit', '-m', 'apply change'], dir);
 
-    const result = await runCli(['run', '.', '--dry-run'], dir);
+    const result = await runCliInProcess(['run', '.'], { cwd: dir });
     assert.strictEqual(result.code, 0, result.stderr);
     assert.match(result.stdout, /No changes to review/);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
+  });
 });
 
-test('river run fails gracefully outside git repos', async () => {
-  const dir = mkdtempSync(join(tmpdir(), 'river-cli-empty-'));
-  await mkdir(resolve(dir, 'nested'));
-  const result = await runCli(['run', '.'], dir);
+// -----------------------------------------------------------------------------
+// river run - markdown output
+// -----------------------------------------------------------------------------
 
-  assert.notStrictEqual(result.code, 0);
-  assert.match(result.stderr, /Not a git repository/);
-  await rm(dir, { recursive: true, force: true });
+describe('river run - markdown output', () => {
+  test('supports markdown output for PR comments', async (t) => {
+    const { dir, cleanup } = await createRepoWithSilentCatchChange();
+    t.after(cleanup);
+
+    const result = await runCliInProcess(['run', '.', '--dry-run', '--output', 'markdown'], {
+      cwd: dir,
+    });
+    assert.strictEqual(result.code, 0, result.stderr);
+    assert.match(result.stdout, /^<!-- river-reviewer -->/);
+    assert.match(result.stdout, /## River Reviewer/);
+    assert.match(result.stdout, /### 指摘/);
+    // skill id はサニタイズでハイフンがエスケープされる
+    assert.match(result.stdout, /#### 🔍 rr\\-midstream\\-logging\\-observability\\-001/);
+    assert.doesNotMatch(result.stdout, /--- diff preview ---/);
+    assert.match(result.stderr, /River Reviewer \(local\)/);
+  });
+
+  test('writes debug output to stderr when markdown output is selected', async (t) => {
+    const { dir, cleanup } = await createRepoWithSilentCatchChange();
+    t.after(cleanup);
+
+    const result = await runCliInProcess(
+      ['run', '.', '--dry-run', '--output', 'markdown', '--debug'],
+      { cwd: dir }
+    );
+    assert.strictEqual(result.code, 0, result.stderr);
+    assert.doesNotMatch(result.stdout, /--- diff preview ---/);
+    assert.match(result.stderr, /--- diff preview ---/);
+  });
 });
 
-test('river doctor reports basic setup status', async t => {
-  const { dir } = await createRepoWithChange();
-  t.after(async () => rm(dir, { recursive: true, force: true }));
+// -----------------------------------------------------------------------------
+// river run - guards & error paths
+// -----------------------------------------------------------------------------
 
-  const result = await runCli(['doctor', '.', '--debug'], dir);
-  assert.strictEqual(result.code, 0, result.stderr);
-  assert.match(result.stdout, /River Reviewer doctor/);
-  assert.match(result.stdout, /Skills loaded:/);
-  assert.match(result.stdout, /Merge base:/);
-  assert.match(result.stdout, /--- diff preview ---/);
+describe('river run - guards & error paths', () => {
+  test('skips when PR labels match exclude list', async (t) => {
+    const { dir, cleanup } = await createRepoWithSilentCatchChange();
+    t.after(cleanup);
+
+    const configPath = join(dir, '.river-reviewer.json');
+    writeFileSync(
+      configPath,
+      JSON.stringify({ exclude: { prLabelsToIgnore: ['skip-review'] } }, null, 2),
+      'utf8'
+    );
+
+    const result = await runCliInProcess(['run', '.'], {
+      cwd: dir,
+      env: { RIVER_PR_LABELS: 'skip-review' },
+    });
+
+    assert.strictEqual(result.code, 0, result.stderr);
+    assert.match(result.stdout, /Review skipped: PR labels matched exclude patterns/);
+  });
+
+  test('supports cost estimation only', async (t) => {
+    const { dir, cleanup } = await createRepoWithSilentCatchChange();
+    t.after(cleanup);
+
+    const result = await runCliInProcess(['run', '.', '--estimate'], { cwd: dir });
+    assert.strictEqual(result.code, 0, result.stderr);
+    assert.match(result.stdout, /Cost Estimate/);
+  });
+
+  test('aborts when max-cost is exceeded', async (t) => {
+    const { dir, cleanup } = await createRepoWithSilentCatchChange();
+    t.after(cleanup);
+
+    const result = await runCliInProcess(['run', '.', '--max-cost', '0.0001'], { cwd: dir });
+    assert.notStrictEqual(result.code, 0);
+    assert.match(result.stdout + result.stderr, /exceeds max-cost/i);
+  });
+
+  test('rejects negative max-cost value', async (t) => {
+    const { dir, cleanup } = await createRepoWithSilentCatchChange();
+    t.after(cleanup);
+
+    const result = await runCliInProcess(['run', '.', '--max-cost', '-1'], { cwd: dir });
+    assert.strictEqual(result.code, 0);
+    assert.match(result.stderr, /requires a non-negative numeric value/i);
+  });
+
+  test('skips markdown-only changes after optimization', async (t) => {
+    const { dir, cleanup } = await createTempGitRepo({
+      prefix: 'river-cli-md-',
+      initialFiles: { 'README.md': '# first\n' },
+      changedFiles: { 'README.md': '# second\n' },
+    });
+    t.after(cleanup);
+
+    const result = await runCliInProcess(['run', '.', '--dry-run'], { cwd: dir });
+    assert.strictEqual(result.code, 0, result.stderr);
+    assert.match(result.stdout, /No changes to review/);
+  });
+
+  test('fails gracefully outside git repos', async (t) => {
+    const dir = createTempDir({ prefix: 'river-cli-empty-' });
+    t.after(() => cleanupTempDirAsync(dir));
+    mkdirSync(resolve(dir, 'nested'));
+
+    const result = await runCliInProcess(['run', '.'], { cwd: dir });
+    assert.notStrictEqual(result.code, 0);
+    assert.match(result.stderr, /Not a git repository/);
+  });
 });
 
-test('river doctor fails gracefully outside git repos', async t => {
-  const dir = mkdtempSync(join(tmpdir(), 'river-cli-empty-'));
-  t.after(async () => rm(dir, { recursive: true, force: true }));
-  await mkdir(resolve(dir, 'nested'));
-  const result = await runCli(['doctor', '.'], dir);
+// -----------------------------------------------------------------------------
+// river doctor
+// -----------------------------------------------------------------------------
 
-  assert.notStrictEqual(result.code, 0);
-  assert.match(result.stderr, /Not a git repository/);
+describe('river doctor', () => {
+  test('reports basic setup status', async (t) => {
+    const { dir, cleanup } = await createRepoWithSilentCatchChange();
+    t.after(cleanup);
+
+    const result = await runCliInProcess(['doctor', '.', '--debug'], { cwd: dir });
+    assert.strictEqual(result.code, 0, result.stderr);
+    assert.match(result.stdout, /River Reviewer doctor/);
+    assert.match(result.stdout, /Skills loaded:/);
+    assert.match(result.stdout, /Merge base:/);
+    assert.match(result.stdout, /--- diff preview ---/);
+  });
+
+  test('fails gracefully outside git repos', async (t) => {
+    const dir = createTempDir({ prefix: 'river-cli-empty-' });
+    t.after(() => cleanupTempDirAsync(dir));
+    mkdirSync(resolve(dir, 'nested'));
+
+    const result = await runCliInProcess(['doctor', '.'], { cwd: dir });
+    assert.notStrictEqual(result.code, 0);
+    assert.match(result.stderr, /Not a git repository/);
+  });
 });
 
-// ---------------------------------------------------------------------------
-// skills subcommands
-// ---------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
+// river skills subcommands
+// -----------------------------------------------------------------------------
 
-test('river skills import --loose --dry-run exits 0 with summary', async t => {
-  const fixturesDir = resolve('tests', 'fixtures', 'agent-skills');
-  const result = await runCli(
-    ['skills', 'import', '--from', fixturesDir, '--loose', '--dry-run'],
-    process.cwd(),
-  );
-  assert.strictEqual(result.code, 0, `stderr: ${result.stderr}`);
-  assert.match(result.stdout, /Import complete/);
+describe('river skills subcommands', () => {
+  test('import --loose --dry-run exits 0 with summary', async () => {
+    const fixturesDir = resolve('tests', 'fixtures', 'agent-skills');
+    const result = await runCliInProcess(
+      ['skills', 'import', '--from', fixturesDir, '--loose', '--dry-run'],
+      { cwd: process.cwd() }
+    );
+    assert.strictEqual(result.code, 0, `stderr: ${result.stderr}`);
+    assert.match(result.stdout, /Import complete/);
+  });
+
+  test('list --source rr exits 0 and shows table', async () => {
+    const result = await runCliInProcess(['skills', 'list', '--source', 'rr'], {
+      cwd: process.cwd(),
+    });
+    assert.strictEqual(result.code, 0, `stderr: ${result.stderr}`);
+    assert.match(result.stdout, /ID/);
+    assert.match(result.stdout, /Total:/);
+  });
+
+  test('import with empty dir emits warning and exits 0', async (t) => {
+    const emptyDir = createTempDir({ prefix: 'river-cli-empty-skills-' });
+    t.after(() => cleanupTempDirAsync(emptyDir));
+
+    const result = await runCliInProcess(['skills', 'import', '--from', emptyDir, '--dry-run'], {
+      cwd: process.cwd(),
+    });
+    assert.strictEqual(result.code, 0, `stderr: ${result.stderr}`);
+    assert.match(result.stdout + result.stderr, /No Agent Skills/);
+  });
 });
 
-test('river skills list --source rr exits 0 and shows table', async t => {
-  const result = await runCli(['skills', 'list', '--source', 'rr'], process.cwd());
-  assert.strictEqual(result.code, 0, `stderr: ${result.stderr}`);
-  assert.match(result.stdout, /ID/);
-  assert.match(result.stdout, /Total:/);
-});
-
-test('river skills import with empty dir emits warning and exits 0', async t => {
-  const emptyDir = mkdtempSync(join(tmpdir(), 'river-cli-empty-skills-'));
-  t.after(async () => rm(emptyDir, { recursive: true, force: true }));
-
-  const result = await runCli(
-    ['skills', 'import', '--from', emptyDir, '--dry-run'],
-    process.cwd(),
-  );
-  assert.strictEqual(result.code, 0, `stderr: ${result.stderr}`);
-  assert.match(result.stdout + result.stderr, /No Agent Skills/);
-});
+// Keep a reference to runCliAsSubprocess so lint / unused-import warnings don't
+// fire — it remains exported from helpers for future tests that need true
+// process isolation, even though this file migrated to in-process.
+void runCliAsSubprocess;
+// writeFile is re-exported for potential use in follow-up tests.
+void writeFile;

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -16,11 +16,10 @@
 
 import assert from 'node:assert';
 import { mkdirSync, writeFileSync } from 'node:fs';
-import { writeFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import test, { describe } from 'node:test';
 
-import { runCliAsSubprocess, runCliInProcess } from './helpers/cli.mjs';
+import { runCliInProcess } from './helpers/cli.mjs';
 import {
   createTempGitRepo,
   createRepoWithSilentCatchChange,
@@ -273,10 +272,3 @@ describe('river skills subcommands', () => {
     assert.match(result.stdout + result.stderr, /No Agent Skills/);
   });
 });
-
-// Keep a reference to runCliAsSubprocess so lint / unused-import warnings don't
-// fire — it remains exported from helpers for future tests that need true
-// process isolation, even though this file migrated to in-process.
-void runCliAsSubprocess;
-// writeFile is re-exported for potential use in follow-up tests.
-void writeFile;

--- a/tests/helpers/README.md
+++ b/tests/helpers/README.md
@@ -30,6 +30,21 @@
 
 `runCliInProcess` は内部で `process.env` / `process.argv` / `process.cwd` を一時的に差し替える。テスト終了時に必ず元の値に戻すので、呼び出し側が追加で cleanup する必要はない。
 
+ただし、**グローバルなプロセス状態を差し替える性質上、`runCliInProcess` の呼び出しは
+同一プロセス内で逐次実行しなければならない**。`Promise.all([runCliInProcess(...), runCliInProcess(...)])`
+のような並行呼び出しはお互いの override を上書きし合い、意図しない状態リークを起こす。
+node:test の `describe` 内テストはデフォルトで逐次実行なので、通常の利用では問題ないが、
+明示的に `{ concurrency: true }` を指定した describe 内で複数の runCliInProcess を
+走らせないこと。環境変数・CWD 依存のないテストでもサブコマンド出力が混ざる。
+
+## ambient な `process.env` の取り扱い
+
+in-process 化により、ホストプロセスの `process.env.RIVER_PHASE` / `RIVER_PLANNER_MODE`
+といった CLI デフォルト値に影響する環境変数は、テストに直接漏れ込む。テスト実行時の
+環境にこれらが設定されている場合、`parseArgs` のデフォルトが変わって誤判定する可能性がある。
+デフォルト値に依存するテストは `runCliInProcess` の `env` オプションで明示的にクリア
+（`env: { RIVER_PHASE: undefined }`）するか、`withCleanEnv` 相当のラッパーで囲むこと。
+
 ## stdio 差し替えに関する注意
 
 `captureConsole` は `console.log` / `console.error` / `console.warn` / `console.info` のみを差し替える。`process.stdout.write` / `process.stderr.write` は**差し替えない**（node:test ランナー自身が TAP 出力に使っているため、ここを横取りすると後続のサブテストが silently drop される）。`src/cli.mjs` の出力はほぼ console 経由なので問題はないが、`src/lib/agent-skill-bridge.mjs` などで直接 `process.stderr.write` しているケースはキャプチャされず実 stderr に出る。テストのアサーションはこの点を前提に組むこと。

--- a/tests/helpers/README.md
+++ b/tests/helpers/README.md
@@ -1,0 +1,48 @@
+# tests/helpers/
+
+テスト間で重複していた一時ディレクトリ生成・git リポジトリ構築・CLI 起動・Riverbed Memory 初期化のヘルパーを集約する場所。
+
+## 方針
+
+- **既存の重複を吸収**することが目的。将来のための抽象化を先取りしない
+- **Node 標準 API のみ**で実装する。外部依存（tmp, tempy 等）は追加しない
+- 全ヘルパーは副作用を呼び出し側から制御できるよう、`withXxx(fn)` の callback 版と `createXxx() + cleanup()` の手動版を併記する
+
+## 提供しているヘルパー
+
+| ファイル        | 主な API                                                                      |
+| --------------- | ----------------------------------------------------------------------------- |
+| `temp-dir.mjs`  | `createTempDir()`, `cleanupTempDir()`, `withTempDir(fn)`                      |
+| `temp-repo.mjs` | `createTempGitRepo(opts)`, `createRepoWithSilentCatchChange()`, `runGit()`    |
+| `cli.mjs`       | `runCliAsSubprocess(argv, opts)`, `runCliInProcess(argv, opts)`               |
+| `memory.mjs`    | `createTempMemory({ layout, entries })`, `makeMemoryEntry()`, `writeMemoryIndex()` |
+
+## CLI ヘルパーの使い分け
+
+| 状況                                           | 使うヘルパー               |
+| ---------------------------------------------- | -------------------------- |
+| 通常のアサーション（stdout/stderr/exit code）  | `runCliInProcess`（速い）  |
+| process 終了ロジック / ネイティブモジュール読込の検証 | `runCliAsSubprocess`  |
+
+`runCliInProcess` は `src/cli.mjs` が `main()` を export している前提で動作する。import 時に動的 URL + timestamp を用いてモジュールキャッシュを避け、テスト間の副作用を遮断する。
+
+## 環境変数・CWD の扱い
+
+`runCliInProcess` は内部で `process.env` / `process.argv` / `process.cwd` を一時的に差し替える。テスト終了時に必ず元の値に戻すので、呼び出し側が追加で cleanup する必要はない。
+
+## 重複排除前の Before/After
+
+```javascript
+// Before: tests/riverbed-memory.test.mjs で独自定義
+function tmpIndex() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rr-memory-'));
+  return { dir, indexPath: path.join(dir, 'index.json') };
+}
+function cleanup(dir) {
+  fs.rmSync(dir, { recursive: true });
+}
+
+// After: helpers から import
+import { createTempMemory } from '../helpers/memory.mjs';
+const { dir, indexPath, cleanup } = createTempMemory({ layout: 'flat' });
+```

--- a/tests/helpers/README.md
+++ b/tests/helpers/README.md
@@ -10,25 +10,29 @@
 
 ## 提供しているヘルパー
 
-| ファイル        | 主な API                                                                      |
-| --------------- | ----------------------------------------------------------------------------- |
-| `temp-dir.mjs`  | `createTempDir()`, `cleanupTempDir()`, `withTempDir(fn)`                      |
-| `temp-repo.mjs` | `createTempGitRepo(opts)`, `createRepoWithSilentCatchChange()`, `runGit()`    |
-| `cli.mjs`       | `runCliAsSubprocess(argv, opts)`, `runCliInProcess(argv, opts)`               |
+| ファイル        | 主な API                                                                           |
+| --------------- | ---------------------------------------------------------------------------------- |
+| `temp-dir.mjs`  | `createTempDir()`, `cleanupTempDir()`, `withTempDir(fn)`                           |
+| `temp-repo.mjs` | `createTempGitRepo(opts)`, `createRepoWithSilentCatchChange()`, `runGit()`         |
+| `cli.mjs`       | `runCliAsSubprocess(argv, opts)`, `runCliInProcess(argv, opts)`                    |
 | `memory.mjs`    | `createTempMemory({ layout, entries })`, `makeMemoryEntry()`, `writeMemoryIndex()` |
 
 ## CLI ヘルパーの使い分け
 
-| 状況                                           | 使うヘルパー               |
-| ---------------------------------------------- | -------------------------- |
-| 通常のアサーション（stdout/stderr/exit code）  | `runCliInProcess`（速い）  |
-| process 終了ロジック / ネイティブモジュール読込の検証 | `runCliAsSubprocess`  |
+| 状況                                                  | 使うヘルパー              |
+| ----------------------------------------------------- | ------------------------- |
+| 通常のアサーション（stdout/stderr/exit code）         | `runCliInProcess`（速い） |
+| process 終了ロジック / ネイティブモジュール読込の検証 | `runCliAsSubprocess`      |
 
-`runCliInProcess` は `src/cli.mjs` が `main()` を export している前提で動作する。import 時に動的 URL + timestamp を用いてモジュールキャッシュを避け、テスト間の副作用を遮断する。
+`runCliInProcess` は `src/cli.mjs` が `main()` を export している前提で動作する。初回呼び出し時に `cli.mjs` を動的 import し、その結果はモジュールスコープにキャッシュして後続のテストで再利用する。テスト間の副作用は `withProcessOverrides`（env/argv/cwd のスナップショット・復元）と `captureConsole`（console.\* の差し替え）で隔離する。
 
 ## 環境変数・CWD の扱い
 
 `runCliInProcess` は内部で `process.env` / `process.argv` / `process.cwd` を一時的に差し替える。テスト終了時に必ず元の値に戻すので、呼び出し側が追加で cleanup する必要はない。
+
+## stdio 差し替えに関する注意
+
+`captureConsole` は `console.log` / `console.error` / `console.warn` / `console.info` のみを差し替える。`process.stdout.write` / `process.stderr.write` は**差し替えない**（node:test ランナー自身が TAP 出力に使っているため、ここを横取りすると後続のサブテストが silently drop される）。`src/cli.mjs` の出力はほぼ console 経由なので問題はないが、`src/lib/agent-skill-bridge.mjs` などで直接 `process.stderr.write` しているケースはキャプチャされず実 stderr に出る。テストのアサーションはこの点を前提に組むこと。
 
 ## 重複排除前の Before/After
 

--- a/tests/helpers/__tests__/cli.test.mjs
+++ b/tests/helpers/__tests__/cli.test.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { runCliAsSubprocess } from '../cli.mjs';
+
+test('runCliAsSubprocess: help flag exits 0 and prints usage', async () => {
+  const result = await runCliAsSubprocess(['--help']);
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Usage: river/);
+});
+
+test('runCliAsSubprocess: unknown command prints help', async () => {
+  const result = await runCliAsSubprocess(['no-such-command']);
+  // CLI は未知のコマンドでも help を出して 0 で終了する既存挙動
+  assert.equal(result.code, 0);
+  assert.match(result.stdout, /Usage: river/);
+});
+
+test('runCliAsSubprocess: passes through env variables', async () => {
+  const result = await runCliAsSubprocess(['--help'], {
+    env: { RIVER_TEST_MARKER: 'present' },
+  });
+  // help は env を使わないが、少なくとも失敗せずに終わること
+  assert.equal(result.code, 0);
+});
+
+test('runCliInProcess: --help returns 0 and prints usage in-process', async () => {
+  const { runCliInProcess } = await import('../cli.mjs');
+  const result = await runCliInProcess(['--help']);
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Usage: river/);
+});
+
+test('runCliInProcess: restores process.env after run', async () => {
+  const { runCliInProcess } = await import('../cli.mjs');
+  const before = process.env.RIVER_TEST_OVERRIDE;
+  await runCliInProcess(['--help'], {
+    env: { RIVER_TEST_OVERRIDE: 'yes' },
+  });
+  assert.equal(process.env.RIVER_TEST_OVERRIDE, before);
+});

--- a/tests/helpers/__tests__/memory.test.mjs
+++ b/tests/helpers/__tests__/memory.test.mjs
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import test from 'node:test';
+
+import {
+  createTempMemory,
+  makeMemoryEntry,
+  writeMemoryIndex,
+} from '../memory.mjs';
+
+test('createTempMemory (nested) creates .river/memory/ structure', () => {
+  const { dir, indexPath, cleanup } = createTempMemory({ layout: 'nested' });
+  try {
+    assert.match(indexPath, /\.river[\\/]memory[\\/]index\.json$/);
+    assert.ok(existsSync(dirname(indexPath)));
+    // index.json はまだ書き込まれていない（entries 未指定）
+    assert.ok(!existsSync(indexPath));
+  } finally {
+    cleanup();
+  }
+});
+
+test('createTempMemory (flat) places index.json directly in the dir', () => {
+  const { dir, indexPath, cleanup } = createTempMemory({ layout: 'flat' });
+  try {
+    assert.equal(dirname(indexPath), dir);
+  } finally {
+    cleanup();
+  }
+});
+
+test('createTempMemory writes provided entries to index.json', () => {
+  const entry = makeMemoryEntry({ id: 'seed-1', type: 'review', content: 'seed' });
+  const { indexPath, cleanup } = createTempMemory({
+    layout: 'nested',
+    entries: [entry],
+  });
+  try {
+    const parsed = JSON.parse(readFileSync(indexPath, 'utf8'));
+    assert.equal(parsed.entries.length, 1);
+    assert.equal(parsed.entries[0].id, 'seed-1');
+    assert.equal(parsed.version, '1');
+  } finally {
+    cleanup();
+  }
+});
+
+test('makeMemoryEntry produces unique ids on repeated calls', () => {
+  const a = makeMemoryEntry();
+  const b = makeMemoryEntry();
+  assert.notEqual(a.id, b.id);
+  assert.equal(a.type, 'review');
+  assert.ok(a.metadata.createdAt);
+  assert.equal(a.metadata.author, 'test');
+});
+
+test('makeMemoryEntry merges metadata overrides without dropping defaults', () => {
+  const entry = makeMemoryEntry({
+    metadata: { phase: 'upstream', tags: ['security'] },
+  });
+  assert.equal(entry.metadata.phase, 'upstream');
+  assert.deepEqual(entry.metadata.tags, ['security']);
+  assert.ok(entry.metadata.createdAt); // default preserved
+  assert.equal(entry.metadata.author, 'test'); // default preserved
+});
+
+test('writeMemoryIndex overwrites the index file with given entries', () => {
+  const { indexPath, cleanup } = createTempMemory({ layout: 'flat' });
+  try {
+    writeMemoryIndex(indexPath, [makeMemoryEntry({ id: 'a' })]);
+    const first = JSON.parse(readFileSync(indexPath, 'utf8'));
+    assert.equal(first.entries.length, 1);
+
+    writeMemoryIndex(indexPath, [
+      makeMemoryEntry({ id: 'b' }),
+      makeMemoryEntry({ id: 'c' }),
+    ]);
+    const second = JSON.parse(readFileSync(indexPath, 'utf8'));
+    assert.equal(second.entries.length, 2);
+    assert.equal(second.entries[0].id, 'b');
+  } finally {
+    cleanup();
+  }
+});

--- a/tests/helpers/__tests__/temp-dir.test.mjs
+++ b/tests/helpers/__tests__/temp-dir.test.mjs
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import { existsSync, statSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+  createTempDir,
+  createTempDirAsync,
+  cleanupTempDir,
+  cleanupTempDirAsync,
+  withTempDir,
+} from '../temp-dir.mjs';
+
+test('createTempDir returns an existing directory path', () => {
+  const dir = createTempDir();
+  try {
+    assert.equal(typeof dir, 'string');
+    assert.ok(existsSync(dir));
+    assert.ok(statSync(dir).isDirectory());
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('createTempDir honors prefix option', () => {
+  const dir = createTempDir({ prefix: 'custom-prefix-' });
+  try {
+    assert.match(dir, /custom-prefix-/);
+  } finally {
+    cleanupTempDir(dir);
+  }
+});
+
+test('cleanupTempDir removes the directory and nested files', () => {
+  const dir = createTempDir();
+  writeFileSync(join(dir, 'nested.txt'), 'hello');
+  assert.ok(existsSync(join(dir, 'nested.txt')));
+  cleanupTempDir(dir);
+  assert.ok(!existsSync(dir));
+});
+
+test('withTempDir auto-cleans the directory on success', async () => {
+  let capturedDir;
+  const result = await withTempDir(async (dir) => {
+    capturedDir = dir;
+    writeFileSync(join(dir, 'touch.txt'), 'x');
+    return 42;
+  });
+  assert.equal(result, 42);
+  assert.ok(capturedDir);
+  assert.ok(!existsSync(capturedDir));
+});
+
+test('withTempDir auto-cleans the directory when callback throws', async () => {
+  let capturedDir;
+  await assert.rejects(
+    withTempDir(async (dir) => {
+      capturedDir = dir;
+      throw new Error('boom');
+    }),
+    /boom/,
+  );
+  assert.ok(capturedDir);
+  assert.ok(!existsSync(capturedDir));
+});
+
+test('createTempDirAsync + cleanupTempDirAsync roundtrip', async () => {
+  const dir = await createTempDirAsync({ prefix: 'async-' });
+  assert.ok(existsSync(dir));
+  await cleanupTempDirAsync(dir);
+  assert.ok(!existsSync(dir));
+});

--- a/tests/helpers/__tests__/temp-repo.test.mjs
+++ b/tests/helpers/__tests__/temp-repo.test.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+  createTempGitRepo,
+  createRepoWithSilentCatchChange,
+  runGit,
+} from '../temp-repo.mjs';
+
+test('createTempGitRepo creates an initialized git repo with default branch', async (t) => {
+  const { dir, cleanup } = await createTempGitRepo();
+  t.after(cleanup);
+  assert.ok(existsSync(join(dir, '.git')));
+  const { stdout } = await runGit(['rev-parse', '--abbrev-ref', 'HEAD'], dir);
+  assert.equal(stdout.trim(), 'main');
+});
+
+test('createTempGitRepo commits initialFiles and leaves changedFiles unstaged', async (t) => {
+  const { dir, cleanup } = await createTempGitRepo({
+    initialFiles: { 'src/a.js': 'export const v = 1;\n' },
+    changedFiles: { 'src/a.js': 'export const v = 2;\n' },
+  });
+  t.after(cleanup);
+
+  // committed snapshot is the initial content
+  const { stdout: show } = await runGit(['show', 'HEAD:src/a.js'], dir);
+  assert.equal(show.trim(), 'export const v = 1;');
+
+  // working tree has the changed content
+  const current = readFileSync(join(dir, 'src/a.js'), 'utf8');
+  assert.equal(current.trim(), 'export const v = 2;');
+
+  // status shows it as modified
+  const { stdout: status } = await runGit(['status', '--porcelain'], dir);
+  assert.match(status, /src\/a\.js/);
+});
+
+test('createTempGitRepo writes .river/rules.md when rules option provided', async (t) => {
+  const { dir, cleanup } = await createTempGitRepo({
+    rules: '- Use semantic naming\n',
+  });
+  t.after(cleanup);
+  const rulesPath = join(dir, '.river', 'rules.md');
+  assert.ok(existsSync(rulesPath));
+  assert.equal(readFileSync(rulesPath, 'utf8'), '- Use semantic naming\n');
+});
+
+test('createRepoWithSilentCatchChange includes the silent catch pattern', async (t) => {
+  const { dir, cleanup, appPath } = await createRepoWithSilentCatchChange();
+  t.after(cleanup);
+  assert.equal(appPath, join(dir, 'src', 'app.js'));
+  const content = readFileSync(appPath, 'utf8');
+  assert.match(content, /catch\(e\)/);
+  assert.match(content, /return;/);
+});

--- a/tests/helpers/cli.mjs
+++ b/tests/helpers/cli.mjs
@@ -15,12 +15,15 @@
 //   { code: number, stdout: string, stderr: string }
 
 import { execFile } from 'node:child_process';
-import { resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
 
-const DEFAULT_CLI_PATH = resolve('src/cli.mjs');
+// このヘルパーファイル自身からの相対パスで src/cli.mjs を解決する。
+// `resolve('src/cli.mjs')` だと実行時の cwd に依存して壊れるため、
+// import.meta.url ベースの絶対パスに固定する。
+const DEFAULT_CLI_PATH = fileURLToPath(new URL('../../src/cli.mjs', import.meta.url));
 
 /**
  * 子プロセスとして river CLI を起動する。
@@ -52,13 +55,19 @@ export async function runCliAsSubprocess(argv, options = {}) {
 
 /**
  * process.env / process.argv / process.cwd をテスト実行中のみ上書きし、終了後に復元する。
+ *
  * @template T
- * @param {{ argv?: string[], env?: Record<string,string>, cwd?: string }} overrides
+ * @param {{
+ *   argv?: string[],
+ *   env?: Record<string,string>,
+ *   cwd?: string,
+ *   cliPath?: string,  // process.argv[1] として使用する CLI スクリプトパス
+ * }} overrides
  * @param {() => T | Promise<T>} fn
  * @returns {Promise<T>}
  */
 async function withProcessOverrides(overrides, fn) {
-  const { argv, env, cwd } = overrides;
+  const { argv, env, cwd, cliPath = DEFAULT_CLI_PATH } = overrides;
 
   const envBackup = {};
   if (env) {
@@ -76,7 +85,7 @@ async function withProcessOverrides(overrides, fn) {
 
   const argvBackup = argv ? [...process.argv] : null;
   if (argv) {
-    process.argv = [process.argv[0], DEFAULT_CLI_PATH, ...argv];
+    process.argv = [process.argv[0], cliPath, ...argv];
   }
 
   const cwdBackup = cwd ? process.cwd() : null;
@@ -197,19 +206,20 @@ export async function runCliInProcess(argv, options = {}) {
   const { cwd, env, cliPath = DEFAULT_CLI_PATH } = options;
 
   if (!cliModuleCache || cliModuleCachePath !== cliPath) {
-    cliModuleCache = await import(`file://${cliPath}`);
+    // Windows パス対応のため pathToFileURL を経由する
+    cliModuleCache = await import(pathToFileURL(cliPath).href);
     cliModuleCachePath = cliPath;
   }
   const mod = cliModuleCache;
   if (typeof mod.main !== 'function') {
     throw new Error(
       'runCliInProcess: src/cli.mjs does not export main(). ' +
-        'This helper requires Phase 1.2 (cli.mjs export refactor).',
+        'This helper requires Phase 1.2 (cli.mjs export refactor).'
     );
   }
 
   let code = 0;
-  const captured = await withProcessOverrides({ argv, env, cwd }, () =>
+  const captured = await withProcessOverrides({ argv, env, cwd, cliPath }, () =>
     captureConsole(async () => {
       try {
         const result = await mod.main(argv);
@@ -222,7 +232,7 @@ export async function runCliInProcess(argv, options = {}) {
         console.error(`${error.stack || error.message}`);
         code = 1;
       }
-    }),
+    })
   );
 
   return { code, stdout: captured.stdout, stderr: captured.stderr };

--- a/tests/helpers/cli.mjs
+++ b/tests/helpers/cli.mjs
@@ -1,0 +1,229 @@
+// tests/helpers/cli.mjs
+//
+// CLI 起動用ヘルパー。2 種類の実行方式を提供する:
+//
+//   - runCliAsSubprocess(argv, { cwd, env })
+//     従来の execFile ベース。exit code の厳密な検証や process 終了挙動の確認が必要な場合に使う。
+//     起動コストが大きい（~150ms × テスト数）ため、通常テストでは in-process 版を推奨。
+//
+//   - runCliInProcess(argv, { cwd, env })
+//     src/cli.mjs から export された main() を直接呼び出し、stdout/stderr をキャプチャする。
+//     環境変数・CWD はスコープ内で差し替え、呼出し後に必ず復元する。
+//     Phase 1.2 で src/cli.mjs が parseArgs/main を export するようになってから利用可能。
+//
+// 返却フォーマットは両者で揃える:
+//   { code: number, stdout: string, stderr: string }
+
+import { execFile } from 'node:child_process';
+import { resolve } from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const DEFAULT_CLI_PATH = resolve('src/cli.mjs');
+
+/**
+ * 子プロセスとして river CLI を起動する。
+ *
+ * @param {string[]} argv CLI 引数（例: ['run', '.', '--dry-run']）
+ * @param {{ cwd?: string, env?: Record<string,string>, cliPath?: string }} [options]
+ * @returns {Promise<{ code: number, stdout: string, stderr: string }>}
+ */
+export async function runCliAsSubprocess(argv, options = {}) {
+  const { cwd = process.cwd(), env = {}, cliPath = DEFAULT_CLI_PATH } = options;
+  try {
+    const { stdout, stderr } = await execFileAsync('node', [cliPath, ...argv], {
+      cwd,
+      env: { ...process.env, ...env },
+    });
+    return {
+      code: 0,
+      stdout: stdout.toString(),
+      stderr: stderr ? stderr.toString() : '',
+    };
+  } catch (error) {
+    return {
+      code: typeof error.code === 'number' ? error.code : 1,
+      stdout: error.stdout ? error.stdout.toString() : '',
+      stderr: error.stderr ? error.stderr.toString() : '',
+    };
+  }
+}
+
+/**
+ * process.env / process.argv / process.cwd をテスト実行中のみ上書きし、終了後に復元する。
+ * @template T
+ * @param {{ argv?: string[], env?: Record<string,string>, cwd?: string }} overrides
+ * @param {() => T | Promise<T>} fn
+ * @returns {Promise<T>}
+ */
+async function withProcessOverrides(overrides, fn) {
+  const { argv, env, cwd } = overrides;
+
+  const envBackup = {};
+  if (env) {
+    for (const key of Object.keys(env)) {
+      envBackup[key] = Object.prototype.hasOwnProperty.call(process.env, key)
+        ? process.env[key]
+        : undefined;
+      if (env[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = env[key];
+      }
+    }
+  }
+
+  const argvBackup = argv ? [...process.argv] : null;
+  if (argv) {
+    process.argv = [process.argv[0], DEFAULT_CLI_PATH, ...argv];
+  }
+
+  const cwdBackup = cwd ? process.cwd() : null;
+  if (cwd) {
+    process.chdir(cwd);
+  }
+
+  const exitCodeBackup = process.exitCode;
+  process.exitCode = undefined;
+
+  try {
+    return await fn();
+  } finally {
+    if (cwdBackup) {
+      try {
+        process.chdir(cwdBackup);
+      } catch {
+        /* ignore */
+      }
+    }
+    if (argvBackup) {
+      process.argv = argvBackup;
+    }
+    if (env) {
+      for (const [key, prev] of Object.entries(envBackup)) {
+        if (prev === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = prev;
+        }
+      }
+    }
+    process.exitCode = exitCodeBackup;
+  }
+}
+
+/**
+ * console.log/error/warn/info を一時的にキャプチャする。
+ *
+ * 注意: process.stdout.write / process.stderr.write は差し替えない。
+ * node:test は内部的に process.stdout.write で TAP 出力を書き込むため、ここを差し替えると
+ * 後続のテスト発見・報告が壊れる（子テストが silently drop される）。
+ *
+ * cli.mjs の出力はほぼ console.log/error のみで、一部の src/lib/agent-skill-bridge.mjs での
+ * 直接的な process.stderr.write は本ヘルパーではキャプチャせず、実際の stderr に出る。
+ * テストアサーションはこれを前提に組む（skills import の No Agent Skills メッセージは
+ * console.error 経由なので問題なし）。
+ *
+ * @template T
+ * @param {() => T | Promise<T>} fn
+ * @returns {Promise<{ stdout: string, stderr: string }>}
+ */
+async function captureConsole(fn) {
+  const chunks = { stdout: [], stderr: [] };
+
+  const origLog = console.log;
+  const origError = console.error;
+  const origWarn = console.warn;
+  const origInfo = console.info;
+
+  console.log = (...args) => {
+    chunks.stdout.push(args.map(formatConsoleArg).join(' ') + '\n');
+  };
+  console.info = (...args) => {
+    chunks.stdout.push(args.map(formatConsoleArg).join(' ') + '\n');
+  };
+  console.error = (...args) => {
+    chunks.stderr.push(args.map(formatConsoleArg).join(' ') + '\n');
+  };
+  console.warn = (...args) => {
+    chunks.stderr.push(args.map(formatConsoleArg).join(' ') + '\n');
+  };
+
+  try {
+    await fn();
+    return {
+      stdout: chunks.stdout.join(''),
+      stderr: chunks.stderr.join(''),
+    };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+    console.warn = origWarn;
+    console.info = origInfo;
+  }
+}
+
+function formatConsoleArg(arg) {
+  if (typeof arg === 'string') return arg;
+  if (arg instanceof Error) return arg.stack || arg.message;
+  try {
+    return JSON.stringify(arg);
+  } catch {
+    return String(arg);
+  }
+}
+
+// src/cli.mjs のモジュールキャッシュ。テスト間で使い回すことで高速化する。
+// 状態の分離は withProcessOverrides（env/argv/cwd）で実現しており、
+// モジュール本体の再ロードは不要（cli.mjs には import.meta.url ガードがあるため
+// import しても main() は自動起動しない）。
+let cliModuleCache = null;
+let cliModuleCachePath = null;
+
+/**
+ * in-process で river CLI を実行する。
+ * 事前条件: src/cli.mjs が parseArgs / main を export している（Phase 1.2 以降）。
+ *
+ * @param {string[]} argv CLI 引数
+ * @param {{
+ *   cwd?: string,
+ *   env?: Record<string,string>,
+ *   cliPath?: string,
+ * }} [options]
+ * @returns {Promise<{ code: number, stdout: string, stderr: string }>}
+ */
+export async function runCliInProcess(argv, options = {}) {
+  const { cwd, env, cliPath = DEFAULT_CLI_PATH } = options;
+
+  if (!cliModuleCache || cliModuleCachePath !== cliPath) {
+    cliModuleCache = await import(`file://${cliPath}`);
+    cliModuleCachePath = cliPath;
+  }
+  const mod = cliModuleCache;
+  if (typeof mod.main !== 'function') {
+    throw new Error(
+      'runCliInProcess: src/cli.mjs does not export main(). ' +
+        'This helper requires Phase 1.2 (cli.mjs export refactor).',
+    );
+  }
+
+  let code = 0;
+  const captured = await withProcessOverrides({ argv, env, cwd }, () =>
+    captureConsole(async () => {
+      try {
+        const result = await mod.main(argv);
+        if (typeof result === 'number') {
+          code = result;
+        } else if (typeof process.exitCode === 'number') {
+          code = process.exitCode;
+        }
+      } catch (error) {
+        console.error(`${error.stack || error.message}`);
+        code = 1;
+      }
+    }),
+  );
+
+  return { code, stdout: captured.stdout, stderr: captured.stderr };
+}

--- a/tests/helpers/memory.mjs
+++ b/tests/helpers/memory.mjs
@@ -1,0 +1,100 @@
+// tests/helpers/memory.mjs
+//
+// Riverbed Memory 関連テストの重複ヘルパーを集約する。
+//   - riverbed-memory.test.mjs:  フラット配置（dir/index.json）
+//   - suppression.test.mjs:      nested 配置（dir/.river/memory/index.json）
+//   - memory-context.test.mjs:   nested 配置 + writeIndex ヘルパー
+//
+// createTempMemory() は両方の layout を { layout: 'flat' | 'nested' } で切替可能にする。
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { createTempDir, cleanupTempDir } from './temp-dir.mjs';
+
+/**
+ * Riverbed Memory 用の一時ディレクトリを生成する。
+ *
+ * @param {{
+ *   layout?: 'flat' | 'nested',   // flat: dir/index.json / nested: dir/.river/memory/index.json
+ *   entries?: Array<object>,      // 初期 entries
+ *   prefix?: string,
+ * }} [options]
+ * @returns {{
+ *   dir: string,
+ *   indexPath: string,
+ *   cleanup: () => void,
+ * }}
+ */
+export function createTempMemory(options = {}) {
+  const {
+    layout = 'nested',
+    entries = null,
+    prefix = 'river-mem-',
+  } = options;
+
+  const dir = createTempDir({ prefix });
+  let indexPath;
+  if (layout === 'nested') {
+    const memDir = join(dir, '.river', 'memory');
+    mkdirSync(memDir, { recursive: true });
+    indexPath = join(memDir, 'index.json');
+  } else {
+    indexPath = join(dir, 'index.json');
+  }
+
+  if (entries) {
+    writeFileSync(
+      indexPath,
+      JSON.stringify({ entries, version: '1' }, null, 2),
+      'utf8',
+    );
+  }
+
+  const cleanup = () => cleanupTempDir(dir);
+  return { dir, indexPath, cleanup };
+}
+
+let entryCounter = 0;
+
+/**
+ * Riverbed Memory テスト用の entry を生成する。
+ * id はグローバルカウンタ + タイムスタンプで一意性を担保する（Math.random() 非利用）。
+ *
+ * @param {object} [overrides]
+ * @returns {object}
+ */
+export function makeMemoryEntry(overrides = {}) {
+  entryCounter += 1;
+  const defaults = {
+    id: `test-entry-${Date.now()}-${entryCounter}`,
+    type: 'review',
+    content: 'Test content',
+    metadata: {
+      createdAt: new Date().toISOString(),
+      author: 'test',
+    },
+  };
+  // metadata をマージ（overrides.metadata があれば上書き）
+  return {
+    ...defaults,
+    ...overrides,
+    metadata: {
+      ...defaults.metadata,
+      ...(overrides.metadata || {}),
+    },
+  };
+}
+
+/**
+ * 指定した index.json に entries 配列をそのまま書き込む。
+ * @param {string} indexPath
+ * @param {Array<object>} entries
+ */
+export function writeMemoryIndex(indexPath, entries) {
+  writeFileSync(
+    indexPath,
+    JSON.stringify({ entries, version: '1' }, null, 2),
+    'utf8',
+  );
+}

--- a/tests/helpers/temp-dir.mjs
+++ b/tests/helpers/temp-dir.mjs
@@ -1,0 +1,74 @@
+// tests/helpers/temp-dir.mjs
+//
+// 一時ディレクトリの生成・後片付けを集約するヘルパー。
+// 既存テストで mkdtempSync + finally { rm } パターンが 10+ ファイルに散在していたのを
+// 単一の API に集約する。
+//
+// 使い分け:
+//   - withTempDir(async (dir) => {...}) : callback スコープ。自動 cleanup。
+//   - createTempDir({ prefix }) : 手動 cleanup。t.after(() => cleanupTempDir(dir)) と併用。
+//
+// See also: tests/helpers/README.md
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const DEFAULT_PREFIX = 'river-test-';
+
+/**
+ * 同期版の一時ディレクトリ生成。cleanup は呼び出し側の責務。
+ * @param {{ prefix?: string }} [options]
+ * @returns {string} 生成された絶対パス
+ */
+export function createTempDir(options = {}) {
+  const { prefix = DEFAULT_PREFIX } = options;
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+/**
+ * 非同期版の一時ディレクトリ生成。cleanup は呼び出し側の責務。
+ * @param {{ prefix?: string }} [options]
+ * @returns {Promise<string>}
+ */
+export async function createTempDirAsync(options = {}) {
+  const { prefix = DEFAULT_PREFIX } = options;
+  return mkdtemp(join(tmpdir(), prefix));
+}
+
+/**
+ * 一時ディレクトリを削除する（存在しなくてもエラーにしない）。
+ * @param {string} dir
+ */
+export function cleanupTempDir(dir) {
+  if (!dir) return;
+  rmSync(dir, { recursive: true, force: true });
+}
+
+/**
+ * 非同期版の cleanup。
+ * @param {string} dir
+ */
+export async function cleanupTempDirAsync(dir) {
+  if (!dir) return;
+  await rm(dir, { recursive: true, force: true });
+}
+
+/**
+ * callback スコープで一時ディレクトリを提供し、終了時に自動で削除する。
+ * callback が throw しても cleanup は実行される。
+ *
+ * @template T
+ * @param {(dir: string) => T | Promise<T>} fn
+ * @param {{ prefix?: string }} [options]
+ * @returns {Promise<T>}
+ */
+export async function withTempDir(fn, options = {}) {
+  const dir = await createTempDirAsync(options);
+  try {
+    return await fn(dir);
+  } finally {
+    await cleanupTempDirAsync(dir);
+  }
+}

--- a/tests/helpers/temp-repo.mjs
+++ b/tests/helpers/temp-repo.mjs
@@ -59,37 +59,38 @@ export function writeFileRelative(rootDir, relPath, content) {
  * @returns {Promise<{ dir: string, cleanup: () => Promise<void> }>}
  */
 export async function createTempGitRepo(options = {}) {
-  const {
-    initialFiles,
-    changedFiles,
-    rules,
-    branch = 'main',
-    prefix = 'river-repo-',
-  } = options;
+  const { initialFiles, changedFiles, rules, branch = 'main', prefix = 'river-repo-' } = options;
 
   const dir = createTempDir({ prefix });
-  await runGit(['init', '-b', branch], dir);
-  await runGit(['config', 'user.email', 'test@example.com'], dir);
-  await runGit(['config', 'user.name', 'River Tester'], dir);
+  // セットアップ中に失敗したときは一時ディレクトリをリークさせないよう、
+  // 個別のエラーをキャッチして cleanup を実行してから再 throw する。
+  try {
+    await runGit(['init', '-b', branch], dir);
+    await runGit(['config', 'user.email', 'test@example.com'], dir);
+    await runGit(['config', 'user.name', 'River Tester'], dir);
 
-  if (initialFiles && Object.keys(initialFiles).length > 0) {
-    for (const [relPath, content] of Object.entries(initialFiles)) {
-      writeFileRelative(dir, relPath, content);
+    if (initialFiles && Object.keys(initialFiles).length > 0) {
+      for (const [relPath, content] of Object.entries(initialFiles)) {
+        writeFileRelative(dir, relPath, content);
+      }
+      await runGit(['add', '.'], dir);
+      await runGit(['commit', '-m', 'init'], dir);
+    } else {
+      await runGit(['commit', '--allow-empty', '-m', 'init'], dir);
     }
-    await runGit(['add', '.'], dir);
-    await runGit(['commit', '-m', 'init'], dir);
-  } else {
-    await runGit(['commit', '--allow-empty', '-m', 'init'], dir);
-  }
 
-  if (changedFiles) {
-    for (const [relPath, content] of Object.entries(changedFiles)) {
-      writeFileRelative(dir, relPath, content);
+    if (changedFiles) {
+      for (const [relPath, content] of Object.entries(changedFiles)) {
+        writeFileRelative(dir, relPath, content);
+      }
     }
-  }
 
-  if (typeof rules === 'string') {
-    writeFileRelative(dir, '.river/rules.md', rules);
+    if (typeof rules === 'string') {
+      writeFileRelative(dir, '.river/rules.md', rules);
+    }
+  } catch (error) {
+    await cleanupTempDirAsync(dir);
+    throw error;
   }
 
   const cleanup = () => cleanupTempDirAsync(dir);

--- a/tests/helpers/temp-repo.mjs
+++ b/tests/helpers/temp-repo.mjs
@@ -1,0 +1,124 @@
+// tests/helpers/temp-repo.mjs
+//
+// git リポジトリ付き一時ディレクトリの生成ヘルパー。
+// cli.test.mjs / integration/local-review.test.mjs で
+// createRepoWithChange / setupRepoWithDiff が独自実装されていたのを統合する。
+//
+// 典型的な利用例:
+//   const { dir, cleanup } = await createTempGitRepo({ files: {...}, rules: '...' });
+//   t.after(cleanup);
+
+import { execFile } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { promisify } from 'node:util';
+
+import { createTempDir, cleanupTempDirAsync } from './temp-dir.mjs';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * 指定ディレクトリで git コマンドを実行する。
+ * @param {string[]} args
+ * @param {string} cwd
+ */
+export async function runGit(args, cwd) {
+  return execFileAsync('git', args, { cwd });
+}
+
+/**
+ * 指定ディレクトリの相対パスにファイルを書き込む（必要に応じて親を作成）。
+ * @param {string} rootDir
+ * @param {string} relPath
+ * @param {string} content
+ */
+export function writeFileRelative(rootDir, relPath, content) {
+  const abs = join(rootDir, relPath);
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(abs, content);
+}
+
+/**
+ * git 初期化済みの一時リポジトリを生成する。
+ *
+ * オプション:
+ * - initialFiles: 初期コミット時点で存在させたいファイル群（{ relPath: content }）
+ * - changedFiles: 初期コミット後に適用する（unstaged な）変更群
+ * - rules: .river/rules.md に書き込む内容（指定時のみ作成）
+ * - commitInitial: 初期 empty commit を使うか（デフォルト false、initialFiles を使う場合 true 強制）
+ * - branch: 初期ブランチ名（デフォルト 'main'）
+ * - prefix: 一時ディレクトリ名の prefix
+ *
+ * @param {{
+ *   initialFiles?: Record<string,string>,
+ *   changedFiles?: Record<string,string>,
+ *   rules?: string,
+ *   branch?: string,
+ *   prefix?: string,
+ * }} [options]
+ * @returns {Promise<{ dir: string, cleanup: () => Promise<void> }>}
+ */
+export async function createTempGitRepo(options = {}) {
+  const {
+    initialFiles,
+    changedFiles,
+    rules,
+    branch = 'main',
+    prefix = 'river-repo-',
+  } = options;
+
+  const dir = createTempDir({ prefix });
+  await runGit(['init', '-b', branch], dir);
+  await runGit(['config', 'user.email', 'test@example.com'], dir);
+  await runGit(['config', 'user.name', 'River Tester'], dir);
+
+  if (initialFiles && Object.keys(initialFiles).length > 0) {
+    for (const [relPath, content] of Object.entries(initialFiles)) {
+      writeFileRelative(dir, relPath, content);
+    }
+    await runGit(['add', '.'], dir);
+    await runGit(['commit', '-m', 'init'], dir);
+  } else {
+    await runGit(['commit', '--allow-empty', '-m', 'init'], dir);
+  }
+
+  if (changedFiles) {
+    for (const [relPath, content] of Object.entries(changedFiles)) {
+      writeFileRelative(dir, relPath, content);
+    }
+  }
+
+  if (typeof rules === 'string') {
+    writeFileRelative(dir, '.river/rules.md', rules);
+  }
+
+  const cleanup = () => cleanupTempDirAsync(dir);
+  return { dir, cleanup };
+}
+
+/**
+ * cli.test.mjs で使われていた「silent catch を含む変更」を再現するビルダー。
+ * 既存テストの細部を壊さないよう、ファイル構造を保つ。
+ *
+ * @param {{ prefix?: string }} [options]
+ * @returns {Promise<{ dir: string, cleanup: () => Promise<void>, appPath: string }>}
+ */
+export async function createRepoWithSilentCatchChange(options = {}) {
+  const { prefix = 'river-cli-' } = options;
+  const { dir, cleanup } = await createTempGitRepo({
+    prefix,
+    initialFiles: { 'src/app.js': 'export const value = 1;\n' },
+    changedFiles: {
+      'src/app.js': `export const value = 2;
+export function test() {
+  try {
+    run();
+  } catch(e) {
+    return;
+  }
+}
+`,
+    },
+  });
+  return { dir, cleanup, appPath: join(dir, 'src', 'app.js') };
+}

--- a/tests/integration/local-review.test.mjs
+++ b/tests/integration/local-review.test.mjs
@@ -1,6 +1,5 @@
 import assert from 'node:assert';
 import fs from 'node:fs';
-import { mkdir } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import test from 'node:test';
 
@@ -17,18 +16,19 @@ async function applySampleDiff(repoDir) {
     .filter((line) => line.startsWith('+') && !line.startsWith('+++'))
     .map((line) => line.slice(1));
   const targetPath = join(repoDir, 'src', 'utils');
-  await mkdir(targetPath, { recursive: true });
+  await fs.promises.mkdir(targetPath, { recursive: true });
   await fs.promises.writeFile(join(targetPath, 'math.ts'), `${lines.join('\n')}\n`, 'utf8');
 }
 
 async function setupRepoWithDiff() {
-  const { dir, cleanup } = await createTempGitRepo({ prefix: 'river-int-' });
+  const rulesText = await fs.promises.readFile(SAMPLE_RULES, 'utf8');
+  const { dir, cleanup } = await createTempGitRepo({
+    prefix: 'river-int-',
+    rules: rulesText,
+  });
   await applySampleDiff(dir);
   // 新規ファイルは git add しないと diff に現れないため明示的にステージする
   await runGit(['add', '.'], dir);
-  const rulesDir = join(dir, '.river');
-  await mkdir(rulesDir, { recursive: true });
-  await fs.promises.copyFile(SAMPLE_RULES, join(rulesDir, 'rules.md'));
   return { dir, cleanup };
 }
 

--- a/tests/integration/local-review.test.mjs
+++ b/tests/integration/local-review.test.mjs
@@ -1,109 +1,80 @@
 import assert from 'node:assert';
-import { execFile } from 'node:child_process';
 import fs from 'node:fs';
-import { mkdir, rm } from 'node:fs/promises';
-import { mkdtempSync } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
-import { tmpdir } from 'node:os';
-import { promisify } from 'node:util';
 import test from 'node:test';
 
-const execFileAsync = promisify(execFile);
-const CLI_PATH = resolve('src/cli.mjs');
+import { runCliInProcess } from '../helpers/cli.mjs';
+import { createTempGitRepo, runGit } from '../helpers/temp-repo.mjs';
+
 const SAMPLE_DIFF = resolve('tests/fixtures/sample-diff.txt');
 const SAMPLE_RULES = resolve('tests/fixtures/.river/rules.md');
-
-async function runCli(args, cwd) {
-  try {
-    const { stdout, stderr } = await execFileAsync('node', [CLI_PATH, ...args], { cwd });
-    return { code: 0, stdout: stdout.toString(), stderr: stderr?.toString() ?? '' };
-  } catch (error) {
-    return {
-      code: error.code ?? 1,
-      stdout: error.stdout?.toString() ?? '',
-      stderr: error.stderr?.toString() ?? '',
-    };
-  }
-}
-
-async function runGit(args, cwd) {
-  return execFileAsync('git', args, { cwd });
-}
 
 async function applySampleDiff(repoDir) {
   const raw = await fs.promises.readFile(SAMPLE_DIFF, 'utf8');
   const lines = raw
     .split('\n')
-    .filter(line => line.startsWith('+') && !line.startsWith('+++'))
-    .map(line => line.slice(1));
+    .filter((line) => line.startsWith('+') && !line.startsWith('+++'))
+    .map((line) => line.slice(1));
   const targetPath = join(repoDir, 'src', 'utils');
   await mkdir(targetPath, { recursive: true });
   await fs.promises.writeFile(join(targetPath, 'math.ts'), `${lines.join('\n')}\n`, 'utf8');
 }
 
 async function setupRepoWithDiff() {
-  const dir = mkdtempSync(join(tmpdir(), 'river-int-'));
-  await runGit(['init', '-b', 'main'], dir);
-  await runGit(['config', 'user.email', 'integration@example.com'], dir);
-  await runGit(['config', 'user.name', 'Integration Tester'], dir);
-  await runGit(['commit', '--allow-empty', '-m', 'init'], dir);
+  const { dir, cleanup } = await createTempGitRepo({ prefix: 'river-int-' });
   await applySampleDiff(dir);
+  // 新規ファイルは git add しないと diff に現れないため明示的にステージする
   await runGit(['add', '.'], dir);
   const rulesDir = join(dir, '.river');
   await mkdir(rulesDir, { recursive: true });
   await fs.promises.copyFile(SAMPLE_RULES, join(rulesDir, 'rules.md'));
-  return dir;
+  return { dir, cleanup };
 }
 
-test('runs dry-run review with sample diff and project rules', async () => {
-  const dir = await setupRepoWithDiff();
-  try {
-    const result = await runCli(['run', '.', '--dry-run', '--debug'], dir);
+test('runs dry-run review with sample diff and project rules', async (t) => {
+  const { dir, cleanup } = await setupRepoWithDiff();
+  t.after(cleanup);
 
-    assert.strictEqual(result.code, 0, result.stderr);
-    assert.match(result.stdout, /River Reviewer/);
-    assert.match(result.stdout, /Project rules: present/);
-    assert.match(result.stdout, /src\/utils\/math.ts/);
-    assert.match(result.stdout, /Review comments/);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
+  const result = await runCliInProcess(['run', '.', '--dry-run', '--debug'], { cwd: dir });
+
+  assert.strictEqual(result.code, 0, result.stderr);
+  assert.match(result.stdout, /River Reviewer/);
+  assert.match(result.stdout, /Project rules: present/);
+  assert.match(result.stdout, /src\/utils\/math.ts/);
+  assert.match(result.stdout, /Review comments/);
 });
 
-test('respects phase flag in integration run', async () => {
-  const dir = await setupRepoWithDiff();
-  try {
-    const result = await runCli(['run', '.', '--phase', 'downstream', '--dry-run'], dir);
-    assert.strictEqual(result.code, 0, result.stderr);
-    assert.match(result.stdout, /Phase: downstream/);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
+test('respects phase flag in integration run', async (t) => {
+  const { dir, cleanup } = await setupRepoWithDiff();
+  t.after(cleanup);
+
+  const result = await runCliInProcess(['run', '.', '--phase', 'downstream', '--dry-run'], {
+    cwd: dir,
+  });
+  assert.strictEqual(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Phase: downstream/);
 });
 
-test('debug output shows token estimation and reduction', async () => {
-  const dir = await setupRepoWithDiff();
-  try {
-    const result = await runCli(['run', '.', '--dry-run', '--debug'], dir);
-    assert.strictEqual(result.code, 0, result.stderr);
-    assert.match(result.stdout, /Token estimate/);
-    assert.match(result.stdout, /Changed files/);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
+test('debug output shows token estimation and reduction', async (t) => {
+  const { dir, cleanup } = await setupRepoWithDiff();
+  t.after(cleanup);
+
+  const result = await runCliInProcess(['run', '.', '--dry-run', '--debug'], { cwd: dir });
+  assert.strictEqual(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Token estimate/);
+  assert.match(result.stdout, /Changed files/);
 });
 
-test('fails clearly when project rules cannot be read', async () => {
-  const dir = await setupRepoWithDiff();
-  try {
-    const rulesPath = join(dir, '.river', 'rules.md');
-    await fs.promises.rm(rulesPath, { force: true });
-    await fs.promises.mkdir(rulesPath, { recursive: true });
-    const result = await runCli(['run', '.'], dir);
+test('fails clearly when project rules cannot be read', async (t) => {
+  const { dir, cleanup } = await setupRepoWithDiff();
+  t.after(cleanup);
 
-    assert.notStrictEqual(result.code, 0);
-    assert.match(result.stderr, /Failed to read project rules/);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
+  const rulesPath = join(dir, '.river', 'rules.md');
+  await fs.promises.rm(rulesPath, { force: true });
+  await fs.promises.mkdir(rulesPath, { recursive: true });
+
+  const result = await runCliInProcess(['run', '.'], { cwd: dir });
+  assert.notStrictEqual(result.code, 0);
+  assert.match(result.stderr, /Failed to read project rules/);
 });

--- a/tests/memory-context.test.mjs
+++ b/tests/memory-context.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import test from 'node:test';
 
@@ -9,28 +9,20 @@ import {
   buildReviewEntry,
 } from '../src/lib/memory-context.mjs';
 import { createTempDir, cleanupTempDir } from './helpers/temp-dir.mjs';
-import { makeMemoryEntry } from './helpers/memory.mjs';
-
-function tempCtxDir() {
-  return createTempDir({ prefix: 'river-mem-ctx-' });
-}
+import { makeMemoryEntry as makeEntry, writeMemoryIndex } from './helpers/memory.mjs';
 
 // memory-context.mjs は <repoRoot>/.river/memory/index.json を期待するため、
-// 既存ディレクトリ直下に nested layout を書き込む専用ヘルパーを使う。
-// helpers/memory.mjs の createTempMemory は自前で新しい一時ディレクトリを
-// 作るので、ここでは直接 fs で作成する。
+// createTempDir が作成した既存の一時ディレクトリ直下に nested layout を
+// 書き込む必要がある。createTempMemory は新しい一時ディレクトリを作るため、
+// ここではディレクトリ作成だけ自前で行い、ファイル書き込みは helper に委譲する。
 function writeIndexSync(dir, entries) {
   const memDir = join(dir, '.river', 'memory');
   mkdirSync(memDir, { recursive: true });
-  writeFileSync(join(memDir, 'index.json'), JSON.stringify({ entries, version: '1' }, null, 2));
-}
-
-function makeEntry(overrides = {}) {
-  return makeMemoryEntry(overrides);
+  writeMemoryIndex(join(memDir, 'index.json'), entries);
 }
 
 test('loadReviewMemory returns empty buckets when index missing', () => {
-  const dir = tempCtxDir();
+  const dir = createTempDir({ prefix: 'river-mem-ctx-' });
   try {
     const ctx = loadReviewMemory(dir);
     assert.deepEqual(ctx.entries, []);
@@ -42,7 +34,7 @@ test('loadReviewMemory returns empty buckets when index missing', () => {
 });
 
 test('loadReviewMemory buckets entries by type', () => {
-  const dir = tempCtxDir();
+  const dir = createTempDir({ prefix: 'river-mem-ctx-' });
   try {
     writeIndexSync(dir, [
       makeEntry({ id: 'w1', type: 'wontfix' }),
@@ -63,7 +55,7 @@ test('loadReviewMemory buckets entries by type', () => {
 });
 
 test('loadReviewMemory filters by phase', () => {
-  const dir = tempCtxDir();
+  const dir = createTempDir({ prefix: 'river-mem-ctx-' });
   try {
     writeIndexSync(dir, [
       makeEntry({
@@ -86,7 +78,7 @@ test('loadReviewMemory filters by phase', () => {
 });
 
 test('loadReviewMemory filters by relatedFiles overlap', () => {
-  const dir = tempCtxDir();
+  const dir = createTempDir({ prefix: 'river-mem-ctx-' });
   try {
     writeIndexSync(dir, [
       makeEntry({
@@ -117,7 +109,7 @@ test('loadReviewMemory filters by relatedFiles overlap', () => {
 });
 
 test('loadReviewMemory includes entries without relatedFiles', () => {
-  const dir = tempCtxDir();
+  const dir = createTempDir({ prefix: 'river-mem-ctx-' });
   try {
     writeIndexSync(dir, [
       makeEntry({

--- a/tests/memory-context.test.mjs
+++ b/tests/memory-context.test.mjs
@@ -1,35 +1,55 @@
 import assert from 'node:assert/strict';
-import fs from 'node:fs';
-import { mkdtempSync } from 'node:fs';
-import path from 'node:path';
-import { tmpdir } from 'node:os';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import test from 'node:test';
-import { loadReviewMemory, formatMemoryForPrompt, buildReviewEntry } from '../src/lib/memory-context.mjs';
 
-function createTempDir() { return mkdtempSync(path.join(tmpdir(), 'river-mem-ctx-')); }
-function writeIndex(dir, entries) {
-  const memDir = path.join(dir, '.river', 'memory');
-  fs.mkdirSync(memDir, { recursive: true });
-  fs.writeFileSync(path.join(memDir, 'index.json'), JSON.stringify({ entries, version: '1' }, null, 2));
+import {
+  loadReviewMemory,
+  formatMemoryForPrompt,
+  buildReviewEntry,
+} from '../src/lib/memory-context.mjs';
+import { createTempDir, cleanupTempDir } from './helpers/temp-dir.mjs';
+import { makeMemoryEntry } from './helpers/memory.mjs';
+
+function tempCtxDir() {
+  return createTempDir({ prefix: 'river-mem-ctx-' });
 }
+
+// memory-context.mjs は <repoRoot>/.river/memory/index.json を期待するため、
+// 既存ディレクトリ直下に nested layout を書き込む専用ヘルパーを使う。
+// helpers/memory.mjs の createTempMemory は自前で新しい一時ディレクトリを
+// 作るので、ここでは直接 fs で作成する。
+function writeIndexSync(dir, entries) {
+  const memDir = join(dir, '.river', 'memory');
+  mkdirSync(memDir, { recursive: true });
+  writeFileSync(join(memDir, 'index.json'), JSON.stringify({ entries, version: '1' }, null, 2));
+}
+
 function makeEntry(overrides = {}) {
-  return { id: 'test-' + Date.now() + '-' + Math.random().toString(36).slice(2,6), type: 'review', content: 'test', metadata: { createdAt: new Date().toISOString(), author: 'test' }, ...overrides };
+  return makeMemoryEntry(overrides);
 }
 
 test('loadReviewMemory returns empty buckets when index missing', () => {
-  const dir = createTempDir();
+  const dir = tempCtxDir();
   try {
     const ctx = loadReviewMemory(dir);
     assert.deepEqual(ctx.entries, []);
     assert.deepEqual(ctx.wontfixes, []);
     assert.deepEqual(ctx.patterns, []);
-  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+  } finally {
+    cleanupTempDir(dir);
+  }
 });
 
 test('loadReviewMemory buckets entries by type', () => {
-  const dir = createTempDir();
+  const dir = tempCtxDir();
   try {
-    writeIndex(dir, [makeEntry({id:'w1',type:'wontfix'}), makeEntry({id:'p1',type:'pattern'}), makeEntry({id:'d1',type:'decision'}), makeEntry({id:'r1',type:'review'})]);
+    writeIndexSync(dir, [
+      makeEntry({ id: 'w1', type: 'wontfix' }),
+      makeEntry({ id: 'p1', type: 'pattern' }),
+      makeEntry({ id: 'd1', type: 'decision' }),
+      makeEntry({ id: 'r1', type: 'review' }),
+    ]);
     const ctx = loadReviewMemory(dir);
     assert.equal(ctx.entries.length, 4);
     assert.equal(ctx.wontfixes.length, 1);
@@ -37,50 +57,104 @@ test('loadReviewMemory buckets entries by type', () => {
     assert.equal(ctx.decisions.length, 1);
     assert.equal(ctx.reviews.length, 1);
     assert.equal(ctx.suppressions.length, 0);
-  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+  } finally {
+    cleanupTempDir(dir);
+  }
 });
 
 test('loadReviewMemory filters by phase', () => {
-  const dir = createTempDir();
+  const dir = tempCtxDir();
   try {
-    writeIndex(dir, [
-      makeEntry({id:'u1',type:'pattern',metadata:{createdAt:'2026-01-01T00:00:00Z',author:'t',phase:'upstream'}}),
-      makeEntry({id:'m1',type:'pattern',metadata:{createdAt:'2026-01-01T00:00:00Z',author:'t',phase:'midstream'}}),
+    writeIndexSync(dir, [
+      makeEntry({
+        id: 'u1',
+        type: 'pattern',
+        metadata: { createdAt: '2026-01-01T00:00:00Z', author: 't', phase: 'upstream' },
+      }),
+      makeEntry({
+        id: 'm1',
+        type: 'pattern',
+        metadata: { createdAt: '2026-01-01T00:00:00Z', author: 't', phase: 'midstream' },
+      }),
     ]);
     const ctx = loadReviewMemory(dir, { phase: 'midstream' });
     assert.equal(ctx.entries.length, 1);
     assert.equal(ctx.entries[0].id, 'm1');
-  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+  } finally {
+    cleanupTempDir(dir);
+  }
 });
 
 test('loadReviewMemory filters by relatedFiles overlap', () => {
-  const dir = createTempDir();
+  const dir = tempCtxDir();
   try {
-    writeIndex(dir, [
-      makeEntry({id:'a1',type:'wontfix',metadata:{createdAt:'2026-01-01T00:00:00Z',author:'t',relatedFiles:['src/auth.ts']}}),
-      makeEntry({id:'b1',type:'wontfix',metadata:{createdAt:'2026-01-01T00:00:00Z',author:'t',relatedFiles:['src/billing.ts']}}),
+    writeIndexSync(dir, [
+      makeEntry({
+        id: 'a1',
+        type: 'wontfix',
+        metadata: {
+          createdAt: '2026-01-01T00:00:00Z',
+          author: 't',
+          relatedFiles: ['src/auth.ts'],
+        },
+      }),
+      makeEntry({
+        id: 'b1',
+        type: 'wontfix',
+        metadata: {
+          createdAt: '2026-01-01T00:00:00Z',
+          author: 't',
+          relatedFiles: ['src/billing.ts'],
+        },
+      }),
     ]);
     const ctx = loadReviewMemory(dir, { changedFiles: ['src/auth.ts'] });
     assert.equal(ctx.wontfixes.length, 1);
     assert.equal(ctx.wontfixes[0].id, 'a1');
-  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+  } finally {
+    cleanupTempDir(dir);
+  }
 });
 
 test('loadReviewMemory includes entries without relatedFiles', () => {
-  const dir = createTempDir();
+  const dir = tempCtxDir();
   try {
-    writeIndex(dir, [
-      makeEntry({id:'nr1',type:'pattern',metadata:{createdAt:'2026-01-01T00:00:00Z',author:'t'}}),
-      makeEntry({id:'r1',type:'pattern',metadata:{createdAt:'2026-01-01T00:00:00Z',author:'t',relatedFiles:['unrelated.ts']}}),
+    writeIndexSync(dir, [
+      makeEntry({
+        id: 'nr1',
+        type: 'pattern',
+        metadata: { createdAt: '2026-01-01T00:00:00Z', author: 't' },
+      }),
+      makeEntry({
+        id: 'r1',
+        type: 'pattern',
+        metadata: {
+          createdAt: '2026-01-01T00:00:00Z',
+          author: 't',
+          relatedFiles: ['unrelated.ts'],
+        },
+      }),
     ]);
     const ctx = loadReviewMemory(dir, { changedFiles: ['src/app.ts'] });
     assert.equal(ctx.patterns.length, 1);
     assert.equal(ctx.patterns[0].id, 'nr1');
-  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+  } finally {
+    cleanupTempDir(dir);
+  }
 });
 
 test('formatMemoryForPrompt returns empty string for empty context', () => {
-  assert.equal(formatMemoryForPrompt({ entries:[], wontfixes:[], patterns:[], decisions:[], reviews:[], suppressions:[] }), '');
+  assert.equal(
+    formatMemoryForPrompt({
+      entries: [],
+      wontfixes: [],
+      patterns: [],
+      decisions: [],
+      reviews: [],
+      suppressions: [],
+    }),
+    ''
+  );
 });
 
 test('formatMemoryForPrompt returns empty string for null', () => {
@@ -88,26 +162,45 @@ test('formatMemoryForPrompt returns empty string for null', () => {
 });
 
 test('formatMemoryForPrompt formats wontfix entries', () => {
-  const text = formatMemoryForPrompt({ wontfixes:[{id:'wf1',title:'Accepted logging',content:''}], patterns:[], decisions:[] });
+  const text = formatMemoryForPrompt({
+    wontfixes: [{ id: 'wf1', title: 'Accepted logging', content: '' }],
+    patterns: [],
+    decisions: [],
+  });
   assert.ok(text.includes('受け入れ済み'));
   assert.ok(text.includes('wf1'));
 });
 
 test('formatMemoryForPrompt formats pattern entries', () => {
-  const text = formatMemoryForPrompt({ wontfixes:[], patterns:[{id:'p1',title:'Use pure functions',content:''}], decisions:[] });
+  const text = formatMemoryForPrompt({
+    wontfixes: [],
+    patterns: [{ id: 'p1', title: 'Use pure functions', content: '' }],
+    decisions: [],
+  });
   assert.ok(text.includes('チーム規約'));
   assert.ok(text.includes('Use pure functions'));
 });
 
 test('formatMemoryForPrompt truncates to maxChars', () => {
-  const ctx = { wontfixes: Array.from({length:50},(_,i)=>({id:'wf'+i,title:'Long entry '+i+' padding text here',content:''})), patterns:[], decisions:[] };
+  const ctx = {
+    wontfixes: Array.from({ length: 50 }, (_, i) => ({
+      id: 'wf' + i,
+      title: 'Long entry ' + i + ' padding text here',
+      content: '',
+    })),
+    patterns: [],
+    decisions: [],
+  };
   const text = formatMemoryForPrompt(ctx, { maxChars: 200 });
   assert.ok(text.length <= 215);
   assert.ok(text.includes('[truncated]'));
 });
 
 test('buildReviewEntry returns valid entry structure', () => {
-  const entry = buildReviewEntry({ comments:[{file:'a.ts',line:1,message:'test'}] }, { phase:'midstream', changedFiles:['a.ts'], commit:'abc123' });
+  const entry = buildReviewEntry(
+    { comments: [{ file: 'a.ts', line: 1, message: 'test' }] },
+    { phase: 'midstream', changedFiles: ['a.ts'], commit: 'abc123' }
+  );
   assert.equal(entry.type, 'review');
   assert.ok(entry.id.startsWith('review-abc123-'));
   assert.equal(entry.metadata.author, 'river-reviewer');
@@ -116,6 +209,6 @@ test('buildReviewEntry returns valid entry structure', () => {
 });
 
 test('buildReviewEntry uses unknown when no commit', () => {
-  const entry = buildReviewEntry({ comments:[] }, {});
+  const entry = buildReviewEntry({ comments: [] }, {});
   assert.ok(entry.id.startsWith('review-unknown-'));
 });

--- a/tests/riverbed-memory.test.mjs
+++ b/tests/riverbed-memory.test.mjs
@@ -9,19 +9,9 @@ import {
   supersede,
   expireEntries,
 } from '../src/lib/riverbed-memory.mjs';
-import { createTempMemory, makeMemoryEntry } from './helpers/memory.mjs';
+import { createTempMemory, makeMemoryEntry as makeEntry } from './helpers/memory.mjs';
 
-function tmpIndex() {
-  const { dir, indexPath, cleanup } = createTempMemory({
-    layout: 'flat',
-    prefix: 'rr-memory-',
-  });
-  return { dir, indexPath, cleanup };
-}
-
-function makeEntry(overrides = {}) {
-  return makeMemoryEntry(overrides);
-}
+const tmpIndex = () => createTempMemory({ layout: 'flat', prefix: 'rr-memory-' });
 
 test('loadMemory: returns empty structure for missing file', () => {
   const { cleanup, indexPath } = tmpIndex();

--- a/tests/riverbed-memory.test.mjs
+++ b/tests/riverbed-memory.test.mjs
@@ -1,7 +1,5 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
 import test from 'node:test';
 
 import {
@@ -11,64 +9,73 @@ import {
   supersede,
   expireEntries,
 } from '../src/lib/riverbed-memory.mjs';
+import { createTempMemory, makeMemoryEntry } from './helpers/memory.mjs';
 
 function tmpIndex() {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rr-memory-'));
-  return { dir, indexPath: path.join(dir, 'index.json') };
-}
-
-function cleanup(dir) {
-  fs.rmSync(dir, { recursive: true });
+  const { dir, indexPath, cleanup } = createTempMemory({
+    layout: 'flat',
+    prefix: 'rr-memory-',
+  });
+  return { dir, indexPath, cleanup };
 }
 
 function makeEntry(overrides = {}) {
-  return {
-    id: `test-${Date.now()}`,
-    type: 'review',
-    content: 'Test content',
-    metadata: { createdAt: new Date().toISOString(), author: 'test' },
-    ...overrides,
-  };
+  return makeMemoryEntry(overrides);
 }
 
 test('loadMemory: returns empty structure for missing file', () => {
-  const { dir, indexPath } = tmpIndex();
-  const mem = loadMemory(indexPath);
-  assert.deepEqual(mem.entries, []);
-  assert.equal(mem.version, '1');
-  cleanup(dir);
+  const { cleanup, indexPath } = tmpIndex();
+  try {
+    const mem = loadMemory(indexPath);
+    assert.deepEqual(mem.entries, []);
+    assert.equal(mem.version, '1');
+  } finally {
+    cleanup();
+  }
 });
 
 test('loadMemory: reads existing index', () => {
-  const { dir, indexPath } = tmpIndex();
-  const data = { entries: [makeEntry()], version: '1' };
-  fs.writeFileSync(indexPath, JSON.stringify(data));
-  const mem = loadMemory(indexPath);
-  assert.equal(mem.entries.length, 1);
-  cleanup(dir);
+  const { cleanup, indexPath } = tmpIndex();
+  try {
+    const data = { entries: [makeEntry()], version: '1' };
+    fs.writeFileSync(indexPath, JSON.stringify(data));
+    const mem = loadMemory(indexPath);
+    assert.equal(mem.entries.length, 1);
+  } finally {
+    cleanup();
+  }
 });
 
 test('appendEntry: creates file and adds entry', () => {
-  const { dir, indexPath } = tmpIndex();
-  const entry = makeEntry({ id: 'e1' });
-  appendEntry(indexPath, entry);
-  const mem = loadMemory(indexPath);
-  assert.equal(mem.entries.length, 1);
-  assert.equal(mem.entries[0].id, 'e1');
-  cleanup(dir);
+  const { cleanup, indexPath } = tmpIndex();
+  try {
+    const entry = makeEntry({ id: 'e1' });
+    appendEntry(indexPath, entry);
+    const mem = loadMemory(indexPath);
+    assert.equal(mem.entries.length, 1);
+    assert.equal(mem.entries[0].id, 'e1');
+  } finally {
+    cleanup();
+  }
 });
 
 test('appendEntry: rejects duplicate ID', () => {
-  const { dir, indexPath } = tmpIndex();
-  appendEntry(indexPath, makeEntry({ id: 'dup' }));
-  assert.throws(() => appendEntry(indexPath, makeEntry({ id: 'dup' })), /Duplicate/);
-  cleanup(dir);
+  const { cleanup, indexPath } = tmpIndex();
+  try {
+    appendEntry(indexPath, makeEntry({ id: 'dup' }));
+    assert.throws(() => appendEntry(indexPath, makeEntry({ id: 'dup' })), /Duplicate/);
+  } finally {
+    cleanup();
+  }
 });
 
 test('appendEntry: rejects entry without required fields', () => {
-  const { dir, indexPath } = tmpIndex();
-  assert.throws(() => appendEntry(indexPath, { id: 'x' }), /must have/);
-  cleanup(dir);
+  const { cleanup, indexPath } = tmpIndex();
+  try {
+    assert.throws(() => appendEntry(indexPath, { id: 'x' }), /must have/);
+  } finally {
+    cleanup();
+  }
 });
 
 test('queryMemory: filters by type', () => {
@@ -151,35 +158,44 @@ test('queryMemory: includeInactive returns all', () => {
 });
 
 test('supersede: marks entry as superseded', () => {
-  const { dir, indexPath } = tmpIndex();
-  appendEntry(indexPath, makeEntry({ id: 'old-adr' }));
-  appendEntry(indexPath, makeEntry({ id: 'new-adr' }));
-  supersede(indexPath, 'old-adr', 'new-adr');
-  const mem = loadMemory(indexPath);
-  const old = mem.entries.find((e) => e.id === 'old-adr');
-  assert.equal(old.status, 'superseded');
-  assert.equal(old.supersededBy, 'new-adr');
-  cleanup(dir);
+  const { cleanup, indexPath } = tmpIndex();
+  try {
+    appendEntry(indexPath, makeEntry({ id: 'old-adr' }));
+    appendEntry(indexPath, makeEntry({ id: 'new-adr' }));
+    supersede(indexPath, 'old-adr', 'new-adr');
+    const mem = loadMemory(indexPath);
+    const old = mem.entries.find((e) => e.id === 'old-adr');
+    assert.equal(old.status, 'superseded');
+    assert.equal(old.supersededBy, 'new-adr');
+  } finally {
+    cleanup();
+  }
 });
 
 test('supersede: throws for unknown id', () => {
-  const { dir, indexPath } = tmpIndex();
-  appendEntry(indexPath, makeEntry({ id: 'exists' }));
-  assert.throws(() => supersede(indexPath, 'missing', 'exists'), /not found/);
-  cleanup(dir);
+  const { cleanup, indexPath } = tmpIndex();
+  try {
+    appendEntry(indexPath, makeEntry({ id: 'exists' }));
+    assert.throws(() => supersede(indexPath, 'missing', 'exists'), /not found/);
+  } finally {
+    cleanup();
+  }
 });
 
 test('expireEntries: archives expired entries', () => {
-  const { dir, indexPath } = tmpIndex();
-  const past = new Date(Date.now() - 86400000).toISOString();
-  const future = new Date(Date.now() + 86400000).toISOString();
-  appendEntry(indexPath, makeEntry({ id: 'expired', expiresAt: past }));
-  appendEntry(indexPath, makeEntry({ id: 'valid', expiresAt: future }));
-  appendEntry(indexPath, makeEntry({ id: 'no-expiry' }));
-  const count = expireEntries(indexPath);
-  assert.equal(count, 1);
-  const mem = loadMemory(indexPath);
-  assert.equal(mem.entries.find((e) => e.id === 'expired').status, 'archived');
-  assert.equal(mem.entries.find((e) => e.id === 'valid').status, undefined);
-  cleanup(dir);
+  const { cleanup, indexPath } = tmpIndex();
+  try {
+    const past = new Date(Date.now() - 86400000).toISOString();
+    const future = new Date(Date.now() + 86400000).toISOString();
+    appendEntry(indexPath, makeEntry({ id: 'expired', expiresAt: past }));
+    appendEntry(indexPath, makeEntry({ id: 'valid', expiresAt: future }));
+    appendEntry(indexPath, makeEntry({ id: 'no-expiry' }));
+    const count = expireEntries(indexPath);
+    assert.equal(count, 1);
+    const mem = loadMemory(indexPath);
+    assert.equal(mem.entries.find((e) => e.id === 'expired').status, 'archived');
+    assert.equal(mem.entries.find((e) => e.id === 'valid').status, undefined);
+  } finally {
+    cleanup();
+  }
 });

--- a/tests/rules.test.mjs
+++ b/tests/rules.test.mjs
@@ -1,53 +1,48 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, writeFileSync } from 'node:fs';
-import { mkdir, rm } from 'node:fs/promises';
+import { writeFileSync } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
 import path from 'node:path';
-import { tmpdir } from 'node:os';
 import test from 'node:test';
 import { loadProjectRules } from '../src/lib/rules.mjs';
-
-function createTempRepoDir() {
-  return mkdtempSync(path.join(tmpdir(), 'river-rules-'));
-}
+import { withTempDir } from './helpers/temp-dir.mjs';
 
 test('loadProjectRules returns null when rules file is absent', async () => {
-  const dir = createTempRepoDir();
-  try {
-    const { rulesText } = await loadProjectRules(dir);
-    assert.equal(rulesText, null);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
+  await withTempDir(
+    async (dir) => {
+      const { rulesText } = await loadProjectRules(dir);
+      assert.equal(rulesText, null);
+    },
+    { prefix: 'river-rules-' }
+  );
 });
 
 test('loadProjectRules loads content when rules file exists', async () => {
-  const dir = createTempRepoDir();
-  const rulesDir = path.join(dir, '.river');
-  await rm(rulesDir, { recursive: true, force: true }).catch(() => {});
-  await mkdir(rulesDir, { recursive: true });
-  const rulesPath = path.join(rulesDir, 'rules.md');
-  writeFileSync(rulesPath, '- Follow project guide');
+  await withTempDir(
+    async (dir) => {
+      const rulesDir = path.join(dir, '.river');
+      await mkdir(rulesDir, { recursive: true });
+      const rulesPath = path.join(rulesDir, 'rules.md');
+      writeFileSync(rulesPath, '- Follow project guide');
 
-  try {
-    const { rulesText, path: resolvedPath } = await loadProjectRules(dir);
-    assert.equal(rulesText, '- Follow project guide');
-    assert.equal(resolvedPath, rulesPath);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
+      const { rulesText, path: resolvedPath } = await loadProjectRules(dir);
+      assert.equal(rulesText, '- Follow project guide');
+      assert.equal(resolvedPath, rulesPath);
+    },
+    { prefix: 'river-rules-' }
+  );
 });
 
 test('loadProjectRules returns null when rules file is empty or whitespace', async () => {
-  const dir = createTempRepoDir();
-  const rulesDir = path.join(dir, '.river');
-  await mkdir(rulesDir, { recursive: true });
-  const rulesPath = path.join(rulesDir, 'rules.md');
-  writeFileSync(rulesPath, '   \n  ');
+  await withTempDir(
+    async (dir) => {
+      const rulesDir = path.join(dir, '.river');
+      await mkdir(rulesDir, { recursive: true });
+      const rulesPath = path.join(rulesDir, 'rules.md');
+      writeFileSync(rulesPath, '   \n  ');
 
-  try {
-    const { rulesText } = await loadProjectRules(dir);
-    assert.equal(rulesText, null);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
+      const { rulesText } = await loadProjectRules(dir);
+      assert.equal(rulesText, null);
+    },
+    { prefix: 'river-rules-' }
+  );
 });

--- a/tests/skill-loader.test.mjs
+++ b/tests/skill-loader.test.mjs
@@ -9,19 +9,17 @@ import {
   loadSkillFile,
   loadSkills,
 } from '../runners/core/skill-loader.mjs';
-import { withTempDir as sharedWithTempDir, createTempDirAsync } from './helpers/temp-dir.mjs';
+import { withTempDir, createTempDirAsync } from './helpers/temp-dir.mjs';
+
+const TMP_PREFIX = 'skill-loader-';
 
 async function buildValidator(schemaPath = defaultPaths.schemaPath) {
   const schema = await loadSchema(schemaPath);
   return createSkillValidator(schema);
 }
 
-// skill-loader テスト専用の prefix 付きラッパー
-function withTempDir(fn) {
-  return sharedWithTempDir(fn, { prefix: 'skill-loader-' });
-}
 async function createTempSkillDir() {
-  return createTempDirAsync({ prefix: 'skill-loader-' });
+  return createTempDirAsync({ prefix: TMP_PREFIX });
 }
 
 test('loads existing sample skill and applies default outputKind', async () => {

--- a/tests/skill-loader.test.mjs
+++ b/tests/skill-loader.test.mjs
@@ -1,7 +1,6 @@
 import assert from 'node:assert/strict';
-import os from 'node:os';
 import path from 'node:path';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { writeFile } from 'node:fs/promises';
 import test from 'node:test';
 import {
   createSkillValidator,
@@ -10,19 +9,19 @@ import {
   loadSkillFile,
   loadSkills,
 } from '../runners/core/skill-loader.mjs';
+import { withTempDir as sharedWithTempDir, createTempDirAsync } from './helpers/temp-dir.mjs';
 
 async function buildValidator(schemaPath = defaultPaths.schemaPath) {
   const schema = await loadSchema(schemaPath);
   return createSkillValidator(schema);
 }
 
-async function withTempDir(fn) {
-  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'skill-loader-'));
-  try {
-    return await fn(tmpDir);
-  } finally {
-    await rm(tmpDir, { recursive: true, force: true });
-  }
+// skill-loader テスト専用の prefix 付きラッパー
+function withTempDir(fn) {
+  return sharedWithTempDir(fn, { prefix: 'skill-loader-' });
+}
+async function createTempSkillDir() {
+  return createTempDirAsync({ prefix: 'skill-loader-' });
 }
 
 test('loads existing sample skill and applies default outputKind', async () => {
@@ -41,7 +40,7 @@ test('loads existing sample skill and applies default outputKind', async () => {
 
 test('loads skill with extended metadata fields', async () => {
   const validator = await buildValidator();
-  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'skill-loader-'));
+  const tmpDir = await createTempSkillDir();
   const skillPath = path.join(tmpDir, 'with-extensions.md');
   const content = `---
 id: rr-downstream-newmeta-001
@@ -76,7 +75,7 @@ Body content
 
 test('loads skill with trigger container and normalizes phase/applyTo', async () => {
   const validator = await buildValidator();
-  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'skill-loader-'));
+  const tmpDir = await createTempSkillDir();
   const skillPath = path.join(tmpDir, 'with-trigger.md');
   const content = `---
 id: rr-midstream-trigger-001
@@ -99,7 +98,7 @@ Body content
 
 test('trigger does not override top-level phase/applyTo', async () => {
   const validator = await buildValidator();
-  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'skill-loader-'));
+  const tmpDir = await createTempSkillDir();
   const skillPath = path.join(tmpDir, 'with-trigger-precedence.md');
   const content = `---
 id: rr-midstream-trigger-002
@@ -181,7 +180,7 @@ Body content
 
 test('fails when dependencies contain unsupported values', async () => {
   const validator = await buildValidator();
-  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'skill-loader-'));
+  const tmpDir = await createTempSkillDir();
   const skillPath = path.join(tmpDir, 'invalid-deps.md');
   const content = `---
 id: rr-upstream-invalid-deps-001
@@ -204,7 +203,7 @@ dependencies:
 
 test('fails validation when required fields are missing', async () => {
   const validator = await buildValidator();
-  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'skill-loader-'));
+  const tmpDir = await createTempSkillDir();
   const skillPath = path.join(tmpDir, 'invalid-skill.md');
   const content = `---
 id: rr-upstream-missing-applyto-001

--- a/tests/suppression.test.mjs
+++ b/tests/suppression.test.mjs
@@ -1,17 +1,17 @@
 import assert from 'node:assert/strict';
-import fs from 'node:fs';
-import { mkdtempSync } from 'node:fs';
-import path from 'node:path';
-import { tmpdir } from 'node:os';
 import test from 'node:test';
-import { hashFinding, inferSubsystem, createSuppression, revokeSuppression, findActiveSuppressions } from '../src/lib/suppression.mjs';
+import {
+  hashFinding,
+  inferSubsystem,
+  createSuppression,
+  revokeSuppression,
+  findActiveSuppressions,
+} from '../src/lib/suppression.mjs';
 import { loadMemory } from '../src/lib/riverbed-memory.mjs';
+import { createTempMemory } from './helpers/memory.mjs';
 
 function tmpIndex() {
-  const dir = mkdtempSync(path.join(tmpdir(), 'river-supp-'));
-  const memDir = path.join(dir, '.river', 'memory');
-  fs.mkdirSync(memDir, { recursive: true });
-  return { dir, indexPath: path.join(memDir, 'index.json') };
+  return createTempMemory({ layout: 'nested', prefix: 'river-supp-' });
 }
 
 test('hashFinding produces stable hash for same input', () => {
@@ -35,7 +35,7 @@ test('inferSubsystem extracts correct subsystem', () => {
 });
 
 test('createSuppression creates valid entry', () => {
-  const { dir, indexPath } = tmpIndex();
+  const { cleanup, indexPath } = tmpIndex();
   try {
     const entry = createSuppression({
       indexPath,
@@ -53,33 +53,63 @@ test('createSuppression creates valid entry', () => {
     assert.ok(entry.context.active);
     const index = loadMemory(indexPath);
     assert.equal(index.entries.length, 1);
-  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+  } finally {
+    cleanup();
+  }
 });
 
 test('createSuppression rejects missing rationale', () => {
-  const { dir, indexPath } = tmpIndex();
+  const { cleanup, indexPath } = tmpIndex();
   try {
     assert.throws(() => createSuppression({ indexPath, filePaths: ['a.ts'] }), /rationale/);
-  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+  } finally {
+    cleanup();
+  }
 });
 
 test('revokeSuppression appends resurface entry', () => {
-  const { dir, indexPath } = tmpIndex();
+  const { cleanup, indexPath } = tmpIndex();
   try {
-    createSuppression({ indexPath, findingId: 'f1', findingHash: 'h1', filePaths: ['a.ts'], rationale: 'ok' });
-    const entry = revokeSuppression(indexPath, 'suppression-h1-123', { reason: 'no longer valid' });
+    createSuppression({
+      indexPath,
+      findingId: 'f1',
+      findingHash: 'h1',
+      filePaths: ['a.ts'],
+      rationale: 'ok',
+    });
+    const entry = revokeSuppression(indexPath, 'suppression-h1-123', {
+      reason: 'no longer valid',
+    });
     assert.equal(entry.type, 'resurface');
     assert.equal(entry.context.action, 'revoke');
     const index = loadMemory(indexPath);
     assert.equal(index.entries.length, 2);
-  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+  } finally {
+    cleanup();
+  }
 });
 
 test('findActiveSuppressions matches by file path', () => {
   const index = {
     entries: [
-      { id: 's1', type: 'suppression', content: 'ok', metadata: { createdAt: '2026-01-01T00:00:00Z', author: 't', relatedFiles: ['src/auth.ts'] }, context: { active: true, scope: 'file' } },
-      { id: 's2', type: 'suppression', content: 'ok', metadata: { createdAt: '2026-01-01T00:00:00Z', author: 't', relatedFiles: ['src/billing.ts'] }, context: { active: true, scope: 'file' } },
+      {
+        id: 's1',
+        type: 'suppression',
+        content: 'ok',
+        metadata: { createdAt: '2026-01-01T00:00:00Z', author: 't', relatedFiles: ['src/auth.ts'] },
+        context: { active: true, scope: 'file' },
+      },
+      {
+        id: 's2',
+        type: 'suppression',
+        content: 'ok',
+        metadata: {
+          createdAt: '2026-01-01T00:00:00Z',
+          author: 't',
+          relatedFiles: ['src/billing.ts'],
+        },
+        context: { active: true, scope: 'file' },
+      },
     ],
   };
   const result = findActiveSuppressions(index, ['src/auth.ts']);
@@ -90,8 +120,20 @@ test('findActiveSuppressions matches by file path', () => {
 test('findActiveSuppressions excludes revoked suppressions', () => {
   const index = {
     entries: [
-      { id: 's1', type: 'suppression', content: 'ok', metadata: { createdAt: '2026-01-01T00:00:00Z', author: 't', relatedFiles: ['src/auth.ts'] }, context: { active: true, scope: 'file' } },
-      { id: 'r1', type: 'resurface', content: 'revoked', metadata: { createdAt: '2026-01-02T00:00:00Z', author: 't' }, context: { suppressionId: 's1', action: 'revoke' } },
+      {
+        id: 's1',
+        type: 'suppression',
+        content: 'ok',
+        metadata: { createdAt: '2026-01-01T00:00:00Z', author: 't', relatedFiles: ['src/auth.ts'] },
+        context: { active: true, scope: 'file' },
+      },
+      {
+        id: 'r1',
+        type: 'resurface',
+        content: 'revoked',
+        metadata: { createdAt: '2026-01-02T00:00:00Z', author: 't' },
+        context: { suppressionId: 's1', action: 'revoke' },
+      },
     ],
   };
   const result = findActiveSuppressions(index, ['src/auth.ts']);
@@ -101,7 +143,13 @@ test('findActiveSuppressions excludes revoked suppressions', () => {
 test('findActiveSuppressions excludes expired suppressions', () => {
   const index = {
     entries: [
-      { id: 's1', type: 'suppression', content: 'ok', metadata: { createdAt: '2024-01-01T00:00:00Z', author: 't', relatedFiles: ['src/auth.ts'] }, context: { active: true, scope: 'file', expiresAt: '2025-01-01T00:00:00Z' } },
+      {
+        id: 's1',
+        type: 'suppression',
+        content: 'ok',
+        metadata: { createdAt: '2024-01-01T00:00:00Z', author: 't', relatedFiles: ['src/auth.ts'] },
+        context: { active: true, scope: 'file', expiresAt: '2025-01-01T00:00:00Z' },
+      },
     ],
   };
   const result = findActiveSuppressions(index, ['src/auth.ts']);
@@ -111,7 +159,17 @@ test('findActiveSuppressions excludes expired suppressions', () => {
 test('findActiveSuppressions matches subsystem scope', () => {
   const index = {
     entries: [
-      { id: 's1', type: 'suppression', content: 'ok', metadata: { createdAt: '2026-01-01T00:00:00Z', author: 't', relatedFiles: ['src/auth/login.ts'] }, context: { active: true, scope: 'subsystem' } },
+      {
+        id: 's1',
+        type: 'suppression',
+        content: 'ok',
+        metadata: {
+          createdAt: '2026-01-01T00:00:00Z',
+          author: 't',
+          relatedFiles: ['src/auth/login.ts'],
+        },
+        context: { active: true, scope: 'subsystem' },
+      },
     ],
   };
   const result = findActiveSuppressions(index, ['src/auth/oauth.ts']);

--- a/tests/suppression.test.mjs
+++ b/tests/suppression.test.mjs
@@ -10,9 +10,7 @@ import {
 import { loadMemory } from '../src/lib/riverbed-memory.mjs';
 import { createTempMemory } from './helpers/memory.mjs';
 
-function tmpIndex() {
-  return createTempMemory({ layout: 'nested', prefix: 'river-supp-' });
-}
+const tmpIndex = () => createTempMemory({ layout: 'nested', prefix: 'river-supp-' });
 
 test('hashFinding produces stable hash for same input', () => {
   const h1 = hashFinding({ file: 'a.ts', message: 'test', ruleId: 'r1' });


### PR DESCRIPTION
## Summary

ユニットテスト改善・最適化の Phase 1。重複していたテストヘルパーを `tests/helpers/` に集約し、`src/cli.mjs` の `main()` / `parseArgs` を export することで CLI テストを in-process 実行に切り替え、CLI テストの実行時間を **6.5s → 3.7s（-43%）** に短縮。

これは [plan file](https://github.com/s977043/river-reviewer/blob/main/.claude/plans/greedy-beaming-eclipse.md) の Phase 1 に相当し、Phase 2（MUST ファイルのカバレッジ埋め）と Phase 3（SHOULD ファイルのカバレッジ埋め）は別 PR で実装予定。

## 変更内容

### 新規ファイル

- **`tests/helpers/`**
  - `temp-dir.mjs` — `withTempDir(fn)` / `createTempDir()` / `cleanupTempDir()`
  - `temp-repo.mjs` — `createTempGitRepo({ initialFiles, changedFiles, rules, branch })` / `createRepoWithSilentCatchChange()` / `runGit()`
  - `cli.mjs` — `runCliAsSubprocess(argv, opts)` / `runCliInProcess(argv, opts)`
  - `memory.mjs` — `createTempMemory({ layout, entries })` / `makeMemoryEntry()` / `writeMemoryIndex()`
  - `README.md` — 使い分けガイド
  - `__tests__/` 配下に 4 個の helper 単体テスト（**20 テスト**）
- **`tests/cli-parse-args.test.mjs`** — `parseArgs` の純粋関数テスト（**32 テスト / < 300ms**）

### 既存ファイルの修正

- **`src/cli.mjs`** — `parseArgs` / `main` を export、`import.meta.url === \`file://\${process.argv[1]}\`` ガードで直接実行時のみ main() を呼び出し（import 時は副作用なし）
- **`tests/cli.test.mjs`** — 5 つの describe ブロックに整理、`execFile` 経由 subprocess から `runCliInProcess` に切り替え
- **`tests/integration/local-review.test.mjs`** — helpers 経由 + in-process 化
- **`tests/rules.test.mjs` / `riverbed-memory.test.mjs` / `suppression.test.mjs` / `memory-context.test.mjs` / `skill-loader.test.mjs`** — ローカル定義の `mkdtempSync` / `cleanup` / `tmpIndex` / `makeEntry` を helpers からの import に置き換え

## 実装中の発見（gotcha）

初期実装では `runCliInProcess` が `process.stdout.write` / `process.stderr.write` をグローバルに差し替えて出力をキャプチャしていたが、これにより **`node:test` ランナー自身の TAP 出力が横取りされ、`cli.test.mjs` の 5 テストが silently drop される** 問題が発生した（`tests 18 → 13` で、pass/fail/skipped カウントに現れない "消失" を起こす）。

原因特定には minimum reproducer を作成し、`describe` ブロック跨ぎでこの現象が発生することを確認した。修正は `captureConsole` を導入し、`console.log/error/warn/info` のみ差し替える形に変更（`process.stdout.write` は差し替えない）。`cli.mjs` は ほぼ `console.log/error` 経由で出力しているため、これで十分カバーできる。

## 計測結果

| 項目 | Before | After | 改善 |
| ---- | ------ | ----- | ---- |
| `npm test` 全体（壁時計） | ~10.2s | ~6.5s | **-37%** |
| `node --test tests/cli.test.mjs` | 6.5s | 3.7s | **-43%** |
| `tests/integration/local-review.test.mjs` | 1.8s | 1.4s | -22% |
| 全テスト数 | 328 | **385** | +57 |
| parseArgs 純粋関数テスト | 0 | 32（< 300ms 合計） | — |

ローカル測定: Darwin 25.4.0 / Node 22.x

## 影響範囲とリスク

- **プロダクションコードへの影響**: `src/cli.mjs` の `import.meta.url` ガード追加のみ。直接実行時の動作は変わらない（従来の top-level `main()` 呼び出しと等価）。
- **後方互換**: すべて additive / refactor。既存の CLI ユーザー・テストの挙動は変更なし。
- **CI 負荷**: テスト数が増えたが、実行時間は短縮されているため負荷は軽減。

## Test plan

- [x] `npm test` → 385 tests 全通過
- [x] `node --test tests/cli.test.mjs` → 18 tests 通過、~3.7s
- [x] `node --test tests/helpers/__tests__/*.test.mjs` → 20 tests 通過
- [x] `node --test tests/cli-parse-args.test.mjs` → 32 tests 通過、< 300ms
- [x] `node --test tests/integration/local-review.test.mjs` → 4 tests 通過
- [x] `node src/cli.mjs --help` → 直接実行時の挙動維持
- [ ] CI で Node 20.x / 22.x 両方で全通過することを確認（リモート）

## Next Phases（別 PR 予定）

- **Phase 2**: MUST ファイルのカバレッジ埋め（`src/lib/git.mjs`, `openai-planner.mjs`, `local-runner.mjs` 内部, `ai/factory.mjs`, `runners/cli/.../create.mjs`）— 約 90 テスト追加
- **Phase 3**: SHOULD ファイルのカバレッジ埋め（rules, diff-optimizer, adr-linker, prompt-builder など）— 約 35 テスト追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)