### PR TITLE
test: add unit tests for git.mjs, local-runner internals, and ai/factory (phase 2)

### DIFF
--- a/src/ai/factory.mjs
+++ b/src/ai/factory.mjs
@@ -10,7 +10,8 @@ function isRetriableError(err) {
   const status = err?.status ?? err?.response?.status;
   if (status === 429 || (status >= 500 && status < 600)) return true;
   if (err?.name === 'AbortError') return true;
-  if (err?.code === 'ETIMEDOUT' || err?.code === 'ECONNRESET' || err?.code === 'ENOTFOUND') return true;
+  if (err?.code === 'ETIMEDOUT' || err?.code === 'ECONNRESET' || err?.code === 'ENOTFOUND')
+    return true;
   return false;
 }
 
@@ -34,10 +35,13 @@ async function withRetry(fn) {
         // eslint-disable-next-line no-console
         console.warn(`[AI retry] attempt ${attempt} failed (${err?.message || err}); retrying...`);
       }
-      await new Promise(res => setTimeout(res, RETRY_DELAY_MS * attempt));
+      await new Promise((res) => setTimeout(res, RETRY_DELAY_MS * attempt));
     }
   }
 }
+
+// --- テスト用 named export (内部ヘルパー) ---
+export { isRetriableError, withRetry };
 
 export class AIClientFactory {
   static create({ modelName, temperature }) {
@@ -86,7 +90,7 @@ class GeminiClient {
           { role: 'user', parts: [{ text: systemPrompt }] },
           { role: 'user', parts: [{ text: `Here is the code diff to review:\n\n${diff}` }] },
         ],
-      }),
+      })
     );
 
     return result.response.text();
@@ -123,7 +127,7 @@ class OpenAIClient {
         model: this.modelName,
         messages,
         temperature: this.temperature,
-      }),
+      })
     );
 
     return response.choices[0].message.content || '';

--- a/src/lib/local-runner.mjs
+++ b/src/lib/local-runner.mjs
@@ -152,6 +152,15 @@ async function collectLocalContext({
   };
 }
 
