### PR TITLE
feat(skills): add Greptile-inspired cross-context core skills

### DIFF
--- a/skills/midstream/rr-midstream-api-compatibility-001/SKILL.md
+++ b/skills/midstream/rr-midstream-api-compatibility-001/SKILL.md
@@ -1,0 +1,57 @@
+---
+id: rr-midstream-api-compatibility-001
+name: API Compatibility and Test Gap Review
+description: Detect breaking API contract changes (DTO shape, schema, endpoint signature) and missing tests for changed API contracts.
+version: 0.1.0
+category: midstream
+phase: midstream
+applyTo:
+  - '**/*.ts'
+  - '**/*.tsx'
+  - '**/*.js'
+tags:
+  - api
+  - compatibility
+  - testing
+  - midstream
+severity: major
+inputContext:
+  - diff
+  - fullFile
+outputKind:
+  - findings
+modelHint: high-accuracy
+---
+
+## Pattern declaration
+
+Primary pattern: Reviewer
+Secondary patterns: Inversion
+Why: API変更は下位互換性の破壊に気づきにくく、テスト不足のまま出荷されやすい
+
+## Guidance
+
+- Flag removal of required fields from API response types/interfaces without a migration path.
+- Flag addition of required (non-optional) fields to request DTOs — existing callers will break.
+- Check if changed API handler or schema has corresponding test updates in `*.test.*` or `*.spec.*` files.
+- Flag endpoint URL changes that may break existing consumers without a deprecation notice.
+- Check for missing error response type coverage: adding new error codes without updating error type unions.
+
+## Non-goals
+
+- 内部専用関数（`private`、`_`プレフィックス、非exportメンバー）は対象外。
+- バージョニングされたAPI（`/v2/`等）の同バージョン内の変更は後方互換が別途保証される前提。
+
+## Pre-execution Gate / 実行前ゲート
+
+このスキルは以下の条件がすべて満たされない限り`NO_REVIEW`を返す。
+
+- [ ] 差分にAPI handler、DTO型定義、またはschema定義の変更が含まれている
+
+ゲート不成立時の出力: `NO_REVIEW: rr-midstream-api-compatibility-001 — API contract関連の変更が検出されない`
+
+## False-positive guards
+
+- 型の追加がoptional（`?:`）であれば後方互換として黙る。
+- 同一PRにtest追加が含まれていれば追加のtest要求はしない。
+- deprecatedマーカーがついているフィールドの削除は指摘しない。

--- a/skills/midstream/rr-midstream-api-compatibility-001/fixtures/01-required-field-added-without-test.md
+++ b/skills/midstream/rr-midstream-api-compatibility-001/fixtures/01-required-field-added-without-test.md
@@ -1,0 +1,46 @@
+# Test Case: Required DTO Field Added Without Test Update (Should Detect)
+
+## Description
+
+This test verifies that the skill correctly identifies a DTO change that makes a previously optional field required, without updating the corresponding API tests to include the new required field.
+
+## Input Diff
+
+```diff
+diff --git a/src/types/create-order.dto.ts b/src/types/create-order.dto.ts
+index 1234567..abcdef0 100644
+--- a/src/types/create-order.dto.ts
++++ b/src/types/create-order.dto.ts
+@@ -4,10 +4,11 @@ export interface CreateOrderDto {
+   customerId: string;
+   items: OrderItem[];
+-  shippingAddressId?: string;
++  shippingAddressId: string;
+   paymentMethodId: string;
++  couponCode?: string;
+ }
+diff --git a/src/api/orders.ts b/src/api/orders.ts
+index 2345678..3456789 100644
+--- a/src/api/orders.ts
++++ b/src/api/orders.ts
+@@ -6,7 +6,7 @@ export async function createOrder(dto: CreateOrderDto): Promise<Order> {
+   const response = await fetch('/api/orders', {
+     method: 'POST',
+     headers: { 'Content-Type': 'application/json' },
+-    body: JSON.stringify(dto),
++    body: JSON.stringify({ ...dto, source: 'web' }),
+   });
+   return response.json();
+ }
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. Detect that `shippingAddressId` was changed from optional (`?`) to required in `CreateOrderDto`
+2. Flag this as a potentially breaking change — existing callers that omit `shippingAddressId` will now have a TypeScript error
+3. Note that no test files are updated in the diff to cover this change
+4. Suggest finding all call sites of `createOrder` to confirm `shippingAddressId` is always provided
+5. Suggest adding or updating tests to verify the new required field behavior
+6. Set severity to "major"

--- a/skills/midstream/rr-midstream-api-compatibility-001/fixtures/01-should-detect.md
+++ b/skills/midstream/rr-midstream-api-compatibility-001/fixtures/01-should-detect.md
@@ -1,0 +1,28 @@
+# Test Case: Breaking DTO Change Without Tests (Should Detect)
+
+## Description
+
+A required field is added to a request DTO, breaking all existing callers, and no test file is updated.
+
+## Input Diff
+
+```diff
+diff --git a/src/types/api.ts b/src/types/api.ts
+index abc1234..def5678 100644
+--- a/src/types/api.ts
++++ b/src/types/api.ts
+@@ -3,5 +3,6 @@ export interface CreateOrderRequest {
+   productId: string;
+   quantity: number;
++  warehouseId: string;
+ }
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. Detect that `warehouseId: string` (non-optional) was added to a request DTO — existing callers passing `{productId, quantity}` will fail TypeScript compilation
+2. Flag absence of corresponding test file changes
+3. Severity: major
+4. Suggest either making the field optional (`warehouseId?: string`) or adding a migration note

