### PR TITLE
fix(docs): bump action tag references to v0.13.0

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -109,16 +109,16 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run River Reviewer (midstream)
-        uses: s977043/river-reviewer/runners/github-action@v0.12.0
+        uses: s977043/river-reviewer/runners/github-action@v0.13.0
         with:
           phase: midstream # upstream|midstream|downstream|all (future-ready)
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 ```
 
-Pin to a release tag such as `@v0.12.0` for stability. Optionally, you can maintain a floating alias tag like `@v0`.
+Pin to a release tag such as `@v0.13.0` for stability. Optionally, you can maintain a floating alias tag like `@v0`.
 
-Latest release: [v0.12.0](https://github.com/s977043/river-reviewer/releases/tag/v0.12.0)
+Latest release: [v0.13.0](https://github.com/s977043/river-reviewer/releases/tag/v0.13.0)
 
 > **ℹ️ Upgrading from v0.1.x:** v0.2.0 and later use the new GitHub Action path `runners/github-action` instead of `.github/actions/river-reviewer`. See [Migration Guide](docs/migration/runners-architecture-guide.md) and [DEPRECATED.md](docs/deprecated.md) for details.
 

--- a/README.md
+++ b/README.md
@@ -119,16 +119,16 @@ jobs:
         with:
           fetch-depth: 0 # merge-base を安定取得
       - name: Run River Reviewer (midstream)
-        uses: s977043/river-reviewer/runners/github-action@v0.12.0
+        uses: s977043/river-reviewer/runners/github-action@v0.13.0
         with:
           phase: midstream # upstream|midstream|downstream|all (future-ready)
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 ```
 
-タグは `@v0.12.0` などのリリースタグにピン留めしてください。浮動タグを使う場合は `@v0` のようなエイリアスタグを用意して運用します（任意）。
+タグは `@v0.13.0` などのリリースタグにピン留めしてください。浮動タグを使う場合は `@v0` のようなエイリアスタグを用意して運用します（任意）。
 
