### PR TITLE
fix(eval): rubric schema scope, direction field, and integrity tests (#481)

### DIFF
--- a/eval/README.md
+++ b/eval/README.md
@@ -4,6 +4,12 @@
 
 ## rubric.yaml
 
-- 用途: severity と phase の定義/説明を統一するためのルーブリックです。
-- 参照: 現時点ではコードや CLI から直接読み込まれておらず、運用/設計の参照用です。
+- 用途: severity / phase の語彙と、多次元スコアリング用の `dimensions` ルーブリックを統一するためのファイルです。
+- 構成: 3 つのトップレベルセクションを持ちます。
+  - `severity` — severity ラベル（critical / major / minor / notice）の説明とアクション
+  - `phase` — レビューフェーズ（design / implementation / test / improve）の説明
+  - `dimensions` — 多次元スコアリングの定義。各次元は `id` / `name` / `weight` / `scoringMethod` / `direction` / `automatable` を持ち、weight 合計は 1.0
+- 参照: 現時点ではコードや CLI から直接読み込まれておらず、運用/設計の参照用です（ランタイム統合は後続 Issue で追跡）。
+- 整合性検証: `tests/eval-rubric.test.mjs` が `eval/rubric.yaml` と `schemas/eval-rubric.schema.json` の整合、および weight 合計 = 1.0 を検証します。
 - 実行コマンド: rubric.yaml を読む専用コマンドはありません。評価ランナーは `npm run eval:fixtures` を利用します。
+- 関連ドキュメント: `pages/reference/evaluation-rubric.md`

--- a/eval/rubric.yaml
+++ b/eval/rubric.yaml
@@ -47,40 +47,47 @@ dimensions:
     description: レビューが期待された問題を検出できたか
     weight: 0.25
     scoringMethod: ratio
+    direction: higher_is_better
     automatable: true
   - id: false_positive_rate
     name: 偽陽性率
     description: guard case で誤って指摘を出した割合
     weight: 0.2
     scoringMethod: ratio
+    direction: lower_is_better
     automatable: true
   - id: evidence_quality
     name: エビデンス品質
     description: 指摘に Evidence ラベルが含まれているか
     weight: 0.15
     scoringMethod: ratio
+    direction: higher_is_better
     automatable: true
   - id: severity_alignment
     name: 重要度適切性
     description: 付与された severity が期待値と一致するか
     weight: 0.15
     scoringMethod: ratio
+    direction: higher_is_better
     automatable: true
   - id: phase_consistency
     name: フェーズ一貫性
     description: 指摘がレビューフェーズと一貫しているか
     weight: 0.1
     scoringMethod: binary
+    direction: higher_is_better
     automatable: true
   - id: actionability
     name: アクショナビリティ
     description: 指摘が実行可能な改善提案を含むか
     weight: 0.1
     scoringMethod: manual
+    direction: higher_is_better
     automatable: false
   - id: token_efficiency
     name: トークン効率
     description: Context Budget に対する出力の効率
     weight: 0.05
     scoringMethod: ratio
+    direction: higher_is_better
     automatable: true

--- a/pages/reference/evaluation-rubric.en.md
+++ b/pages/reference/evaluation-rubric.en.md
@@ -2,19 +2,28 @@
 
 River Reviewer's evaluation framework provides a rubric to quantify review quality across multiple dimensions. Each dimension has an independent score, and a weighted sum produces the overall score.
 
+> **Status**: This document is a specification. Runtime integration (wiring `dimensionScores` generation into `scripts/evaluate-review-fixtures.mjs` / `src/lib/review-fixtures-eval.mjs`) is tracked in a follow-up issue. At present only the schema, rubric definitions, and the consistency test (`tests/eval-rubric.test.mjs`) are implemented.
+
 ## Dimension List
 
-| ID                    | Name                | Description                                                 | Weight | Scoring Method | Automatable |
-| --------------------- | ------------------- | ----------------------------------------------------------- | ------ | -------------- | ----------- |
-| `detection_accuracy`  | Detection Accuracy  | Whether the review detected expected issues                 | 0.25   | ratio          | Yes         |
-| `false_positive_rate` | False Positive Rate | Proportion of erroneous findings on guard cases             | 0.20   | ratio          | Yes         |
-| `evidence_quality`    | Evidence Quality    | Whether findings include Evidence labels                    | 0.15   | ratio          | Yes         |
-| `severity_alignment`  | Severity Alignment  | Whether assigned severity matches expectation               | 0.15   | ratio          | Yes         |
-| `phase_consistency`   | Phase Consistency   | Whether findings are consistent with the review phase       | 0.10   | binary         | Yes         |
-| `actionability`       | Actionability       | Whether findings include actionable improvement suggestions | 0.10   | manual         | No          |
-| `token_efficiency`    | Token Efficiency    | Output efficiency relative to the Context Budget            | 0.05   | ratio          | Yes         |
+| ID                    | Name                | Description                                                 | Weight | Scoring Method | Direction        | Automatable |
+| --------------------- | ------------------- | ----------------------------------------------------------- | ------ | -------------- | ---------------- | ----------- |
+| `detection_accuracy`  | Detection Accuracy  | Whether the review detected expected issues                 | 0.25   | ratio          | higher_is_better | Yes         |
+| `false_positive_rate` | False Positive Rate | Proportion of erroneous findings on guard cases             | 0.20   | ratio          | lower_is_better  | Yes         |
+| `evidence_quality`    | Evidence Quality    | Whether findings include Evidence labels                    | 0.15   | ratio          | higher_is_better | Yes         |
+| `severity_alignment`  | Severity Alignment  | Whether assigned severity matches expectation               | 0.15   | ratio          | higher_is_better | Yes         |
+| `phase_consistency`   | Phase Consistency   | Whether findings are consistent with the review phase       | 0.10   | binary         | higher_is_better | Yes         |
+| `actionability`       | Actionability       | Whether findings include actionable improvement suggestions | 0.10   | manual         | higher_is_better | No          |
+| `token_efficiency`    | Token Efficiency    | Output efficiency relative to the Context Budget            | 0.05   | ratio          | higher_is_better | Yes         |
 
-Weights sum to 1.0.
+Weights sum to 1.0 (validated by `tests/eval-rubric.test.mjs`).
+
+## Direction (Sign Correction)
+
+Each dimension declares a `direction` field indicating whether a higher or lower score is better. When computing the weighted sum, `lower_is_better` dimensions must be transformed via `(1 - score)` before summing.
+
+- `higher_is_better` (default): a higher score is better.
+- `lower_is_better`: a lower score is better (e.g. `false_positive_rate`).
 
 ## Scoring Methods
 
@@ -49,13 +58,13 @@ A `dimensionScores` array has been added to each evaluation entry.
     {
       "dimensionId": "detection_accuracy",
       "score": 0.85,
-      "method": "ratio",
+      "scoringMethod": "ratio",
       "details": "17/20 expected findings detected"
     },
     {
       "dimensionId": "actionability",
       "score": null,
-      "method": "manual",
+      "scoringMethod": "manual",
       "details": "Pending human review"
     }
   ]
