### PR TITLE
docs(cli): add CLI architecture overview to clarify two CLI systems

### DIFF
--- a/docs/CLI-architecture.md
+++ b/docs/CLI-architecture.md
@@ -1,0 +1,53 @@
+# CLI Architecture
+
+> 内部資料: River Reviewer リポジトリには 2 系統の CLI が並立している。本ドキュメントはコントリビュータ向けに、各系統の責務・対象ユーザー・サブコマンドの境界を整理する。
+
+## 2 系統の CLI
+
+| 系統           | 実体                                                       | npm bin                                             | サブコマンド                                                 | 対象ユーザー                                               |
+| -------------- | ---------------------------------------------------------- | --------------------------------------------------- | ------------------------------------------------------------ | ---------------------------------------------------------- |
+| **メイン CLI** | `src/cli.mjs`                                              | `river` / `river-reviewer` (`package.json#bin`)     | `run`, `skills` (`import`/`export`/`list`), `doctor`, `eval` | エンドユーザー、GitHub Action runner                       |
+| **Runner CLI** | `runners/cli/src/index.mjs` (`@river-reviewer/cli-runner`) | パッケージ内 `bin/river` のみ (private、npm 未公開) | `review`, `eval`, `create`                                   | リポジトリ内ツール、スキル開発者向け実験的インターフェース |
+
+`runners/cli/package.json` は `"private": true` ではないが、`runners/` 配下の独立 npm package として `commander` ベースで実装されており、ルートの `package.json#bin` からは引き出されていない。実行は `node runners/cli/bin/river …` で行う。
+
+## なぜ並立しているのか
+
+- メイン CLI (`src/cli.mjs`) は GitHub Action 経由で `node ${GITHUB_ACTION_PATH}/dist/index.mjs run <repo>` の形で呼ばれる本番経路 (`runners/github-action/action.yml` L72)。`runners/github-action/dist/index.mjs` は `runners/github-action/src/index.mjs` (これが `src/cli.mjs` を import するシム) を ncc でバンドルした成果物。GitHub Action 入力 (`phase`, `dry_run`, `debug`, `--planner`, `--max-cost`, `--output`) との 1:1 対応が要件。
+- Runner CLI (`runners/cli/`) は v0.2 系で導入されたスキル開発者向けの新インターフェース (`review` / `eval` / `create`)。`commander` を採用し、`@inquirer/prompts` でインタラクティブに `create skill` などを提供。GitHub Action 経路には載せていない。
+
+両者は併用前提で、置き換え計画は無い (2026-04 時点)。
+
+## サブコマンド対応表
+
+| 用途                                | メイン CLI                                          | Runner CLI                             |
+| ----------------------------------- | --------------------------------------------------- | -------------------------------------- |
+| ローカル差分のレビュー実行          | `river run <path>`                                  | `river review [files...]` (簡易確認用) |
+| スキルファイル単体の検証            | `river skills list` / `npm run skills:validate`     | `river eval <skill>`                   |
+| 全スキル評価                        | `npm run eval:all` (`scripts/evaluate-all.mjs`)     | `river eval --all`                     |
+| 新規スキルの雛形生成                | `npm run create:skill` (`scripts/create-skill.mjs`) | `river create skill` (interactive)     |
+| Agent Skills の入出力               | `river skills import` / `river skills export`       | (なし)                                 |
+| 設定診断                            | `river doctor <path>`                               | (なし)                                 |
+| Fixtures eval (must_include checks) | `river eval --cases <path>`                         | (なし)                                 |
+
+「同じ名前で別物」なサブコマンド (`eval`) があるため、ドキュメントでは必ずどちらの CLI かを明示する。
+
+## どちらを使うべきか
+
+- **GitHub Action / 本番ローカル実行 / リリース前検証**: メイン CLI (`river run` / `river skills` / `river doctor`)。`runners/github-action` も内部でこれを呼ぶ。
+- **スキルを書く / インタラクティブな雛形生成 / 単発の eval プロトタイプ**: Runner CLI (`river review` / `river eval` / `river create skill`)。
+- **CI でのスキーマ検証**: `npm run skills:validate` / `npm run agents:validate` (どちらの CLI も経由しない直接スクリプト)。
+
+## ドキュメント側の参照
+
+- メイン CLI のオプション仕様: `pages/reference/stable-interfaces.md` § "CLI (`river`) リファレンス（最小）"
+- Runner CLI のヘルプ: `runners/cli/README.md`
+- スキーマ検証コマンドの導入: `pages/reference/runner-cli-reference.md`
+- 新スキル作成手順: `pages/guides/add-new-skill.md`
+
+## 既知の境界 / 注意点
+
+- ルートの `package.json#bin` がメイン CLI (`src/cli.mjs`) にしか登録されていないため、`npx river review …` は **Runner CLI ではなくメイン CLI** に解釈され、メイン CLI には `review` コマンドが無いので unknown command エラーになる。Runner CLI を呼ぶ場合は `node runners/cli/bin/river …` あるいは `runners/cli` 内で `npm exec river …` を使う。
+- GitHub Action は `runners/github-action/dist/` 配下のバンドル済み JS を実行するため、`runners/github-action/src/**` を変更したら `npm run build:action` で `dist/` を再生成しないと CI の "Action dist freshness" が落ちる (`docs/development/dist-check-rebuild-guide.md` 参照)。
+- 両 CLI ともデフォルト `phase` は `midstream`。`RIVER_PHASE` 環境変数はメイン CLI でのみ参照される (Runner CLI は `--phase` 明示が必要)。
+- Runner CLI は `commander` の自動 help を使うため、メイン CLI の `printHelp()` (`src/cli.mjs`) と書式が揃っていない。両ヘルプを同期する責務は今のところ無い。

