### PR TITLE
feat(eval): add Phase 3 skill fixtures for typescript-nullcheck and typescript-strict

### DIFF
--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -5,19 +5,19 @@ on:
     branches:
       - main
     paths:
-      - 'skills/*/eval/**'
-      - 'skills/*/prompt/**'
-      - 'skills/*/fixtures/**'
-      - 'skills/*/golden/**'
+      - 'skills/*/*/eval/**'
+      - 'skills/*/*/prompt/**'
+      - 'skills/*/*/fixtures/**'
+      - 'skills/*/*/golden/**'
       - '.github/workflows/skill-eval.yml'
   pull_request:
     branches:
       - main
     paths:
-      - 'skills/*/eval/**'
-      - 'skills/*/prompt/**'
-      - 'skills/*/fixtures/**'
-      - 'skills/*/golden/**'
+      - 'skills/*/*/eval/**'
+      - 'skills/*/*/prompt/**'
+      - 'skills/*/*/fixtures/**'
+      - 'skills/*/*/golden/**'
       - '.github/workflows/skill-eval.yml'
   schedule:
     # Run weekly on Mondays at 9:00 AM JST (00:00 UTC)

--- a/docs/skills-structure.md
+++ b/docs/skills-structure.md
@@ -133,3 +133,82 @@ river-review-<domain>
 - [ ] `skills/agent-skills/` ディレクトリを作成
 - [ ] 入口スキル `river-review` を作成
 - [ ] テンプレート（#311）を使用して専門スキルを追加
+
+---
+
+## Per-Skill Eval Fixture Convention
+
+スキルごとの回帰テスト用フィクスチャの配置ルール。
+
+### ディレクトリ構造
+
+```text
+skills/<phase>/<skillId>/
+├── eval/
+│   └── promptfoo.yaml    # promptfoo 設定（テスト定義）
+├── fixtures/
+│   ├── 01-<name>-happy.md      # 検出すべき diff（happy path）
+│   └── 02-<name>-false-positive.md  # 誤検知すべきでない diff（guard）
+└── golden/
+    └── 01-<name>-happy.md      # 期待する出力（similarity チェック用）
+```
+
+### 最小フィクスチャ要件
+
+各スキルに最低 2 つのテストケースが必要:
+
+1. **Happy path** (`01-*-happy.md`): スキルが問題を検出すべき diff
+2. **False-positive guard** (`02-*-false-positive.md`): スキルが誤検知してはならない diff
+
+### フィクスチャファイル形式
+
+```markdown
+# Test Case: <タイトル>
+
+## Description
+
+テストの目的
+
+## Input Diff
+
+\`\`\`diff
+(実際の git diff 形式)
+\`\`\`
+
+## Expected Behavior
+
+- 検出 / 非検出の期待値を箇条書きで記述
+```
+
+### Golden ファイル形式
+
+```markdown
+# Expected Output: <タイトル>
+
+**Finding:** <問題の概要>
+**Evidence:** <証拠コード>
+**Impact:** <影響>
+**Fix:** <修正案>
+**Severity:** major|minor|critical|info
+**Confidence:** high|medium|low
+```
+
+### promptfoo.yaml のアサーション型
+
+| アサーション型 | 用途                                                     |
+| -------------- | -------------------------------------------------------- |
+| `llm-rubric`   | LLM による意味的な合否判定（主観的な基準）               |
+| `contains`     | 必須文字列が含まれるか                                   |
+| `not-contains` | false-positive guard（誤検知がないか）                   |
+| `similar`      | golden ファイルとのコサイン類似度（threshold: 0.7 推奨） |
+
+### ローカル実行
+
+```bash
+cd skills/<phase>/<skillId>/eval
+promptfoo eval
+```
+
+### CI ゲート
+
+`.github/workflows/skill-eval.yml` が `eval/promptfoo.yaml` を持つ全スキルを自動検出し、PR ごとに実行する。`continue-on-error: false` のため、失敗はマージをブロックする。

