### PR TITLE
fix(docs): bump action tag references to v0.14.1

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -109,14 +109,14 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run River Reviewer (midstream)
-        uses: s977043/river-reviewer/runners/github-action@v0.13.1
+        uses: s977043/river-reviewer/runners/github-action@v0.14.1
         with:
           phase: midstream # upstream|midstream|downstream|all (future-ready)
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 ```
 
-Pin to a release tag such as `@v0.13.1` for stability. Optionally, you can maintain a floating alias tag like `@v0`.
+Pin to a release tag such as `@v0.14.1` for stability. Optionally, you can maintain a floating alias tag like `@v0`.
 
 <!-- x-release-please-start-version -->
 

--- a/README.md
+++ b/README.md
@@ -119,14 +119,14 @@ jobs:
         with:
           fetch-depth: 0 # merge-base を安定取得
       - name: Run River Reviewer (midstream)
-        uses: s977043/river-reviewer/runners/github-action@v0.13.1
+        uses: s977043/river-reviewer/runners/github-action@v0.14.1
         with:
           phase: midstream # upstream|midstream|downstream|all (future-ready)
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 ```
 
-タグは `@v0.13.1` などのリリースタグにピン留めしてください。浮動タグを使う場合は `@v0` のようなエイリアスタグを用意して運用します（任意）。
+タグは `@v0.14.1` などのリリースタグにピン留めしてください。浮動タグを使う場合は `@v0` のようなエイリアスタグを用意して運用します（任意）。
 
 <!-- x-release-please-start-version -->
 
