### PR TITLE
docs(readme): reposition as artifact-driven review agent

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -55,6 +55,39 @@ We define team-specific judgment criteria and review procedures as reusable **Ag
 - **Downstream (tests/QA)**: test-focused skills highlight coverage gaps and failure paths.
 - **Phase-aware routing**: skills are selected by `phase` and file metadata, so feedback matches where you are in the stream.
 
+## Positioning: artifact-driven review agent
+
+River Reviewer is a **PlanGate-independent, artifact-driven review agent**. It does not require a special integration with PlanGate v6 or any other upstream workflow. Instead, it consumes externally supplied artifacts (`plan` / `diff` / `test-cases` / `junit`, etc.) and produces review results that include `findings`. The input contract is defined in the [Artifact Input Contract](pages/reference/artifact-input-contract.en.md), and the output schema in the [Review Artifact](pages/reference/review-artifact.en.md) reference.
+
+### Four use cases
+
+The same CLI (`river review plan` / `river review exec`) switches use cases based on which artifacts you supply.
+
+- **Design review**: pass `pbi-input` / `plan` to check plan integrity and completeness with upstream skills (e.g. `skills/upstream/rr-upstream-plangate-plan-integrity-001/`).
+- **Implementation review**: pass `plan` + `diff` to check that the code change matches the plan (e.g. `skills/upstream/rr-upstream-plangate-exec-conformance-001/`).
+- **QA review**: pass `test-cases` / `junit` / `coverage` so downstream skills can surface coverage gaps and failure paths.
+- **Double-check (W-check)**: pass existing AI or human review output as `review-self` / `review-external` to review the review itself.
+
+### CLI examples
+
+See [`river review plan` CLI spec](pages/reference/cli-review-plan-spec.en.md) and [`river review exec` CLI spec](pages/reference/cli-review-exec-spec.en.md) for full details.
+
+```bash
+# Design review: inspect the plan alone
+river review plan --artifact plan=./artifacts/plan.md
+
+# Implementation review: check the diff against the plan
+river review exec \
+  --artifact plan=./artifacts/plan.md \
+  --artifact diff=./artifacts/diff.patch
+
+# QA review: add test-related artifacts
+river review exec \
+  --artifact diff=./artifacts/diff.patch \
+  --artifact test-cases=./artifacts/test-cases.md \
+  --artifact junit=./artifacts/junit.xml
+```
+
 ## Quick start (GitHub Actions)
 
 Minimal workflow using the v1 action tag. `phase` is a future/optional input that will route skills per SDLC phase.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ River Reviewer は、単にコードをAIに読ませるツールではありま
 
 ## ポジション: artifact-driven review agent
 
-River Reviewer は **PlanGate 非依存の artifact-driven review agent** です。PlanGate v6 などの上流ワークフローに特別な統合を前提とせず、外部から渡されるアーティファクト（`plan` / `diff` / `test-cases` / `junit` ほか）を入力として読み取り、`findings` を含むレビュー結果を出力します。入力の契約は [Artifact Input Contract](pages/reference/artifact-input-contract.md) で、出力スキーマは [Review Artifact](pages/reference/review-artifact.md) で固定されています。
+River Reviewer は **PlanGate 非依存の artifact-driven review agent** です。PlanGate v6 などの上流ワークフローに特別な統合を前提とせず、外部から渡されるアーティファクト（`plan` / `diff` / `test-cases` / `junit` ほか）を入力として読み取り、`findings` を含むレビュー結果を出力します。入力の契約は [Artifact Input Contract](pages/reference/artifact-input-contract.md) で、出力スキーマは [Review Artifact](pages/reference/review-artifact.md) で定義されています。
 
 ### 4 つのユースケース
 
@@ -86,12 +86,12 @@ River Reviewer は **PlanGate 非依存の artifact-driven review agent** です
 # 設計レビュー: plan 単体を検査
 river review plan --artifact plan=./artifacts/plan.md
 
-# 実装レビュー: plan と diff の整合を検査
+# 実装レビュー: plan と diff の整合性を検査
 river review exec \
   --artifact plan=./artifacts/plan.md \
   --artifact diff=./artifacts/diff.patch
 
-# QA レビュー: テスト観点の artifact を追加
+# QA レビュー: テスト観点のアーティファクトを追加
 river review exec \
   --artifact diff=./artifacts/diff.patch \
   --artifact test-cases=./artifacts/test-cases.md \