--- a/skills/midstream/rr-midstream-typescript-nullcheck-001/eval/promptfoo.yaml
+++ b/skills/midstream/rr-midstream-typescript-nullcheck-001/eval/promptfoo.yaml
@@ -1,0 +1,60 @@
+# promptfoo configuration for TypeScript Null Safety Guardrails skill evaluation
+# See: https://www.promptfoo.dev/docs/configuration/guide
+
+prompts:
+  - file://../prompt/system.md
+  - file://../prompt/user.md
+
+providers:
+  - id: openai:gpt-4o
+    config:
+      temperature: 0.1
+      max_tokens: 2000
+
+  - id: anthropic:claude-3-5-sonnet-20241022
+    config:
+      temperature: 0.1
+      max_tokens: 2000
+
+tests:
+  - description: Non-Null Assertion Detection (Happy Path)
+    vars:
+      diff: file://../fixtures/01-non-null-assertion-happy.md
+    assert:
+      - type: llm-rubric
+        value: |
+          The output must identify the unsafe non-null assertion on the API response.
+          Score 1 if the output mentions non-null assertion, `!` operator, or null safety risk.
+          Score 0 otherwise.
+
+      - type: contains
+        value: '!'
+
+      - type: llm-rubric
+        value: |
+          The output must suggest a safer alternative.
+          Score 1 if it suggests optional chaining (?.), null check, or early return.
+          Score 0 otherwise.
+
+      - type: similar
+        value: file://../golden/01-non-null-assertion-happy.md
+        threshold: 0.7
+
+  - description: Type Guard False Positive Avoidance
+    vars:
+      diff: file://../fixtures/02-type-guarded-false-positive.md
+    assert:
+      - type: llm-rubric
+        value: |
+          The output should NOT flag the code after assertConfig() as unsafe.
+          Score 1 if it recognizes the `asserts` narrowing or type guard makes access safe.
+          Score 0 if it incorrectly flags a null safety issue in the guarded code path.
+
+      - type: not-contains
+        value: 'Severity: major'
+
+defaultTest:
+  options:
+    provider: openai:gpt-4o
+
+outputPath: eval/results.json

--- a/skills/midstream/rr-midstream-typescript-nullcheck-001/fixtures/01-non-null-assertion-happy.md
+++ b/skills/midstream/rr-midstream-typescript-nullcheck-001/fixtures/01-non-null-assertion-happy.md
@@ -1,0 +1,31 @@
+# Test Case: Non-Null Assertion on API Response (Happy Path)
+
+## Description
+
+This test verifies that the skill correctly identifies unsafe non-null assertion on an external API response value.
+
+## Input Diff
+
+```diff
+diff --git a/src/services/user-service.ts b/src/services/user-service.ts
+index 1234567..89abcdef 100644
+--- a/src/services/user-service.ts
++++ b/src/services/user-service.ts
+@@ -8,7 +8,7 @@ export async function getUserName(userId: string): Promise<string> {
+   const response = await fetch(`/api/users/${userId}`);
+   const data = await response.json();
+
+-  return data.profile?.name ?? 'Anonymous';
++  return data.profile!.name;
+ }
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. Detect the unsafe non-null assertion `data.profile!.name`
+2. Note that `data` is from an external API response and could be null/undefined
+3. Explain the runtime crash risk
+4. Suggest using optional chaining or null guard instead
+5. Set severity to "major" and confidence to "high"

--- a/skills/midstream/rr-midstream-typescript-nullcheck-001/fixtures/02-type-guarded-false-positive.md
+++ b/skills/midstream/rr-midstream-typescript-nullcheck-001/fixtures/02-type-guarded-false-positive.md
@@ -1,0 +1,38 @@
+# Test Case: Type-Guarded Value (False Positive Guard)
+
+## Description
+
+This test verifies that the skill does NOT flag code where null is statically excluded by the type system with a proper type guard.
+
+## Input Diff
+
+```diff
+diff --git a/src/utils/config.ts b/src/utils/config.ts
+index 1234567..89abcdef 100644
+--- a/src/utils/config.ts
++++ b/src/utils/config.ts
+@@ -12,6 +12,14 @@ interface Config {
+   apiUrl: string;
+ }
+
++function assertConfig(cfg: Partial<Config>): asserts cfg is Config {
++  if (!cfg.apiUrl) {
++    throw new Error('apiUrl is required');
++  }
++}
++
+ export function getConfig(): Config {
+   const raw = loadRaw();
++  assertConfig(raw);
+   return raw;
+ }
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. Recognize the `assertConfig` function uses TypeScript `asserts` narrowing
+2. NOT flag `raw` access after `assertConfig(raw)` as unsafe
+3. Either return no findings or explicitly acknowledge the type guard makes the access safe
+4. NOT produce false positive warnings about null safety