-最新リリース: [v0.12.0](https://github.com/s977043/river-reviewer/releases/tag/v0.12.0)
+最新リリース: [v0.13.0](https://github.com/s977043/river-reviewer/releases/tag/v0.13.0)
 
 > **ℹ️ v0.1.x からのアップグレード:** v0.2.0以降では、GitHub Actionのパスが `.github/actions/river-reviewer` から `runners/github-action` に変更されています。詳細は[移行ガイド](docs/migration/runners-architecture-guide.md)と[DEPRECATED.md](docs/deprecated.md)をご確認ください。
 
@@ -143,7 +143,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.13.0
         with: { phase: upstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 
@@ -152,7 +152,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.13.0
         with: { phase: midstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 
@@ -161,7 +161,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.13.0
         with: { phase: downstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 ```
@@ -175,7 +175,7 @@ review:
   steps:
     - uses: actions/checkout@v6
       with: { fetch-depth: 0 }
-    - uses: s977043/river-reviewer/runners/github-action@v0.12.0
+    - uses: s977043/river-reviewer/runners/github-action@v0.13.0
       with:
         phase: midstream
         estimate: true # コスト見積もりのみ
@@ -193,7 +193,7 @@ review:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.13.0
         with:
           phase: midstream
           dry_run: true            # Draft はドライランでプロンプト確認のみ
@@ -206,7 +206,7 @@ review:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.13.0
         with:
           phase: midstream
           dry_run: false           # Ready ではフルレビュー

--- a/docs/use-cases/github-actions.md
+++ b/docs/use-cases/github-actions.md
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0 # Required for git diff
 
       - name: Run River Reviewer
-        uses: s977043/river-reviewer/runners/github-action@v0.12.0
+        uses: s977043/river-reviewer/runners/github-action@v0.13.0
         with:
           phase: midstream
         env:
@@ -67,7 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.13.0
         with: { phase: upstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 
@@ -81,7 +81,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.13.0
         with: { phase: midstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 
@@ -95,7 +95,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.13.0
         with: { phase: downstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 ```
@@ -122,7 +122,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.13.0
         with: { phase: ${{ matrix.phase }} }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 ```
@@ -140,7 +140,7 @@ jobs:
 ### Example: Custom Skills Directory
 
 ```yaml
-- uses: s977043/river-reviewer/runners/github-action@v0.12.0
+- uses: s977043/river-reviewer/runners/github-action@v0.13.0
   with:
     phase: midstream
     skills-dir: custom-skills # Use custom skill location
@@ -149,7 +149,7 @@ jobs:
 ### Example: JSON Output
 
 ```yaml
-- uses: s977043/river-reviewer/runners/github-action@v0.12.0
+- uses: s977043/river-reviewer/runners/github-action@v0.13.0
   with:
     phase: midstream
     output-format: json
@@ -213,7 +213,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.13.0
         with: { phase: midstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 ```
@@ -238,7 +238,7 @@ jobs:
           repository: your-org/shared-skills
           path: shared-skills
 
-      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.13.0
         with:
           phase: midstream
           skills-dir: shared-skills
@@ -257,7 +257,7 @@ jobs:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
 
-      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.13.0
         with:
           phase: midstream
         env:
@@ -298,7 +298,7 @@ jobs:
           ref: refs/pull/${{ inputs.pr_number }}/head
           fetch-depth: 0
 
-      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.13.0
         with:
           phase: ${{ inputs.phase }}
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
@@ -322,7 +322,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.13.0
         with: { phase: midstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 ```
@@ -434,7 +434,7 @@ Line 15: ...
 ## Best Practices
 
 1. **Use Specific Phases** - Run only relevant skills to save time and costs
-2. **Pin Action Versions** - Use `@v0.12.0` instead of `@main` for stability
+2. **Pin Action Versions** - Use `@v0.13.0` instead of `@main` for stability
 3. **Set Permissions Explicitly** - Define minimum required permissions
 4. **Monitor API Usage** - Track LLM API costs and set budgets
 5. **Test Locally First** - Validate skills work before running in CI
@@ -462,7 +462,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.13.0
         with: { phase: midstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 
@@ -474,7 +474,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.13.0
         with: { phase: downstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 ```
@@ -507,7 +507,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.12.0
+      - uses: s977043/river-reviewer/runners/github-action@v0.13.0
         with: { phase: ${{ matrix.phase }} }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 ```


### PR DESCRIPTION
## Summary

- release-please が v0.13.0 を release 済だが、README / docs 内の `@v0.12.0` 参照が未更新
- これにより main で Meta consistency CI が FAILURE 状態、派生 PR (例: #589) もブロック
- 3 ファイルを一括更新して main を green に戻す

## Context

PR #461 (release-please) のマージで `package.json` は v0.13.0 に更新されたが、README と docs の action tag 参照は v0.12.0 のまま残存。`scripts/validate-meta-consistency.mjs` が `package.json` と README 等の tag 整合性を検証しており、5 個の error で CI が failure。

派生 PR #589 の CI も同じ原因で fail しているため、governance.md "マージ前チェックリスト" の規定 ("pre-existing 失敗は main 向け fix PR で先に解消") に従い本 PR を分離して起票。

## Changes

- \`README.md\`: \`@v0.12.0\` × 9 箇所 → \`@v0.13.0\`、"最新リリース" link も更新
- \`README.en.md\`: \`@v0.12.0\` × 2 箇所 → \`@v0.13.0\`、"Latest release" link も更新
- \`docs/use-cases/github-actions.md\`: \`@v0.12.0\` × 16 箇所 → \`@v0.13.0\`

## Verification

ローカルで実行済:

- \`npm run meta:validate\` → \`Meta consistency: OK\`
- \`npm test\` → 523/523 PASS

## Test plan

- [ ] CI required checks 7 個すべて pass
- [ ] main merge 後に PR #589 の rebase で Meta consistency が green 化することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)