### PR TITLE
chore(ci): unify actions/setup-node to @v6

### DIFF
--- a/runners/github-action/action.yml
+++ b/runners/github-action/action.yml
@@ -48,7 +48,7 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node_version }}
     - name: Run River Reviewer


### PR DESCRIPTION
## Summary

Follow-up to #502. `runners/github-action/action.yml` was the last remaining entrypoint still pinning `actions/setup-node@v4`. All `.github/workflows/*.yml` and `.github/actions/setup-node-deps/action.yml` had already moved to `@v6` (majority via dependabot #531), so this PR aligns the composite action to `@v6` so every entrypoint uses the same major version.

## Changes

- `runners/github-action/action.yml`: `actions/setup-node@v4` -> `@v6` (1 line)

## Verification

- `grep -rn "setup-node@" .github/ runners/` -> all references report `@v6`
- `npx prettier --check .github/workflows/ .github/actions/ runners/github-action/action.yml` -> pass

## Test plan

- [ ] CI green on this PR (unit tests / lint)
- [ ] Nightly jobs (`nightly-audit.yml`, `nightly-eval.yml`) remain green after merge — both already use `@v6` via the shared composite, so no behavior change expected

Closes #527