### PR TITLE
fix(schema): align riverbed-index schema with v1 inline-entries impl (closes #565)

### DIFF
--- a/schemas/riverbed-index.schema.json
+++ b/schemas/riverbed-index.schema.json
@@ -1,58 +1,26 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://river-reviewer.vercel.app/schemas/riverbed-index.schema.json",
   "title": "Riverbed Memory Index Schema",
+  "description": "Schema for .river/memory/index.json written by src/lib/riverbed-memory.mjs. v1 stores full entries inline (not references to separate JSON files).",
   "type": "object",
-  "required": ["entries"],
+  "required": ["version", "entries"],
   "additionalProperties": false,
-  "$defs": {
-    "entryReference": {
-      "type": "object",
-      "required": ["id", "type", "path"],
-      "additionalProperties": false,
-      "properties": {
-        "id": { "type": "string" },
-        "type": {
-          "type": "string",
-          "enum": [
-            "adr",
-            "review",
-            "wontfix",
-            "pattern",
-            "decision",
-            "eval_result",
-            "suppression",
-            "resurface"
-          ]
-        },
-        "path": { "type": "string", "description": "Relative path to the entry JSON file." },
-        "title": { "type": "string" },
-        "tags": {
-          "type": "array",
-          "items": { "type": "string" },
-          "uniqueItems": true
-        },
-        "phase": {
-          "type": "string",
-          "enum": ["upstream", "midstream", "downstream"]
-        },
-        "createdAt": { "type": "string", "format": "date-time" },
-        "summary": { "type": "string" },
-        "status": {
-          "type": "string",
-          "enum": ["active", "superseded", "archived"]
-        }
-      }
-    }
-  },
   "properties": {
+    "version": {
+      "type": "string",
+      "const": "1",
+      "description": "Index schema version. Currently fixed at \"1\"."
+    },
     "generatedAt": {
       "type": "string",
       "format": "date-time",
-      "description": "Timestamp when this index was generated."
+      "description": "Optional timestamp when this index was last generated/written."
     },
     "entries": {
       "type": "array",
-      "items": { "$ref": "#/$defs/entryReference" }
+      "description": "Full entry objects conforming to riverbed-entry.schema.json, stored inline.",
+      "items": { "$ref": "./riverbed-entry.schema.json" }
     }
   }
 }

--- a/tests/riverbed-index-schema.test.mjs
+++ b/tests/riverbed-index-schema.test.mjs
@@ -10,12 +10,7 @@ import test, { describe } from 'node:test';
 import Ajv2020 from 'ajv/dist/2020.js';
 import addFormats from 'ajv-formats';
 
-import {
-  loadMemory,
-  appendEntry,
-  supersede,
-  expireEntries,
-} from '../src/lib/riverbed-memory.mjs';
+import { loadMemory, appendEntry, supersede, expireEntries } from '../src/lib/riverbed-memory.mjs';
 import { createTempMemory, makeMemoryEntry } from './helpers/memory.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -24,24 +19,23 @@ const entrySchemaPath = resolve(__dirname, '..', 'schemas', 'riverbed-entry.sche
 const indexSchema = JSON.parse(readFileSync(indexSchemaPath, 'utf8'));
 const entrySchema = JSON.parse(readFileSync(entrySchemaPath, 'utf8'));
 
