### PR TITLE
fix(ci): grant id-token: write to unit-tests for codecov OIDC

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       matrix:
         node-version: [20.x, 22.x]


### PR DESCRIPTION
## Summary

- Add `permissions: { contents: read, id-token: write }` to the `Unit tests` job so `codecov/codecov-action@v6` can use tokenless OIDC upload.
- Closes #545.

## Why

`fail_ci_if_error: false` masks upload failures, so we cannot tell from CI status alone whether coverage reaches Codecov. Codecov v5+ uses OIDC as the default tokenless path, which requires `id-token: write` on the job. The repo currently has only the workflow-level default `permissions: contents: read` and no visible `CODECOV_TOKEN` reference, so OIDC is the lowest-friction fix.

If `CODECOV_TOKEN` is in fact configured as a repo secret, the action prefers the token and this permission becomes a harmless additional capability.

## Test plan

- [ ] Watch the next `Unit tests` run on this PR; the `Upload coverage to Codecov` step should print `Token: present (oidc)` (or similar) instead of falling back to anonymous.
- [ ] Confirm the PR appears on https://app.codecov.io for this repo.
- [ ] If Codecov still fails, switch follow-up to adding `CODECOV_TOKEN` and revert this change.