### PR TITLE
fix(release-please): emit plain tag format and guard alias generation (#597)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,6 +39,17 @@ jobs:
         run: |
           set -euo pipefail
           TAG="${{ steps.release.outputs.tag_name }}"
+
+          # Expect plain tag format like "v0.14.0".
+          # Defensive: reject component-prefixed tags (e.g. "river-reviewer-v0.14.0")
+          # to avoid generating garbled alias names like "vriver-reviewer-v0".
+          # See #597 for the original bug.
+          if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Unexpected tag format: ${TAG}. Expected plain vX.Y.Z."
+            echo "::error::Check release-please-config.json include-component-in-tag setting."
+            exit 1
+          fi
+
           VERSION="${TAG#v}"
           MAJOR="${VERSION%%.*}"
           MAJOR_TAG="v${MAJOR}"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,8 +1,10 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "include-component-in-tag": false,
   "packages": {
     ".": {
       "release-type": "node",
+      "component": "",
       "extra-files": [
         {
           "type": "generic",


### PR DESCRIPTION
## Summary

PR #593 で \`release-please-config.json\` に \`packages\` 構造を導入した副作用として、v0.14.0 release で **tag 命名が壊れる** バグを解消する。

## 症状 (Issue #597)

v0.14.0 release 直後に以下の問題を検出:

| 期待 | 実際 |
|---|---|
| \`v0.14.0\` tag | ❌ 404 Not Found |
| \`@v0.14.0\` pinning | ❌ 失敗 |
| \`@v0\` floating alias | ❌ v0.13.1 のまま |
| \`river-reviewer-v0.14.0\` | ✅ 存在 |
| \`vriver-reviewer-v0\` | ⚠️ 意図しない壊れた tag 生成 |

## 原因

1. release-please が \`packages\` wrapper の下で component name prefix を付与
2. workflow の major alias shell script が \`\${TAG#v}\` で先頭 \`v\` 除去を想定していたが、 \`river-reviewer-v0.14.0\` 形式では先頭が \`r\` で除去されず、最終的に \`vriver-reviewer-v0\` という壊れた alias を生成

## 修正

### \`release-please-config.json\`

- \`include-component-in-tag: false\`: tag を \`vX.Y.Z\` plain 形式に戻す
- \`component: \"\"\`: 念のため component name を明示的に空に設定

### \`.github/workflows/release-please.yml\`

- major alias 生成前に正規表現バリデーション \`^v[0-9]+\.[0-9]+\.[0-9]+$\` を追加
- 予期しない tag 形式で alias 生成を blocker に (壊れた tag の push 前に CI fail)

## 既存 v0.14.0 救済 (本 PR とは独立、手動実行済)

- \`v0.14.0\` tag を 53ecacf に新規作成 (additive)
- \`v0\` alias を 53ecacf に force-update
- 壊れた \`vriver-reviewer-v0\` tag を削除

## Verification

- [x] lint / format
- [ ] CI 7 required checks pass
- [ ] 次 release PR で tag format が \`vX.Y.Z\` に戻ることを merge 後に確認 (本 PR 自体は release 生成しない)

## 関連

- Issue #597 (本 PR で close)
- PR #593 (original bug 源)
- PR #594 (症状発生、手動 URL 修正含む release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)