--- a/skills/midstream/rr-midstream-api-compatibility-001/fixtures/02-additive-optional-field-safe.md
+++ b/skills/midstream/rr-midstream-api-compatibility-001/fixtures/02-additive-optional-field-safe.md
@@ -1,0 +1,63 @@
+# Test Case: New Optional Response Field with Test Coverage (False Positive Guard)
+
+## Description
+
+This test verifies that the skill does NOT flag a backward-compatible additive change — a new optional field added to a response DTO — when the change includes corresponding test updates.
+
+## Input Diff
+
+```diff
+diff --git a/src/types/user-profile.dto.ts b/src/types/user-profile.dto.ts
+index 1234567..abcdef0 100644
+--- a/src/types/user-profile.dto.ts
++++ b/src/types/user-profile.dto.ts
+@@ -5,6 +5,8 @@ export interface UserProfileDto {
+   id: string;
+   name: string;
+   email: string;
++  avatarUrl?: string;
++  lastLoginAt?: string;
+ }
+diff --git a/src/api/users.ts b/src/api/users.ts
+index 2345678..3456789 100644
+--- a/src/api/users.ts
++++ b/src/api/users.ts
+@@ -8,6 +8,12 @@ export async function getUserProfile(userId: string): Promise<UserProfileDto> {
+   return response.json();
+ }
++
++export function getAvatarUrl(profile: UserProfileDto): string {
++  return profile.avatarUrl ?? '/default-avatar.png';
++}
+diff --git a/tests/api/users.test.ts b/tests/api/users.test.ts
+index 3456789..4567890 100644
+--- a/tests/api/users.test.ts
++++ b/tests/api/users.test.ts
+@@ -15,6 +15,20 @@ describe('getUserProfile', () => {
+     expect(profile.name).toBe('Alice');
+   });
++
++  it('returns default avatar when avatarUrl is absent', async () => {
++    const profile: UserProfileDto = { id: '1', name: 'Alice', email: 'a@example.com' };
++    expect(getAvatarUrl(profile)).toBe('/default-avatar.png');
++  });
++
++  it('returns avatarUrl when present', async () => {
++    const profile: UserProfileDto = {
++      id: '1', name: 'Alice', email: 'a@example.com',
++      avatarUrl: 'https://cdn.example.com/alice.jpg',
++    };
++    expect(getAvatarUrl(profile)).toBe('https://cdn.example.com/alice.jpg');
++  });
+ });
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. Recognize that `avatarUrl` and `lastLoginAt` are added as optional fields (`?`) — this is a backward-compatible additive change
+2. Note that `getAvatarUrl` handles the nullable case with `?? '/default-avatar.png'`
+3. Observe that tests cover both the present and absent cases for the new field
+4. NOT flag this as a breaking change or a test gap
+5. Either return no findings or explicitly confirm the change is backward-compatible and well-tested

--- a/skills/midstream/rr-midstream-api-compatibility-001/fixtures/02-should-not-detect.md
+++ b/skills/midstream/rr-midstream-api-compatibility-001/fixtures/02-should-not-detect.md
@@ -1,0 +1,33 @@
+# Test Case: Optional Field Addition With Tests (Should NOT Detect)
+
+## Description
+
+A new optional field is added to a response DTO, and the test file is updated.
+
+## Input Diff
+
+```diff
+diff --git a/src/types/api.ts b/src/types/api.ts
+index abc1234..def5678 100644
+--- a/src/types/api.ts
++++ b/src/types/api.ts
+@@ -3,4 +3,5 @@ export interface OrderResponse {
+   id: string;
+   status: string;
++  estimatedDelivery?: string;
+ }
+diff --git a/src/api/orders.test.ts b/src/api/orders.test.ts
+index 1111111..2222222 100644
+--- a/src/api/orders.test.ts
++++ b/src/api/orders.test.ts
+@@ -15,5 +15,9 @@ describe('GET /orders/:id', () => {
+   it('returns order with estimated delivery when available', async () => {
++    const res = await request(app).get('/orders/123');
++    expect(res.body.estimatedDelivery).toBeUndefined(); // optional
+   });
+ });
+```
+
+## Expected Behavior
+
+The skill should NOT flag this — adding an optional field (`?:`) is backward-compatible, and the test file is updated accordingly.

--- a/skills/midstream/rr-midstream-i18n-unused-key-001/SKILL.md
+++ b/skills/midstream/rr-midstream-i18n-unused-key-001/SKILL.md
@@ -1,0 +1,58 @@
+---
+id: rr-midstream-i18n-unused-key-001
+name: i18n Unused Key Review
+description: Detect i18n/locale keys that are removed from source but remain in locale files, or keys added to locale files without source usage.
+version: 0.1.0
+category: midstream
+phase: midstream
+applyTo:
+  - '**/i18n/**'
+  - '**/locales/**'
+  - '**/messages/**'
+  - '**/*.json'
+tags:
+  - i18n
+  - localization
+  - dead-code
+  - midstream
+severity: minor
+inputContext:
+  - diff
+  - fullFile
+outputKind:
+  - findings
+modelHint: balanced
+---
+
+## Pattern declaration
+
+Primary pattern: Reviewer
+Secondary patterns: Inversion
+Why: i18n key管理はdiff単体では判断が難しく、ファイル全体とソース参照の両方を踏まえる必要がある
+
+## Guidance
+
+- Check if translation keys deleted from source code (e.g., `t('key')`, `i18n.t('key')`, `$t('key')`) still exist in locale JSON files — report as unused key.
+- Check if new keys added to locale JSON files are referenced in source code — report as potentially orphaned key.
+- Look for patterns like `t('user.profile.name')`, `i18n('common.cancel')`, `formatMessage({ id: 'key' })`.
+- When source file is deleted entirely, flag all its keys in locale files as candidates for removal.
+
+## Non-goals
+
+- 動的に構築されるkey（テンプレートリテラルやconcat）は誤検知になりやすいため指摘しない。
+- 外部ライブラリのkey（third-party component内部のi18n keyなど）は対象外。
+
+## Pre-execution Gate / 実行前ゲート
+
+このスキルは以下の条件がすべて満たされない限り`NO_REVIEW`を返す。
+
+- [ ] 差分にi18n/locale関連ファイル（\*.json, **/i18n/**, **/locales/**）の変更が含まれている
+- [ ] または差分にUI文言を削除・変更するソースコードの変更が含まれている
+
+ゲート不成立時の出力: `NO_REVIEW: rr-midstream-i18n-unused-key-001 — i18n/locale関連の変更が検出されない`
+
+## False-positive guards
+
+- keyがワイルドカードや動的参照で使用されている可能性がある場合は黙る。
+- テスト用フィクスチャやstorybook内のkey定義は対象外。
+- 同一PR内で追加と削除が対になっている（リネーム）場合は指摘しない。

--- a/skills/midstream/rr-midstream-i18n-unused-key-001/fixtures/01-removed-component-key-left-behind.md
+++ b/skills/midstream/rr-midstream-i18n-unused-key-001/fixtures/01-removed-component-key-left-behind.md
@@ -1,0 +1,49 @@
+# Test Case: Removed Component Leaves Unused i18n Key (Should Detect)
+
+## Description
+
+This test verifies that the skill correctly identifies an unused locale key left in the JSON file after the corresponding UI component was removed.
+
+## Input Diff
+
+```diff
+diff --git a/src/components/UserBadge.tsx b/src/components/UserBadge.tsx
+deleted file mode 100644
+index 1234567..0000000
+--- a/src/components/UserBadge.tsx
++++ /dev/null
+@@ -1,12 +0,0 @@
+-import { useTranslation } from 'react-i18next';
+-
+-export function UserBadge({ role }: { role: string }) {
+-  const { t } = useTranslation();
+-  return (
+-    <span className="badge">
+-      {t('userBadge.roleLabel')}: {role}
+-    </span>
+-  );
+-}
+diff --git a/src/locales/en.json b/src/locales/en.json
+index 2345678..3456789 100644
+--- a/src/locales/en.json
++++ b/src/locales/en.json
+@@ -10,7 +10,7 @@
+   "userCard": {
+     "title": "User",
+     "subtitle": "Profile"
+-  }
++  },
++  "userBadge": {
++    "roleLabel": "Role"
++  }
+ }
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. Detect that `UserBadge.tsx` was deleted and no longer calls `t('userBadge.roleLabel')`
+2. Flag that the `userBadge.roleLabel` key added to `en.json` is now unreferenced
+3. Suggest removing the `userBadge` section from all locale files
+4. Set severity to "minor" and note the dead-code risk

