### PR TITLE
docs(spec): add river gc CLI spec (#576)

### DIFF
--- a/pages/reference/_meta.json
+++ b/pages/reference/_meta.json
@@ -18,5 +18,6 @@
   "glossary": "用語集",
   "eval-keep-discard-policy": "評価ベースの採否基準",
   "cli-review-exec-spec": "CLI Spec — river review exec",
-  "cli-review-verify-spec": "CLI Spec — river review verify"
+  "cli-review-verify-spec": "CLI Spec — river review verify",
+  "cli-gc-spec": "CLI Spec — river gc"
 }

--- a/pages/reference/cli-gc-spec.en.md
+++ b/pages/reference/cli-gc-spec.en.md
@@ -1,0 +1,190 @@
+---
+title: CLI Spec — `river gc`
+---
+
+`river gc` is River Reviewer's **deterministic garbage-collection** entrypoint. It is a maintenance CLI that runs outside the review pipeline and deletes (or flags) stale artifacts under `.river/memory/`, `artifacts/evals/`, `artifacts/review-artifact*.json`, and temp files left behind by previous CLI runs. It is NOT a review CLI — it shares CLI ergonomics with `river review *` only for consistency, so CI can call it with familiar flags.
+
+> Related issues: #576 (Task) / #509 (Capability) / #507 (Epic)
+> Related workflow: `.github/workflows/weekly-gc.yml`
+
+## Positioning
+
+- `river gc` is **not a review CLI**. It is not a sibling of `river review plan` / `river review exec` / `river review verify`; it is an independent maintenance CLI that collects the artifacts those commands produce.
+- "Deterministic" means: given the same filesystem state, the same retention policy, and the same reference timestamp (`--now`), the same set of files is always chosen for removal. Ties are broken by lexicographic path order.
+- Stability: **Beta**. Adding flags is minor; changing defaults, removing flags, or altering semantics requires a major bump. The following defaults are **Stable Contract**:
+  - `--retention-days` default `90`
+  - `--max-entries` default `1000`
+  - `--max-size-mb` default `500`
+
+## Usage
+
+```bash
+river gc [options]
+```
+
+### Examples
+
+```bash
+# 1) Default is dry-run — list what would be removed, do not delete
+river gc
+
+# 2) Actually delete (typical CI / weekly workflow usage)
+river gc --force
+
+# 3) Emit machine-readable result for CI to consume
+river gc --force --json --output-file ./artifacts/gc-result.json
+
+# 4) Only memory and evals, only entries older than 30 days, dry-run
+river gc --scope memory --scope evals --retention-days 30
+
+# 5) Protect important temp files from deletion
+river gc --force --exclude 'artifacts/keep/**'
+```
+
+## Arguments and Options
+
+### Retention knobs
+
+| Option                  | Type   | Default      | Description                                                                                                    |
+| ----------------------- | ------ | ------------ | -------------------------------------------------------------------------------------------------------------- |
+| `--retention-days <N>`  | number | `90`         | Delete entries older than N days, based on artifact metadata `timestamp` (mtime fallback).                     |
+| `--max-entries <N>`     | number | `1000`       | When per-scope entry count exceeds N, drop the oldest until at most N remain.                                  |
+| `--max-size-mb <N>`     | number | `500`        | When per-scope total size exceeds N MB, drop the oldest until the sum is ≤ N MB.                               |
+| `--now <iso-timestamp>` | string | system clock | Pin the reference timestamp for deterministic test runs. Used when comparing against the `timestamp` metadata. |
+
+`--retention-days` / `--max-entries` / `--max-size-mb` are evaluated as a **union**: a file matched by any one of them is eligible for removal. Files matched by multiple policies are still removed exactly once.
+
+### Scope selectors
+
+| Option             | Type                                                    | Default | Description                                                                         |
+| ------------------ | ------------------------------------------------------- | ------- | ----------------------------------------------------------------------------------- |
+| `--scope <value>`  | `memory` / `evals` / `review-artifacts` / `tmp` / `all` | `all`   | Repeatable. Multiple values are unioned. `all` expands to the four concrete scopes. |
+| `--exclude <glob>` | string                                                  | -       | Repeatable glob (`.gitignore` syntax) of paths to protect from deletion.            |
+
+Files matching `--exclude` are **always kept**, regardless of retention policy. They do not appear in `removed[]` with reason `exclude-override` — "not deleted because excluded" is not logged; the exclusion is reflected only in `keptSummary` counts.
+
+### Mode
+
+| Option      | Type | Default                         | Description                                                                                           |
+| ----------- | ---- | ------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `--dry-run` | flag | `true` when `--force` is absent | Enumerate deletion candidates only; do not remove. Exit `0`.                                          |
+| `--force`   | flag | `false`                         | Actually delete. If both `--dry-run` and `--force` are supplied, **`--dry-run` wins** (safety-first). |
+
+`river gc` performs **no destructive action** unless `--force` is explicitly set. CI jobs that perform real deletion must always pass `--force`.
+
+### Output
+
+| Option                 | Type   | Default | Description                                                                                                      |
+| ---------------------- | ------ | ------- | ---------------------------------------------------------------------------------------------------------------- |
+| `--json`               | flag   | `false` | Emit the machine-readable plan / result (see below) on stdout. Human summary is routed to stderr.                |
+| `--output-file <path>` | string | -       | Destination for `--json`. When set, stdout is untouched and JSON is written to the file.                         |
+| `--quiet`              | flag   | `false` | Suppress the human-readable summary. With `--json`, also silences the stderr summary. Errors still go to stderr. |
+| `--debug`              | flag   | `false` | Verbose stderr logging. May populate extra detail in `errors[]`.                                                 |
+
+## GC scopes
+
+The paths each scope touches, and what it explicitly keeps.
+
+| Scope              | Target directories / patterns                              | Included                                      | Explicitly excluded                                         |
+| ------------------ | ---------------------------------------------------------- | --------------------------------------------- | ----------------------------------------------------------- |
+| `memory`           | `.river/memory/**`                                         | Indexes, embeddings, conversation history     | `.river/memory/index.json` (the current index itself)       |
+| `evals`            | `artifacts/evals/**`                                       | Per-run eval results and snapshots            | `artifacts/evals/latest/**` (symlink to the current run)    |
+| `review-artifacts` | `artifacts/review-artifact*.json`, `artifacts/review-*.md` | Review Artifacts and human-readable summaries | `artifacts/review-artifact.schema.json` (the schema itself) |
+| `tmp`              | `.river/tmp/**`, `artifacts/.tmp/**`                       | Intermediate files left by CLI runs           | (none; empty directories are preserved)                     |
+
+- "Single sources of truth" (the live memory index, `evals/latest`, schema files) are **hard-guarded**: no retention policy can delete them.
+- Deletion is per-file. Empty directories are left in place to avoid breaking symlinks or relative references.
+
+## Output JSON
+
+Shape emitted when `--json` is set:
+
+```text
+{
+  "version": "1",
+  "mode": "dry-run" | "force",
+  "scopes": ["memory", "evals", ...],
+  "retention": { "days": N, "maxEntries": N, "maxSizeMb": N },
+  "removed": [
+    { "path": "...", "sizeBytes": N, "reason": "age" | "count" | "size" | "exclude-override" },
+    ...
+  ],
+  "keptSummary": {
+    "memory":           { "count": N, "sizeBytes": N },
+    "evals":            { "count": N, "sizeBytes": N },
+    "review-artifacts": { "count": N, "sizeBytes": N },
+    "tmp":              { "count": N, "sizeBytes": N }
+  },
+  "errors": [
+    { "path": "...", "message": "..." }
+  ]
+}
+```
+
+### Field definitions
+
+| Field         | Type     | Description                                                                                                 |
+| ------------- | -------- | ----------------------------------------------------------------------------------------------------------- |
+| `version`     | string   | Schema version. Currently `"1"`. Bumped on breaking changes.                                                |
+| `mode`        | string   | `"dry-run"` or `"force"`. `force` only when `--force` was set and honored.                                  |
+| `scopes`      | string[] | Resolved scope list (`all` is expanded).                                                                    |
+| `retention`   | object   | Retention knobs actually applied. Defaults appear verbatim when flags were not supplied.                    |
+| `removed`     | array    | Files that were removed (or would be removed, in dry-run). `reason` records the first matching policy only. |
+| `keptSummary` | object   | Per-scope count and total bytes of retained entries. Files protected by `--exclude` count here.             |
+| `errors`      | array    | Per-file failures (delete failure, stat failure). A non-empty `errors` does not stop other deletions.       |
+
+- `removed[]` is sorted by **lexicographic path order**. This is one of the pillars of determinism.
+- When a file matches more than one of `age` / `count` / `size`, the recorded `reason` uses precedence `age` > `count` > `size`.
+
+## Exit codes
+
+| Exit | Meaning                                                                                                                                                       |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `0`  | Success. Both dry-run and force exit `0` when `errors` is empty.                                                                                              |
+| `1`  | Runtime failure. `errors` has at least one entry (delete / IO error), or a retention knob threw a parse error mid-run.                                        |
+| `2`  | Config error. Unknown `--scope` value, malformed glob, non-numeric `--retention-days` / `--max-entries` / `--max-size-mb`, or mutually exclusive flag misuse. |
+
+Supplying both `--dry-run` and `--force` is not a config error — `--dry-run` wins, as stated above.
+
+### mode × exit code
+
+| mode      | errors    | Exit | Meaning                                                                              |
+| --------- | --------- | ---- | ------------------------------------------------------------------------------------ |
+| `dry-run` | empty     | `0`  | Candidates listed. No side effects.                                                  |
+| `dry-run` | non-empty | `1`  | IO error occurred while enumerating (e.g. permission denied).                        |
+| `force`   | empty     | `0`  | All listed files deleted successfully.                                               |
+| `force`   | non-empty | `1`  | Some deletions failed. Successful deletions are NOT rolled back (idempotency first). |
+
+## Determinism guarantee
+
+`river gc` is deterministic when the following three conditions all hold.
+
+1. **Same filesystem state**: the set of files under the selected scopes, with identical `timestamp` metadata (or mtime fallback) and identical sizes.
+2. **Same retention policy**: identical values for `--retention-days` / `--max-entries` / `--max-size-mb`.
+3. **Same reference time**: identical `--now` (omitting `--now` uses system time and therefore breaks determinism).
+
+Under these conditions the **contents, order, and `reason` of `removed[]`** are identical across runs.
+
+- Tie-break rule: when two files share the same `timestamp`, they are ordered **lexicographically by path** (oldest-first within equal timestamps). `--max-entries` / `--max-size-mb` boundaries honor this same ordering.
+- `--exclude` globs are normalized before matching, so matches themselves are also lexicographically stable.
+
+## CI / `weekly-gc.yml` integration
+
+Standard CI invocation contract:
+
+```bash
+river gc --force --json --output-file ./artifacts/gc-result.json
+```
+
+- `artifacts/gc-result.json` should be uploaded as a workflow artifact for auditing.
+- Exit `0` means "retention policy applied cleanly" — **including when zero files were removed** (nothing to clean is still success).
+- Non-zero exit feeds into the `weekly-gc.yml` "create issue on failure" path.
+- The current `.github/workflows/weekly-gc.yml` does not yet invoke `river gc`; it runs lint / structure test / build as a placeholder. This spec is the **prerequisite contract** for wiring `river gc` into that workflow once the implementation lands.
+
+## Related documents
+
+- [Artifact Input Contract](./artifact-input-contract.en.md) — input artifact SSoT (prerequisite for scope targeting)
+- [Review Artifact](./review-artifact.en.md) — schema managed by the `review-artifacts` scope
+- [Riverbed Memory](./riverbed-storage.en.md) — persistent storage managed by the `memory` scope
+- [Stable Interfaces](./stable-interfaces.en.md) — CLI / GitHub Actions stability contract
+- [`river review exec`](./cli-review-exec-spec.en.md) / [`river review plan`](./cli-review-plan-spec.en.md) — the review CLIs (distinct responsibility from GC)

