### PR TITLE
fix(codex): replace invalid approval_policy `full-auto` with `on-request`

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -41,7 +41,7 @@ npm run codex:exec -- "review this branch"
 
 - 設定: `.codex/config.toml`（承認ポリシー / サンドボックス）
 - 環境変数は最小限のみ forward する（PATH, HOME, USER, SHELL, LANG, LC_ALL）
-- 承認ポリシーは`full-auto`（sandbox_modeで安全性を担保）。`--model`、`--profile`、`--search`、`--add-dir`は実行時に上書きする
+- 承認ポリシーは`on-request`（`sandbox_mode=workspace-write` と併用で CLI の `--full-auto` 相当。sandbox_modeで安全性を担保）。`--model`、`--profile`、`--search`、`--add-dir`は実行時に上書きする
 - web search や sandbox bypass は repo 既定値にしない
 
 ## Quick Reference

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -10,8 +10,9 @@
 #   --add-dir <DIR>
 #
 # Do not set web search or sandbox-bypass flags here.
-# approval_policy is full-auto; safety relies on sandbox_mode and shell_environment_policy.
-approval_policy = "full-auto"
+# approval_policy is on-request (equivalent to `--full-auto` when combined with
+# sandbox_mode = workspace-write); safety relies on sandbox_mode and shell_environment_policy.
+approval_policy = "on-request"
 sandbox_mode = "workspace-write"
 
 # Optional tuning (uncomment only after team agreement)

--- a/pages/reference/output-format-yaml.en.md
+++ b/pages/reference/output-format-yaml.en.md
@@ -1,5 +1,5 @@
 ---
-id: output-format-yaml
+id: output-format-yaml-en
 title: YAML Output Format (Scoring + Verdict)
 description: River Reviewer YAML output format with scoring and verdict model.
 ---
@@ -94,7 +94,7 @@ Each axis starts at 100 and is deducted per finding by severity.
 | -------------------------- | ------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | `auto-approve`             | overall ≥90 AND security ≥95 AND critical=0 AND major=0 | Recommended for auto-approval. **HITL policy still applies**; humans make the final merge call. |
 | `human-review-recommended` | Not the above AND critical=0 AND overall ≥70            | Human review recommended.                                                                       |
-| `human-review-required`    | critical ≥1 OR overall <70                              | Human review required.                                                                          |
+| `human-review-required`    | critical ≥1 OR overall &lt;70                           | Human review required.                                                                          |
 
 ## Important caveats
 

--- a/pages/reference/output-format-yaml.md
+++ b/pages/reference/output-format-yaml.md
@@ -94,7 +94,7 @@ overall は 5 axis の平均値。
 | -------------------------- | ------------------------------------------------------- | ------------------------------------------------------------- |
 | `auto-approve`             | overall ≥90 AND security ≥95 AND critical=0 AND major=0 | 自動承認 **推奨**。ただし HITL 方針のため実マージは人間判断。 |
 | `human-review-recommended` | 上記に該当しない AND critical=0 AND overall ≥70         | 人間レビュー推奨。                                            |
-| `human-review-required`    | critical ≥1 OR overall <70                              | 人間レビュー必須。                                            |
+| `human-review-required`    | critical ≥1 OR overall &lt;70                           | 人間レビュー必須。                                            |
 
 ## 重要な注意事項
 


### PR DESCRIPTION
## Summary

Codex CLI `0.115.0` no longer accepts `full-auto` as an `approval_policy` value in `.codex/config.toml`. Starting Codex with the old value fails at config load:

```
failed to read configuration layers: /Users/.../.codex/config.toml:14:19:
unknown variant `full-auto`, expected one of `untrusted`, `on-failure`,
`on-request`, `granular`, `never`
```

`--full-auto` remains a valid CLI flag, but it's a convenience alias for `-a on-request --sandbox workspace-write`. So the correct config-level equivalent is `approval_policy = "on-request"`. Safety continues to be delegated to `sandbox_mode = "workspace-write"`.

## Changes

- `.codex/config.toml`: `approval_policy = "full-auto"` → `"on-request"`; comment updated to reflect the `--full-auto` CLI-alias equivalence.
- `.codex/AGENTS.md`: matching wording update.

## Test plan

- [x] `codex exec` loads the config without the `unknown variant` error (verified locally; startup banner now shows `approval: never` because non-interactive exec overrides to `never` per `codex --help`).
- [x] Interactive invocation honors `on-request`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)