### PR TITLE
chore(github): add Epic/Capability issue templates with pre-implementation checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/capability.yml
+++ b/.github/ISSUE_TEMPLATE/capability.yml
@@ -46,17 +46,18 @@ body:
     validations:
       required: false
 
-  - type: textarea
+  - type: checkboxes
     id: pre_implementation
     attributes:
       label: Pre-implementation checklist
       description: 着手前に必ず満たすこと。既存資産確認と実行計画の用意は必須。
-      value: |
-        - [ ] 既存コードベース・skill・docs を確認して重複や前提を洗い出した
-        - [ ] 実行計画（変更対象ファイル、影響範囲、検証手順）を本 Issue または PR に記載した
-        - [ ] Why と Non-goals が現状でも妥当か再確認した
-    validations:
-      required: true
+      options:
+        - label: 既存コードベース・skill・docs を確認して重複や前提を洗い出した
+          required: true
+        - label: 実行計画（変更対象ファイル、影響範囲、検証手順）を本 Issue または PR に記載した
+          required: true
+        - label: Why と Non-goals が現状でも妥当か再確認した
+          required: true
 
   - type: textarea
     id: notes

--- a/.github/ISSUE_TEMPLATE/capability.yml
+++ b/.github/ISSUE_TEMPLATE/capability.yml
@@ -1,0 +1,67 @@
+name: 'Capability'
+description: 機能・責務単位の中位 Issue。Why と Done when を保ったまま Task に落とすための器。
+title: 'Capability: '
+labels: ['capability', 'status:triage']
+body:
+  - type: textarea
+    id: why
+    attributes:
+      label: Why
+      description: なぜこの Capability が必要か。背景・課題・狙いを書く。
+    validations:
+      required: true
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What
+      description: 今回やること。実装・設計・運用の対象範囲。
+    validations:
+      required: true
+
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals
+      description: 今回やらないこと。スコープ外を明記する。
+    validations:
+      required: true
+
+  - type: textarea
+    id: done_when
+    attributes:
+      label: Done when
+      description: 完了条件。Yes/No で確認できる状態。
+    validations:
+      required: true
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: 依存 Issue・前提・親 Epic。
+      placeholder: |
+        - Epic: #NN
+        - Depends on: #NN
+    validations:
+      required: false
+
+  - type: textarea
+    id: pre_implementation
+    attributes:
+      label: Pre-implementation checklist
+      description: 着手前に必ず満たすこと。既存資産確認と実行計画の用意は必須。
+      value: |
+        - [ ] 既存コードベース・skill・docs を確認して重複や前提を洗い出した
+        - [ ] 実行計画（変更対象ファイル、影響範囲、検証手順）を本 Issue または PR に記載した
+        - [ ] Why と Non-goals が現状でも妥当か再確認した
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: 補足、検討メモ、リンク。
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,75 @@
+name: 'Epic'
+description: 上位の意思決定を固定するための親 Issue。Why を厚く、Capability を束ねる。
+title: 'Epic: '
+labels: ['epic', 'status:triage']
+body:
+  - type: textarea
+    id: why
+    attributes:
+      label: Why
+      description: なぜこの Epic が必要か。背景・課題・狙いを書く。
+    validations:
+      required: true
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What
+      description: 今回やることの全体像。実装・設計・運用の対象範囲。
+    validations:
+      required: true
+
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals
+      description: 今回やらないこと。誤解を防ぐために明示する。
+    validations:
+      required: true
+
+  - type: textarea
+    id: done_when
+    attributes:
+      label: Done when
+      description: 完了条件。レビュー時に Yes/No で確認できる状態。
+    validations:
+      required: true
+
+  - type: textarea
+    id: capabilities
+    attributes:
+      label: Capabilities
+      description: この Epic にぶら下がる Capability Issue のチェックリスト。
+      placeholder: |
+        - [ ] #NN Capability: ...
+        - [ ] #NN Capability: ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: 依存 Issue・前提・ブロッカー。
+    validations:
+      required: false
+
+  - type: textarea
+    id: pre_implementation
+    attributes:
+      label: Pre-implementation checklist
+      description: 着手前に必ず満たすこと。既存資産確認と実行計画の用意は必須。
+      value: |
+        - [ ] 既存コードベース・skill・docs を確認して重複や前提を洗い出した
+        - [ ] 実行計画（変更対象ファイル、影響範囲、検証手順）を本 Issue または PR に記載した
+        - [ ] Why と Non-goals が現状でも妥当か再確認した
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: 補足、検討メモ、リンク。
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -54,17 +54,18 @@ body:
     validations:
       required: false
 
-  - type: textarea
+  - type: checkboxes
     id: pre_implementation
     attributes:
       label: Pre-implementation checklist
       description: 着手前に必ず満たすこと。既存資産確認と実行計画の用意は必須。