--- a/docs/CLI-architecture.md
+++ b/docs/CLI-architecture.md
@@ -20,15 +20,16 @@
 
 ## サブコマンド対応表
 
-| 用途                                | メイン CLI                                          | Runner CLI                             |
-| ----------------------------------- | --------------------------------------------------- | -------------------------------------- |
-| ローカル差分のレビュー実行          | `river run <path>`                                  | `river review [files...]` (簡易確認用) |
-| スキルファイル単体の検証            | `river skills list` / `npm run skills:validate`     | `river eval <skill>`                   |
-| 全スキル評価                        | `npm run eval:all` (`scripts/evaluate-all.mjs`)     | `river eval --all`                     |
-| 新規スキルの雛形生成                | `npm run create:skill` (`scripts/create-skill.mjs`) | `river create skill` (interactive)     |
-| Agent Skills の入出力               | `river skills import` / `river skills export`       | (なし)                                 |
-| 設定診断                            | `river doctor <path>`                               | (なし)                                 |
-| Fixtures eval (must_include checks) | `river eval --cases <path>`                         | (なし)                                 |
+| 用途                                | メイン CLI                                                                | Runner CLI                             |
+| ----------------------------------- | ------------------------------------------------------------------------- | -------------------------------------- |
+| ローカル差分のレビュー実行          | `river run <path>`                                                        | `river review [files...]` (簡易確認用) |
+| スキル一覧表示                      | `river skills list` (RR + Agent Skills 一覧)                              | (なし)                                 |
+| スキルファイル単体の検証            | `npm run skills:validate` (リポジトリ全体、`scripts/validate-skills.mjs`) | `river eval <skill>`                   |
+| 全スキル評価                        | `npm run eval:all` (`scripts/evaluate-all.mjs`)                           | `river eval --all`                     |
+| 新規スキルの雛形生成                | `npm run create:skill` (`scripts/create-skill.mjs`)                       | `river create skill` (interactive)     |
+| Agent Skills の入出力               | `river skills import` / `river skills export`                             | (なし)                                 |
+| 設定診断                            | `river doctor <path>`                                                     | (なし)                                 |
+| Fixtures eval (must_include checks) | `river eval --cases <path>`                                               | (なし)                                 |
 
 「同じ名前で別物」なサブコマンド (`eval`) があるため、ドキュメントでは必ずどちらの CLI かを明示する。
 
@@ -42,12 +43,12 @@
 
 - メイン CLI のオプション仕様: `pages/reference/stable-interfaces.md` § "CLI (`river`) リファレンス（最小）"
 - Runner CLI のヘルプ: `runners/cli/README.md`
