### PR TITLE
feat(eval): enable skill eval CI gate (Phase 3)

### DIFF
--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -86,8 +86,8 @@ jobs:
     name: Evaluate ${{ matrix.skill }}
     needs: discover-skills
     if: needs.discover-skills.outputs.has_skills == 'true'
-    # Continue on error - evaluations are informational and shouldn't block PRs
-    continue-on-error: true
+    # Eval failures block PRs — skills with promptfoo.yaml fixtures are gated
+    continue-on-error: false
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:


### PR DESCRIPTION
Fixes part of #645

## Summary
- Enable skill eval CI gate by flipping `continue-on-error: false`
- `skills/*/prompt/**` was already in the trigger paths (no change needed there)

## Why this is safe
8 skills already have complete `eval/promptfoo.yaml` fixtures. The gate only
blocks when a skill that HAS fixtures fails its assertions.

Existing fixtures:
- `upstream/rr-upstream-cache-strategy-consistency-001`
- `upstream/rr-upstream-architecture-validation-plan-001`
- `upstream/rr-upstream-multitenancy-isolation-001`
- `upstream/rr-upstream-security-privacy-design-001`
- `upstream/rr-upstream-plangate-plan-integrity-001`
- `upstream/rr-upstream-plangate-exec-conformance-001`
- `midstream/rr-midstream-logging-observability-001`
- `midstream/rr-midstream-security-basic-001`

## Test plan
- [ ] CI passes (existing 8 skill fixtures should pass)
- [ ] A PR touching `skills/**` triggers the skill-eval job

🤖 Generated with [Claude Code](https://claude.com/claude-code)