### PR TITLE
docs(explanation): align intro / what-is with Context Engineering / Skill Registry framing

### DIFF
--- a/pages/explanation/intro.en.md
+++ b/pages/explanation/intro.en.md
@@ -3,7 +3,7 @@ id: intro-en
 title: Welcome to River Reviewer
 ---
 
-River Reviewer (RR) is a framework for organizing and executing team review perspectives along the **Upstream → Midstream → Downstream** flow. Skills are defined using YAML frontmatter + Markdown and validated against `schemas/skill.schema.json`.
+River Reviewer (RR) is a **Context Engineering-driven, Skill Registry-centric code review framework** that captures team-specific tacit knowledge as reusable **Agent Skills** and runs them along the **Upstream → Midstream → Downstream** flow. Skills are defined using YAML frontmatter + Markdown and validated against `schemas/skill.schema.json`.
 
 This documentation covers:
 

--- a/pages/explanation/intro.en.md
+++ b/pages/explanation/intro.en.md
@@ -3,7 +3,9 @@ id: intro-en
 title: Welcome to River Reviewer
 ---
 
-River Reviewer (RR) is a **Context Engineering-driven, Skill Registry-centric code review framework** that captures team-specific tacit knowledge as reusable **Agent Skills** and runs them along the **Upstream → Midstream → Downstream** flow. Skills are defined using YAML frontmatter + Markdown and validated against `schemas/skill.schema.json`.
+River Reviewer (RR) is a **Context Engineering-driven, Skill Registry-centric code review framework** that captures team-specific tacit knowledge as reusable **Agent Skills** and runs them along the **Upstream → Midstream → Downstream** flow.
+
+Skills are defined using YAML frontmatter + Markdown and validated against `schemas/skill.schema.json`.
 
 This documentation covers:
 

--- a/pages/explanation/intro.md
+++ b/pages/explanation/intro.md
@@ -3,7 +3,9 @@ id: intro
 title: River Reviewer へようこそ
 ---
 
-River Reviewer (RR) は、**Upstream → Midstream → Downstream** の流れに沿ってチームのレビュー観点を整理・実行するためのフレームワークです。スキルは YAML フロントマター + Markdown で記述し、`schemas/skill.schema.json` で検証します。
+River Reviewer (RR) は **Context Engineering に基づく Skill Registry 中心のコードレビューフレームワーク**です。チーム固有の暗黙知を再利用可能な「Agent Skills」として明示化・バージョン管理し、**Upstream → Midstream → Downstream** の流れに沿って実行します。
+
+スキルは YAML フロントマター + Markdown で記述し、`schemas/skill.schema.json` で検証します。
 
 このドキュメントでは以下をカバーします。
 

--- a/pages/explanation/what-is-river-reviewer.en.md
+++ b/pages/explanation/what-is-river-reviewer.en.md
@@ -5,7 +5,7 @@ title: What is River Reviewer
 
 River Reviewer is a **Context Engineering-driven, Skill Registry-centric code review framework** — a flow-based agent that carries review perspectives along three phases (Upstream, Midstream, Downstream) as reusable **Agent Skills**.
 
-By defining team-specific judgment criteria and procedures as version-controlled Agent Skills, it makes review findings reproducible while keeping operating costs in check.
+By defining team-specific judgment criteria and procedures as version-controlled **Agent Skills**, it makes review findings reproducible while keeping operating costs in check.
 
 ## Purpose
 

--- a/pages/explanation/what-is-river-reviewer.en.md
+++ b/pages/explanation/what-is-river-reviewer.en.md
@@ -3,7 +3,9 @@ id: what-is-river-reviewer-en
 title: What is River Reviewer
 ---
 
-River Reviewer is a flow-based agent that carries review perspectives along three phases: Upstream, Midstream, and Downstream.
+River Reviewer is a **Context Engineering-driven, Skill Registry-centric code review framework** — a flow-based agent that carries review perspectives along three phases (Upstream, Midstream, Downstream) as reusable **Agent Skills**.
+
+By defining team-specific judgment criteria and procedures as version-controlled Agent Skills, it makes review findings reproducible while keeping operating costs in check.
 
 ## Purpose
 

--- a/pages/explanation/what-is-river-reviewer.md
+++ b/pages/explanation/what-is-river-reviewer.md
@@ -3,7 +3,9 @@ id: what-is-river-reviewer
 title: River Reviewer とは
 ---
 
-River Reviewer は、上流 (upstream)、中流 (midstream)、下流 (downstream) の3フェーズに沿ってレビュー観点を運び続けるフロー型のエージェントです。
+River Reviewer は **Context Engineering に基づく Skill Registry 中心のコードレビューフレームワーク**です。上流 (upstream)、中流 (midstream)、下流 (downstream) の 3 フェーズに沿って、レビュー観点を「Agent Skills」として運び続けるフロー型のエージェントです。
+
+チーム固有の判断基準・手順といった暗黙知を、バージョン管理可能な Agent Skills として定義することで、レビューの再現性と運用コストを両立します。
 
 ## 目的
 

--- a/pages/explanation/what-is-river-reviewer.md
+++ b/pages/explanation/what-is-river-reviewer.md
@@ -5,7 +5,7 @@ title: River Reviewer とは
 
 River Reviewer は **Context Engineering に基づく Skill Registry 中心のコードレビューフレームワーク**です。上流 (upstream)、中流 (midstream)、下流 (downstream) の 3 フェーズに沿って、レビュー観点を「Agent Skills」として運び続けるフロー型のエージェントです。
 
-チーム固有の判断基準・手順といった暗黙知を、バージョン管理可能な Agent Skills として定義することで、レビューの再現性と運用コストを両立します。
+チーム固有の判断基準・手順といった暗黙知を、バージョン管理可能な「Agent Skills」として定義することで、レビューの再現性と運用コストを両立します。
 
 ## 目的
 


### PR DESCRIPTION
## Summary

ドキュメント整備フォロー (LOW)。\`README.md:34\` の正規表現「Context Engineering に基づく Skill Registry 中心のコードレビューフレームワーク」が \`pages/explanation/{intro,what-is-river-reviewer}\` 系に反映されておらず、最初の入口ページが「Upstream → Midstream → Downstream のフロー型エージェント」止まりの説明だった。

## Changes

- \`intro.{md,en.md}\`: 冒頭文に Context Engineering / Skill Registry / Agent Skills の位置付けを追加。フロー説明とスキーマ参照は別段落に分離。
- \`what-is-river-reviewer.{md,en.md}\`: 冒頭定義を Context Engineering / Skill Registry / Agent Skills の framing に更新し、「再現性と運用コストの両立」という README の motivation を追記。

textlint の sentence-length 制約 (150 字) に合わせて 1 文を 2 段落に分割。

## Test plan

- [x] \`npm run lint\` 通過 (textlint / markdownlint / prettier)
- [x] README.md L34 と framing が一致する文言

## Context

ドキュメント整備フォロー (本セッション最終 LOW タスク)。前: #553-#557, #563-#564, #566-#568, #571。

🤖 Generated with [Claude Code](https://claude.com/claude-code)