@@ -64,7 +73,7 @@ A `dimensionScores` array has been added to each evaluation entry.
 
 - `dimensionId` (string, required): Corresponds to `id` in `eval-rubric.schema.json`
 - `score` (number | null, required): Score value. `null` when manual evaluation is pending.
-- `method` (string): Scoring method used.
+- `scoringMethod` (string): Scoring method used (matches the rubric's `scoringMethod`).
 - `details` (string): Supplementary explanation.
 
 ## Relationship to Existing Fixtures

--- a/pages/reference/evaluation-rubric.md
+++ b/pages/reference/evaluation-rubric.md
@@ -2,19 +2,28 @@
 
 River Reviewer の評価フレームワークは、レビュー品質を多次元で定量化するルーブリックを提供します。各次元は独立したスコアを持ち、加重合計により総合スコアを算出します。
 
+> **Status**: 本書は仕様であり、ランタイム統合（`scripts/evaluate-review-fixtures.mjs` / `src/lib/review-fixtures-eval.mjs` への `dimensionScores` 生成ロジックの組み込み）は後続 Issue で追跡します。現時点ではスキーマ・ルーブリック定義と整合性テスト（`tests/eval-rubric.test.mjs`）のみが実装済みです。
+
 ## 次元一覧
 
-| ID                    | 名前               | 説明                                     | Weight | スコアリング方式 | 自動化 |
-| --------------------- | ------------------ | ---------------------------------------- | ------ | ---------------- | ------ |
-| `detection_accuracy`  | 検出精度           | レビューが期待された問題を検出できたか   | 0.25   | ratio            | Yes    |
-| `false_positive_rate` | 偽陽性率           | guard case で誤って指摘を出した割合      | 0.20   | ratio            | Yes    |
-| `evidence_quality`    | エビデンス品質     | 指摘に Evidence ラベルが含まれているか   | 0.15   | ratio            | Yes    |
-| `severity_alignment`  | 重要度適切性       | 付与された severity が期待値と一致するか | 0.15   | ratio            | Yes    |
-| `phase_consistency`   | フェーズ一貫性     | 指摘がレビューフェーズと一貫しているか   | 0.10   | binary           | Yes    |
-| `actionability`       | アクショナビリティ | 指摘が実行可能な改善提案を含むか         | 0.10   | manual           | No     |
-| `token_efficiency`    | トークン効率       | Context Budget に対する出力の効率        | 0.05   | ratio            | Yes    |
+| ID                    | 名前               | 説明                                     | Weight | スコアリング方式 | Direction        | 自動化 |
+| --------------------- | ------------------ | ---------------------------------------- | ------ | ---------------- | ---------------- | ------ |
+| `detection_accuracy`  | 検出精度           | レビューが期待された問題を検出できたか   | 0.25   | ratio            | higher_is_better | Yes    |
+| `false_positive_rate` | 偽陽性率           | guard case で誤って指摘を出した割合      | 0.20   | ratio            | lower_is_better  | Yes    |
+| `evidence_quality`    | エビデンス品質     | 指摘に Evidence ラベルが含まれているか   | 0.15   | ratio            | higher_is_better | Yes    |
+| `severity_alignment`  | 重要度適切性       | 付与された severity が期待値と一致するか | 0.15   | ratio            | higher_is_better | Yes    |
+| `phase_consistency`   | フェーズ一貫性     | 指摘がレビューフェーズと一貫しているか   | 0.10   | binary           | higher_is_better | Yes    |
+| `actionability`       | アクショナビリティ | 指摘が実行可能な改善提案を含むか         | 0.10   | manual           | higher_is_better | No     |
+| `token_efficiency`    | トークン効率       | Context Budget に対する出力の効率        | 0.05   | ratio            | higher_is_better | Yes    |
 
-Weight 合計は 1.0 です。
+Weight 合計は 1.0 です（`tests/eval-rubric.test.mjs` で検証）。
+
+## Direction（方向補正）
+
+各次元は `direction` フィールドで「高いほど良い」か「低いほど良い」かを明示します。加重合計を計算する際、`lower_is_better` の次元は `(1 - score)` に変換してから合計する必要があります。
+
+- `higher_is_better`（デフォルト）: スコアが高いほど良い
+- `lower_is_better`: スコアが低いほど良い（例: `false_positive_rate`）
 
 ## スコアリング方式
 
@@ -49,13 +58,13 @@ Weight 合計は 1.0 です。
     {
       "dimensionId": "detection_accuracy",
       "score": 0.85,
-      "method": "ratio",
+      "scoringMethod": "ratio",
       "details": "17/20 expected findings detected"
     },
     {
       "dimensionId": "actionability",
       "score": null,
-      "method": "manual",
+      "scoringMethod": "manual",
       "details": "Pending human review"
     }
   ]