--- a/skills/midstream/rr-midstream-i18n-unused-key-001/fixtures/01-should-detect.md
+++ b/skills/midstream/rr-midstream-i18n-unused-key-001/fixtures/01-should-detect.md
@@ -1,0 +1,41 @@
+# Test Case: i18n Unused Key (Should Detect)
+
+## Description
+
+A UI component removes a translated string reference, but the key remains in the locale file.
+
+## Input Diff
+
+```diff
+diff --git a/src/components/UserProfile.tsx b/src/components/UserProfile.tsx
+index abc1234..def5678 100644
+--- a/src/components/UserProfile.tsx
++++ b/src/components/UserProfile.tsx
+@@ -8,7 +8,6 @@ export function UserProfile({ user }: Props) {
+   return (
+     <div>
+       <h1>{t('user.profile.title')}</h1>
+-      <p>{t('user.profile.deprecated_bio_label')}</p>
+       <p>{user.bio}</p>
+     </div>
+   );
+diff --git a/src/i18n/en.json b/src/i18n/en.json
+index 1111111..2222222 100644
+--- a/src/i18n/en.json
++++ b/src/i18n/en.json
+@@ -5,6 +5,7 @@ {
+     "title": "User Profile",
+-    "bio_label": "Bio"
++    "bio_label": "Bio",
++    "deprecated_bio_label": "Biography (deprecated)"
+   }
+ }
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. Detect that `user.profile.deprecated_bio_label` was added to the locale file but is no longer referenced in source
+2. Set severity to "minor"
+3. Suggest removing the orphaned key from locale files

--- a/skills/midstream/rr-midstream-i18n-unused-key-001/fixtures/02-dynamic-key-false-positive.md
+++ b/skills/midstream/rr-midstream-i18n-unused-key-001/fixtures/02-dynamic-key-false-positive.md
@@ -1,0 +1,47 @@
+# Test Case: Dynamic i18n Key Reference (False Positive Guard)
+
+## Description
+
+This test verifies that the skill does NOT flag locale keys that are referenced via dynamic key generation (template literals or computed property keys), which cannot be statically resolved.
+
+## Input Diff
+
+```diff
+diff --git a/src/locales/en.json b/src/locales/en.json
+index 2345678..3456789 100644
+--- a/src/locales/en.json
++++ b/src/locales/en.json
+@@ -5,6 +5,12 @@
+   "common": {
+     "save": "Save",
+     "cancel": "Cancel"
++  },
++  "status": {
++    "active": "Active",
++    "inactive": "Inactive",
++    "pending": "Pending",
++    "archived": "Archived"
+   }
+ }
+diff --git a/src/components/StatusBadge.tsx b/src/components/StatusBadge.tsx
+index abcdef0..1234567 100644
+--- a/src/components/StatusBadge.tsx
++++ b/src/components/StatusBadge.tsx
+@@ -3,7 +3,9 @@ import { useTranslation } from 'react-i18next';
+
+ export function StatusBadge({ status }: { status: string }) {
+   const { t } = useTranslation();
+-  return <span>{status}</span>;
++  // Dynamic key: key is constructed at runtime from the status value
++  return <span>{t(`status.${status}`)}</span>;
+ }
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. Recognize the `t(\`status.${status}\`)` call uses a dynamic template literal key
+2. NOT flag the `status.*` keys in `en.json` as unused — they are referenced dynamically
+3. Either return no findings or explicitly acknowledge dynamic key usage makes static analysis unreliable
+4. NOT produce false positive warnings about unused keys for dynamically-generated references

