### PR TITLE
docs(runbook,readme-en): align dev runbook with .nvmrc/composite, sync README.en

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -116,7 +116,8 @@ Skills are Markdown files with YAML frontmatter; River Reviewer uses the metadat
 id: rr-midstream-code-quality-sample-001
 name: Sample Code Quality Pass
 description: Checks common code quality and maintainability risks.
-phase: midstream
+category: midstream
+phase: midstream # kept for backward compatibility
 applyTo:
   - 'src/**/*.ts'
 tags: [style, maintainability, midstream]
@@ -129,7 +130,7 @@ severity: minor
 - Sample skills: `skills/upstream/sample-architecture-review.md`, `skills/midstream/sample-code-quality.md`, `skills/downstream/sample-test-review.md`
 - Examples: `examples/README.md`
 - Schemas: `schemas/skill.schema.json` (skill metadata) and `schemas/output.schema.json` (structured review output)
-- References: Skill schema details live in `pages/reference/skill-schema-reference.md`; Riverbed Memory design draft lives in `pages/explanation/riverbed-memory.md`.
+- References: Skill schema details live in `pages/reference/skill-schema-reference.md`; Riverbed Memory v1 (shipped in #474) is documented in `pages/explanation/riverbed-memory.md` and `pages/guides/use-riverbed-memory.md`.
 - Known limitations: `pages/reference/known-limitations.md`
 - Troubleshooting: `pages/guides/troubleshooting.md`
 

--- a/docs/runbook/dev.md
+++ b/docs/runbook/dev.md
@@ -2,14 +2,17 @@
 
 ## 前提
 
-- Node.js 22.x
+- Node.js—リポジトリ直下の `.nvmrc` でピン留めされたバージョン (現状 `22.22.2`) を使用する。`nvm use` または同等の version manager で揃える。CI も同じ `.nvmrc` を SSoT として参照する。
 - npm
 
 ## 初期セットアップ
 
 ```bash
+nvm use      # .nvmrc を読み込む (任意の version manager 可)
 npm ci
 ```
+
+CI ではこれらの手順を `.github/actions/setup-node-deps` (composite action) に集約しており、`actions/setup-node@v6` + `npm ci --prefer-offline` を一括で実行する。
 
 ## 日常の検証コマンド
 
@@ -64,3 +67,7 @@ npm test
 npm run agents:validate
 npm run skills:validate
 ```
+
+`runners/github-action/src/**` を変更した場合、または CI の "Action dist freshness" が失敗した場合は、`.nvmrc` の Node バージョンに揃えてから `npm run build:action` で `runners/github-action/dist/` を再生成する。詳細は `docs/development/dist-check-rebuild-guide.md` を参照。
+
+PR マージ前のチェックリスト（CI green / レビュアーコメント disposition / preflight など）は `docs/governance.md` § "PR レビューとマージ" にまとまっている。


### PR DESCRIPTION
## Summary

\`docs/runbook/dev.md\`:

- 前提を \`.nvmrc\` (\`22.22.2\`) ピン留めに合わせて書き直し、CI 側の \`.github/actions/setup-node-deps\` (composite action, #528) を併記。
- PR 前チェックに dist 再ビルド時の Node 整合 (\`docs/development/dist-check-rebuild-guide.md\`) と PR マージ前チェックリスト (\`docs/governance.md\`) への参照を追加。

\`README.en.md\`:

- Skill 例の YAML frontmatter を category-first に更新 (#556 と整合)。
- \"Riverbed Memory design draft\" を v1 実装済み (#474) の記述に修正し、\`pages/explanation/riverbed-memory.md\` と \`pages/guides/use-riverbed-memory.md\` の両方を案内。

## スコープ外 (フォロー Issue 化候補)

- \`README.en.md\` の完全翻訳同期 (\`README.md\` 440 行 vs \`README.en.md\` 189 行)
- \`docs/CLI-architecture.md\` 新規作成 (src/cli.mjs と runners/cli の二系統整理)
- CLAUDE.md \"AI Misoperation Guards\" を governance.md に集約後の文面短縮

## Test plan

- [x] \`npm run lint\` 通過
- [x] \`npm test\` 全 517 件 pass
- [x] dev.md / README.en.md とも \`.nvmrc\`・\`@v0.12.0\`・category-first を反映

## Context

ドキュメント全面棚卸し計画 (PR 5/5)。先行: #553 (Action タグ + /preflight), #554 (Riverbed v1), #555 (governance), #556 (skill schema)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)