--- a/README.md
+++ b/README.md
@@ -65,6 +65,39 @@ River Reviewer は、単にコードをAIに読ませるツールではありま
 - **下流（テスト/QA）**: テスト指向のスキルがカバレッジ不足や失敗パスを浮かび上がらせます。
 - **フェーズ指向ルーティング**: `phase` とファイルメタデータを見て、開発段階に合ったスキルを選択します。
 
+## ポジション: artifact-driven review agent
+
+River Reviewer は **PlanGate 非依存の artifact-driven review agent** です。PlanGate v6 などの上流ワークフローに特別な統合を前提とせず、外部から渡されるアーティファクト（`plan` / `diff` / `test-cases` / `junit` ほか）を入力として読み取り、`findings` を含むレビュー結果を出力します。入力の契約は [Artifact Input Contract](pages/reference/artifact-input-contract.md) で、出力スキーマは [Review Artifact](pages/reference/review-artifact.md) で固定されています。
+
+### 4 つのユースケース
+
+同じ CLI（`river review plan` / `river review exec`）が、入力として渡すアーティファクトの組み合わせでユースケースを切り替えます。
+
+- **設計レビュー**: `pbi-input` / `plan` を入力に、計画の整合性・網羅性を上流 skill で検査します（例: `skills/upstream/rr-upstream-plangate-plan-integrity-001/`）。
+- **実装レビュー**: `plan` と `diff` を入力に、実装差分が計画と一致しているかを検査します（例: `skills/upstream/rr-upstream-plangate-exec-conformance-001/`）。
+- **QA レビュー**: `test-cases` / `junit` / `coverage` を入力に、テストカバレッジや失敗パスの抜けを下流 skill で浮かび上がらせます。
+- **W チェック（二重レビュー）**: 既存の AI / 人間レビュー結果を `review-self` / `review-external` として渡し、レビューそのものを再点検します。
+
+### CLI 利用例
+
+詳細な仕様は [`river review plan` CLI 仕様](pages/reference/cli-review-plan-spec.md) / [`river review exec` CLI 仕様](pages/reference/cli-review-exec-spec.md) を参照してください。
+
+```bash
+# 設計レビュー: plan 単体を検査
+river review plan --artifact plan=./artifacts/plan.md
+
+# 実装レビュー: plan と diff の整合を検査
+river review exec \
+  --artifact plan=./artifacts/plan.md \
+  --artifact diff=./artifacts/diff.patch
+
+# QA レビュー: テスト観点の artifact を追加
+river review exec \
+  --artifact diff=./artifacts/diff.patch \
+  --artifact test-cases=./artifacts/test-cases.md \
+  --artifact junit=./artifacts/junit.xml
+```
+
 ## クイックスタート（GitHub Actions）
 
 `v1` タグを使った最小構成のワークフロー例です。`phase` は将来拡張を見据えた任意入力で、SDLC のフェーズごとにスキルを振り分けます。Permissions/fetch-depth などを明示して安定動作させます。


### PR DESCRIPTION
## Summary

- Reposition README.md / README.en.md under a new "artifact-driven review agent" section that makes it explicit River Reviewer does **not** require a special PlanGate integration.
- Document four use cases (design review / implementation review / QA review / W-check) each tied to existing upstream skills and artifacts.
- Add minimal CLI examples linking to the already-merged `river review plan` and `river review exec` CLI specs and the Artifact Input Contract.

## Design notes

- Inserted a single new section between "フローのストーリー" / "Flow story" and "クイックスタート（GitHub Actions）" to keep the diff local and avoid touching the license table, philosophy, quick-start, and skills sections that other parallel PRs (#553–#567) recently edited.
- Wording ("artifact-driven", "review agent", "W チェック（二重レビュー）" / "Double-check (W-check)") matches the SSoT in `pages/reference/artifact-input-contract.md` and `.en.md`.
- All referenced paths (`pages/reference/artifact-input-contract{,.en}.md`, `pages/reference/cli-review-{plan,exec}-spec{,.en}.md`, `pages/reference/review-artifact{,.en}.md`, `skills/upstream/rr-upstream-plangate-plan-integrity-001/`, `skills/upstream/rr-upstream-plangate-exec-conformance-001/`) were verified to exist on `main`.

## Acceptance criteria (#524)

- [x] README 冒頭が新ポジションに沿って更新されている
- [x] CLI examples が記載されている
- [x] PlanGate 特別統合が前提でないことが読める
- [x] 既存 docs IA を破壊していない（新規 H2 を 1 つ追加しただけで、既存の目次・セクションは保持）

## Test plan

- [x] `npm run lint` (format:check / check:dashes / lint:md / lint:text) — local pass
- [ ] CI green on the PR

Closes #524
Refs #514 #507