--- a/skills/midstream/rr-midstream-i18n-unused-key-001/fixtures/02-should-not-detect.md
+++ b/skills/midstream/rr-midstream-i18n-unused-key-001/fixtures/02-should-not-detect.md
@@ -1,0 +1,32 @@
+# Test Case: i18n Key Rename (Should NOT Detect)
+
+## Description
+
+A translation key is renamed — both the source reference and the locale entry are updated together.
+
+## Input Diff
+
+```diff
+diff --git a/src/components/Header.tsx b/src/components/Header.tsx
+index abc1234..def5678 100644
+--- a/src/components/Header.tsx
++++ b/src/components/Header.tsx
+@@ -5,5 +5,5 @@ export function Header() {
+-  return <h1>{t('header.title_old')}</h1>;
++  return <h1>{t('header.title')}</h1>;
+ }
+diff --git a/src/i18n/en.json b/src/i18n/en.json
+index 1111111..2222222 100644
+--- a/src/i18n/en.json
++++ b/src/i18n/en.json
+@@ -2,5 +2,5 @@ {
+   "header": {
+-    "title_old": "My App"
++    "title": "My App"
+   }
+ }
+```
+
+## Expected Behavior
+
+The skill should NOT flag this — the old key is removed and the new key is added together (a rename). No orphaned keys exist after the change.

--- a/skills/midstream/rr-midstream-loading-state-001/SKILL.md
+++ b/skills/midstream/rr-midstream-loading-state-001/SKILL.md
@@ -1,0 +1,58 @@
+---
+id: rr-midstream-loading-state-001
+name: Loading State Transition Review
+description: Detect missing loading/error/empty state handling that could trap users in spinners or disabled states.
+version: 0.1.0
+category: midstream
+phase: midstream
+applyTo:
+  - '**/*.tsx'
+  - '**/*.jsx'
+  - '**/*.ts'
+  - '**/*.js'
+tags:
+  - ux
+  - loading-state
+  - error-handling
+  - midstream
+severity: major
+inputContext:
+  - diff
+outputKind:
+  - findings
+modelHint: balanced
+---
+
+## Pattern declaration
+
+Primary pattern: Reviewer
+Secondary patterns: Inversion
+Why: ローディング状態の管理ミスはUXに直結するが、テストで気づきにくい
+
+## Guidance
+
+- Check if async data fetching (useQuery, useSWR, fetch, axios) handles all three states: loading, success, error.
+- Flag missing `error` state when `loading` state is handled.
+- Flag missing `loading` guard when mutation is triggered (e.g., submit button not disabled during pending).
+- Check for missing early returns that could render UI before data is available (`if (!data) return null`).
+- Flag `isLoading && <Spinner />` without a corresponding `isError && <ErrorMessage />`.
+
+## Non-goals
+
+- グローバルなローディングインジケーターの存在は前提として受け入れる（実装詳細は不問）。
+- テストファイル内のモックデータや固定値は対象外。
+
+## Pre-execution Gate / 実行前ゲート
+
+このスキルは以下の条件がすべて満たされない限り`NO_REVIEW`を返す。
+
+- [ ] 差分にasync data fetchingまたはUIコンポーネントのレンダリングロジックが含まれている
+- [ ] loading/error/data stateを扱うコードパターンが存在する（useQuery, useSWR, useState + fetch等）
+
+ゲート不成立時の出力: `NO_REVIEW: rr-midstream-loading-state-001 — loading state関連のUI変更が検出されない`
+
+## False-positive guards
+
+- ライブラリがSuspenseやError Boundaryで上位でハンドリングしている場合は黙る。
+- テスト専用のコンポーネントは対象外。
+- 意図的に簡略化されたadmin-onlyビューは緩く扱う。

--- a/skills/midstream/rr-midstream-loading-state-001/fixtures/01-missing-error-state.md
+++ b/skills/midstream/rr-midstream-loading-state-001/fixtures/01-missing-error-state.md
@@ -1,0 +1,48 @@
+# Test Case: Missing Error State in Data-Fetching Component (Should Detect)
+
+## Description
+
+This test verifies that the skill correctly identifies a React component that handles loading state but omits error state handling for an async data fetch.
+
+## Input Diff
+
+```diff
+diff --git a/src/components/UserList.tsx b/src/components/UserList.tsx
+new file mode 100644
+index 0000000..abcdef0
+--- /dev/null
++++ b/src/components/UserList.tsx
+@@ -0,0 +1,32 @@
++import React from 'react';
++import { useQuery } from '@tanstack/react-query';
++import { fetchUsers } from '../api/users';
++
++export function UserList() {
++  const { data: users, isLoading } = useQuery({
++    queryKey: ['users'],
++    queryFn: fetchUsers,
++  });
++
++  if (isLoading) {
++    return <div className="spinner">Loading...</div>;
++  }
++
++  return (
++    <ul>
++      {users?.map(user => (
++        <li key={user.id}>{user.name}</li>
++      ))}
++    </ul>
++  );
++}
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. Detect that `useQuery` is used but only `isLoading` is destructured — `error` / `isError` are ignored
+2. Flag the missing error state handling — if the query fails, the component silently renders an empty list
+3. Note there is no empty state fallback when `users` is an empty array
+4. Suggest adding `isError` handling (error UI or toast) and an empty state
+5. Set severity to "major"

--- a/skills/midstream/rr-midstream-loading-state-001/fixtures/01-should-detect.md
+++ b/skills/midstream/rr-midstream-loading-state-001/fixtures/01-should-detect.md
@@ -1,0 +1,36 @@
+# Test Case: Missing Error State (Should Detect)
+
+## Description
+
+A component handles the loading state but forgets the error state, leaving users with no feedback on failure.
+
+## Input Diff
+
+```diff
+diff --git a/src/components/UserList.tsx b/src/components/UserList.tsx
+index abc1234..def5678 100644
+--- a/src/components/UserList.tsx
++++ b/src/components/UserList.tsx
+@@ -1,8 +1,16 @@ import { useQuery } from '@tanstack/react-query';
++
++export function UserList() {
++  const { data, isLoading } = useQuery({ queryKey: ['users'], queryFn: fetchUsers });
++
++  if (isLoading) return <Spinner />;
++
++  return (
++    <ul>
++      {data?.map((user) => <li key={user.id}>{user.name}</li>)}
++    </ul>
++  );
++}
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. Detect that `isError` (or `error`) is destructured but not handled
+2. Flag that users will see an empty list instead of an error message on API failure
+3. Severity: major
+4. Suggest adding `if (isError) return <ErrorMessage />`

