### PR TITLE
chore(gitignore): exclude Codex CLI runtime artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,11 @@ CLAUDE.local.md
 .gemini/
 .codex/runtime-home/
 .codex/automations/
+.codex/sessions/
+.codex/logs_*.sqlite
+.codex/state_*.sqlite
+.codex/tmp/
+.codex/skills/.system/
 .lycheecache
 .worktrees/
 .vale/Microsoft


### PR DESCRIPTION
## Summary

Codex CLI を repo 内で実行すると `.codex/` 配下に runtime artifacts（セッションログ / SQLite DB / tmp / 内部 skills キャッシュ）が生成されるが、既存 `.gitignore` は `.codex/runtime-home/` と `.codex/automations/` しかカバーしておらず、`git status` が毎回汚れる状態だった。

## Changes

Extend `.gitignore` to cover:

- `.codex/sessions/` — per-day rollout JSONL logs
- `.codex/logs_*.sqlite` — Codex log DB
- `.codex/state_*.sqlite` — Codex state DB
- `.codex/tmp/` — ephemeral scratch space
- `.codex/skills/.system/` — Codex-generated internal skills cache (tracked skills 用のディレクトリを将来に残す余地として `.codex/skills/` 全体ではなく `.system/` のみ除外)

## Test plan

- [x] `git check-ignore -v` で上記パスが `.gitignore` にマッチすることを確認
- [x] `git status` が `.codex/` 配下で何も報告しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)