+// --- テスト用 named export (内部ヘルパー) ---
+export {
+  normalizePhase,
+  shouldExclude,
+  shouldSkipByLabel,
+  resolveAvailableContexts,
+  resolveAvailableDependencies,
+};
+
 export async function planLocalReview({
   cwd = process.cwd(),
   phase = 'midstream',

--- a/tests/ai-factory.test.mjs
+++ b/tests/ai-factory.test.mjs
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import test, { describe } from 'node:test';
+
+import { isRetriableError, withRetry, AIClientFactory } from '../src/ai/factory.mjs';
+
+// ---------------------------------------------------------------------------
+// isRetriableError
+// ---------------------------------------------------------------------------
+
+describe('isRetriableError', () => {
+  test('returns true for HTTP 429 (rate limit)', () => {
+    assert.equal(isRetriableError({ status: 429 }), true);
+  });
+
+  test('returns true for HTTP 500 (server error)', () => {
+    assert.equal(isRetriableError({ status: 500 }), true);
+  });
+
+  test('returns true for HTTP 503 (service unavailable)', () => {
+    assert.equal(isRetriableError({ status: 503 }), true);
+  });
+
+  test('returns true for nested response.status 429', () => {
+    assert.equal(isRetriableError({ response: { status: 429 } }), true);
+  });
+
+  test('returns true for AbortError', () => {
+    assert.equal(isRetriableError({ name: 'AbortError' }), true);
+  });
+
+  test('returns true for ETIMEDOUT', () => {
+    assert.equal(isRetriableError({ code: 'ETIMEDOUT' }), true);
+  });
+
+  test('returns true for ECONNRESET', () => {
+    assert.equal(isRetriableError({ code: 'ECONNRESET' }), true);
+  });
+
+  test('returns true for ENOTFOUND', () => {
+    assert.equal(isRetriableError({ code: 'ENOTFOUND' }), true);
+  });
+
+  test('returns false for HTTP 401 (auth error)', () => {
+    assert.equal(isRetriableError({ status: 401 }), false);
+  });
+
+  test('returns false for HTTP 400 (bad request)', () => {
+    assert.equal(isRetriableError({ status: 400 }), false);
+  });
+
+  test('returns false for generic Error', () => {
+    assert.equal(isRetriableError(new Error('something')), false);
+  });
+
+  test('returns false for null/undefined', () => {
+    assert.equal(isRetriableError(null), false);
+    assert.equal(isRetriableError(undefined), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// withRetry
+// ---------------------------------------------------------------------------
+
+describe('withRetry', () => {
+  test('returns value on success', async () => {
+    const result = await withRetry(() => Promise.resolve(42));
+    assert.equal(result, 42);
+  });
+
+  test('retries on retriable error and succeeds', async () => {
+    let attempt = 0;
+    const result = await withRetry(() => {
+      attempt += 1;
+      if (attempt < 2) {
+        const err = new Error('rate limited');
+        err.status = 429;
+        throw err;
+      }
+      return 'ok';
+    });
+    assert.equal(result, 'ok');
+    assert.equal(attempt, 2);
+  });
+
+  test('throws after max retries exceeded', async () => {
+    let attempt = 0;
+    await assert.rejects(
+      withRetry(() => {
+        attempt += 1;
+        const err = new Error('timeout');
+        err.code = 'ETIMEDOUT';
+        throw err;
+      }),
+      (err) => {
+        assert.match(err.message, /timeout/);
+        return true;
+      },
+    );
+    // MAX_RETRIES = 2, so attempt should be 3 (1 initial + 2 retries)
+    assert.equal(attempt, 3);
+  });
+
+  test('does not retry non-retriable errors', async () => {
+    let attempt = 0;
+    await assert.rejects(
+      withRetry(() => {
+        attempt += 1;
+        const err = new Error('auth');
+        err.status = 401;
+        throw err;
+      }),
+      (err) => {
+        assert.match(err.message, /auth/);
+        return true;
+      },
+    );
+    assert.equal(attempt, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AIClientFactory.create
+// ---------------------------------------------------------------------------
+
+describe('AIClientFactory.create', () => {
+  test('throws when modelName is not provided', () => {
+    assert.throws(() => AIClientFactory.create({}), /モデル名/);
+    assert.throws(() => AIClientFactory.create({ modelName: '' }), /モデル名/);
+  });
+
+  test('throws for unsupported model name', () => {
+    assert.throws(() => AIClientFactory.create({ modelName: 'claude-3' }), /Unsupported model/);
+  });
+});

--- a/tests/git.test.mjs
+++ b/tests/git.test.mjs
@@ -1,0 +1,248 @@
+import assert from 'node:assert/strict';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import test, { describe } from 'node:test';
+
+import {
+  ensureGitRepo,
+  detectDefaultBranch,
+  findMergeBase,
+  listChangedFiles,
+  diffWithContext,
+  collectAddedLineHints,
+  GitError,
+  GitRepoNotFoundError,
+} from '../src/lib/git.mjs';
+import { createTempGitRepo, runGit, writeFileRelative } from './helpers/temp-repo.mjs';
+import { createTempDir, cleanupTempDir } from './helpers/temp-dir.mjs';
+
+// ---------------------------------------------------------------------------
+// ensureGitRepo
+// ---------------------------------------------------------------------------
+
+describe('ensureGitRepo', () => {
+  test('returns repo root for valid git repo', async (t) => {
+    const { dir, cleanup } = await createTempGitRepo();
+    t.after(cleanup);
+    const root = await ensureGitRepo(dir);
+    // macOS realpath: /tmp -> /private/tmp
+    assert.ok(root.endsWith(dir.replace(/^\/private/, '')) || dir.endsWith(root.replace(/^\/private/, '')));
+  });
+
+  test('throws GitRepoNotFoundError for non-repo directory', async (t) => {
+    const dir = createTempDir({ prefix: 'git-no-repo-' });
+    t.after(() => cleanupTempDir(dir));
+    await assert.rejects(ensureGitRepo(dir), (err) => {
+      assert.ok(err instanceof GitRepoNotFoundError);
+      assert.match(err.message, /Not a git repository/);
+      return true;
+    });
+  });
+
+  test('throws for non-existent path', async () => {
+    await assert.rejects(ensureGitRepo('/tmp/nonexistent-path-xyz-' + Date.now()), (err) => {
+      assert.ok(err instanceof GitError);
+      return true;
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectDefaultBranch
+// ---------------------------------------------------------------------------
+
+describe('detectDefaultBranch', () => {
+  test('returns main for repo with main branch', async (t) => {
+    const { dir, cleanup } = await createTempGitRepo({ branch: 'main' });
+    t.after(cleanup);
+    const branch = await detectDefaultBranch(dir);
+    assert.equal(branch, 'main');
+  });
+
+  test('returns master for repo with master branch', async (t) => {
+    const { dir, cleanup } = await createTempGitRepo({ branch: 'master' });
+    t.after(cleanup);
+    const branch = await detectDefaultBranch(dir);
+    assert.equal(branch, 'master');
+  });
+
+  test('returns HEAD as fallback when no main/master branch', async (t) => {
+    const { dir, cleanup } = await createTempGitRepo({ branch: 'develop' });
+    t.after(cleanup);
+    const branch = await detectDefaultBranch(dir);
+    assert.equal(branch, 'HEAD');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findMergeBase
+// ---------------------------------------------------------------------------
+
+describe('findMergeBase', () => {
+  test('returns merge base commit', async (t) => {
+    const { dir, cleanup } = await createTempGitRepo({
+      initialFiles: { 'a.txt': 'initial\n' },
+    });
+    t.after(cleanup);
+    // create a second commit on main
+    writeFileRelative(dir, 'b.txt', 'second\n');
+    await runGit(['add', '.'], dir);
+    await runGit(['commit', '-m', 'second'], dir);
+
+    const base = await findMergeBase(dir, 'main');
+    assert.ok(base);
+    assert.match(base, /^[0-9a-f]{40}$/);
+  });
+
+  test('falls back to HEAD when baseRef does not exist', async (t) => {
+    const { dir, cleanup } = await createTempGitRepo({
+      initialFiles: { 'a.txt': 'initial\n' },
+    });
+    t.after(cleanup);
+    const base = await findMergeBase(dir, 'nonexistent-branch');
+    const head = (await runGit(['rev-parse', 'HEAD'], dir)).stdout.trim();
+    assert.equal(base, head);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listChangedFiles
+// ---------------------------------------------------------------------------
+
+describe('listChangedFiles', () => {
+  test('lists added files', async (t) => {
+    const { dir, cleanup } = await createTempGitRepo({
+      initialFiles: { 'a.txt': 'initial\n' },
+      changedFiles: { 'b.txt': 'new file\n' },
+    });
+    t.after(cleanup);
+    await runGit(['add', '.'], dir);
+    const head = (await runGit(['rev-parse', 'HEAD'], dir)).stdout.trim();
+    const files = await listChangedFiles(dir, head);
+    assert.ok(files.includes('b.txt'));
+  });
+
+  test('lists modified files', async (t) => {
+    const { dir, cleanup } = await createTempGitRepo({
+      initialFiles: { 'a.txt': 'initial\n' },
+      changedFiles: { 'a.txt': 'modified\n' },
+    });
+    t.after(cleanup);
+    const head = (await runGit(['rev-parse', 'HEAD'], dir)).stdout.trim();
+    const files = await listChangedFiles(dir, head);
+    assert.ok(files.includes('a.txt'));
+  });
+
+  test('returns empty array when no changes', async (t) => {
+    const { dir, cleanup } = await createTempGitRepo({
+      initialFiles: { 'a.txt': 'initial\n' },
+    });
+    t.after(cleanup);
+    const head = (await runGit(['rev-parse', 'HEAD'], dir)).stdout.trim();
+    const files = await listChangedFiles(dir, head);
+    assert.deepEqual(files, []);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// diffWithContext
+// ---------------------------------------------------------------------------
+
+describe('diffWithContext', () => {
+  test('returns unified diff text', async (t) => {
+    const { dir, cleanup } = await createTempGitRepo({
+      initialFiles: { 'src/app.js': 'const a = 1;\n' },
+      changedFiles: { 'src/app.js': 'const a = 2;\n' },
+    });
+    t.after(cleanup);
+    const head = (await runGit(['rev-parse', 'HEAD'], dir)).stdout.trim();
+    const diff = await diffWithContext(dir, head);
+    assert.match(diff, /--- a\/src\/app\.js/);
+    assert.match(diff, /\+\+\+ b\/src\/app\.js/);
+    assert.match(diff, /const a = 2/);
+  });
+
+  test('respects unified context lines option', async (t) => {
+    const { dir, cleanup } = await createTempGitRepo({
+      initialFiles: { 'x.txt': 'line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\n' },
+      changedFiles: { 'x.txt': 'line1\nline2\nline3\nCHANGED\nline5\nline6\nline7\nline8\n' },
+    });
+    t.after(cleanup);
+    const head = (await runGit(['rev-parse', 'HEAD'], dir)).stdout.trim();
+
+    const diff0 = await diffWithContext(dir, head, { unified: 0 });
+    const diff5 = await diffWithContext(dir, head, { unified: 5 });
+    // With 0 context, diff is shorter
+    assert.ok(diff0.length < diff5.length);
+  });
+
+  test('returns empty string when no changes', async (t) => {
+    const { dir, cleanup } = await createTempGitRepo({
+      initialFiles: { 'a.txt': 'stable\n' },
+    });
+    t.after(cleanup);
+    const head = (await runGit(['rev-parse', 'HEAD'], dir)).stdout.trim();
+    const diff = await diffWithContext(dir, head);
+    assert.equal(diff, '');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// collectAddedLineHints
+// ---------------------------------------------------------------------------
+
+describe('collectAddedLineHints', () => {
+  test('extracts first hunk start line per file', () => {
+    const diff = `diff --git a/src/app.js b/src/app.js
+--- a/src/app.js
++++ b/src/app.js
+@@ -1,3 +1,4 @@
+ const a = 1;
++const b = 2;
+ const c = 3;
+diff --git a/src/utils.js b/src/utils.js
+--- a/src/utils.js
++++ b/src/utils.js
+@@ -10,2 +10,5 @@
+ function helper() {}
++function newHelper() {}
+`;
+    const hints = collectAddedLineHints(diff);
+    assert.equal(hints.get('src/app.js'), 1);
+    assert.equal(hints.get('src/utils.js'), 10);
+    assert.equal(hints.size, 2);
+  });
+
+  test('returns empty map for empty diff', () => {
+    assert.equal(collectAddedLineHints('').size, 0);
+  });
+
+  test('only records first hunk per file', () => {
+    const diff = `diff --git a/f.js b/f.js
+--- a/f.js
++++ b/f.js
+@@ -5,3 +5,4 @@
+ line5
++added1
+@@ -20,3 +21,4 @@
+ line20
++added2
+`;
+    const hints = collectAddedLineHints(diff);
+    assert.equal(hints.get('f.js'), 5);
+    assert.equal(hints.size, 1);
+  });
+
+  test('handles new file diff (no --- a/ header)', () => {
+    const diff = `diff --git a/new.js b/new.js
+--- /dev/null
++++ b/new.js
+@@ -0,0 +1,3 @@
++const x = 1;
++const y = 2;
++const z = 3;
+`;
+    const hints = collectAddedLineHints(diff);
+    assert.equal(hints.get('new.js'), 1);
+  });
+});

--- a/tests/local-runner-internals.test.mjs
+++ b/tests/local-runner-internals.test.mjs
@@ -1,0 +1,222 @@
+import assert from 'node:assert/strict';
+import test, { describe } from 'node:test';
+
+import {
+  normalizePhase,
+  shouldExclude,
+  shouldSkipByLabel,
+  resolveAvailableContexts,
+  resolveAvailableDependencies,
+} from '../src/lib/local-runner.mjs';
+
+// ---------------------------------------------------------------------------
+// normalizePhase
+// ---------------------------------------------------------------------------
+
+describe('normalizePhase', () => {
+  test('returns valid phases as-is (lowercase)', () => {
+    assert.equal(normalizePhase('upstream'), 'upstream');
+    assert.equal(normalizePhase('midstream'), 'midstream');
+    assert.equal(normalizePhase('downstream'), 'downstream');
+  });
+
+  test('normalizes case', () => {
+    assert.equal(normalizePhase('UPSTREAM'), 'upstream');
+    assert.equal(normalizePhase('Midstream'), 'midstream');
+  });
+
+  test('falls back to midstream for invalid values', () => {
+    assert.equal(normalizePhase('invalid'), 'midstream');
+    assert.equal(normalizePhase(''), 'midstream');
+    assert.equal(normalizePhase(null), 'midstream');
+    assert.equal(normalizePhase(undefined), 'midstream');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shouldExclude
+// ---------------------------------------------------------------------------
+
+describe('shouldExclude', () => {
+  test('matches glob patterns', () => {
+    assert.equal(shouldExclude('docs/README.md', ['docs/**']), true);
+    assert.equal(shouldExclude('src/app.js', ['docs/**']), false);
+  });
+
+  test('matches exact file name', () => {
+    assert.equal(shouldExclude('package-lock.json', ['package-lock.json']), true);
+  });
+
+  test('matches dot files', () => {
+    assert.equal(shouldExclude('.env', ['.*']), true);
+    assert.equal(shouldExclude('.gitignore', ['.git*']), true);
+  });
+
+  test('returns false for empty patterns', () => {
+    assert.equal(shouldExclude('anything.js', []), false);
+    assert.equal(shouldExclude('anything.js'), false);
+  });
+
+  test('returns false when no match', () => {
+    assert.equal(shouldExclude('src/app.ts', ['*.md', '*.json']), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shouldSkipByLabel
+// ---------------------------------------------------------------------------
+
+describe('shouldSkipByLabel', () => {
+  test('returns shouldSkip true when label matches pattern', () => {
+    const result = shouldSkipByLabel(['skip-review', 'docs'], ['skip-review']);
+    assert.equal(result.shouldSkip, true);
+    assert.deepEqual(result.matched, ['skip-review']);
+  });
+
+  test('matches case-insensitively', () => {
+    const result = shouldSkipByLabel(['Skip-Review'], ['skip-review']);
+    assert.equal(result.shouldSkip, true);
+  });
+
+  test('matches partial patterns (substring)', () => {
+    const result = shouldSkipByLabel(['skip-ai-review'], ['skip']);
+    assert.equal(result.shouldSkip, true);
+  });
+
+  test('returns shouldSkip false when no match', () => {
+    const result = shouldSkipByLabel(['enhancement', 'bug'], ['skip-review']);
+    assert.equal(result.shouldSkip, false);
+    assert.deepEqual(result.matched, []);
+  });
+
+  test('returns shouldSkip false for empty labels', () => {
+    const result = shouldSkipByLabel([], ['skip-review']);
+    assert.equal(result.shouldSkip, false);
+  });
+
+  test('returns shouldSkip false for empty patterns', () => {
+    const result = shouldSkipByLabel(['skip-review'], []);
+    assert.equal(result.shouldSkip, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAvailableContexts
+// ---------------------------------------------------------------------------
+
+describe('resolveAvailableContexts', () => {
+  // 環境変数の backup/restore
+  function withEnv(key, value, fn) {
+    const backup = process.env[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+    try {
+      return fn();
+    } finally {
+      if (backup === undefined) delete process.env[key];
+      else process.env[key] = backup;
+    }
+  }
+
+  test('defaults to [diff] with no input and no env', () => {
+    withEnv('RIVER_AVAILABLE_CONTEXTS', undefined, () => {
+      const result = resolveAvailableContexts(null);
+      assert.deepEqual(result, ['diff']);
+    });
+  });
+
+  test('uses input contexts when provided', () => {
+    withEnv('RIVER_AVAILABLE_CONTEXTS', undefined, () => {
+      const result = resolveAvailableContexts(['diff', 'fullFile']);
+      assert.deepEqual(result, ['diff', 'fullFile']);
+    });
+  });
+
+  test('merges env contexts with input', () => {
+    withEnv('RIVER_AVAILABLE_CONTEXTS', 'tests,commitMessage', () => {
+      const result = resolveAvailableContexts(['diff']);
+      assert.ok(result.includes('diff'));
+      assert.ok(result.includes('tests'));
+      assert.ok(result.includes('commitMessage'));
+    });
+  });
+
+  test('deduplicates merged contexts', () => {
+    withEnv('RIVER_AVAILABLE_CONTEXTS', 'diff,tests', () => {
+      const result = resolveAvailableContexts(['diff']);
+      assert.equal(result.filter((c) => c === 'diff').length, 1);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAvailableDependencies
+// ---------------------------------------------------------------------------
+
+describe('resolveAvailableDependencies', () => {
+  function withEnv(overrides, fn) {
+    const keys = Object.keys(overrides);
+    const backup = {};
+    for (const k of keys) {
+      backup[k] = process.env[k];
+      if (overrides[k] === undefined) delete process.env[k];
+      else process.env[k] = overrides[k];
+    }
+    try {
+      return fn();
+    } finally {
+      for (const k of keys) {
+        if (backup[k] === undefined) delete process.env[k];
+        else process.env[k] = backup[k];
+      }
+    }
+  }
+
+  test('returns null with no input and no env (disables dependency skipping)', () => {
+    withEnv({ RIVER_AVAILABLE_DEPENDENCIES: undefined, RIVER_DEPENDENCY_STUBS: undefined }, () => {
+      const result = resolveAvailableDependencies(null);
+      assert.equal(result, null);
+    });
+  });
+
+  test('uses input dependencies when provided', () => {
+    withEnv({ RIVER_AVAILABLE_DEPENDENCIES: undefined, RIVER_DEPENDENCY_STUBS: undefined }, () => {
+      const result = resolveAvailableDependencies(['code_search']);
+      assert.deepEqual(result, ['code_search']);
+    });
+  });
+
+  test('uses env dependencies when no input', () => {
+    withEnv(
+      { RIVER_AVAILABLE_DEPENDENCIES: 'code_search,test_runner', RIVER_DEPENDENCY_STUBS: undefined },
+      () => {
+        const result = resolveAvailableDependencies(null);
+        assert.ok(result.includes('code_search'));
+        assert.ok(result.includes('test_runner'));
+      },
+    );
+  });
+
+  test('returns stub list when RIVER_DEPENDENCY_STUBS is enabled', () => {
+    withEnv({ RIVER_AVAILABLE_DEPENDENCIES: undefined, RIVER_DEPENDENCY_STUBS: 'true' }, () => {
+      const result = resolveAvailableDependencies(null);
+      assert.ok(Array.isArray(result));
+      assert.ok(result.length > 0);
+      assert.ok(result.includes('code_search'));
+    });
+  });
+
+  test('input takes precedence over env', () => {
+    withEnv({ RIVER_AVAILABLE_DEPENDENCIES: 'code_search', RIVER_DEPENDENCY_STUBS: undefined }, () => {
+      const result = resolveAvailableDependencies(['test_runner']);
+      assert.deepEqual(result, ['test_runner']);
+    });
+  });
+
+  test('deduplicates results', () => {
+    withEnv({ RIVER_AVAILABLE_DEPENDENCIES: undefined, RIVER_DEPENDENCY_STUBS: undefined }, () => {
+      const result = resolveAvailableDependencies(['code_search', 'code_search']);
+      assert.equal(result.length, 1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

テスト改善 Phase 2。直接テストが無かった優先度の高い 3 ファイルにユニットテストを追加。

- `src/lib/git.mjs` — パイプライン全体の基盤。6 つの export 関数すべてをカバー
- `src/lib/local-runner.mjs` — 内部ヘルパー 5 関数を export して直接テスト
- `src/ai/factory.mjs` — `isRetriableError` / `withRetry` を export して直接テスト

**テスト数**: 385 → 445 (+60)

## 変更内容

### 新規テスト

| ファイル | テスト数 | 対象 |
| --- | --- | --- |
| `tests/git.test.mjs` | 18 | ensureGitRepo, detectDefaultBranch, findMergeBase, listChangedFiles, diffWithContext, collectAddedLineHints |
| `tests/local-runner-internals.test.mjs` | 24 | normalizePhase, shouldExclude, shouldSkipByLabel, resolveAvailableContexts, resolveAvailableDependencies |
| `tests/ai-factory.test.mjs` | 18 | isRetriableError (12), withRetry (4), AIClientFactory.create (2) |

### ソース修正（export 追加のみ）

- `src/lib/local-runner.mjs`: `normalizePhase`, `shouldExclude`, `shouldSkipByLabel`, `resolveAvailableContexts`, `resolveAvailableDependencies` を export
- `src/ai/factory.mjs`: `isRetriableError`, `withRetry` を export

プロダクション動作への影響はゼロ（既存コードパスは変更なし、export 追加のみ）。

## Test plan

- [x] `node --test tests/git.test.mjs` → 18 tests pass
- [x] `node --test tests/local-runner-internals.test.mjs` → 24 tests pass
- [x] `node --test tests/ai-factory.test.mjs` → 18 tests pass
- [x] `npm test` → 445 tests pass, 0 fail
- [ ] CI Node 20.x / 22.x で全通過（リモート）

🤖 Generated with [Claude Code](https://claude.com/claude-code)