--- a/skills/midstream/rr-midstream-loading-state-001/fixtures/02-should-not-detect.md
+++ b/skills/midstream/rr-midstream-loading-state-001/fixtures/02-should-not-detect.md
@@ -1,0 +1,35 @@
+# Test Case: Complete State Handling (Should NOT Detect)
+
+## Description
+
+A component properly handles all three states: loading, error, and success.
+
+## Input Diff
+
+```diff
+diff --git a/src/components/ProductList.tsx b/src/components/ProductList.tsx
+index abc1234..def5678 100644
+--- a/src/components/ProductList.tsx
++++ b/src/components/ProductList.tsx
+@@ -1,6 +1,18 @@ import { useQuery } from '@tanstack/react-query';
++
++export function ProductList() {
++  const { data, isLoading, isError, error } = useQuery({
++    queryKey: ['products'],
++    queryFn: fetchProducts,
++  });
++
++  if (isLoading) return <Spinner />;
++  if (isError) return <ErrorMessage message={error.message} />;
++
++  return (
++    <ul>
++      {data.map((p) => <li key={p.id}>{p.name}</li>)}
++    </ul>
++  );
++}
+```
+
+## Expected Behavior
+
+The skill should NOT flag this — all three states (loading, error, success) are handled correctly.

--- a/skills/midstream/rr-midstream-loading-state-001/fixtures/02-suspense-boundary-false-positive.md
+++ b/skills/midstream/rr-midstream-loading-state-001/fixtures/02-suspense-boundary-false-positive.md
@@ -1,0 +1,65 @@
+# Test Case: Suspense + ErrorBoundary Delegation (False Positive Guard)
+
+## Description
+
+This test verifies that the skill does NOT flag a component that intentionally delegates loading and error state handling to parent Suspense and ErrorBoundary components.
+
+## Input Diff
+
+```diff
+diff --git a/src/components/ProductDetail.tsx b/src/components/ProductDetail.tsx
+new file mode 100644
+index 0000000..abcdef0
+--- /dev/null
++++ b/src/components/ProductDetail.tsx
+@@ -0,0 +1,22 @@
++import React, { Suspense } from 'react';
++import { ErrorBoundary } from 'react-error-boundary';
++import { ProductDetailContent } from './ProductDetailContent';
++import { LoadingSpinner } from '../ui/LoadingSpinner';
++import { ErrorFallback } from '../ui/ErrorFallback';
++
++// Loading and error states are handled by Suspense + ErrorBoundary
++export function ProductDetail({ productId }: { productId: string }) {
++  return (
++    <ErrorBoundary FallbackComponent={ErrorFallback}>
++      <Suspense fallback={<LoadingSpinner />}>
++        <ProductDetailContent productId={productId} />
++      </Suspense>
++    </ErrorBoundary>
++  );
++}
+diff --git a/src/components/ProductDetailContent.tsx b/src/components/ProductDetailContent.tsx
+new file mode 100644
+index 0000000..1234567
+--- /dev/null
++++ b/src/components/ProductDetailContent.tsx
+@@ -0,0 +1,16 @@
++import { useSuspenseQuery } from '@tanstack/react-query';
++import { fetchProduct } from '../api/products';
++
++// This component suspends — loading/error handled by parent boundary
++export function ProductDetailContent({ productId }: { productId: string }) {
++  const { data: product } = useSuspenseQuery({
++    queryKey: ['product', productId],
++    queryFn: () => fetchProduct(productId),
++  });
++
++  return (
++    <div>
++      <h1>{product.name}</h1>
++      <p>{product.description}</p>
++    </div>
++  );
++}
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. Recognize that `useSuspenseQuery` is used — loading state is handled via React Suspense protocol
+2. Recognize that `ProductDetail` wraps with `<ErrorBoundary>` and `<Suspense>` providing both loading and error handling
+3. NOT flag the absence of explicit `isLoading`/`isError` checks in `ProductDetailContent`
+4. Either return no findings or explicitly acknowledge that the Suspense + ErrorBoundary pattern satisfies state handling requirements
+5. NOT produce false positive warnings about missing loading/error states

--- a/skills/midstream/rr-midstream-normalization-consistency-001/SKILL.md
+++ b/skills/midstream/rr-midstream-normalization-consistency-001/SKILL.md
@@ -1,0 +1,58 @@
+---
+id: rr-midstream-normalization-consistency-001
+name: Normalization Consistency Review
+description: Detect inconsistencies in ID formatting, date/time display, monetary amounts, and enum/status labels compared to existing patterns in the codebase.
+version: 0.1.0
+category: midstream
+phase: midstream
+applyTo:
+  - '**/*.ts'
+  - '**/*.tsx'
+  - '**/*.js'
+  - '**/*.jsx'
+tags:
+  - consistency
+  - normalization
+  - formatting
+  - midstream
+severity: major
+inputContext:
+  - diff
+  - fullFile
+outputKind:
+  - findings
+modelHint: high-accuracy
+---
+
+## Pattern declaration
+
+Primary pattern: Reviewer
+Secondary patterns: Inversion
+Why: 正規化の不整合は差分単体では見えにくく、既存コードとの比較が必要
+
+## Guidance
+
+- Compare new date/time formatting with existing patterns (e.g., mixing `format(date, 'yyyy/MM/dd')` with `date.toLocaleDateString()`, or `dayjs` vs `date-fns`).
+- Check monetary amount display: inconsistent currency symbols, decimal places, or formatting utilities (`toLocaleString` vs `Intl.NumberFormat`).
+- Check ID formatting: mixing hyphenated UUIDs with non-hyphenated, or mixing numeric IDs with string IDs in the same context.
+- Check enum/status label rendering: if existing code uses a `statusLabel()` helper, flag direct string literals for status values.
+- Flag when new code introduces a different normalization approach for the same data type.
+
+## Non-goals
+
+- 意図的なフォーマット差異（管理画面と公開画面の表示形式が異なる等）は指摘しない。
+- テストコード内のハードコードされた値は対象外。
+
+## Pre-execution Gate / 実行前ゲート
+
+このスキルは以下の条件がすべて満たされない限り`NO_REVIEW`を返す。
+
+- [ ] 差分にUI表示に関連するコード（date, amount, id, status labelの表示処理）が含まれている
+- [ ] または差分にフォーマット処理関数の変更が含まれている
+
+ゲート不成立時の出力: `NO_REVIEW: rr-midstream-normalization-consistency-001 — 表示正規化に関連する変更が検出されない`
+
+## False-positive guards
+
+- 既存パターンと同じユーティリティを使っている場合は指摘しない。
+- コメントやdoc stringのみの変更は対象外。

--- a/skills/midstream/rr-midstream-normalization-consistency-001/fixtures/01-inline-date-format.md
+++ b/skills/midstream/rr-midstream-normalization-consistency-001/fixtures/01-inline-date-format.md
@@ -1,0 +1,53 @@
+# Test Case: Inline Date Formatting Instead of Shared Utility (Should Detect)
+
+## Description
+
+This test verifies that the skill correctly identifies a new component that implements its own date formatting logic instead of using the project's shared `formatDate` utility.
+
+## Input Diff
+
+```diff
+diff --git a/src/components/InvoiceDate.tsx b/src/components/InvoiceDate.tsx
+new file mode 100644
+index 0000000..abcdef0
+--- /dev/null
++++ b/src/components/InvoiceDate.tsx
+@@ -0,0 +1,18 @@
++import React from 'react';
++
++interface InvoiceDateProps {
++  date: Date;
++}
++
++export function InvoiceDate({ date }: InvoiceDateProps) {
++  // Custom date formatting inline
++  const formatted = `${date.getFullYear()}/${String(date.getMonth() + 1).padStart(2, '0')}/${String(date.getDate()).padStart(2, '0')}`;
++  return <span className="invoice-date">{formatted}</span>;
++}
+diff --git a/src/components/OrderDate.tsx b/src/components/OrderDate.tsx
+index 1234567..2345678 100644
+--- a/src/components/OrderDate.tsx
++++ b/src/components/OrderDate.tsx
+@@ -1,9 +1,10 @@
+ import React from 'react';
++import { formatDate } from '../utils/date';
+
+ interface OrderDateProps {
+   date: Date;
+ }
+
+ export function OrderDate({ date }: OrderDateProps) {
+-  return <span>{date.toLocaleDateString('ja-JP')}</span>;
++  return <span className="order-date">{formatDate(date)}</span>;
+ }
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. Detect that `InvoiceDate.tsx` implements custom date formatting via `getFullYear()` / `getMonth()` / `getDate()` manipulation
+2. Note that the existing `OrderDate.tsx` uses `formatDate` from a shared utility
+3. Flag the inconsistency — inline formatting deviates from the established pattern
+4. Suggest using the shared `formatDate` utility instead
+5. Set severity to "major"

