### PR TITLE
fix(docs): correct CHANGELOG compare URL for v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 * **release-please:** emit plain tag format and guard alias generation ([#597](https://github.com/s977043/river-reviewer/issues/597)) ([#598](https://github.com/s977043/river-reviewer/issues/598)) ([2de682a](https://github.com/s977043/river-reviewer/commit/2de682ad13a5dc6d7054e392a2444cbb93983d07))
 
-## [0.14.0](https://github.com/s977043/river-reviewer/compare/river-reviewer-v0.13.1...river-reviewer-v0.14.0) (2026-04-18)
+## [0.14.0](https://github.com/s977043/river-reviewer/compare/v0.13.1...v0.14.0) (2026-04-18)
 
 
 ### Features


### PR DESCRIPTION
## Summary

- CHANGELOG.md の v0.14.0 entry に含まれる compare URL が 404 を返し、scheduled lychee link check の唯一の破損リンクとなっていた
- 原因: v0.14.0 release 時点では release-please が component-prefixed tag format (`river-reviewer-v0.X.Y`) を emit していた。#598 で plain format (`v0.X.Y`) に切り替え済だが、古い entry は regenerate されない
- 実在する tag は `v0.13.1` / `v0.14.0` のみ（`git tag -l | sort -V` で確認）

## Change

`CHANGELOG.md:10`

```diff
-## [0.14.0](https://github.com/s977043/river-reviewer/compare/river-reviewer-v0.13.1...river-reviewer-v0.14.0) (2026-04-18)
+## [0.14.0](https://github.com/s977043/river-reviewer/compare/v0.13.1...v0.14.0) (2026-04-18)
```

## Test plan

- [x] `grep -c 'compare/river-reviewer-' CHANGELOG.md` → 0 (before was 1)
- [ ] lychee 再実行で 404 が消えること（CI で確認）
- [x] release-please の将来 release が古い entry を regenerate しない仕様であることを確認（standard behavior）

## Related

- #598 (plain tag format 導入)
- PR #609 / #610 の lychee 失敗の唯一の原因だった

🤖 Generated with [Claude Code](https://claude.com/claude-code)