### PR TITLE
feat(ci): add weekly GC workflow for deterministic maintenance checks

### DIFF
--- a/.github/workflows/weekly-gc.yml
+++ b/.github/workflows/weekly-gc.yml
@@ -1,0 +1,148 @@
+name: Weekly GC
+
+# Runs the deterministic subset of `river gc` maintenance checks on a weekly
+# cadence, separate from per-PR CI. The workflow orchestrates the existing
+# npm scripts that already encode the deterministic rules (lint, structure
+# test, build). Dead-code / unused-export / typecheck coverage is intentionally
+# not wired yet — those require new tooling (see Issue #522 Non-goals).
+
+on:
+  schedule:
+    # 09:00 JST on Monday (00:00 UTC Monday)
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: weekly-gc
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  gc:
+    name: Weekly GC checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-node-deps
+
+      - name: Lint
+        id: lint
+        continue-on-error: true
+        run: npm run lint
+
+      - name: Structure test (unit + structure)
+        id: structure_test
+        continue-on-error: true
+        run: npm test
+
+      - name: Build (docusaurus)
+        id: build
+        continue-on-error: true
+        run: npm run build
+
+      - name: Summarize GC results
+        id: summary
+        run: |
+          {
+            echo "# Weekly GC Summary"
+            echo ""
+            echo "| Check | Outcome |"
+            echo "| --- | --- |"
+            echo "| lint | ${{ steps.lint.outcome }} |"
+            echo "| structure test | ${{ steps.structure_test.outcome }} |"
+            echo "| build | ${{ steps.build.outcome }} |"
+            echo ""
+            echo "Deterministic rules currently covered: lint, structure test, build."
+            echo "Deferred (require new tooling / human judgement): typecheck, dead code, unused export."
+          } | tee "$GITHUB_STEP_SUMMARY"
+
+          # Aggregate outcome for downstream steps.
+          if [ "${{ steps.lint.outcome }}" != "success" ] \
+             || [ "${{ steps.structure_test.outcome }}" != "success" ] \
+             || [ "${{ steps.build.outcome }}" != "success" ]; then
+            echo "gc_failed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "gc_failed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub issue on failure (schedule only)
+        if: github.event_name == 'schedule' && steps.summary.outputs.gc_failed == 'true'
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const title = '定期チェック: Weekly GC が失敗しました';
+            const labelName = 'scheduled-check';
+
+            const openIssues = await github.paginate(
+              github.rest.issues.listForRepo,
+              {
+                owner,
+                repo,
+                state: 'open',
+                labels: labelName,
+                per_page: 100,
+              },
+            );
+            if (openIssues.some(issue => issue.title === title)) {
+              console.log('既存の Issue があるため新規作成をスキップします。');
+              return;
+            }
+
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${owner}/${repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const body = [
+              '週次 GC CI (`.github/workflows/weekly-gc.yml`) が失敗しました。',
+              '',
+              `- 実行: ${runUrl}`,
+              '- 対象チェック: lint / structure test / build',
+              '- 失敗したステップの詳細は上記ラン URL の Step Summary を参照してください。',
+              '',
+              '破壊的な自動修正は行いません (Issue #522 Non-goals)。',
+              '人間が内容を確認し、対応が不要なら Issue を close してください。',
+            ].join('\n');
+
+            let useLabelForIssue = true;
+            try {
+              await github.rest.issues.createLabel({
+                owner,
+                repo,
+                name: labelName,
+                color: 'f29513',
+                description: '定期実行の自動検証で見つかった問題',
+              });
+            } catch (err) {
+              if (err.status !== 422) {
+                console.warn(`ラベル作成に失敗しましたが、処理を継続します: ${err.message}`);
+                useLabelForIssue = false;
+              }
+            }
+
+            try {
+              await github.rest.issues.create({
+                owner,
+                repo,
+                title,
+                body,
+                labels: useLabelForIssue ? [labelName] : [],
+              });
+              console.log(`Issue を作成しました: ${title}`);
+            } catch (err) {
+              console.error(`Issue 作成に失敗しました: ${err.message}`);
+              throw err;
+            }
+
+      - name: Fail workflow if any GC check failed
+        if: steps.summary.outputs.gc_failed == 'true'
+        run: |
+          echo "::error::One or more weekly GC checks failed. See the Step Summary for details."
+          exit 1


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/weekly-gc.yml` that runs the deterministic maintenance checks (`lint` / `npm test` structure test / `build`) on a weekly schedule, separate from per-PR CI.
- Schedule: cron `0 0 * * 1` (Monday 09:00 JST) + `workflow_dispatch` for manual runs.
- On failure (schedule only), opens a deduplicated `scheduled-check` issue mirroring the pattern in `.github/workflows/link-check.yml`. Honors Issue #522 Non-goals: no destructive auto-fix, no auto-PR.

## Scope per Issue #522 "決定論的ルールで扱える範囲"

| Check | Status | Notes |
| --- | --- | --- |
| lint | Covered | `npm run lint` (prettier + dashes + markdownlint + textlint) |
| structure test | Covered | `npm test` (node:test) |
| build | Covered | `npm run build` (docusaurus) |
| typecheck | Deferred | no TS/typecheck script in repo |
| dead code | Deferred | no knip/ts-prune in deps |
| unused export | Deferred | same — needs new tooling |

The deferred checks require adding new dependencies, which is out of scope for this task (one logical change per branch).

## Implementation notes

- `continue-on-error: true` on each check step so the workflow collects all failures in one run before failing the job.
- Aggregated `gc_failed` output drives both the issue-creation and final fail step.
- Uses the same `actions/checkout@v6` + `./.github/actions/setup-node-deps` composite as existing workflows.
- `permissions: contents: read, issues: write` (minimum needed for issue creation).
- `timeout-minutes: 45` (matches `nightly-eval.yml`).

## Test plan

- [ ] Confirm `npm run lint` passes locally (done — prettier, dashes, markdownlint, textlint all green)
- [ ] YAML parses via `js-yaml` (done — name/cron/permissions/jobs verified)
- [ ] After merge, trigger `workflow_dispatch` manually to verify the workflow runs end-to-end before waiting for the first scheduled run
- [ ] Verify issue dedup logic by deliberately failing a check in a fork (optional — logic mirrors link-check.yml which is already in production)

Refs #507, #512
Closes #522