### PR TITLE
ci(dist-check): rebuild and diff before failing on stale timestamp

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,6 +87,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+      - run: npm ci
       - name: Check dist is up to date
         run: |
           src_ts=$(git log -1 --format=%ct -- 'runners/github-action/src/' 'src/')
@@ -102,18 +107,36 @@ jobs:
             exit 1
           fi
 
-          if [ "$src_ts" -gt "$dist_ts" ]; then
+          if [ "$src_ts" -le "$dist_ts" ]; then
             src_date=$(git log -1 --format=%ci -- 'runners/github-action/src/' 'src/')
             dist_date=$(git log -1 --format=%ci -- 'runners/github-action/dist/')
-            echo "::error::dist/ is stale. Source last changed at ${src_date} but dist last rebuilt at ${dist_date}. Run 'npm run build:action' and commit."
-            echo "Recent src changes:"
-            git log -3 --oneline -- 'runners/github-action/src/' 'src/'
-            exit 1
+            echo "dist/ is current (dist: ${dist_date}, src: ${src_date})"
+            exit 0
+          fi
+
+          # Timestamp says dist is stale, but the src change might not be
+          # transitively imported by the bundle (e.g., a sibling helper that
+          # the action runner does not load). Rebuild and compare bytes
+          # before failing — only fail if the rebuild actually produces a
+          # diff. This avoids false positives that block PRs whose src/
+          # change is genuinely not part of the shipped bundle.
+          echo "Timestamp suggests dist is stale; rebuilding to verify..."
+          npm run build:action
+          if git diff --quiet -- runners/github-action/dist/; then
+            src_date=$(git log -1 --format=%ci -- 'runners/github-action/src/' 'src/')
+            dist_date=$(git log -1 --format=%ci -- 'runners/github-action/dist/')
+            echo "dist/ rebuild produced no changes; bundle is genuinely fresh (dist commit: ${dist_date}, src commit: ${src_date})."
+            exit 0
           fi
 
           src_date=$(git log -1 --format=%ci -- 'runners/github-action/src/' 'src/')
           dist_date=$(git log -1 --format=%ci -- 'runners/github-action/dist/')
-          echo "dist/ is current (dist: ${dist_date}, src: ${src_date})"
+          echo "::error::dist/ is stale. Source last changed at ${src_date} but dist last rebuilt at ${dist_date}, and rebuild produced byte-level changes. Run 'npm run build:action' and commit."
+          echo "Recent src changes:"
+          git log -3 --oneline -- 'runners/github-action/src/' 'src/'
+          echo "Rebuild diff (file list):"
+          git diff --name-only -- runners/github-action/dist/
+          exit 1
 
   integration-test:
     name: Integration (CLI)

--- a/docs/development/dist-check-rebuild-guide.md
+++ b/docs/development/dist-check-rebuild-guide.md
@@ -65,6 +65,8 @@ git commit -m "chore(action): rebuild github-action dist"
 - `runners/github-action/src/index.mjs` から import される `src/**` のモジュール
 - `package.json` / `package-lock.json` の ncc 依存 (`@vercel/ncc` 自体の bump、または bundle 対象に入る dependency の bump)
 
+> CI の `Action dist freshness` job は src commit timestamp が dist より新しい場合に **追加で `npm run build:action` を実行して byte 差分を確認**する。再 build しても dist に diff が出ないなら、その src 変更は bundle に含まれていない sibling と判断され、ローカル commit なしでも pass する（false positive 回避）。逆に diff が出た場合は依然として rebuild commit が必要。
+
 ## トラブルシューティング
 
 | 症状                                                                            | 原因                             | 対応                                             |


### PR DESCRIPTION
## Summary

Fixes a false-positive failure mode in the \`Action dist freshness\` job. The job currently fails any \`src/\` change whose timestamp is newer than the latest \`dist/\` commit, even when the change is **not** transitively bundled into \`runners/github-action/dist/index.mjs\`.

This blocks PRs like #695 (#687 PR-A: \`src/lib/suppression.mjs\` extension), where the modified file is a sibling helper that the action runner does not load. Verified locally: \`npm run build:action\` on Node 22.22.2 produces zero byte diff under \`runners/github-action/dist/\`.

## Change

When the timestamp comparison says dist is stale, the job now:

1. Runs \`npm run build:action\` (with \`actions/setup-node\` pinned to \`.nvmrc\` and \`npm ci\`)
2. **Passes** if \`git diff --quiet -- runners/github-action/dist/\` — the bundle is genuinely fresh
3. **Fails** only when the rebuild produces a real diff, with the prior error message and the file list of the diff

The strict path is preserved for the genuine staleness case. \`docs/development/dist-check-rebuild-guide.md\` is updated to describe the new behavior so contributors understand when a local rebuild commit is or is not required.

## Why this is the right fix (root cause)

- Per memory \`feedback_root_cause_after_n_retries.md\`, when a CI gate misfires we should fix the gate rather than work around it
- The build is deterministic for this codebase on the pinned Node version, so \`build + diff\` is a reliable freshness signal
- Future PRs that touch sibling \`src/\` helpers (planned: #687 PR-B/C, #688, #689 plans) will hit the same issue without this fix

## Verification

- The job now runs in CI; expect this PR's own dist-check to pass since it modifies neither \`src/\` nor \`runners/github-action/src/\`
- The next PR (#695) re-run after this lands should clear

## Test plan

- [ ] CI green on this PR
- [ ] After merge, re-run #695 \`Action dist freshness\` and confirm pass via the new "rebuild produced no changes" path
- [ ] Smoke test by intentionally introducing a real dist-impacting change in a follow-up branch and confirm the job still fails correctly

Refs CLAUDE.md "Run before claiming" / \`docs/development/dist-check-rebuild-guide.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)