-function makeValidator() {
-  const ajv = new Ajv2020({ allErrors: true, strict: false });
+// Compile the schema once — ajv compile is expensive and the schemas are static.
+// strict mode stays on so future schema typos / unknown keywords surface here.
+const validate = (() => {
+  const ajv = new Ajv2020({ allErrors: true });
   addFormats(ajv);
   // The index schema references riverbed-entry.schema.json via relative $ref,
-  // which ajv resolves against the index schema's $id. Register the entry
-  // schema under that resolved URL so compile() can find it.
-  ajv.addSchema(
-    entrySchema,
-    'https://river-reviewer.vercel.app/schemas/riverbed-entry.schema.json',
-  );
+  // which ajv resolves against the index schema's $id. Resolve the entry
+  // schema URL from $id so a future $id change does not silently break this.
+  const entryRefId = new URL('./riverbed-entry.schema.json', indexSchema.$id).toString();
+  ajv.addSchema(entrySchema, entryRefId);
   return ajv.compile(indexSchema);
-}
+})();
 
 describe('riverbed-index.schema.json', () => {
   test('empty index from loadMemory conforms to schema', () => {
     const { cleanup, indexPath } = createTempMemory({ layout: 'flat', prefix: 'rr-idx-' });
     try {
-      const validate = makeValidator();
       const mem = loadMemory(indexPath);
       assert.equal(validate(mem), true, JSON.stringify(validate.errors, null, 2));
     } finally {
@@ -55,7 +49,6 @@ describe('riverbed-index.schema.json', () => {
       appendEntry(indexPath, makeMemoryEntry({ type: 'review' }));
       appendEntry(indexPath, makeMemoryEntry({ type: 'wontfix' }));
       const mem = loadMemory(indexPath);
-      const validate = makeValidator();
       assert.equal(validate(mem), true, JSON.stringify(validate.errors, null, 2));
       assert.equal(mem.entries.length, 2);
     } finally {
@@ -72,7 +65,6 @@ describe('riverbed-index.schema.json', () => {
       appendEntry(indexPath, newEntry);
       supersede(indexPath, 'old-1', 'new-1');
       const mem = loadMemory(indexPath);
-      const validate = makeValidator();
       assert.equal(validate(mem), true, JSON.stringify(validate.errors, null, 2));
       const superseded = mem.entries.find((e) => e.id === 'old-1');
       assert.equal(superseded.status, 'superseded');
@@ -87,32 +79,23 @@ describe('riverbed-index.schema.json', () => {
     try {
       appendEntry(
         indexPath,
-        makeMemoryEntry({ id: 'expired-1', expiresAt: '2020-01-01T00:00:00Z' }),
+        makeMemoryEntry({ id: 'expired-1', expiresAt: '2020-01-01T00:00:00Z' })
       );
       appendEntry(indexPath, makeMemoryEntry({ id: 'active-1' }));
       expireEntries(indexPath);
       const mem = loadMemory(indexPath);
-      const validate = makeValidator();
       assert.equal(validate(mem), true, JSON.stringify(validate.errors, null, 2));
-      assert.equal(
-        mem.entries.find((e) => e.id === 'expired-1').status,
-        'archived',
-      );
+      assert.equal(mem.entries.find((e) => e.id === 'expired-1').status, 'archived');
     } finally {
       cleanup();
     }
   });
 
   test('missing version field is rejected', () => {
-    const validate = makeValidator();
     assert.equal(validate({ entries: [] }), false);
   });
 
   test('extra top-level property is rejected', () => {
-    const validate = makeValidator();
-    assert.equal(
-      validate({ version: '1', entries: [], unexpected: true }),
-      false,
-    );
+    assert.equal(validate({ version: '1', entries: [], unexpected: true }), false);
   });
 });

--- a/tests/riverbed-index-schema.test.mjs
+++ b/tests/riverbed-index-schema.test.mjs
@@ -1,0 +1,118 @@
+// Ensures schemas/riverbed-index.schema.json matches what src/lib/riverbed-memory.mjs writes.
+// If the index schema drifts from the v1 implementation again (see #563/#565), this test catches it.
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import test, { describe } from 'node:test';
+
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+import {
+  loadMemory,
+  appendEntry,
+  supersede,
+  expireEntries,
+} from '../src/lib/riverbed-memory.mjs';
+import { createTempMemory, makeMemoryEntry } from './helpers/memory.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const indexSchemaPath = resolve(__dirname, '..', 'schemas', 'riverbed-index.schema.json');
+const entrySchemaPath = resolve(__dirname, '..', 'schemas', 'riverbed-entry.schema.json');
+const indexSchema = JSON.parse(readFileSync(indexSchemaPath, 'utf8'));
+const entrySchema = JSON.parse(readFileSync(entrySchemaPath, 'utf8'));
+
+function makeValidator() {
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  // The index schema references riverbed-entry.schema.json via relative $ref,
+  // which ajv resolves against the index schema's $id. Register the entry
+  // schema under that resolved URL so compile() can find it.
+  ajv.addSchema(
+    entrySchema,
+    'https://river-reviewer.vercel.app/schemas/riverbed-entry.schema.json',
+  );
+  return ajv.compile(indexSchema);
+}
+
+describe('riverbed-index.schema.json', () => {
+  test('empty index from loadMemory conforms to schema', () => {
+    const { cleanup, indexPath } = createTempMemory({ layout: 'flat', prefix: 'rr-idx-' });
+    try {
+      const validate = makeValidator();
+      const mem = loadMemory(indexPath);
+      assert.equal(validate(mem), true, JSON.stringify(validate.errors, null, 2));
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('index after appendEntry conforms to schema', () => {
+    const { cleanup, indexPath } = createTempMemory({ layout: 'flat', prefix: 'rr-idx-' });
+    try {
+      appendEntry(indexPath, makeMemoryEntry({ type: 'review' }));
+      appendEntry(indexPath, makeMemoryEntry({ type: 'wontfix' }));
+      const mem = loadMemory(indexPath);
+      const validate = makeValidator();
+      assert.equal(validate(mem), true, JSON.stringify(validate.errors, null, 2));
+      assert.equal(mem.entries.length, 2);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('index after supersede conforms to schema', () => {
+    const { cleanup, indexPath } = createTempMemory({ layout: 'flat', prefix: 'rr-idx-' });
+    try {
+      const oldEntry = makeMemoryEntry({ id: 'old-1' });
+      const newEntry = makeMemoryEntry({ id: 'new-1' });
+      appendEntry(indexPath, oldEntry);
+      appendEntry(indexPath, newEntry);
+      supersede(indexPath, 'old-1', 'new-1');
+      const mem = loadMemory(indexPath);
+      const validate = makeValidator();
+      assert.equal(validate(mem), true, JSON.stringify(validate.errors, null, 2));
+      const superseded = mem.entries.find((e) => e.id === 'old-1');
+      assert.equal(superseded.status, 'superseded');
+      assert.equal(superseded.supersededBy, 'new-1');
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('index after expireEntries conforms to schema', () => {
+    const { cleanup, indexPath } = createTempMemory({ layout: 'flat', prefix: 'rr-idx-' });
+    try {
+      appendEntry(
+        indexPath,
+        makeMemoryEntry({ id: 'expired-1', expiresAt: '2020-01-01T00:00:00Z' }),
+      );
+      appendEntry(indexPath, makeMemoryEntry({ id: 'active-1' }));
+      expireEntries(indexPath);
+      const mem = loadMemory(indexPath);
+      const validate = makeValidator();
+      assert.equal(validate(mem), true, JSON.stringify(validate.errors, null, 2));
+      assert.equal(
+        mem.entries.find((e) => e.id === 'expired-1').status,
+        'archived',
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('missing version field is rejected', () => {
+    const validate = makeValidator();
+    assert.equal(validate({ entries: [] }), false);
+  });
+
+  test('extra top-level property is rejected', () => {
+    const validate = makeValidator();
+    assert.equal(
+      validate({ version: '1', entries: [], unexpected: true }),
+      false,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

\`schemas/riverbed-index.schema.json\` は v0 の reference モデル (entries は別 JSON への path 必須リファレンス) を前提にしていたが、v1 実装 (\`src/lib/riverbed-memory.mjs\`, #474) は単一 \`.river/memory/index.json\` に full entry オブジェクトを inline で追記する方式。スキーマと実装が乖離していたため、#563 で reviewer (gemini-code-assist) から構造矛盾の指摘を受けた。

## Changes

**\`schemas/riverbed-index.schema.json\`**

- top-level required を \`[\"version\", \"entries\"]\` に変更し、\`version: const \"1\"\` を追加 (実装と整合)
- \`entries[]\` の items を \`riverbed-entry.schema.json\` への \`\$ref\` に置換 — v0 の \`entryReference\` (path 必須・additionalProperties: false) を削除し v1 の full entry が validate を通るように
- 不要になった v0 専用 \`entryReference\` \$defs と \`path\` 要件を削除
- \`generatedAt\` は optional として保持
- \`\$id\` を追加して entry schema への参照を解決可能にする

**\`tests/riverbed-index-schema.test.mjs\` (新規, 6 ケース)**

- \`loadMemory\` で生成される空 index がスキーマを満たす
- \`appendEntry\` 後の index がスキーマを満たす
- \`supersede\` 後の index がスキーマを満たす
- \`expireEntries\` 後の index がスキーマを満たす
- \`version\` 欠落は reject される
- 余計な top-level プロパティは reject される

## Why

ドキュメント整備セルフレビュー (#563 + 3 エージェント並列) で「スキーマが v1 実装と矛盾」が検出された。スキーマは src/ や tests/ から元々参照されていない (\`grep -rln 0 件\`) ため実行時影響は無いが、\`pages/reference/riverbed-storage.md\` が「\`schemas/riverbed-index.schema.json\` に準拠」と記載するため、SSoT を実装に合わせる必要があった。

今回テストを追加したことで、再ドリフトすれば CI で落ちる。

## Test plan

- [x] \`node --test tests/riverbed-index-schema.test.mjs\` 6/6 pass
- [x] \`npm test\` 全 523 件 pass (新規 6 + 既存 517)
- [x] \`npm run lint\` 通過

## Context

ドキュメント整備フォロー (Issue #565)。前: #553-#557 (5 PR セット), #563-#564 (セルフレビュー由来の追加 2 PR)。

Closes #565
Refs #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)