--- a/pages/reference/cli-gc-spec.en.md
+++ b/pages/reference/cli-gc-spec.en.md
@@ -61,7 +61,7 @@ river gc --force --exclude 'artifacts/keep/**'
 | `--scope <value>`  | `memory` / `evals` / `review-artifacts` / `tmp` / `all` | `all`   | Repeatable. Multiple values are unioned. `all` expands to the four concrete scopes. |
 | `--exclude <glob>` | string                                                  | -       | Repeatable glob (`.gitignore` syntax) of paths to protect from deletion.            |
 
-Files matching `--exclude` are **always kept**, regardless of retention policy. They do not appear in `removed[]` with reason `exclude-override` — "not deleted because excluded" is not logged; the exclusion is reflected only in `keptSummary` counts.
+Files matching `--exclude` are **always kept**, regardless of retention policy. Excluded files never appear in `removed[]`; the exclusion is reflected only in `keptSummary` counts.
 
 ### Mode
 
@@ -106,7 +106,7 @@ Shape emitted when `--json` is set:
   "scopes": ["memory", "evals", ...],
   "retention": { "days": N, "maxEntries": N, "maxSizeMb": N },
   "removed": [
-    { "path": "...", "sizeBytes": N, "reason": "age" | "count" | "size" | "exclude-override" },
+    { "path": "...", "sizeBytes": N, "reason": "age" | "count" | "size" },
     ...
   ],
   "keptSummary": {
@@ -138,11 +138,11 @@ Shape emitted when `--json` is set:
 
 ## Exit codes
 
-| Exit | Meaning                                                                                                                                                       |
-| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `0`  | Success. Both dry-run and force exit `0` when `errors` is empty.                                                                                              |
-| `1`  | Runtime failure. `errors` has at least one entry (delete / IO error), or a retention knob threw a parse error mid-run.                                        |
-| `2`  | Config error. Unknown `--scope` value, malformed glob, non-numeric `--retention-days` / `--max-entries` / `--max-size-mb`, or mutually exclusive flag misuse. |
+| Exit | Meaning                                                                                                                                                                                                                                                   |
+| ---- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `0`  | Success. Both dry-run and force exit `0` when `errors` is empty.                                                                                                                                                                                          |
+| `1`  | Runtime failure. `errors` has at least one entry (delete / IO / permission error during execution).                                                                                                                                                       |
+| `2`  | Config error. Unknown `--scope` value, malformed glob, non-numeric `--retention-days` / `--max-entries` / `--max-size-mb`, or mutually exclusive flag misuse. Argument validation completes at startup, so these errors are caught before any skill runs. |
 
 Supplying both `--dry-run` and `--force` is not a config error — `--dry-run` wins, as stated above.
 

--- a/pages/reference/cli-gc-spec.md
+++ b/pages/reference/cli-gc-spec.md
@@ -61,7 +61,7 @@ river gc --force --exclude 'artifacts/keep/**'
 | `--scope <value>`  | `memory` / `evals` / `review-artifacts` / `tmp` / `all` | `all`  | 繰り返し可。複数指定した場合は union。`all` は 4 scope すべてを含む。      |
 | `--exclude <glob>` | string                                                  | -      | 繰り返し可。削除対象から除外するパス glob。`.gitignore` と同じ glob 構文。 |
 
-`--exclude` に一致したパスは retention policy の判定結果にかかわらず **常に保持** される。ただし出力 JSON の `removed[].reason: "exclude-override"` としては出現しない（「除外されたので消さなかった」ものは記録対象外。`keptSummary` のカウントのみに影響する）。
+`--exclude` に一致したパスは retention policy の判定結果にかかわらず **常に保持** される。除外されて保持されたファイルは `removed[]` に現れず、`keptSummary` のカウントのみに影響する。
 
 ### Mode（動作モード）
 
@@ -106,7 +106,7 @@ river gc --force --exclude 'artifacts/keep/**'
   "scopes": ["memory", "evals", ...],
   "retention": { "days": N, "maxEntries": N, "maxSizeMb": N },
   "removed": [
-    { "path": "...", "sizeBytes": N, "reason": "age" | "count" | "size" | "exclude-override" },
+    { "path": "...", "sizeBytes": N, "reason": "age" | "count" | "size" },
     ...
   ],
   "keptSummary": {
@@ -138,11 +138,11 @@ river gc --force --exclude 'artifacts/keep/**'
 
 ## 終了コード
 
-| Exit | 意味                                                                                                                                      |
-| ---- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `0`  | 成功。dry-run と force のどちらでも、`errors` が空なら `0`。                                                                              |
-| `1`  | ランタイム失敗。削除エラーや IO エラーが `errors` に 1 件以上含まれる、または実行中に retention knob の解釈エラーが発生した場合。         |
-| `2`  | 設定エラー。未知の `--scope` 値、不正な glob、`--retention-days` / `--max-entries` / `--max-size-mb` の数値パース失敗、相互排他違反など。 |
+| Exit | 意味                                                                                                                                                                                                                           |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `0`  | 成功。dry-run と force のどちらでも、`errors` が空なら `0`。                                                                                                                                                                   |
+| `1`  | ランタイム失敗。削除エラー・IO エラー・権限エラー等のランタイム障害が `errors` に 1 件以上含まれる場合。                                                                                                                       |
+| `2`  | 設定エラー。未知の `--scope` 値、不正な glob、`--retention-days` / `--max-entries` / `--max-size-mb` の数値パース失敗、相互排他違反など。引数バリデーションは起動時に完結するため、この種のエラーは skill 実行前に検出される。 |
 
 `--dry-run` と `--force` を両方指定した場合は前述のとおり `--dry-run` が優先されるため、それ自体は設定エラーにならない。
 

--- a/pages/reference/cli-gc-spec.md
+++ b/pages/reference/cli-gc-spec.md
@@ -1,0 +1,190 @@
+---
+title: CLI Spec — `river gc`
+---
+
+`river gc` は River Reviewer の **決定論的ガベージコレクション** エントリポイントです。レビューパイプラインの外側で動くメンテナンス CLI であり、`.river/memory/`・`artifacts/evals/`・`artifacts/review-artifact*.json`・一時ファイルなどの古い成果物を、再現可能なルールで削除（または候補としてフラグ）します。`river review *` とは責務が分かれますが、CI から安定して呼び出せるよう CLI エルゴノミクスだけは揃えています。
+
+> 関連 Issue: #576（Task）/ #509（Capability）/ #507（Epic）
+> 関連 workflow: `.github/workflows/weekly-gc.yml`
+
+## 位置づけ
+
+- `river gc` を **レビュー CLI として扱わない**。`river review plan` / `river review exec` / `river review verify` の姉妹コマンドではなく、それらが生成した成果物を回収するためのメンテナンス CLI として独立している。
+- 決定論の意味は「同じファイルシステム状態・同じ retention policy・同じ基準日 (`--now`) を与えると、常に同じ削除対象集合が得られる」こと。順序の曖昧さはパスの昇順（lexicographic）で解消する。
+- 安定性ラベルは **Beta**。フラグ追加は minor、既定値の変更・フラグ削除・意味変更は major bump とする。ただし以下の既定値は **Stable Contract** として扱う:
+  - `--retention-days` 既定値 `90`
+  - `--max-entries` 既定値 `1000`
+  - `--max-size-mb` 既定値 `500`
+
+## Usage
+
+```bash
+river gc [options]
+```
+
+### 代表例
+
+```bash
+# 1) 既定は dry-run。何が消えるかだけを表示し、実際には削除しない
+river gc
+
+# 2) 実際に削除する（CI / weekly workflow などで使用）
+river gc --force
+
+# 3) CI から machine-readable な結果を受け取る
+river gc --force --json --output-file ./artifacts/gc-result.json
+
+# 4) memory と evals だけを対象にして、30 日より古いものを dry-run で確認
+river gc --scope memory --scope evals --retention-days 30
+
+# 5) 重要な一時ファイルを除外する
+river gc --force --exclude 'artifacts/keep/**'
+```
+
+## 引数とオプション
+
+### Retention（保持ポリシー）
+
+| オプション              | 型     | 既定値 | 説明                                                                                              |
+| ----------------------- | ------ | ------ | ------------------------------------------------------------------------------------------------- |
+| `--retention-days <N>`  | number | `90`   | artifact メタデータの `timestamp`（無ければ mtime）を基準に N 日より古いエントリを削除対象。      |
+| `--max-entries <N>`     | number | `1000` | 対象 scope ごとのエントリ数が N を超えた場合、古い順に N 件まで残して削除対象。                   |
+| `--max-size-mb <N>`     | number | `500`  | 対象 scope ごとの合計サイズが N MB を超えた場合、古い順に削除対象（合計が N MB 以下になるまで）。 |
+| `--now <iso-timestamp>` | string | 実時刻 | 決定論的再現・テスト用に基準時刻を固定する。`timestamp` 比較に使用される。                        |
+
+`--retention-days` / `--max-entries` / `--max-size-mb` は **union** で評価される。いずれか 1 つでもヒットしたファイルは削除対象に入る。全部に引っかかっても 1 回しか削除されない。
+
+### Scope（対象範囲）
+
+| オプション         | 型                                                      | 既定値 | 説明                                                                       |
+| ------------------ | ------------------------------------------------------- | ------ | -------------------------------------------------------------------------- |
+| `--scope <value>`  | `memory` / `evals` / `review-artifacts` / `tmp` / `all` | `all`  | 繰り返し可。複数指定した場合は union。`all` は 4 scope すべてを含む。      |
+| `--exclude <glob>` | string                                                  | -      | 繰り返し可。削除対象から除外するパス glob。`.gitignore` と同じ glob 構文。 |
+
+`--exclude` に一致したパスは retention policy の判定結果にかかわらず **常に保持** される。ただし出力 JSON の `removed[].reason: "exclude-override"` としては出現しない（「除外されたので消さなかった」ものは記録対象外。`keptSummary` のカウントのみに影響する）。
+
+### Mode（動作モード）
+
+| オプション  | 型   | 既定値                      | 説明                                                                                      |
+| ----------- | ---- | --------------------------- | ----------------------------------------------------------------------------------------- |
+| `--dry-run` | flag | `--force` 未指定時は `true` | 削除候補を列挙するだけで、実際には削除しない。exit `0`。                                  |
+| `--force`   | flag | `false`                     | 実際に削除する。`--dry-run` と同時指定した場合は **`--dry-run` が優先**される（安全側）。 |
+
+`--force` を指定しない限り、`river gc` は **破壊的操作を行わない**。CI で本番削除を実行する際は必ず `--force` を明示する。
+
+### Output（出力）
+
+| オプション             | 型     | 既定値  | 説明                                                                                           |
+| ---------------------- | ------ | ------- | ---------------------------------------------------------------------------------------------- |
+| `--json`               | flag   | `false` | 機械可読な計画 / 結果 JSON（後述）を stdout に出力する。指定時は人間向け要約を stderr に回す。 |
+| `--output-file <path>` | string | -       | `--json` の出力先。指定時は stdout に書かずファイルへ書き込む。                                |
+| `--quiet`              | flag   | `false` | 人間向け要約を抑止する。`--json` と併用すると sterr への要約も消える。エラーは常に stderr。    |
+| `--debug`              | flag   | `false` | 詳細ログを stderr に出す。JSON 出力の `errors[]` に補足情報が増えることがある。                |
+
+## GC 対象
+
+各 scope が対象とするパスと除外基準は次の通り。
+
+| Scope              | 対象ディレクトリ / パターン                                 | 含まれるもの                       | 明示的に除外されるもの                                 |
+| ------------------ | ----------------------------------------------------------- | ---------------------------------- | ------------------------------------------------------ |
+| `memory`           | `.river/memory/**`                                          | インデックス / 埋め込み / 会話履歴 | `.river/memory/index.json`（最新インデックス本体）     |
+| `evals`            | `artifacts/evals/**`                                        | 評価ラン結果・スナップショット     | `artifacts/evals/latest/**`（最新 run への symlink）   |
+| `review-artifacts` | `artifacts/review-artifact*.json` / `artifacts/review-*.md` | Review Artifact / 人間向け要約     | `artifacts/review-artifact.schema.json`（schema 本体） |
+| `tmp`              | `.river/tmp/**`・`artifacts/.tmp/**`                        | CLI 実行が残した中間ファイル       | なし（空ディレクトリは保持）                           |
+
+- `memory` の「インデックス本体」「`evals/latest`」「schema ファイル」のように、**それを消すと復元不能になる単一ソース** は、どの retention policy にヒットしても削除しない（hard guard）。
+- 削除は「ファイル単位」で行い、空になったディレクトリは削除しない（symlink / 相対参照を壊さないため）。
+
+## Output JSON
+
+`--json` 指定時に出力される結果 JSON のシェイプは次の通り。
+
+```text
+{
+  "version": "1",
+  "mode": "dry-run" | "force",
+  "scopes": ["memory", "evals", ...],
+  "retention": { "days": N, "maxEntries": N, "maxSizeMb": N },
+  "removed": [
+    { "path": "...", "sizeBytes": N, "reason": "age" | "count" | "size" | "exclude-override" },
+    ...
+  ],
+  "keptSummary": {
+    "memory":           { "count": N, "sizeBytes": N },
+    "evals":            { "count": N, "sizeBytes": N },
+    "review-artifacts": { "count": N, "sizeBytes": N },
+    "tmp":              { "count": N, "sizeBytes": N }
+  },
+  "errors": [
+    { "path": "...", "message": "..." }
+  ]
+}
+```
+
+### フィールド定義
+
+| フィールド    | 型       | 説明                                                                                                                 |
+| ------------- | -------- | -------------------------------------------------------------------------------------------------------------------- |
+| `version`     | string   | スキーマバージョン。現行は `"1"`。破壊的変更時に bump。                                                              |
+| `mode`        | string   | `"dry-run"` または `"force"`。`--force` 指定時のみ `force`。                                                         |
+| `scopes`      | string[] | 解決後の対象 scope 一覧（`all` は展開される）。                                                                      |
+| `retention`   | object   | 適用された retention knob。フラグ未指定時は既定値がそのまま入る。                                                    |
+| `removed`     | array    | 削除された（または dry-run で削除候補となった）ファイル。`reason` は最初にヒットしたポリシー名のみを記録する。       |
+| `keptSummary` | object   | scope ごとに「削除されなかった」エントリの件数と合計サイズ。`--exclude` で保護されたファイルもここにカウントされる。 |
+| `errors`      | array    | ファイル単位の失敗（削除失敗・統計取得失敗など）。`errors` が空でない場合でも他ファイルの削除は継続する。            |
+
+- `removed[]` は **パス昇順（lexicographic）** で並ぶ。これが決定論の根拠のひとつとなる。
+- `removed[].reason` が `age` / `count` / `size` のいずれかに該当し、かつ同時に複数のポリシーにヒットした場合は、優先順位 `age` > `count` > `size` で最初にヒットしたものを記録する。
+
+## 終了コード
+
+| Exit | 意味                                                                                                                                      |
+| ---- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `0`  | 成功。dry-run と force のどちらでも、`errors` が空なら `0`。                                                                              |
+| `1`  | ランタイム失敗。削除エラーや IO エラーが `errors` に 1 件以上含まれる、または実行中に retention knob の解釈エラーが発生した場合。         |
+| `2`  | 設定エラー。未知の `--scope` 値、不正な glob、`--retention-days` / `--max-entries` / `--max-size-mb` の数値パース失敗、相互排他違反など。 |
+
+`--dry-run` と `--force` を両方指定した場合は前述のとおり `--dry-run` が優先されるため、それ自体は設定エラーにならない。
+
+### mode と exit の対応
+
+| mode      | errors | Exit | 意味                                                             |
+| --------- | ------ | ---- | ---------------------------------------------------------------- |
+| `dry-run` | 空     | `0`  | 削除候補のみ列挙。副作用なし。                                   |
+| `dry-run` | 非空   | `1`  | 列挙途中で IO エラーが発生（例: 権限不足）。                     |
+| `force`   | 空     | `0`  | 列挙した全ファイルを削除成功。                                   |
+| `force`   | 非空   | `1`  | 一部削除に失敗。成功した削除はロールバックしない（冪等性優先）。 |
+
+## 決定論保証
+
+`river gc` は次の条件を満たす限り決定論的に振る舞います。
+
+1. **同じファイルシステム状態**: 対象 scope 配下のファイル集合、それぞれの `timestamp` メタデータ（無ければ mtime）、サイズが同一。
+2. **同じ retention policy**: `--retention-days` / `--max-entries` / `--max-size-mb` の値が同一。
+3. **同じ基準時刻**: `--now` が同一（未指定ならシステム時刻に依存するため非決定論的）。
+
+この 3 条件を満たすとき、`removed[]` の **内容・順序・`reason`** が完全に一致する。
+
+- タイブレーク規則: `timestamp` が同じファイルが複数ある場合は **パス昇順（lexicographic）** で古いものから並べる。`--max-entries` / `--max-size-mb` の境界判定もこの順序で行う。
+- `--exclude` の glob は解決時に正規化し、マッチ判定も lexicographic に行う。
+
+## CI / `weekly-gc.yml` との接続
+
+CI からの標準呼び出し契約:
+
+```bash
+river gc --force --json --output-file ./artifacts/gc-result.json
+```
+
+- `artifacts/gc-result.json` は workflow の artifact upload で永続化することを推奨。
+- exit `0` は「retention policy を適用した結果として正常終了」を意味し、**削除件数が 0 でも `0`** を返す（「掃除することが無かった」も成功）。
+- exit `1` / `2` が返った場合は `weekly-gc.yml` が失敗 Issue を自動起票する運用に接続する（詳細は workflow 側のロジックに従う）。
+- 現行の `.github/workflows/weekly-gc.yml` はまだ `river gc` 本体を呼んでおらず、lint / structure test / build を代理で実行している。本 spec は `river gc` 実装後に workflow を接続するための **前提契約** として機能する。
+
+## 関連ドキュメント
+
+- [Artifact Input Contract](./artifact-input-contract.md) — 入力 artifact の SSoT（GC 対象 scope の前提となる）
+- [Review Artifact](./review-artifact.md) — `review-artifacts` scope が扱う出力スキーマ
+- [Riverbed Memory](./riverbed-storage.md) — `memory` scope が扱う永続ストレージ
+- [Stable Interfaces](./stable-interfaces.md) — CLI / GitHub Actions 安定契約
+- [`river review exec`](./cli-review-exec-spec.md) / [`river review plan`](./cli-review-plan-spec.md) — レビュー CLI（GC とは責務が分かれる）


### PR DESCRIPTION
## Summary

Adds the `river gc` CLI spec as SSoT for the deterministic garbage-collection entrypoint. GC is framed as a **maintenance** CLI (not a review CLI), shared only in CLI ergonomics with `river review *` for consistency.

closes #576

### Files added

| File | Lines |
| ---- | ----- |
| `pages/reference/cli-gc-spec.md` (JP primary SSoT) | 190 |
| `pages/reference/cli-gc-spec.en.md` (EN best-effort) | 190 |
| `pages/reference/_meta.json` (sidebar title registration) | +1 |

### Key design decisions

- **Retention defaults as Stable Contract** — `--retention-days 90` / `--max-entries 1000` / `--max-size-mb 500`. Changing them requires a major bump.
- **Dry-run by default, `--force` opt-in** — `river gc` never performs destructive action unless `--force` is explicit. `--dry-run` + `--force` together resolves to dry-run (safety-first).
- **Union semantics for retention knobs** — a file matched by any one of age / count / size is eligible for removal.
- **Determinism rule** — same filesystem state + same retention policy + same `--now` => identical `removed[]` contents, order, and `reason`. Ties broken by lexicographic path order.
- **Exit codes** — `0` success (incl. zero-removal), `1` runtime failure (IO errors in `errors[]` or knob parse failure), `2` config error (unknown scope / malformed glob / non-numeric knob).
- **Hard-guarded paths** — `.river/memory/index.json`, `artifacts/evals/latest/**`, and schema files are never deleted, regardless of policy.
- **CI contract** — documents `river gc --force --json --output-file ./artifacts/gc-result.json` as the standard `weekly-gc.yml` invocation. The current workflow still runs lint/test/build as a placeholder; this spec is the prerequisite contract for wiring `river gc` in once implemented.

## Test plan

- [x] `npm run lint` — pass (prettier + check:dashes + markdownlint + textlint all clean on changed files)
- [x] `npm test` — pass (523 tests, 0 failures)
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)