-      value: |
-        - [ ] 既存コードベース・skill・docs を確認して重複や前提を洗い出した
-        - [ ] 実行計画（変更対象ファイル、影響範囲、検証手順）を本 Issue または PR に記載した
-        - [ ] Why と Non-goals が現状でも妥当か再確認した
-    validations:
-      required: true
+      options:
+        - label: 既存コードベース・skill・docs を確認して重複や前提を洗い出した
+          required: true
+        - label: 実行計画（変更対象ファイル、影響範囲、検証手順）を本 Issue または PR に記載した
+          required: true
+        - label: Why と Non-goals が現状でも妥当か再確認した
+          required: true
 
   - type: textarea
     id: notes

--- a/.github/ISSUE_TEMPLATE/task.yaml
+++ b/.github/ISSUE_TEMPLATE/task.yaml
@@ -35,3 +35,15 @@ body:
       placeholder: 完了条件を書いてください
     validations:
       required: true
+
+  - type: textarea
+    id: pre_implementation
+    attributes:
+      label: Pre-implementation checklist
+      description: 着手前に必ず満たすこと。既存資産確認と実行計画の用意は必須。
+      value: |
+        - [ ] 既存コードベース・skill・docs を確認して重複や前提を洗い出した
+        - [ ] 実行計画（変更対象ファイル、影響範囲、検証手順）を本 Issue または PR に記載した
+        - [ ] 受け入れ条件が現状でも妥当か再確認した
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/task.yaml
+++ b/.github/ISSUE_TEMPLATE/task.yaml
@@ -36,14 +36,15 @@ body:
     validations:
       required: true
 
-  - type: textarea
+  - type: checkboxes
     id: pre_implementation
     attributes:
       label: Pre-implementation checklist
       description: 着手前に必ず満たすこと。既存資産確認と実行計画の用意は必須。
-      value: |
-        - [ ] 既存コードベース・skill・docs を確認して重複や前提を洗い出した
-        - [ ] 実行計画（変更対象ファイル、影響範囲、検証手順）を本 Issue または PR に記載した
-        - [ ] 受け入れ条件が現状でも妥当か再確認した
-    validations:
-      required: true
+      options:
+        - label: 既存コードベース・skill・docs を確認して重複や前提を洗い出した
+          required: true
+        - label: 実行計画（変更対象ファイル、影響範囲、検証手順）を本 Issue または PR に記載した
+          required: true
+        - label: 受け入れ条件が現状でも妥当か再確認した
+          required: true


### PR DESCRIPTION
## Summary

- `epic.yml` と `capability.yml` を新規追加し、Why / What / Non-goals / Done when / Pre-implementation checklist を必須欄として固定（Dependencies / Notes / Capabilities は任意の補足欄）
- 既存の `task.yaml` に Pre-implementation checklist を追加
- 全テンプレートで「既存コードベース確認」「実行計画の用意」「Why/Non-goals または受け入れ条件の再確認」を着手前の必須項目として `type: checkboxes` で enforce（`enhancement.yaml` と同じパターン）

## Why

これまで Issue が途中でブレる原因として Why が曖昧、What に解決策と目的が混ざる、Out of scope がない、完了条件がない、という構造的問題があった。Epic → Capability → Task の3階層を運用に乗せるために、テンプレート側で構造を強制する。

また、AI Misoperation Guards の "Research before proposing" を Issue 着手フェーズにも拡張し、対応開始前にコードベース確認と実行計画の用意を必須化する。

## Implementation notes

- 初版では Pre-implementation checklist を `type: textarea` + `required: true` の pre-filled value で実装していたが、Copilot review の指摘通りこの形式は「空でない」ことしか保証せず、チェック未了でも submit 可能だった
- `type: checkboxes` に変更し、各 option に `required: true` を付けることで、未チェック項目があると submit 時にエラーが出るようになった（既存 `enhancement.yaml` の docs_impact と同じパターン）
- Task テンプレートのみ 3 項目目を「受け入れ条件の再確認」としている（Why/Non-goals は親 Capability に委ねる設計）

## Test plan

- [ ] GitHub の Issue 作成画面で Epic / Capability / Task テンプレートが選択肢に表示される
- [ ] 各テンプレートの必須欄を空のまま submit するとバリデーションが効く
- [ ] Pre-implementation checklist の全項目にチェックを入れないと submit できない

## Related

- Epic #507 と Capability #508–#514、Task #516–#524 はこのテンプレート構造の実運用例として既に作成済み（本 PR 以前に手書きで作ったため、既存 Issue 本文内のチェックリストは Markdown 表記のまま残ります）

🤖 Generated with [Claude Code](https://claude.com/claude-code)