--- a/skills/midstream/rr-midstream-typescript-nullcheck-001/golden/01-non-null-assertion-happy.md
+++ b/skills/midstream/rr-midstream-typescript-nullcheck-001/golden/01-non-null-assertion-happy.md
@@ -1,0 +1,17 @@
+# Expected Output: Non-Null Assertion on API Response
+
+**Finding:** Unsafe non-null assertion on external API response
+
+**Evidence:** Line 11: `return data.profile!.name;`
+
+**Impact:** If the API returns a response where `profile` is undefined or null, this code will throw a runtime TypeError. External API responses are inherently unpredictable and should never be assumed to be non-null.
+
+**Fix:** Use optional chaining with a fallback or an explicit null guard:
+
+```typescript
+return data.profile?.name ?? 'Anonymous';
+```
+
+**Severity:** major
+
+**Confidence:** high

--- a/skills/midstream/rr-midstream-typescript-nullcheck-001/prompt/system.md
+++ b/skills/midstream/rr-midstream-typescript-nullcheck-001/prompt/system.md
@@ -1,0 +1,46 @@
+# TypeScript Null Safety Guardrails - System Prompt
+
+You are a TypeScript expert code reviewer specializing in null/undefined safety.
+
+## Goal / 目的
+
+差分に含まれる TypeScript コードの null/undefined 安全性の問題を検出し、実行時クラッシュを防ぐ。
+
+## Non-goals / 扱わないこと
+
+- 全コードベースの型定義や API 契約の再設計
+- `strict` モードの導入可否判断
+- ライブラリ側の型定義バグの修正
+
+## Rule / ルール
+
+1. **非 null アサーション禁止**: `foo!` や `as Type` に頼らず、安全な分岐/early return を使う
+2. **外部入力のガード**: API レスポンス・環境変数・クエリパラメータはノーチェックで使わない
+3. **ユニオン型の網羅的ハンドリング**: `switch`/`if` で全ケースをカバーし `assertNever` を置く
+4. **オプショナル値のチェック**: `?.` や `?? fallback` を使い、undefined を安全に扱う
+
+## Heuristics / 判定の手がかり
+
+- `foo!` や `as Type` で未定義かもしれない値を強制している
+- API レスポンス/環境変数/クエリパラメータをノーチェックで使用
+- `switch`/`if` でユニオン型の全ケースをカバーしていない（default で握りつぶし）
+- Promise 戻りを `await` せずに使い、`undefined` アクセスの可能性がある
+
+## False-positive guards / 抑制条件
+
+- null/undefined が型で排除され、追加ガードが不要な箇所
+- `asserts`/バリデータで入力が保証されていると明示されている
+- テスト/fixtures 配下で意図的なモック値である場合
+
+## Good / Bad Examples
+
+- ✅ Good: `if (!value) return err('missing value');` のように early return でガード
+- ❌ Bad: `value!.length` のような非 null アサーション
+- ✅ Good: `switch (state.kind)` で各 kind を列挙し、`default: assertNever(state)` を置く
+- ✅ Good: `data?.profile?.name ?? 'Anonymous'` のようなオプショナルチェーン
+
+## Actions / 改善案
+
+- 外部入力やオプショナル値に対して null/undefined チェックを追加し、早期 return/throw で制御を明確化する
+- 非 null アサーションを排除し、undefined を許容する型定義やパーサーを導入する
+- ユニオン型を網羅する switch/if を書き、`assertNever` などで漏れを検知する

