### PR TITLE
chore(deps): bump @types/node to ^22.10.0 in runners/node-api

### DIFF
--- a/runners/node-api/package.json
+++ b/runners/node-api/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
     "@types/minimatch": "^5.1.2",
-    "@types/node": "^20.17.9",
+    "@types/node": "^22.10.0",
     "typescript": "^5.7.2"
   },
   "engines": {


### PR DESCRIPTION
## Summary

Follow-up to #502 (Node 20→22 baseline upgrade). `runners/node-api/package.json` still pinned `@types/node` to `^20.17.9` while the rest of the project moved to Node 22 LTS. This PR bumps it to `^22.10.0` so that TypeScript can resolve Node 22-only APIs in `runners/node-api/src/*.ts`.

- `runners/node-api/package.json`: `@types/node` `^20.17.9` → `^22.10.0`
- Resolved installed version: `22.19.17` (within `^22.10.0` range).

## Verification

- `npm install` in `runners/node-api/` — succeeds (`added 11 packages`).
- `npm test` at repo root — **492 passed / 0 failed**.
- `npx prettier --check runners/node-api/package.json` — clean.
- Pre-existing `tsc` errors in `runners/node-api/src/index.ts` (module resolution for `@river-reviewer/core-runner/*` subpath exports, implicit any) are reproduced on `main` at `81127bc` and are **unrelated to this bump**. They will be tracked separately.

## Scope

One logical change. No other files touched.

Closes #526