--- a/skills/midstream/rr-midstream-normalization-consistency-001/fixtures/01-should-detect.md
+++ b/skills/midstream/rr-midstream-normalization-consistency-001/fixtures/01-should-detect.md
@@ -1,0 +1,31 @@
+# Test Case: Inconsistent Date Formatting (Should Detect)
+
+## Description
+
+New code introduces a different date formatting approach from existing codebase patterns.
+
+## Input Diff
+
+```diff
+diff --git a/src/components/OrderList.tsx b/src/components/OrderList.tsx
+index abc1234..def5678 100644
+--- a/src/components/OrderList.tsx
++++ b/src/components/OrderList.tsx
+@@ -1,6 +1,10 @@ import { format } from 'date-fns';
++import dayjs from 'dayjs';
+
+ export function OrderRow({ order }: Props) {
+-  const displayDate = format(order.createdAt, 'yyyy/MM/dd');
++  const displayDate = dayjs(order.createdAt).format('MM-DD-YYYY');
+   return <td>{displayDate}</td>;
+ }
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. Detect that the new code uses `dayjs` and a different date format (`MM-DD-YYYY`) while existing code uses `date-fns` with `yyyy/MM/dd`
+2. Flag the inconsistency in both the library used and the format string
+3. Severity: major
+4. Suggest aligning with the existing pattern

--- a/skills/midstream/rr-midstream-normalization-consistency-001/fixtures/02-shared-utility-consistent.md
+++ b/skills/midstream/rr-midstream-normalization-consistency-001/fixtures/02-shared-utility-consistent.md
@@ -1,0 +1,46 @@
+# Test Case: New Component Uses Shared Formatting Utilities (False Positive Guard)
+
+## Description
+
+This test verifies that the skill does NOT flag a new component that correctly uses the project's shared formatting utilities for dates, amounts, and status labels.
+
+## Input Diff
+
+```diff
+diff --git a/src/components/PaymentSummary.tsx b/src/components/PaymentSummary.tsx
+new file mode 100644
+index 0000000..abcdef0
+--- /dev/null
++++ b/src/components/PaymentSummary.tsx
+@@ -0,0 +1,28 @@
++import React from 'react';
++import { formatDate } from '../utils/date';
++import { formatCurrency } from '../utils/currency';
++import { PAYMENT_STATUS_LABELS } from '../constants/paymentStatus';
++
++interface PaymentSummaryProps {
++  date: Date;
++  amount: number;
++  status: 'pending' | 'completed' | 'failed';
++  currency: string;
++}
++
++export function PaymentSummary({ date, amount, status, currency }: PaymentSummaryProps) {
++  return (
++    <div className="payment-summary">
++      <span className="date">{formatDate(date)}</span>
++      <span className="amount">{formatCurrency(amount, currency)}</span>
++      <span className="status">{PAYMENT_STATUS_LABELS[status]}</span>
++    </div>
++  );
++}
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. Recognize that `formatDate`, `formatCurrency`, and `PAYMENT_STATUS_LABELS` are all imported from shared utilities/constants
+2. NOT flag any normalization inconsistency — the component follows the established patterns
+3. Either return no findings or explicitly confirm the component is consistent with existing normalization conventions
+4. NOT produce false positive warnings about formatting approaches