--- a/skills/midstream/rr-midstream-typescript-nullcheck-001/prompt/user.md
+++ b/skills/midstream/rr-midstream-typescript-nullcheck-001/prompt/user.md
@@ -1,0 +1,47 @@
+# TypeScript Null Safety Guardrails - User Prompt
+
+Review the provided code diff and identify null/undefined safety issues based on the rules and heuristics in the system prompt.
+
+## Input
+
+You will receive a code diff showing TypeScript changes.
+
+## Task
+
+1. Analyze the diff for null/undefined safety risks:
+   - Non-null assertions (`!`) on values that could be null/undefined
+   - Unsafe access to API response fields without null checks
+   - Missing optional chaining or null guards for external inputs
+   - Unhandled union type cases
+
+2. For each finding:
+   - Verify it's relevant to the actual diff (not speculative)
+   - Check against false-positive guards (type guards, `asserts`, test context)
+   - Assess confidence level
+
+3. Provide actionable feedback with evidence
+
+## Output Format
+
+For each null safety finding, provide:
+
+```text
+**Finding:** [Brief description of the null safety issue]
+**Evidence:** [Specific code snippet or line reference from diff]
+**Impact:** [What runtime error could occur]
+**Fix:** [Concrete suggestion with safer alternative]
+**Severity:** [critical/major/minor]
+**Confidence:** [high/medium/low]
+```
+
+### Important Notes
+
+- **DO NOT** flag code where the type system already excludes null/undefined
+- **DO NOT** flag `asserts`-based type guards as unsafe
+- **DO NOT** make speculative findings about code outside the diff
+- **DO** suggest optional chaining (`?.`) or early return guards as alternatives to `!`
+
+## 評価指標（Evaluation）
+
+- ✅ 合格基準: 指摘が差分に紐づき、根拠と次アクションが説明されている
+- ❌ 不合格基準: 差分と無関係な指摘、根拠のない断定、抑制条件の無視

--- a/skills/midstream/rr-midstream-typescript-strict-001/eval/promptfoo.yaml
+++ b/skills/midstream/rr-midstream-typescript-strict-001/eval/promptfoo.yaml
@@ -1,0 +1,60 @@
+# promptfoo configuration for TypeScript Strictness Guard skill evaluation
+# See: https://www.promptfoo.dev/docs/configuration/guide
+
+prompts:
+  - file://../prompt/system.md
+  - file://../prompt/user.md
+
+providers:
+  - id: openai:gpt-4o
+    config:
+      temperature: 0.1
+      max_tokens: 2000
+
+  - id: anthropic:claude-3-5-sonnet-20241022
+    config:
+      temperature: 0.1
+      max_tokens: 2000
+
+tests:
+  - description: Unsafe any Type Detection (Happy Path)
+    vars:
+      diff: file://../fixtures/01-any-type-usage-happy.md
+    assert:
+      - type: llm-rubric
+        value: |
+          The output must identify the unsafe `any` type annotations.
+          Score 1 if the output mentions `any` type, type safety risk, or lack of type checking.
+          Score 0 otherwise.
+
+      - type: contains
+        value: 'any'
+
+      - type: llm-rubric
+        value: |
+          The output must suggest a safer alternative to `any`.
+          Score 1 if it suggests `unknown`, explicit interface, or type guard.
+          Score 0 otherwise.
+
+      - type: similar
+        value: file://../golden/01-any-type-usage-happy.md
+        threshold: 0.7
+
+  - description: Test Mock Type Assertion False Positive Avoidance
+    vars:
+      diff: file://../fixtures/02-test-mock-false-positive.md
+    assert:
+      - type: llm-rubric
+        value: |
+          The output should NOT flag `as unknown as` in a Jest mock setup as a type safety violation.
+          Score 1 if it recognizes this is a test mock and does not raise major type safety concerns.
+          Score 0 if it incorrectly flags the mock pattern as a vulnerability.
+
+      - type: not-contains
+        value: 'Severity: major'
+
+defaultTest:
+  options:
+    provider: openai:gpt-4o
+
+outputPath: eval/results.json

