### PR TITLE
chore(gitignore): exclude .claude/scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ artifacts/evals/*
 # Claude Code local-only overrides
 .claude/settings.local.json
 .claude/worktrees/
+.claude/scheduled_tasks.lock
 CLAUDE.local.md
 .gemini/
 .codex/runtime-home/


### PR DESCRIPTION
## Summary

Claude Code が scheduled task 実行中に生成する `.claude/scheduled_tasks.lock` (session ID / PID / timestamp の JSON lock file) を `.gitignore` に追加。既存の `.claude/` ルールは `settings.local.json` と `worktrees/` しかカバーしていなかったため、このファイルが毎回 untracked に現れていた。

## Change

```diff
# Claude Code local-only overrides
.claude/settings.local.json
.claude/worktrees/
+.claude/scheduled_tasks.lock
CLAUDE.local.md
```

## Not in scope

`.claude/stash-audit-2026-04-17.md` は **手動作成の監査ドキュメント**（2026-04-17 から 3 日間 untracked のまま保持）で runtime artifact ではないため、この PR では手を付けません。user が将来 commit する / 削除する判断を残す方針。

## Test plan

- [x] `git check-ignore -v .claude/scheduled_tasks.lock` で `.gitignore:31` に match
- [x] `git check-ignore .claude/stash-audit-2026-04-17.md` が no match（意図通り）
- [x] `git status` で `.claude/scheduled_tasks.lock` が消える

## Related

- #611 (`.codex/` runtime artifacts gitignore) と同じ趣旨、別ツール分。

🤖 Generated with [Claude Code](https://claude.com/claude-code)