--- a/skills/midstream/rr-midstream-normalization-consistency-001/fixtures/02-should-not-detect.md
+++ b/skills/midstream/rr-midstream-normalization-consistency-001/fixtures/02-should-not-detect.md
@@ -1,0 +1,24 @@
+# Test Case: Consistent Date Formatting (Should NOT Detect)
+
+## Description
+
+New code uses the same date formatting approach as existing patterns.
+
+## Input Diff
+
+```diff
+diff --git a/src/components/InvoiceList.tsx b/src/components/InvoiceList.tsx
+index abc1234..def5678 100644
+--- a/src/components/InvoiceList.tsx
++++ b/src/components/InvoiceList.tsx
+@@ -1,4 +1,8 @@ import { format } from 'date-fns';
++
++export function InvoiceRow({ invoice }: Props) {
++  const displayDate = format(invoice.issuedAt, 'yyyy/MM/dd');
++  return <td>{displayDate}</td>;
++}
+```
+
+## Expected Behavior
+
+The skill should NOT flag this — the new code follows the established `date-fns` + `yyyy/MM/dd` pattern used elsewhere.

--- a/skills/midstream/rr-midstream-nullability-contract-001/SKILL.md
+++ b/skills/midstream/rr-midstream-nullability-contract-001/SKILL.md
@@ -1,0 +1,55 @@
+---
+id: rr-midstream-nullability-contract-001
+name: Nullability Contract Review
+description: Detect missing null/undefined/empty guards for API responses, DB results, form inputs, and external service data.
+version: 0.1.0
+category: midstream
+phase: midstream
+applyTo:
+  - '**/*.ts'
+  - '**/*.tsx'
+tags:
+  - nullability
+  - type-safety
+  - error-handling
+  - midstream
+severity: major
+inputContext:
+  - diff
+outputKind:
+  - findings
+modelHint: balanced
+---
+
+## Pattern declaration
+
+Primary pattern: Reviewer
+Secondary patterns: Inversion
+Why: null/undefined参照エラーは実行時に表面化し、型アノテーションだけでは防ぎにくい
+
+## Guidance
+
+- Flag direct property access on values from API responses without null guard: `data.user.name` without `if (!data.user)`.
+- Flag non-null assertion (`!`) on values that could legitimately be null/undefined at runtime.
+- Check optional chaining (`?.`) usage: if used inconsistently on the same object chain, flag the gaps.
+- Flag array operations (`.map`, `.filter`, `.find`) on potentially undefined values without a guard.
+- Check form input values: `event.target.value` or `req.body.field` accessed without validation.
+
+## Non-goals
+
+- 型システムで保証された non-nullable 値への指摘は行わない（`string` に `?.` を強制しない）。
+- テストコードや型定義ファイル（`.d.ts`）は対象外。
+- strictNullChecks が無効な場合は誤検知になるため、TypeScript strict mode 前提で判断する。
+
+## Pre-execution Gate / 実行前ゲート
+
+このスキルは以下の条件がすべて満たされない限り`NO_REVIEW`を返す。
+
+- [ ] 差分にAPIレスポンス、DBクエリ結果、またはユーザー入力の処理コードが含まれている
+
+ゲート不成立時の出力: `NO_REVIEW: rr-midstream-nullability-contract-001 — null/undefined契約に関連する変更が検出されない`
+
+## False-positive guards
+
+- TypeScriptの型定義で`NonNullable<T>`や`T & {}`として明示されている場合は黙る。
+- Optional chainingが一貫して使用されている場合はOK。

--- a/skills/midstream/rr-midstream-nullability-contract-001/fixtures/01-map-get-without-null-check.md
+++ b/skills/midstream/rr-midstream-nullability-contract-001/fixtures/01-map-get-without-null-check.md
@@ -1,0 +1,44 @@
+# Test Case: Map.get() Result Used Without Null Check (Should Detect)
+
+## Description
+
+This test verifies that the skill correctly identifies unsafe use of `Map.get()` result without null/undefined checking, which can cause a runtime TypeError.
+
+## Input Diff
+
+```diff
+diff --git a/src/services/cache-service.ts b/src/services/cache-service.ts
+index 1234567..abcdef0 100644
+--- a/src/services/cache-service.ts
++++ b/src/services/cache-service.ts
+@@ -8,10 +8,18 @@ export class CacheService {
+   private store = new Map<string, CachedItem>();
+
+-  get(key: string): CachedItem | undefined {
+-    return this.store.get(key);
++  get(key: string): CachedItem {
++    return this.store.get(key) as CachedItem;
+   }
++
++  getExpiry(key: string): number {
++    return this.store.get(key).expiresAt;
++  }
++
++  getMetadata(key: string): Record<string, unknown> {
++    const item = this.store.get(key);
++    return item!.metadata;
++  }
+ }
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. Detect that `this.store.get(key)` returns `CachedItem | undefined` but:
+   - `get()` hides the `undefined` case via `as CachedItem` type assertion
+   - `getExpiry()` directly accesses `.expiresAt` without a null check
+   - `getMetadata()` uses non-null assertion `!` on the result
+2. Flag each of the three unsafe patterns
+3. Suggest using early return with null check or throwing a descriptive error when the key is missing
+4. Set severity to "major"

--- a/skills/midstream/rr-midstream-nullability-contract-001/fixtures/01-should-detect.md
+++ b/skills/midstream/rr-midstream-nullability-contract-001/fixtures/01-should-detect.md
@@ -1,0 +1,31 @@
+# Test Case: Unsafe Property Access on API Response (Should Detect)
+
+## Description
+
+Code accesses a nested property from an API response without null guards.
+
+## Input Diff
+
+```diff
+diff --git a/src/api/orders.ts b/src/api/orders.ts
+index abc1234..def5678 100644
+--- a/src/api/orders.ts
++++ b/src/api/orders.ts
+@@ -5,6 +5,10 @@ export async function getOrderSummary(orderId: string) {
+   const response = await fetch(`/api/orders/${orderId}`);
+   const data = await response.json();
++
++  // Display shipping address
++  const city = data.shipping.address.city;
++  const zip = data.shipping.address.zipCode;
++  return { city, zip };
+ }
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. Flag `data.shipping.address.city` as an unsafe chain — `shipping` or `address` may be null/undefined for digital-only orders
+2. Severity: major
+3. Suggest using optional chaining: `data.shipping?.address?.city`