@@ -64,7 +73,7 @@ Weight 合計は 1.0 です。
 
 - `dimensionId`（string, required）: `eval-rubric.schema.json` の `id` と対応
 - `score`（number | null, required）: スコア値。manual 未評価時は `null`
-- `method`（string）: 使用したスコアリング方式
+- `scoringMethod`（string）: 使用したスコアリング方式（rubric の `scoringMethod` と一致）
 - `details`（string）: 補足説明
 
 ## 既存フィクスチャとの関係

--- a/schemas/eval-ledger-entry.schema.json
+++ b/schemas/eval-ledger-entry.schema.json
@@ -69,9 +69,10 @@
           "score": {
             "type": ["number", "null"]
           },
-          "method": {
+          "scoringMethod": {
             "type": "string",
-            "enum": ["binary", "ratio", "manual"]
+            "enum": ["binary", "ratio", "manual"],
+            "description": "Scoring method used for this dimension. Must match the dimension's scoringMethod in eval/rubric.yaml."
           },
           "details": {
             "type": "string"

--- a/schemas/eval-rubric.schema.json
+++ b/schemas/eval-rubric.schema.json
@@ -1,20 +1,53 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Evaluation Rubric Schema",
+  "description": "Schema for eval/rubric.yaml. The file defines three independent sections: 'severity' (severity vocabulary), 'phase' (review phase vocabulary), and 'dimensions' (multi-dimensional scoring rubric). All three sections are optional at the root so that partial fixtures (e.g. dimensions-only) can also be validated against this schema.",
   "type": "object",
-  "required": ["dimensions"],
   "properties": {
+    "severity": {
+      "type": "object",
+      "description": "Severity vocabulary definitions keyed by severity label (e.g. 'critical', 'major').",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "description": { "type": "string" },
+          "action": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "phase": {
+      "type": "object",
+      "description": "Review phase vocabulary definitions keyed by phase name (e.g. 'design', 'implementation').",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "description": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
     "dimensions": {
       "type": "array",
+      "description": "Multi-dimensional scoring rubric. The weighted sum of each dimension's score is the overall evaluation score. Weights should sum to 1.0 (validated by tests/eval-rubric.test.mjs).",
       "items": {
         "type": "object",
         "required": ["id", "name", "weight", "scoringMethod"],
         "properties": {
-          "id": { "type": "string" },
+          "id": {
+            "type": "string",
+            "description": "Stable identifier referenced from eval-ledger-entry.schema.json#dimensionScores[].dimensionId."
+          },
           "name": { "type": "string" },
           "description": { "type": "string" },
           "weight": { "type": "number", "minimum": 0, "maximum": 1 },
           "scoringMethod": { "type": "string", "enum": ["binary", "ratio", "manual"] },
+          "direction": {
+            "type": "string",
+            "enum": ["higher_is_better", "lower_is_better"],
+            "default": "higher_is_better",
+            "description": "Indicates whether a higher or lower score is better. Required for correct sign handling when computing the weighted sum. Defaults to 'higher_is_better' when omitted."
+          },
           "automatable": { "type": "boolean", "default": false }
         },
         "additionalProperties": false

--- a/tests/eval-rubric.test.mjs
+++ b/tests/eval-rubric.test.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import test, { describe } from 'node:test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+import yaml from 'js-yaml';
+import Ajv2020 from 'ajv/dist/2020.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+const rubricPath = path.join(repoRoot, 'eval', 'rubric.yaml');
+const rubricSchemaPath = path.join(repoRoot, 'schemas', 'eval-rubric.schema.json');
+const ledgerSchemaPath = path.join(repoRoot, 'schemas', 'eval-ledger-entry.schema.json');
+
+const rubric = yaml.load(readFileSync(rubricPath, 'utf8'));
+const rubricSchema = JSON.parse(readFileSync(rubricSchemaPath, 'utf8'));
+const ledgerSchema = JSON.parse(readFileSync(ledgerSchemaPath, 'utf8'));
+
+describe('eval/rubric.yaml integrity', () => {
+  test('has severity, phase, and dimensions top-level sections', () => {
+    assert.ok(rubric.severity, 'severity section missing');
+    assert.ok(rubric.phase, 'phase section missing');
+    assert.ok(Array.isArray(rubric.dimensions), 'dimensions section missing or not array');
+  });
+
+  test('validates against schemas/eval-rubric.schema.json', () => {
+    const ajv = new Ajv2020({ allErrors: true, strict: false });
+    const validate = ajv.compile(rubricSchema);
+    const ok = validate(rubric);
+    assert.ok(ok, `rubric.yaml schema violations: ${JSON.stringify(validate.errors, null, 2)}`);
+  });
+
+  test('dimension weights sum to 1.0 (±1e-9)', () => {
+    const total = rubric.dimensions.reduce((acc, d) => acc + d.weight, 0);
+    assert.ok(
+      Math.abs(total - 1.0) < 1e-9,
+      `weight sum is ${total}, expected 1.0 (±1e-9)`,
+    );
+  });
+
+  test('every dimension has a unique id', () => {
+    const ids = rubric.dimensions.map((d) => d.id);
+    const unique = new Set(ids);
+    assert.equal(unique.size, ids.length, `duplicate dimension ids: ${ids.join(', ')}`);
+  });
+
+  test('every dimension declares a direction', () => {
+    for (const d of rubric.dimensions) {
+      assert.ok(
+        d.direction === 'higher_is_better' || d.direction === 'lower_is_better',
+        `dimension '${d.id}' has invalid direction: ${d.direction}`,
+      );
+    }
+  });
+
+  test('false_positive_rate is marked lower_is_better', () => {
+    const fpr = rubric.dimensions.find((d) => d.id === 'false_positive_rate');
+    assert.ok(fpr, 'false_positive_rate dimension not found');
+    assert.equal(fpr.direction, 'lower_is_better');
+  });
+
+  test('scoringMethod values are within the allowed enum', () => {
+    const allowed = new Set(['binary', 'ratio', 'manual']);
+    for (const d of rubric.dimensions) {
+      assert.ok(allowed.has(d.scoringMethod), `invalid scoringMethod on ${d.id}: ${d.scoringMethod}`);
+    }
+  });
+});
+
+describe('ledger/rubric terminology alignment', () => {
+  test('ledger dimensionScores uses scoringMethod (not method)', () => {
+    const dimensionItem =
+      ledgerSchema.properties.dimensionScores.items.properties;
+    assert.ok(
+      dimensionItem.scoringMethod,
+      'ledger schema should expose scoringMethod on dimensionScores items',
+    );
+    assert.ok(
+      !dimensionItem.method,
+      'ledger schema should no longer expose legacy `method` field on dimensionScores items',
+    );
+  });
+
+  test('ledger scoringMethod enum matches rubric scoringMethod enum', () => {
+    const ledgerEnum =
+      ledgerSchema.properties.dimensionScores.items.properties.scoringMethod.enum;
+    const rubricEnum =
+      rubricSchema.properties.dimensions.items.properties.scoringMethod.enum;
+    assert.deepEqual([...ledgerEnum].sort(), [...rubricEnum].sort());
+  });
+});


### PR DESCRIPTION
## Summary

Closes #481 — PR #470 follow-up for the multi-dimensional rubric.

- **Schema scope clarified**: `schemas/eval-rubric.schema.json` now defines `severity`, `phase`, and `dimensions` as independent top-level sections with explicit `title`/`description`. The schema documents that all three sections are optional at the root so partial rubrics remain valid.
- **`direction` field added**: every dimension in `eval/rubric.yaml` declares `direction: higher_is_better | lower_is_better` so weighted-sum sign correction is explicit. `false_positive_rate` is `lower_is_better`.
- **Terminology unified**: `schemas/eval-ledger-entry.schema.json` renames `dimensionScores[].method` → `scoringMethod` to match the rubric vocabulary. No runtime consumers exist yet; docs updated in lockstep.
- **Integrity tests** added in `tests/eval-rubric.test.mjs`:
  - rubric validates against the JSON Schema (Ajv 2020-12 dialect)
  - `dimensions[].weight` sum = 1.0 (±1e-9)
  - unique `id`s
  - `direction` present and valid
  - ledger and rubric share the same `scoringMethod` enum
- **Docs**: `pages/reference/evaluation-rubric.{md,en.md}` add a Status note (runtime integration tracked as a separate issue), a Direction section, and the `direction` column in the dimension table. `eval/README.md` describes the three top-level sections.

## Test plan

- [x] `npm test` — 501/501 pass (new `eval-rubric.test.mjs` suite covers 9 assertions)
- [x] `npm run lint` — prettier / check:dashes / markdownlint / textlint all clean
- [ ] CI (GitHub Actions) green on PR

## Out of scope (follow-up)

- Runtime integration: wiring `dimensionScores` generation into `scripts/evaluate-review-fixtures.mjs` / `src/lib/review-fixtures-eval.mjs` is left for a separate issue, explicitly noted in the docs' new Status block.
- Cross-check script for `dimensionId` referential integrity is omitted as a separate minor task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)