### PR TITLE
docs(commands): add integrity note between CLAUDE.md and commands/README.md

### DIFF
--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -12,3 +12,5 @@ Custom slash commands for Claude Code.
 | `/propose-issue`    | `propose-issue.md`    | Research codebase before creating an issue                |
 | `/plan-merge-order` | `plan-merge-order.md` | Plan merge order for multiple PRs to minimize rebase cost |
 | `/preflight`        | `preflight.md`        | Verify tasks are not obsolete or in parallel before work  |
+
+> **整合性**: CLAUDE.md `Custom Commands` 表と本表は同期必須。コマンド追加時は両方を更新すること。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,6 @@ When a retrospective identifies a recurring mistake or missing guardrail, follow
 | `/challenge`        | Adversarial review (pre-mortem, war game)                 |
 | `/propose-issue`    | Research codebase before creating an issue                |
 | `/plan-merge-order` | Plan merge order for multiple PRs to minimize rebase cost |
-| `/preflight`        | Verify task state before multi-PR work to prevent dupes   |
+| `/preflight`        | Verify tasks are not obsolete or in parallel before work  |
 
 Details: `.claude/commands/`


### PR DESCRIPTION
## Summary

Today の audit-settings skill 実行で発見された軽微な drift リスクを防ぐため、`.claude/commands/README.md` と `CLAUDE.md` の Custom Commands 表が同期必須である旨の note を追加。

## Context

2 つの SSoT（CLAUDE.md と .claude/commands/README.md）でコマンド一覧を重複管理しており、将来ずれる可能性がある。監査可能性を保つため、同期必須の明示を入れる。

## Test plan

- [ ] markdown lint pass
- [ ] CI required checks 7 個 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)