--- a/skills/midstream/rr-midstream-nullability-contract-001/fixtures/02-assert-validated-safe.md
+++ b/skills/midstream/rr-midstream-nullability-contract-001/fixtures/02-assert-validated-safe.md
@@ -1,0 +1,49 @@
+# Test Case: Assert Function Guarantees Non-Null Before Access (False Positive Guard)
+
+## Description
+
+This test verifies that the skill does NOT flag property access that follows an assertion function which guarantees the value is non-null via TypeScript's `asserts` narrowing.
+
+## Input Diff
+
+```diff
+diff --git a/src/services/session-service.ts b/src/services/session-service.ts
+index 1234567..abcdef0 100644
+--- a/src/services/session-service.ts
++++ b/src/services/session-service.ts
+@@ -4,6 +4,22 @@ interface Session {
+   userId: string;
+   token: string;
+   expiresAt: number;
++  preferences: UserPreferences;
+ }
+
++function assertSession(session: Session | null): asserts session is Session {
++  if (session === null) {
++    throw new Error('Session is required but was null');
++  }
++}
++
++export function getUserPreferences(): UserPreferences {
++  const session = sessionStorage.getSession();
++  assertSession(session);
++  // Safe: assertSession narrows session to Session (non-null)
++  return session.preferences;
++}
++
++export function getSessionUserId(): string {
++  const session = sessionStorage.getSession();
++  assertSession(session);
++  return session.userId;
++}
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. Recognize that `assertSession` uses TypeScript's `asserts session is Session` narrowing
+2. Understand that after `assertSession(session)` the type is narrowed to `Session` (non-null)
+3. NOT flag `session.preferences` or `session.userId` as unsafe null access
+4. Either return no findings or explicitly acknowledge that the assert function provides null safety
+5. NOT produce false positive warnings about accessing properties on a potentially-null value

--- a/skills/midstream/rr-midstream-nullability-contract-001/fixtures/02-should-not-detect.md
+++ b/skills/midstream/rr-midstream-nullability-contract-001/fixtures/02-should-not-detect.md
@@ -1,0 +1,26 @@
+# Test Case: Guarded Property Access (Should NOT Detect)
+
+## Description
+
+Code uses optional chaining and null guards consistently.
+
+## Input Diff
+
+```diff
+diff --git a/src/api/profile.ts b/src/api/profile.ts
+index abc1234..def5678 100644
+--- a/src/api/profile.ts
++++ b/src/api/profile.ts
+@@ -5,6 +5,10 @@ export async function getUserProfile(userId: string) {
+   const response = await fetch(`/api/users/${userId}`);
+   const data: UserProfileResponse | null = await response.json();
++
++  if (!data) return null;
++  const displayName = data.profile?.displayName ?? data.username;
++  return { displayName };
+ }
+```
+
+## Expected Behavior
+
+The skill should NOT flag this — the code checks `!data` before accessing properties, and uses optional chaining with a nullish coalescing fallback.

--- a/tests/fixtures/execution-plan-midstream.json
+++ b/tests/fixtures/execution-plan-midstream.json
@@ -15,11 +15,25 @@
       "dependencies": ["code_search"]
     },
     {
+      "id": "rr-midstream-loading-state-001",
+      "phase": "midstream",
+      "modelHint": "balanced",
+      "outputKind": ["findings"],
+      "dependencies": []
+    },
+    {
       "id": "rr-midstream-logging-observability-001",
       "phase": "midstream",
       "modelHint": "balanced",
       "outputKind": ["findings", "actions"],
       "dependencies": ["tracing", "code_search"]
+    },
+    {
+      "id": "rr-midstream-nullability-contract-001",
+      "phase": "midstream",
+      "modelHint": "balanced",
+      "outputKind": ["findings"],
+      "dependencies": []
     },
     {
       "id": "rr-midstream-review-automation-boundary-001",


### PR DESCRIPTION
## Summary

Add 5 midstream skills implementing Greptile-inspired cross-context review patterns:

| Skill | Detects |
|---|---|
| `rr-midstream-i18n-unused-key-001` | Orphaned locale keys after UI text deletions |
| `rr-midstream-normalization-consistency-001` | Inconsistent date/currency/ID/enum formatting vs. existing patterns |
| `rr-midstream-loading-state-001` | Missing error/empty state in async data components |
| `rr-midstream-nullability-contract-001` | Missing null/undefined guards on API response properties |
| `rr-midstream-api-compatibility-001` | Breaking DTO changes and missing tests for API contract changes |

Each skill includes:
- SKILL.md with YAML frontmatter + false-positive guards + pre-execution gate
- 2+ fixtures (should-detect + false-positive guard)

Update `tests/fixtures/execution-plan-midstream.json` snapshot to reflect new skill selection.

Closes #654

## Test plan
- [x] `node scripts/validate-skills.mjs` — all 5 new skills valid
- [x] `node --test tests/*.test.mjs` — 597 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)