### PR TITLE
docs(spec): define river review plan CLI contract (#517)

### DIFF
--- a/pages/reference/_meta.json
+++ b/pages/reference/_meta.json
@@ -9,6 +9,7 @@
   "review-output-example": "レビュー出力例",
   "review-artifact": "レビューアーティファクト",
   "artifact-input-contract": "アーティファクト入力コントラクト",
+  "cli-review-plan-spec": "river review plan CLI 仕様",
   "riverbed-storage": "Riverbed Memory ストレージ設計",
   "stable-interfaces": "安定インターフェース（CLI / GitHub Actions）",
   "runner-cli-reference": "Runner CLI リファレンス",

--- a/pages/reference/cli-review-plan-spec.en.md
+++ b/pages/reference/cli-review-plan-spec.en.md
@@ -1,0 +1,153 @@
+---
+title: river review plan CLI Spec
+---
+
+`river review plan` is the River Reviewer CLI subcommand that **generates and runs a review plan** against upstream artifacts. This document defines the arguments, input artifacts, output formats, exit codes, severity buckets (fail / warn / advisory), and the machine-readable output policy.
+
+> Related issues: #517 (Task) / #509 (Capability) / #507 (Epic)
+> Prerequisite: input artifacts follow the [Artifact Input Contract](./artifact-input-contract.en.md).
+
+## Positioning
+
+- `river review plan` consumes artifacts produced by upstream workflows such as **PlanGate v6**, generates a review plan (skill selection / ordering), and emits the execution result as a [Review Artifact](./review-artifact.en.md).
+- While `river run` is a generic local-developer entry point, `river review plan` provides a **stable contract for CI / batch execution**.
+- Stability label: **Beta** (see [Stable Interfaces](./stable-interfaces.en.md)). Adding flags is a minor bump; removing or changing the meaning of flags is a major bump.
+
+## Usage
+
+```bash
+river review plan [options]
+```
+
+### Minimal examples
+
+```bash
+# Auto-detect input artifacts from the current directory and run
+river review plan
+
+# Specify artifacts explicitly and write JSON output to a file
+river review plan \
+  --artifact pbi-input=./artifacts/pbi-input.md \
+  --artifact plan=./artifacts/plan.md \
+  --artifact diff=./artifacts/diff.patch \
+  --output json \
+  --output-file ./artifacts/review-artifact.json
+
+# Generate the plan only (do not execute skills)
+river review plan --plan-only --output json
+```
+
+## Arguments
+
+### Artifact selection
+
+| Option                   | Type       | Required | Description                                                                                                                                 |
+| ------------------------ | ---------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--artifact <id>=<path>` | repeatable | Optional | Pair of artifact ID (defined in [Artifact Input Contract](./artifact-input-contract.en.md)) and file path. May be specified multiple times. |
+| `--artifacts-dir <path>` | string     | Optional | Base directory used for default-filename auto-detection. Defaults to current working directory.                                             |
+| `--config <path>`        | string     | Optional | Path to `river.config.*`. The `artifacts` section in the config is overridden by `--artifact`.                                              |
+
+Resolution order matches Artifact Input Contract "Input Channels" (CLI args → config file → directory auto-detection).
+
+### Plan control
+
+| Option                 | Type    | Default     | Description                                                                                            |
+| ---------------------- | ------- | ----------- | ------------------------------------------------------------------------------------------------------ |
+| `--phase <value>`      | enum    | `midstream` | One of `upstream` / `midstream` / `downstream`. Review phase.                                          |
+| `--planner <value>`    | enum    | `off`       | One of `off` / `order` / `prune`. AI planner mode.                                                     |
+| `--plan-only`          | flag    | false       | Generate the plan only; do not execute skills. `status` becomes `ok` and `findings` is an empty array. |
+| `--include-skill <id>` | repeat. | -           | Skill ID that must be included in the plan.                                                            |
+| `--exclude-skill <id>` | repeat. | -           | Skill ID to exclude from the plan.                                                                     |
+| `--max-cost <usd>`     | number  | -           | If estimated cost exceeds this threshold, abort without executing and exit with code `1`.              |
+
+### Output control
+
+| Option                  | Type   | Default | Description                                                                                               |
+| ----------------------- | ------ | ------- | --------------------------------------------------------------------------------------------------------- |
+| `--output <format>`     | enum   | `text`  | One of `text` / `markdown` / `json`. `json` is the machine-readable contract (see below).                 |
+| `--output-file <path>`  | string | -       | Output destination. Defaults to stdout when unset.                                                        |
+| `--summary-file <path>` | string | -       | Write a human-readable summary (Markdown) to a separate file. Intended to be paired with `--output json`. |
+| `--quiet`               | flag   | false   | Suppress progress logs on stdout (errors still go to stderr). For CI use.                                 |
+| `--debug`               | flag   | false   | Include debug data in the [Review Artifact](./review-artifact.en.md) `debug` field.                       |
+
+### Failure thresholds
+
+| Option                 | Type | Default    | Description                                                                                            |
+| ---------------------- | ---- | ---------- | ------------------------------------------------------------------------------------------------------ |
+| `--fail-on <severity>` | enum | `critical` | One of `critical` / `major` / `minor` / `info`. A finding at this severity or above counts as a fail.  |
+| `--warn-on <severity>` | enum | `major`    | Threshold for warnings (below `--fail-on`).                                                            |
+| `--advisory-only`      | flag | false      | Always exit with `0` regardless of severity. Findings are still reported but the run does not fail CI. |
+
+The severity vocabulary is the same as [`schemas/output.schema.json`](../../schemas/output.schema.json) and the severity mapping in `.claude/rules/review-core.md` (`critical` / `major` / `minor` / `info`).
+
+## Input Artifacts
+
+`river review plan` recognizes the artifacts listed in [Artifact Input Contract](./artifact-input-contract.en.md) "Artifact Catalog" verbatim (`pbi-input` / `plan` / `todo` / `test-cases` / `review-self` / `review-external` / `diff` / `junit` / `coverage` / `lint` / `typecheck`).
+
+- The set of artifact IDs and their formats is governed by the Artifact Input Contract, not this spec.
+- When `diff` is unspecified and the `git diff` fallback is also empty, `status` becomes `no-changes` and no skills run (exit `0`).
+- Failure to resolve a required artifact exits with code `1` (see below).
+
+## Output Formats
+
+### `--output text` (default)
+
+Prints a human-readable summary to stdout. Format is **outside** the stable contract (may change in minor releases).
+
+### `--output markdown`
+
+Emits Markdown suitable for GitHub Actions PR comments. Format aligns with [Review Output Example](./review-output-example.en.md).
+
+### `--output json` (machine-readable / stable contract)
+
+Emits JSON conforming to [`schemas/review-artifact.schema.json`](../../schemas/review-artifact.schema.json).
+
+- Schema version is governed by the `version` field (currently `"1"`).
+- Each `findings[]` entry is compatible with the `issue` definition in `output.schema.json`.
+- `debug` is included only when `--debug` is set.
+- With `--plan-only`, `findings` is an empty array, `status` is `ok`, and only `plan.selectedSkills` carries meaning.
+
+JSON output is the **single stable machine-readable contract**. Downstream pipelines (Riverbed Memory ingestion, evaluation, CI gating) should consume only this JSON.
+
+## Severity Buckets (fail / warn / advisory)
+
+| Bucket     | Criterion                                                                             | Default behavior                         |
+| ---------- | ------------------------------------------------------------------------------------- | ---------------------------------------- |
+| `fail`     | One or more findings at or above `--fail-on` severity (default `critical`).           | Exit `1`. Fails CI.                      |
+| `warn`     | One or more findings below `--fail-on` but at or above `--warn-on` (default `major`). | Exit `2`. CI may choose how to treat it. |
+| `advisory` | Neither of the above; only `minor` / `info` findings, or `--advisory-only` is set.    | Exit `0`. Informational only.            |
+
+The mapping between internal severity tokens (`blocker` / `warning` / `nit`) and JSON schema tokens (`critical` / `major` / `minor` / `info`) is defined in `.claude/rules/review-core.md`. Unknown severity values fall back to `major` for safety.
+
+## Exit Codes
+
+| Exit | Meaning                                                                                              |
+| ---- | ---------------------------------------------------------------------------------------------------- |
+| `0`  | Success. `status` is `ok` / `no-changes` / `skipped-by-label`, with no fail/warn findings.           |
+| `1`  | Failure. Reached `--fail-on` threshold, required artifact missing, plan/exec error, or `--max-cost`. |
+| `2`  | Warn-only. `--warn-on` threshold reached but `--fail-on` not met.                                    |
+| `3`  | Configuration error. Argument validation failed, config could not be loaded, etc.                    |
+
+When `--advisory-only` is set, fail/warn judgement is disabled and only internal errors (missing artifacts, execution errors) yield non-zero exit.
+
+## CI / Downstream Integration
+
+- **Review Artifact**: persist `--output json --output-file <path>` via the CI artifact upload step.
+- **GitHub Action**: `runners/github-action/action.yml` will map inputs onto this CLI (deferred to follow-up issue #511).
+- **Riverbed Memory**: only the JSON output is canonical for ingestion (see [Riverbed Storage](./riverbed-storage.en.md)).
+- **PR comments**: idempotent updates via the `<!-- river-reviewer -->` marker follow [Stable Interfaces](./stable-interfaces.en.md).
+
+## Compatibility Policy
+
+- The set of `--artifact` IDs grows together with the Artifact Input Contract.
+- Adding flags is a minor bump; removing flags or changing their meaning / default value is a major bump.
+- Exit codes (`0` / `1` / `2` / `3`) are part of the **stable contract** and require a major bump to change.
+- Breaking changes in JSON output follow the versioning rules of [Review Artifact](./review-artifact.en.md).
+
+## See Also
+
+- [Artifact Input Contract](./artifact-input-contract.en.md) — Input artifact contract
+- [Review Artifact](./review-artifact.en.md) — Output JSON schema
+- [Stable Interfaces](./stable-interfaces.en.md) — CLI / GitHub Actions stable contract
+- [Runner CLI Reference](./runner-cli-reference.en.md) — Runner CLI (validators) usage
+- [Review Policy](./review-policy.en.md) — AI review policy

--- a/pages/reference/cli-review-plan-spec.en.md
+++ b/pages/reference/cli-review-plan-spec.en.md
@@ -51,14 +51,14 @@ Resolution order matches Artifact Input Contract "Input Channels" (CLI args → 
 
 ### Plan control
 
-| Option                 | Type    | Default     | Description                                                                                            |
-| ---------------------- | ------- | ----------- | ------------------------------------------------------------------------------------------------------ |
-| `--phase <value>`      | enum    | `midstream` | One of `upstream` / `midstream` / `downstream`. Review phase.                                          |
-| `--planner <value>`    | enum    | `off`       | One of `off` / `order` / `prune`. AI planner mode.                                                     |
-| `--plan-only`          | flag    | false       | Generate the plan only; do not execute skills. `status` becomes `ok` and `findings` is an empty array. |
-| `--include-skill <id>` | repeat. | -           | Skill ID that must be included in the plan.                                                            |
-| `--exclude-skill <id>` | repeat. | -           | Skill ID to exclude from the plan.                                                                     |
-| `--max-cost <usd>`     | number  | -           | If estimated cost exceeds this threshold, abort without executing and exit with code `1`.              |
+| Option                 | Type       | Default     | Description                                                                                            |
+| ---------------------- | ---------- | ----------- | ------------------------------------------------------------------------------------------------------ |
+| `--phase <value>`      | enum       | `midstream` | One of `upstream` / `midstream` / `downstream`. Review phase.                                          |
+| `--planner <value>`    | enum       | `off`       | One of `off` / `order` / `prune`. AI planner mode.                                                     |
+| `--plan-only`          | flag       | false       | Generate the plan only; do not execute skills. `status` becomes `ok` and `findings` is an empty array. |
+| `--include-skill <id>` | repeatable | -           | Skill ID that must be included in the plan.                                                            |
+| `--exclude-skill <id>` | repeatable | -           | Skill ID to exclude from the plan.                                                                     |
+| `--max-cost <usd>`     | number     | -           | If estimated cost exceeds this threshold, abort without executing and exit with code `1`.              |
 
 ### Output control
 
@@ -117,16 +117,16 @@ JSON output is the **single stable machine-readable contract**. Downstream pipel
 | `warn`     | One or more findings below `--fail-on` but at or above `--warn-on` (default `major`). | Exit `2`. CI may choose how to treat it. |
 | `advisory` | Neither of the above; only `minor` / `info` findings, or `--advisory-only` is set.    | Exit `0`. Informational only.            |
 
-The mapping between internal severity tokens (`blocker` / `warning` / `nit`) and JSON schema tokens (`critical` / `major` / `minor` / `info`) is defined in `.claude/rules/review-core.md`. Unknown severity values fall back to `major` for safety.
+The mapping between internal severity tokens (`blocker` / `warning` / `nit`) and JSON schema tokens (`critical` / `major` / `minor` / `info`) is defined in `.claude/rules/review-core.md`. Among the JSON schema tokens, `info` has no direct internal counterpart; it is the auxiliary level assigned to findings without a severity token (the "(なし)" row in `.claude/rules/review-core.md`) and is not produced by any internal-token conversion today. Unknown severity values fall back to `major` for safety.
 
 ## Exit Codes
 
-| Exit | Meaning                                                                                              |
-| ---- | ---------------------------------------------------------------------------------------------------- |
-| `0`  | Success. `status` is `ok` / `no-changes` / `skipped-by-label`, with no fail/warn findings.           |
-| `1`  | Failure. Reached `--fail-on` threshold, required artifact missing, plan/exec error, or `--max-cost`. |
-| `2`  | Warn-only. `--warn-on` threshold reached but `--fail-on` not met.                                    |
-| `3`  | Configuration error. Argument validation failed, config could not be loaded, etc.                    |
+| Exit | Meaning                                                                                                                         |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `0`  | Success. `status` is `ok` / `no-changes` / `skipped-by-label`, with no fail/warn findings.                                      |
+| `1`  | Failure. Reached `--fail-on` threshold (unless `--advisory-only`), required artifact missing, plan/exec error, or `--max-cost`. |
+| `2`  | Warn-only. `--warn-on` threshold reached but `--fail-on` not met.                                                               |
+| `3`  | Configuration error. Argument validation failed, config could not be loaded, etc.                                               |
 
 When `--advisory-only` is set, fail/warn judgement is disabled and only internal errors (missing artifacts, execution errors) yield non-zero exit.
 

--- a/pages/reference/cli-review-plan-spec.md
+++ b/pages/reference/cli-review-plan-spec.md
@@ -117,16 +117,16 @@ JSON 出力は **唯一の安定 machine-readable 契約** とする。後続パ
 | `warn`     | `--fail-on` 未満かつ `--warn-on` 以上（既定 `major`）の finding が 1 件以上                           | exit `2` で終了。CI 設定で扱いを選択可能。 |
 | `advisory` | 上記いずれにも該当しないが finding が存在する（`minor` / `info` のみ、または `--advisory-only` 指定） | exit `0` で終了。情報提供のみ。            |
 
-severity の内部語彙（`blocker` / `warning` / `nit`）と JSON スキーマ語彙（`critical` / `major` / `minor` / `info`）の対応は `.claude/rules/review-core.md` を参照する。不明な severity 値は fail-safe として `major` に分類される。
+severity の内部語彙（`blocker` / `warning` / `nit`）と JSON スキーマ語彙（`critical` / `major` / `minor` / `info`）の対応は `.claude/rules/review-core.md` を参照する。JSON スキーマ語彙のうち `info` は内部語彙に直接対応するトークンを持たず、severity が未指定の finding（`.claude/rules/review-core.md` の「(なし)」列）に割り当てられる補助レベルで、現時点では内部語彙からの変換には使用されない。不明な severity 値は fail-safe として `major` に分類される。
 
 ## 終了コード
 
-| Exit | 意味                                                                                           |
-| ---- | ---------------------------------------------------------------------------------------------- |
-| `0`  | 成功。`status` が `ok` / `no-changes` / `skipped-by-label` で、かつ fail / warn 判定なし。     |
-| `1`  | 失敗。`--fail-on` 閾値到達、必須 artifact 欠損、計画/実行エラー、`--max-cost` 超過、いずれか。 |
-| `2`  | 警告のみ。`--warn-on` 閾値に達したが `--fail-on` には届かない finding が存在する。             |
-| `3`  | 設定エラー。引数バリデーション失敗、設定ファイル読み込み失敗など。                             |
+| Exit | 意味                                                                                                                         |
+| ---- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `0`  | 成功。`status` が `ok` / `no-changes` / `skipped-by-label` で、かつ fail / warn 判定なし。                                   |
+| `1`  | 失敗。`--fail-on` 閾値到達（`--advisory-only` 未指定時）、必須 artifact 欠損、計画/実行エラー、`--max-cost` 超過、いずれか。 |
+| `2`  | 警告のみ。`--warn-on` 閾値に達したが `--fail-on` には届かない finding が存在する。                                           |
+| `3`  | 設定エラー。引数バリデーション失敗、設定ファイル読み込み失敗など。                                                           |
 
 `--advisory-only` を指定した場合、`fail` / `warn` 判定は無効化され、内部エラー（artifact 欠損・実行エラー）以外は常に exit `0`。
 

--- a/pages/reference/cli-review-plan-spec.md
+++ b/pages/reference/cli-review-plan-spec.md
@@ -1,0 +1,153 @@
+---
+title: river review plan CLI 仕様
+---
+
+`river review plan` は River Reviewer が提供する CLI サブコマンドのうち、上流アーティファクトに対して **レビュー計画（plan）を生成・実行する** エントリポイントです。本ドキュメントは引数、入力アーティファクト、出力フォーマット、終了コード、severity 区分（fail / warn / advisory）、machine-readable 出力方針を定義します。
+
+> 関連 Issue: #517（Task）/ #509（Capability）/ #507（Epic）
+> 前提: 入力アーティファクトの契約は [Artifact Input Contract](./artifact-input-contract.md) に従う。
+
+## 位置づけ
+
+- `river review plan` は **PlanGate v6** をはじめとする上流ワークフローが生成した artifact を入力とし、レビュー計画（実行対象 skill の選定・順序）と、その計画に基づく実行結果を [Review Artifact](./review-artifact.md) スキーマで出力する。
+- 既存の `river run` がローカル開発者向けの汎用エントリであるのに対し、`river review plan` は **CI / バッチ実行で安定した契約** を提供することを目的とする。
+- 安定性ラベルは **Beta**（参考: [Stable Interfaces](./stable-interfaces.md)）。CLI オプションの追加は minor、削除/意味変更は major bump とする。
+
+## Usage
+
+```bash
+river review plan [options]
+```
+
+### 最小例
+
+```bash
+# 入力 artifact をカレントディレクトリから自動検出してレビュー計画を実行
+river review plan
+
+# 明示的に artifact を指定し、JSON 出力をファイルへ書き出す
+river review plan \
+  --artifact pbi-input=./artifacts/pbi-input.md \
+  --artifact plan=./artifacts/plan.md \
+  --artifact diff=./artifacts/diff.patch \
+  --output json \
+  --output-file ./artifacts/review-artifact.json
+
+# 計画のみを生成（実行しない）
+river review plan --plan-only --output json
+```
+
+## 引数
+
+### artifact 指定
+
+| オプション               | 型     | 必須 | 説明                                                                                                                |
+| ------------------------ | ------ | ---- | ------------------------------------------------------------------------------------------------------------------- |
+| `--artifact <id>=<path>` | 反復可 | 任意 | [Artifact Input Contract](./artifact-input-contract.md) で定義された artifact ID とファイルパスのペア。複数指定可。 |
+| `--artifacts-dir <path>` | string | 任意 | artifact 既定ファイル名を探索するベースディレクトリ。未指定時はカレントディレクトリ。                               |
+| `--config <path>`        | string | 任意 | `river.config.*` のパス。設定ファイルの `artifacts` セクションが `--artifact` で上書きされる。                      |
+
+artifact 解決の優先順位は Artifact Input Contract「指定方法（入力チャネル）」に従う（CLI 引数 → 設定ファイル → ディレクトリ自動検出）。
+
+### 計画制御
+
+| オプション             | 型     | デフォルト  | 説明                                                                                        |
+| ---------------------- | ------ | ----------- | ------------------------------------------------------------------------------------------- |
+| `--phase <value>`      | enum   | `midstream` | `upstream` / `midstream` / `downstream`。レビューフェーズ。                                 |
+| `--planner <value>`    | enum   | `off`       | `off` / `order` / `prune`。AI プランナーのモード。                                          |
+| `--plan-only`          | flag   | false       | レビュー計画のみを生成し、skill を実行しない。`status` は `ok`、`findings` は空配列となる。 |
+| `--include-skill <id>` | 反復可 | -           | 計画で必ず含める skill ID。                                                                 |
+| `--exclude-skill <id>` | 反復可 | -           | 計画から除外する skill ID。                                                                 |
+| `--max-cost <usd>`     | number | -           | 計画の見積もりコストが上限を超えた場合は実行せず終了コード `1` で終了する。                 |
+
+### 出力制御
+
+| オプション              | 型     | デフォルト | 説明                                                                                   |
+| ----------------------- | ------ | ---------- | -------------------------------------------------------------------------------------- |
+| `--output <format>`     | enum   | `text`     | `text` / `markdown` / `json`。`json` は machine-readable 出力（後述）。                |
+| `--output-file <path>`  | string | -          | 出力先ファイル。未指定時は標準出力。                                                   |
+| `--summary-file <path>` | string | -          | 人間向けサマリ（Markdown）を別ファイルへ書き出す。`--output json` と併用する想定。     |
+| `--quiet`               | flag   | false      | stdout への進捗ログを抑制（エラーは stderr に出力）。CI 用。                           |
+| `--debug`               | flag   | false      | デバッグ情報を [Review Artifact](./review-artifact.md) の `debug` フィールドに含める。 |
+
+### 失敗判定の閾値
+
+| オプション             | 型   | デフォルト | 説明                                                                                                  |
+| ---------------------- | ---- | ---------- | ----------------------------------------------------------------------------------------------------- |
+| `--fail-on <severity>` | enum | `critical` | `critical` / `major` / `minor` / `info`。指定 severity 以上の finding が 1 件でもあれば fail と判定。 |
+| `--warn-on <severity>` | enum | `major`    | `--fail-on` には届かないが warn と扱う閾値。                                                          |
+| `--advisory-only`      | flag | false      | severity に関わらず常に成功扱い（exit `0`）。発見事項は出力されるが CI を落とさない。                 |
+
+severity の語彙は [`schemas/output.schema.json`](../../schemas/output.schema.json) と `.claude/rules/review-core.md` の severity マッピングに準ずる（`critical` / `major` / `minor` / `info`）。
+
+## 入力アーティファクト
+
+`river review plan` が認識する artifact は [Artifact Input Contract](./artifact-input-contract.md) の「対象アーティファクト一覧」と完全に一致する。具体的には `pbi-input` / `plan` / `todo` / `test-cases` / `review-self` / `review-external` / `diff` / `junit` / `coverage` / `lint` / `typecheck` の 11 種類を対象とします。
+
+- artifact ID とファイル形式の追加・変更・削除は本仕様ではなく Artifact Input Contract 側で管理する。
+- `diff` artifact が未指定で `git diff` フォールバックも空の場合、`status` を `no-changes` とし、skill は実行されない（exit `0`）。
+- 必須 artifact の解決に失敗した場合は exit `1`（後述）。
+
+## 出力フォーマット
+
+### `--output text`（デフォルト）
+
+人間が読める要約を stdout に出力する。フォーマットは安定契約の対象外（minor で変更可能）。
+
+### `--output markdown`
+
+GitHub Actions のコメント投稿などで利用する Markdown を出力する。書式は [Review Output Example](./review-output-example.md) と整合する。
+
+### `--output json`（machine-readable / 安定契約）
+
+[`schemas/review-artifact.schema.json`](../../schemas/review-artifact.schema.json) に準拠した JSON を出力する。
+
+- スキーマバージョンは `version` フィールドで管理（現行 `"1"`）。
+- `findings` 配列の各要素は `output.schema.json` の issue 定義と互換。
+- `--debug` 指定時のみ `debug` セクションを含める。
+- `--plan-only` 指定時は `findings` を空配列、`status` を `ok` とし、`plan.selectedSkills` のみが意味を持つ。
+
+JSON 出力は **唯一の安定 machine-readable 契約** とする。後続パイプライン（Riverbed Memory 取り込み、評価、CI gate）は本 JSON のみを参照することを推奨する。
+
+## Severity 区分（fail / warn / advisory）
+
+| 区分       | 判定基準                                                                                              | 既定の振る舞い                             |
+| ---------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| `fail`     | severity が `--fail-on` 以上（既定 `critical`）の finding が 1 件以上                                 | exit `1` で終了。CI を落とす。             |
+| `warn`     | `--fail-on` 未満かつ `--warn-on` 以上（既定 `major`）の finding が 1 件以上                           | exit `2` で終了。CI 設定で扱いを選択可能。 |
+| `advisory` | 上記いずれにも該当しないが finding が存在する（`minor` / `info` のみ、または `--advisory-only` 指定） | exit `0` で終了。情報提供のみ。            |
+
+severity の内部語彙（`blocker` / `warning` / `nit`）と JSON スキーマ語彙（`critical` / `major` / `minor` / `info`）の対応は `.claude/rules/review-core.md` を参照する。不明な severity 値は fail-safe として `major` に分類される。
+
+## 終了コード
+
+| Exit | 意味                                                                                           |
+| ---- | ---------------------------------------------------------------------------------------------- |
+| `0`  | 成功。`status` が `ok` / `no-changes` / `skipped-by-label` で、かつ fail / warn 判定なし。     |
+| `1`  | 失敗。`--fail-on` 閾値到達、必須 artifact 欠損、計画/実行エラー、`--max-cost` 超過、いずれか。 |
+| `2`  | 警告のみ。`--warn-on` 閾値に達したが `--fail-on` には届かない finding が存在する。             |
+| `3`  | 設定エラー。引数バリデーション失敗、設定ファイル読み込み失敗など。                             |
+
+`--advisory-only` を指定した場合、`fail` / `warn` 判定は無効化され、内部エラー（artifact 欠損・実行エラー）以外は常に exit `0`。
+
+## CI / 後続システムとの接続
+
+- **Review Artifact**: `--output json --output-file <path>` を CI の artifact upload で永続化することを推奨する。
+- **GitHub Action**: `runners/github-action/action.yml` の inputs から本 CLI へのマッピングを提供する（詳細は後続 Issue #511）。
+- **Riverbed Memory**: 取り込み入力としては JSON 出力のみを正とする（参考: [Riverbed Storage](./riverbed-storage.md)）。
+- **PR コメント**: idempotent 更新（`<!-- river-reviewer -->` marker）の方針は [Stable Interfaces](./stable-interfaces.md) を継承する。
+
+## 互換性ポリシー
+
+- `--artifact` で渡せる ID 集合は Artifact Input Contract に従い拡張される。
+- フラグ追加は minor、フラグの削除・意味変更・既定値変更は major bump とする。
+- exit code の意味（`0` / `1` / `2` / `3`）は **Stable Contract** として扱い、変更には major bump を要する。
+- JSON 出力スキーマの破壊的変更は [Review Artifact](./review-artifact.md) のバージョニングに従う。
+
+## 関連ドキュメント
+
+- [Artifact Input Contract](./artifact-input-contract.md) — 入力アーティファクトの契約
+- [Review Artifact](./review-artifact.md) — 出力 JSON スキーマ
+- [Stable Interfaces](./stable-interfaces.md) — CLI / GitHub Actions 安定契約
+- [Runner CLI Reference](./runner-cli-reference.md) — Runner CLI（バリデータ）の使い方
+- [Review Policy](./review-policy.md) — AI レビュー標準ポリシー


### PR DESCRIPTION
## Summary

- Issue #517（Task）の受け入れ条件を満たす CLI spec を追加。`river review plan` サブコマンドの引数、入力アーティファクト、出力フォーマット、終了コードを仕様化する。
- 入力アーティファクトは #516 で main にマージ済の `artifact-input-contract.md`（PR #558）を参照する形で契約を継承し、本 spec は CLI 表面（flag と exit code）、fail/warn/advisory severity 区分、machine-readable (JSON) 出力の安定契約を定義する。
- `pages/reference/_meta.json` に index エントリを 1 行追加。

## 追加ファイル

- `pages/reference/cli-review-plan-spec.md`（153 行・日本語 SSoT）
- `pages/reference/cli-review-plan-spec.en.md`（153 行・英語版）

## 受け入れ条件（Issue #517）

- [x] CLI usage 例がある（最小例 3 種を Usage セクションに記載）
- [x] 入力（必須／任意）が input contract spec と整合（artifact-input-contract.md を SSoT として参照）
- [x] 終了コード仕様（CI 用）が定義されている（0 / 1 / 2 / 3）
- [x] human / machine 出力モードが定義されている（`--output text|markdown|json`、JSON のみ安定契約）

## 親・関連

- Closes #517
- Refs: #509（Capability）/ #507（Epic）
- 依存: #516（artifact-input-contract, 既に main へマージ済）

## Test plan

- [x] `npm run lint` pass（prettier / dashes / markdownlint / textlint）
- [ ] レビュワーによる仕様妥当性の確認（特に exit code `2` = warn-only の CI 運用、`--fail-on`/`--warn-on` のデフォルト severity）

🤖 Generated with [Claude Code](https://claude.com/claude-code)