-- スキーマ検証コマンドの導入: `pages/reference/runner-cli-reference.md`
+- スキーマ検証コマンド (Python ランナー / `npm run *:validate`): `pages/reference/runner-cli-reference.md` (注: タイトルは「Runner CLI リファレンス」だが内容は本ドキュメントで言う「Runner CLI = `runners/cli/`」とは別物で、Python 製のスキーマ検証スクリプト群を扱う)
 - 新スキル作成手順: `pages/guides/add-new-skill.md`
 
 ## 既知の境界 / 注意点
 
 - ルートの `package.json#bin` がメイン CLI (`src/cli.mjs`) にしか登録されていないため、`npx river review …` は **Runner CLI ではなくメイン CLI** に解釈され、メイン CLI には `review` コマンドが無いので unknown command エラーになる。Runner CLI を呼ぶ場合は `node runners/cli/bin/river …` あるいは `runners/cli` 内で `npm exec river …` を使う。
 - GitHub Action は `runners/github-action/dist/` 配下のバンドル済み JS を実行するため、`runners/github-action/src/**` を変更したら `npm run build:action` で `dist/` を再生成しないと CI の "Action dist freshness" が落ちる (`docs/development/dist-check-rebuild-guide.md` 参照)。
-- 両 CLI ともデフォルト `phase` は `midstream`。`RIVER_PHASE` 環境変数はメイン CLI でのみ参照される (Runner CLI は `--phase` 明示が必要)。
+- 両 CLI ともデフォルト `phase` は `midstream`。`RIVER_PHASE` / `RIVER_PLANNER_MODE` / `RIVER_AVAILABLE_CONTEXTS` / `RIVER_AVAILABLE_DEPENDENCIES` などの `RIVER_*` 環境変数はメイン CLI でのみ参照される (Runner CLI は対応する `--phase` / `--context` / `--dependency` オプションでの明示が必要)。
 - Runner CLI は `commander` の自動 help を使うため、メイン CLI の `printHelp()` (`src/cli.mjs`) と書式が揃っていない。両ヘルプを同期する責務は今のところ無い。


### PR DESCRIPTION
## Summary

ドキュメント全面棚卸しのフォロー Issue 候補 (LOW) を精算。リポジトリには 2 系統の CLI (\`src/cli.mjs\` と \`runners/cli/\`) が並立しており、コントリビュータがどちらを編集すべきか判断しづらい状態だった。各系統の責務・対象ユーザー・サブコマンド境界を 1 ページ (\`docs/CLI-architecture.md\`) にまとめる。

## Contents

- **2 系統の比較表**: 実体 / npm bin / サブコマンド / 対象ユーザー
- **並立している経緯**: 本番経路 (GH Action) vs スキル開発者向け実験的 IF
- **サブコマンド対応表**: 用途別にメイン / Runner どちらを使うかを整理 (同名 \`eval\` がある点に注意喚起)
- **どちらを使うべきか**: シナリオ別ガイド (本番 / スキル開発 / CI スキーマ検証)
- **ドキュメント側の参照先一覧**
- **既知の境界 / 注意点**: \`npx river …\` の解釈、\`build:action\` 必要性、\`RIVER_PHASE\` 環境変数の扱いの違い

## Why

セルフレビューで「README が \`river run\` 旧系統と \`river review/eval/create-skill\` 新系統を混在記載しており、段階的移行ガイドなし」と指摘されていた。pages/ 公開 SSoT には載せず、まず内部資料 (\`docs/\`) として整える方針。公開ドキュメントへの統合は別 Epic で扱う。

## Test plan

- [x] \`npm run lint\` 通過
- [x] \`runners/github-action/action.yml\` L72 と \`runners/github-action/src/index.mjs\` の実装を確認し、GH Action が ncc bundle 経由で \`src/cli.mjs\` を呼んでいることを記述に反映
- [x] \`runners/cli/package.json\` を確認し \`bin\` / \`commander\` 採用を反映
- [x] サブコマンド一覧は \`src/cli.mjs\` の \`printHelp()\` (L35-69) と \`runners/cli/src/index.mjs\` (L24+) から抜粋

## Context

ドキュメント整備フォロー (LOW 優先タスク)。前: #553-#557, #563-#564 (セルフレビュー), #566 (#565 schema fix), #567 (migration guide 文言精査)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)