### PR TITLE
docs(runbook): document test layout (#506) and Codecov OIDC requirement (#546)

### DIFF
--- a/docs/runbook/dev.md
+++ b/docs/runbook/dev.md
@@ -24,6 +24,18 @@ npm run skills:validate
 npm run agent-skills:validate
 ```
 
+### テスト構成
+
+`npm test` は `node --test` で `tests/**/*.test.mjs` を実行する。レイアウトは:
+
+- `tests/*.test.mjs`—ユニットテスト本体（フラット配置）
+- `tests/core/`—コアロジック単位のユニットテスト
+- `tests/integration/`—`local-runner` などの統合テスト
+- `tests/helpers/`—`createTempMemory` / `createTempDir` など複数テストで共有するヘルパー (#506 で導入)
+- `tests/fixtures/`—eval / レビュー / Riverbed Memory のフィクスチャ
+
+CI ではカバレッジを `NODE_V8_COVERAGE=coverage npm test` で取得し、Codecov へ OIDC (`id-token: write`) でアップロードする (`.github/workflows/test.yml` `unit-tests` ジョブ)。Codecov を呼び出すジョブには `permissions.id-token: write` が必須で、無いと OIDC トークン取得に失敗する (#546 で修正済み)。
+
 ## よくある詰まりどころ
 
 - `npm run check:links` が失敗する場合:


### PR DESCRIPTION
## Summary

ドキュメント整備のフォロー (LOW)。直近の test 構成刷新 (#506/#540/#542) と Codecov OIDC 化 (#546) が docs に未反映だった点を精算。

## Changes

\`docs/runbook/dev.md\` に「テスト構成」サブセクションを追加:

- \`tests/\` のレイアウト (フラット ユニット / \`core/\` / \`integration/\` / \`helpers/\` / \`fixtures/\`) を 1 段落で説明。\`helpers/\` は #506 で導入された共有ヘルパー (\`createTempMemory\` / \`createTempDir\` 等) を担う。
- カバレッジ収集経路 (\`NODE_V8_COVERAGE=coverage npm test\` → \`codecov-action\`) と OIDC 要件 (\`permissions.id-token: write\`) を明記。Codecov 系ジョブを追加するときに必須。

## Why

セルフレビュー (3 エージェント並列) で「test 構成大刷新 (#506/#540/#542)、Codecov OIDC (#546) への参照が docs/ 配下にほぼ無い」と adversarial 指摘されていた残タスクを精算。

## Test plan

- [x] \`npm run lint\` 通過
- [x] \`tests/\` 配下の実ディレクトリ構成と一致する記述
- [x] \`.github/workflows/test.yml\` の \`unit-tests\` ジョブの \`id-token: write\` permissions と整合

## Context

ドキュメント整備フォロー (LOW 優先タスク)。前: #553-#557, #563-#564, #566, #567, #568。

🤖 Generated with [Claude Code](https://claude.com/claude-code)