--- a/skills/midstream/rr-midstream-typescript-strict-001/fixtures/01-any-type-usage-happy.md
+++ b/skills/midstream/rr-midstream-typescript-strict-001/fixtures/01-any-type-usage-happy.md
@@ -1,0 +1,33 @@
+# Test Case: Unsafe `any` Type Usage (Happy Path)
+
+## Description
+
+This test verifies that the skill correctly identifies newly added `any` type usage that weakens TypeScript's type safety.
+
+## Input Diff
+
+```diff
+diff --git a/src/api/parser.ts b/src/api/parser.ts
+index 1234567..89abcdef 100644
+--- a/src/api/parser.ts
++++ b/src/api/parser.ts
+@@ -5,7 +5,11 @@ import { ApiResponse } from './types';
+ export function parseApiResponse(raw: unknown): ApiResponse {
+   const data = JSON.parse(raw as string);
+
+-  return { id: data.id, name: data.name };
++  const result: any = data;
++  const user: any = result.user;
++  return { id: user.id, name: user.name };
+ }
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. Detect the `any` type annotations on `result` and `user`
+2. Note that using `any` bypasses TypeScript's type checking for these variables
+3. Explain the risk of uncaught type errors at runtime
+4. Suggest using `unknown` with type guards or an explicit interface
+5. Set severity to "major" and confidence to "high"

--- a/skills/midstream/rr-midstream-typescript-strict-001/fixtures/02-test-mock-false-positive.md
+++ b/skills/midstream/rr-midstream-typescript-strict-001/fixtures/02-test-mock-false-positive.md
@@ -1,0 +1,34 @@
+# Test Case: Test Mock with Type Assertion (False Positive Guard)
+
+## Description
+
+This test verifies that the skill does NOT flag `as unknown as` used in test files for creating mocks, which is an established TypeScript testing pattern.
+
+## Input Diff
+
+```diff
+diff --git a/tests/user-service.test.ts b/tests/user-service.test.ts
+index 1234567..89abcdef 100644
+--- a/tests/user-service.test.ts
++++ b/tests/user-service.test.ts
+@@ -8,6 +8,12 @@ describe('UserService', () => {
+   let mockRepo: UserRepository;
+
+   beforeEach(() => {
++    mockRepo = {
++      findById: jest.fn().mockResolvedValue({ id: '1', name: 'Alice' }),
++      save: jest.fn(),
++    } as unknown as UserRepository;
+   });
+
+   it('should return user by id', async () => {
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. Recognize this is a test file (path contains `/tests/`)
+2. NOT flag `as unknown as UserRepository` in a mock setup as a type safety violation
+3. Either return no findings or explicitly acknowledge the mock context
+4. NOT produce false positive warnings about `any` or type assertions in test mocks

--- a/skills/midstream/rr-midstream-typescript-strict-001/golden/01-any-type-usage-happy.md
+++ b/skills/midstream/rr-midstream-typescript-strict-001/golden/01-any-type-usage-happy.md
@@ -1,0 +1,21 @@
+# Expected Output: Unsafe `any` Type Usage
+
+**Finding:** Unsafe `any` type annotations bypass TypeScript type checking
+
+**Evidence:** Lines 8-9: `const result: any = data;` and `const user: any = result.user;`
+
+**Impact:** Using `any` disables TypeScript's type checking for these variables. If `data.user` has a different shape than expected, the error will only be caught at runtime rather than compile time.
+
+**Fix:** Use `unknown` with a type guard or define an explicit interface:
+
+```typescript
+interface ParsedData {
+  user: { id: string; name: string };
+}
+const parsed = data as ParsedData;
+return { id: parsed.user.id, name: parsed.user.name };
+```
+
+**Severity:** major
+
+**Confidence:** high

--- a/skills/midstream/rr-midstream-typescript-strict-001/prompt/system.md
+++ b/skills/midstream/rr-midstream-typescript-strict-001/prompt/system.md
@@ -1,0 +1,48 @@
+# TypeScript Strictness Guard - System Prompt
+
+You are a TypeScript expert code reviewer specializing in type safety and strictness enforcement.
+
+## Goal / 目的
+
+差分に含まれる TypeScript コードの `any` 型や型アサーションの乱用を検出し、型安全性の低下を防ぐ。
+
+## Non-goals / 扱わないこと
+
+- プロジェクト全体の strict 設定を変更する提案
+- 既存ライブラリの型定義の不備を修正する
+- 型以外のスタイル/命名のレビュー
+
+## Rule / ルール
+
+1. **`any` の最小化**: `any` の使用や無制限の型アサーションを最小化する
+2. **null/undefined の明示的な扱い**: ガード節を追加し、安全に処理する
+3. **型の明確化**: 型の流れが不明な箇所には型エイリアス/インターフェースを付ける
+4. **`unknown` の活用**: 外部入力は `any` ではなく `unknown` で受けて型ガードを適用する
+
+## Heuristics / 判定の手がかり
+
+- `any`, `as unknown as`, `as any` などが新たに追加されている
+- 非 null アサーション `!` が多用されている
+- 関数戻り値や外部入力が `any` や `object` で受け取られている
+
+## False-positive guards / 抑制条件
+
+- `any` が一時的な実験コードで、明示的なコメントがある
+- 型定義が別ファイルにあり、変更範囲では判定できない
+- テスト/fixtures 配下で Jest モック設定の `as unknown as Type` パターン（確立されたテストパターン）
+- `as unknown as` がモックオブジェクト生成に使われており、テストファイルである場合
+
+## Good / Bad Examples
+
+- ✅ Good: `type User = { id: string; name: string };`
+- ❌ Bad: `const user: any = getUser();`
+- ✅ Good: `if (!value) return;` で null をガード
+- ❌ Bad: `value!.doSomething()` で非 null アサーション連発
+- ✅ Good: `const data: unknown = await fetch(...); if (!isUser(data)) throw new Error()`
+- ❌ Bad: `const data: any = await fetch(...); data.user.id`
+
+## Actions / 改善案
+
+- `unknown` で受けて型ガード関数を追加する
+- null チェックをガード節で追加し、早期 return を使う
+- 型アサーションの代わりに型定義や Zod 等でスキーマを導入する

--- a/skills/midstream/rr-midstream-typescript-strict-001/prompt/user.md
+++ b/skills/midstream/rr-midstream-typescript-strict-001/prompt/user.md
@@ -1,0 +1,47 @@
+# TypeScript Strictness Guard - User Prompt
+
+Review the provided code diff and identify TypeScript type safety issues based on the rules and heuristics in the system prompt.
+
+## Input
+
+You will receive a code diff showing TypeScript changes.
+
+## Task
+
+1. Analyze the diff for TypeScript strictness violations:
+   - Use of `any` type on new variables or function parameters
+   - Unsafe type assertions (`as any`, `as unknown as` in non-test code)
+   - Missing type definitions for external data
+   - Unsafe non-null assertions (`!`) on potentially undefined values
+
+2. For each finding:
+   - Verify it's relevant to the actual diff (not speculative)
+   - Check against false-positive guards (test mocks, experimental code with comments)
+   - Assess confidence level
+
+3. Provide actionable feedback with evidence
+
+## Output Format
+
+For each type safety finding, provide:
+
+```text
+**Finding:** [Brief description of the type safety issue]
+**Evidence:** [Specific code snippet or line reference from diff]
+**Impact:** [What type errors could be missed at compile time]
+**Fix:** [Concrete suggestion with stricter alternative]
+**Severity:** [critical/major/minor]
+**Confidence:** [high/medium/low]
+```
+
+### Important Notes
+
+- **DO NOT** flag `as unknown as` in test mock setup (established Jest/Vitest pattern)
+- **DO NOT** flag `any` with explicit TODO/experimental comment
+- **DO NOT** make speculative findings about code outside the diff
+- **DO** suggest `unknown` + type guards as alternatives to `any`
+
+## 評価指標（Evaluation）
+
+- ✅ 合格基準: 指摘が差分に紐づき、根拠と次アクションが説明されている
+- ❌ 不合格基準: 差分と無関係な指摘、根拠のない断定、抑制条件の無視


### PR DESCRIPTION
## Summary

- Adds `eval/promptfoo.yaml` + fixtures + golden files for `rr-midstream-typescript-nullcheck-001` (non-null assertion detection + TypeScript `asserts` false-positive guard)
- Adds `eval/promptfoo.yaml` + fixtures + golden files for `rr-midstream-typescript-strict-001` (`any` type detection + test mock false-positive guard)
- Documents the per-skill eval fixture convention in `docs/skills-structure.md` (directory layout, fixture format, assertion types, local run command, CI gate description)

Closes #645 acceptance criterion: brings skill eval coverage to **10 skills** (≥10 required).

## Test plan

- [ ] CI: `Discover skills with eval configs` picks up the 2 new skills
- [ ] CI: `Evaluate midstream/rr-midstream-typescript-nullcheck-001` passes
- [ ] CI: `Evaluate midstream/rr-midstream-typescript-strict-001` passes
- [ ] All existing 8 skill evals continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)