@@ -147,7 +147,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.13.1
+      - uses: s977043/river-reviewer/runners/github-action@v0.14.1
         with: { phase: upstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 
@@ -156,7 +156,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.13.1
+      - uses: s977043/river-reviewer/runners/github-action@v0.14.1
         with: { phase: midstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 
@@ -165,7 +165,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.13.1
+      - uses: s977043/river-reviewer/runners/github-action@v0.14.1
         with: { phase: downstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 ```
@@ -179,7 +179,7 @@ review:
   steps:
     - uses: actions/checkout@v6
       with: { fetch-depth: 0 }
-    - uses: s977043/river-reviewer/runners/github-action@v0.13.1
+    - uses: s977043/river-reviewer/runners/github-action@v0.14.1
       with:
         phase: midstream
         estimate: true # コスト見積もりのみ
@@ -197,7 +197,7 @@ review:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.13.1
+      - uses: s977043/river-reviewer/runners/github-action@v0.14.1
         with:
           phase: midstream
           dry_run: true            # Draft はドライランでプロンプト確認のみ
@@ -210,7 +210,7 @@ review:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.13.1
+      - uses: s977043/river-reviewer/runners/github-action@v0.14.1
         with:
           phase: midstream
           dry_run: false           # Ready ではフルレビュー

--- a/docs/migration/runners-migration-guide.md
+++ b/docs/migration/runners-migration-guide.md
@@ -2,7 +2,7 @@
 
 This guide helps you migrate from River Reviewer v0.1.x to v0.2.0+, which introduces the new runners architecture.
 
-> **Status (as of 2026-04):** The current release line is **v0.12.x**, distributed under `runners/github-action`. v0.1.x is a legacy frozen release that predates the runners architecture and receives no further updates. If you are still pinned to `@v0.1.x`, follow this guide to move to the latest release tag (see [README](../../README.md) for the current version).
+> **Status (as of 2026-04):** The current release line is **v0.14.x**, distributed under `runners/github-action`. v0.1.x is a legacy frozen release that predates the runners architecture and receives no further updates. If you are still pinned to `@v0.1.x`, follow this guide to move to the latest release tag (see [README](../../README.md) for the current version).
 
 ## Overview
 
@@ -255,7 +255,7 @@ If migration causes problems:
 
 What you miss while staying on v0.1.x:
 
-- All features and fixes shipped in v0.2.0–v0.12.x (planner / Riverbed Memory v1 / Agent Skills bridge / Codex CLI integration / etc.)
+- All features and fixes shipped in v0.2.0–v0.14.x (planner / Riverbed Memory v1 / Agent Skills bridge / Codex CLI integration / etc.)
 - New interfaces (CLI runner, Node API)
 - Compatibility with current schemas (`skills/`, `schemas/`)
 
@@ -297,7 +297,7 @@ See [Epic #242](https://github.com/s977043/river-reviewer/issues/242) for implem
 | 2025-12-29 | v0.2.0 released with new paths                                       |
 | 2026-01-29 | Migration recommended (1 month)                                      |
 | 2026-02-28 | Migration encouraged (2 months)                                      |
-| 2026-04    | v0.12.x is the current release line; v0.1.x is unmaintained (frozen) |
+| 2026-04    | v0.14.x is the current release line; v0.1.x is unmaintained (frozen) |
 | TBD        | v0.1.x tags may eventually be removed (v1.0.0+)                      |
 
 All feature and fix development happens on the current release line. v0.1.x receives no further updates.

--- a/docs/use-cases/github-actions.md
+++ b/docs/use-cases/github-actions.md
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0 # Required for git diff
 
       - name: Run River Reviewer
-        uses: s977043/river-reviewer/runners/github-action@v0.13.1
+        uses: s977043/river-reviewer/runners/github-action@v0.14.1
         with:
           phase: midstream
         env:
@@ -67,7 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.13.1
+      - uses: s977043/river-reviewer/runners/github-action@v0.14.1
         with: { phase: upstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 
@@ -81,7 +81,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.13.1
+      - uses: s977043/river-reviewer/runners/github-action@v0.14.1
         with: { phase: midstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 
@@ -95,7 +95,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.13.1
+      - uses: s977043/river-reviewer/runners/github-action@v0.14.1
         with: { phase: downstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 ```
@@ -122,7 +122,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.13.1
+      - uses: s977043/river-reviewer/runners/github-action@v0.14.1
         with: { phase: ${{ matrix.phase }} }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 ```
@@ -140,7 +140,7 @@ jobs:
 ### Example: Custom Skills Directory
 
 ```yaml
-- uses: s977043/river-reviewer/runners/github-action@v0.13.1
+- uses: s977043/river-reviewer/runners/github-action@v0.14.1
   with:
     phase: midstream
     skills-dir: custom-skills # Use custom skill location
@@ -149,7 +149,7 @@ jobs:
 ### Example: JSON Output
 
 ```yaml
-- uses: s977043/river-reviewer/runners/github-action@v0.13.1
+- uses: s977043/river-reviewer/runners/github-action@v0.14.1
   with:
     phase: midstream
     output-format: json
@@ -213,7 +213,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.13.1
+      - uses: s977043/river-reviewer/runners/github-action@v0.14.1
         with: { phase: midstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 ```
@@ -238,7 +238,7 @@ jobs:
           repository: your-org/shared-skills
           path: shared-skills
 
-      - uses: s977043/river-reviewer/runners/github-action@v0.13.1
+      - uses: s977043/river-reviewer/runners/github-action@v0.14.1
         with:
           phase: midstream
           skills-dir: shared-skills
@@ -257,7 +257,7 @@ jobs:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
 
-      - uses: s977043/river-reviewer/runners/github-action@v0.13.1
+      - uses: s977043/river-reviewer/runners/github-action@v0.14.1
         with:
           phase: midstream
         env:
@@ -298,7 +298,7 @@ jobs:
           ref: refs/pull/${{ inputs.pr_number }}/head
           fetch-depth: 0
 
-      - uses: s977043/river-reviewer/runners/github-action@v0.13.1
+      - uses: s977043/river-reviewer/runners/github-action@v0.14.1
         with:
           phase: ${{ inputs.phase }}
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
@@ -322,7 +322,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.13.1
+      - uses: s977043/river-reviewer/runners/github-action@v0.14.1
         with: { phase: midstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 ```
@@ -434,7 +434,7 @@ Line 15: ...
 ## Best Practices
 
 1. **Use Specific Phases** - Run only relevant skills to save time and costs
-2. **Pin Action Versions** - Use `@v0.13.1` instead of `@main` for stability
+2. **Pin Action Versions** - Use `@v0.14.1` instead of `@main` for stability
 3. **Set Permissions Explicitly** - Define minimum required permissions
 4. **Monitor API Usage** - Track LLM API costs and set budgets
 5. **Test Locally First** - Validate skills work before running in CI
@@ -462,7 +462,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.13.1
+      - uses: s977043/river-reviewer/runners/github-action@v0.14.1
         with: { phase: midstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 
@@ -474,7 +474,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.13.1
+      - uses: s977043/river-reviewer/runners/github-action@v0.14.1
         with: { phase: downstream }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 ```
@@ -507,7 +507,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: s977043/river-reviewer/runners/github-action@v0.13.1
+      - uses: s977043/river-reviewer/runners/github-action@v0.14.1
         with: { phase: ${{ matrix.phase }} }
         env: { OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} }
 ```


### PR DESCRIPTION
## Summary

- v0.14.1 がリリース済みだが、`README.md` / `docs/use-cases/github-actions.md` の action tag 例が `@v0.13.1` のままだった
- 加えて `docs/migration/runners-migration-guide.md` の "Status (as of 2026-04)" note が "v0.12.x is the current release line" と事実誤認している状態
- リリース時の drift を解消

## Scope

Action tag bumps (`@v0.13.1` → `@v0.14.1`):

- `README.md` (7 instances)
- `README.en.md` (1 instance)
- `docs/use-cases/github-actions.md` (14 instances — "Pin Action Versions" recommendation 行含む)

Migration guide status corrections (`v0.12.x` → `v0.14.x`):

- L5 (Status note)
- L258 (features shipped window)
- L300 (Timeline table)

## Related

- #607 (DRAFT) は `pages/tutorials/` + `pages/guides/` + `pages/reference/` scope をカバー（commit [22049a6](https://github.com/s977043/river-reviewer/commit/22049a6) で v0.13.1→v0.14.1 へ bump 済）。
- 本 PR と #607 を合わせて v0.14.1 リリース後のドキュメント drift を完全に解消。

## Test plan

- [x] `grep -rn 'v0\.13\.1\|v0\.12\.x'` on target files → 0 matches
- [x] pre-commit hook (prettier + markdownlint + check:dashes) passed
- [ ] CI (lint + test + link check) — to be verified on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)