### PR TITLE
feat(memory): add applySuppressions pure function (#687 PR-B)

### DIFF
--- a/src/lib/suppression-apply.mjs
+++ b/src/lib/suppression-apply.mjs
@@ -1,0 +1,129 @@
+// Apply Riverbed Memory suppressions to a list of findings (#687 PR-B).
+//
+// PR-A landed the data model (suppression context schema and the new
+// fingerprint / feedbackType / severity fields on createSuppression). This
+// PR-B is the gate that consumes those entries: given a list of findings
+// already annotated with fingerprints (see src/lib/finding-fingerprint.mjs)
+// and a memoryContext loaded by src/lib/memory-context.mjs, it splits the
+// findings into kept vs suppressed and returns observability metadata.
+//
+// PR-C of #687 will inject one call to applySuppressions inside
+// src/lib/local-runner.mjs:runLocalReview between annotateFingerprints and
+// the return statement so the pipeline behavior changes there, not here.
+//
+// P1 guard policy (do not silently auto-suppress dangerous findings):
+//   - findings of severity `major` or `critical` are kept unless the
+//     suppression's feedbackType is explicitly `accepted_risk`.
+//   - lower severities (`minor`, `info`) are auto-suppressed for any
+//     non-revoked, non-expired suppression that matches the fingerprint.
+//   - the per-suppression `minSeverityToAutoSuppress` (added in PR-A)
+//     can RAISE the bar but never lower it; the global P1 guard wins.
+
+const HIGH_SEVERITY = new Set(['major', 'critical']);
+const SEVERITY_RANK = { info: 0, minor: 1, major: 2, critical: 3 };
+
+function severityOf(finding) {
+  return String(finding.severity || 'info').toLowerCase();
+}
+
+/**
+ * Apply matching suppressions to findings.
+ *
+ * @param {Array<object>} findings  Findings already annotated with `.fingerprint`
+ *   by `annotateFingerprints` (src/lib/finding-fingerprint.mjs).
+ * @param {object} memoryContext    Bucketed memory from `loadReviewMemory`.
+ *   Only `memoryContext.suppressions` is consulted.
+ * @param {object} [opts]
+ * @param {object} [opts.config]    Effective config; `config.memory.suppressionEnabled === false`
+ *   bypasses suppression entirely (returns all findings as-is).
+ * @returns {{ keptFindings: Array<object>, suppressedFindings: Array<object>, applied: Array<object> }}
+ *   `applied` is the observability log. Each entry: `{ fingerprint, suppressionId,
+ *   feedbackType, severity, action: 'suppressed' | 'skipped', reason? }`. Findings
+ *   moved to `suppressedFindings` carry a `status: 'suppressed'` flag and a
+ *   `suppressionRef` pointing back at the suppression entry id.
+ */
+export function applySuppressions(findings, memoryContext, opts = {}) {
+  const list = Array.isArray(findings) ? findings : [];
+  const result = { keptFindings: list, suppressedFindings: [], applied: [] };
+
+  if (opts?.config?.memory?.suppressionEnabled === false) return result;
+
+  const suppressions = memoryContext?.suppressions;
+  if (!Array.isArray(suppressions) || suppressions.length === 0) return result;
+  if (list.length === 0) return result;
+
+  // Index suppressions by canonical fingerprint. Entries that lack a
+  // fingerprint (pre-#687 PR-A) are intentionally ignored — they cannot
+  // gate findings safely without reintroducing the old hashFinding /
+  // computeFingerprint mismatch that PR-A documented as tech debt.
+  const byFingerprint = new Map();
+  for (const s of suppressions) {
+    const fp = s?.context?.fingerprint;
+    if (typeof fp === 'string' && fp.length === 16) byFingerprint.set(fp, s);
+  }
+  if (byFingerprint.size === 0) return result;
+
+  const kept = [];
+  const suppressed = [];
+  const applied = [];
+
+  for (const finding of list) {
+    const fp = finding?.fingerprint;
+    const match = fp ? byFingerprint.get(fp) : undefined;
+    if (!match) {
+      kept.push(finding);
+      continue;
+    }
+
+    const sev = severityOf(finding);
+    const feedbackType = match.context?.feedbackType ?? null;
+    const minSeverity = match.context?.minSeverityToAutoSuppress;
+
+    // Per-suppression cap: `minSeverityToAutoSuppress` is the highest
+    // severity this entry is allowed to auto-suppress. A finding above
+    // that rank stays.
+    if (minSeverity && SEVERITY_RANK[sev] > SEVERITY_RANK[String(minSeverity).toLowerCase()]) {
+      kept.push(finding);
+      applied.push({
+        fingerprint: fp,
+        suppressionId: match.id,
+        feedbackType,
+        severity: sev,
+        action: 'skipped',
+        reason: 'severity-above-min-severity-cap',
+      });
+      continue;
+    }
+
+    // Global P1 guard: never auto-suppress major/critical without
+    // accepted_risk. Other feedbackTypes (false_positive, wont_fix, ...)
+    // require manual handling for high-severity findings.
+    if (HIGH_SEVERITY.has(sev) && feedbackType !== 'accepted_risk') {
+      kept.push(finding);
+      applied.push({
+        fingerprint: fp,
+        suppressionId: match.id,
+        feedbackType,
+        severity: sev,
+        action: 'skipped',
+        reason: 'high-severity-requires-accepted-risk',
+      });
+      continue;
+    }
+
+    suppressed.push({
+      ...finding,
+      status: 'suppressed',
+      suppressionRef: match.id,
+    });
+    applied.push({
+      fingerprint: fp,
+      suppressionId: match.id,
+      feedbackType,
+      severity: sev,
+      action: 'suppressed',
+    });
+  }
+
+  return { keptFindings: kept, suppressedFindings: suppressed, applied };
+}

--- a/tests/suppression-apply.test.mjs
+++ b/tests/suppression-apply.test.mjs
@@ -1,0 +1,235 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { applySuppressions } from '../src/lib/suppression-apply.mjs';
+
+const FP_A = 'a'.repeat(16);
+const FP_B = 'b'.repeat(16);
+const FP_C = 'c'.repeat(16);
+
+function suppressionFor(fingerprint, contextOverride = {}) {
+  return {
+    id: 'suppression-' + fingerprint + '-1',
+    type: 'suppression',
+    content: 'rationale',
+    metadata: { createdAt: '2026-04-01T00:00:00Z', author: 't', tags: ['suppression', 'active'] },
+    context: { scope: 'file', active: true, fingerprint, ...contextOverride },
+  };
+}
+
+function findingFor(fingerprint, severity, extra = {}) {
+  return { id: 'f-' + fingerprint, fingerprint, severity, message: 'msg', file: 'src/x.ts', ...extra };
+}
+
+test('applySuppressions returns inputs unchanged when no suppressions are loaded', () => {
+  const findings = [findingFor(FP_A, 'minor')];
+  const r = applySuppressions(findings, { suppressions: [] });
+  assert.equal(r.keptFindings.length, 1);
+  assert.equal(r.keptFindings[0], findings[0]); // identity preserved
+  assert.equal(r.suppressedFindings.length, 0);
+  assert.equal(r.applied.length, 0);
+});
+
+test('applySuppressions returns inputs unchanged when memoryContext is null/undefined', () => {
+  const findings = [findingFor(FP_A, 'minor')];
+  for (const ctx of [null, undefined, {}]) {
+    const r = applySuppressions(findings, ctx);
+    assert.equal(r.keptFindings.length, 1);
+    assert.equal(r.suppressedFindings.length, 0);
+    assert.equal(r.applied.length, 0);
+  }
+});
+
+test('applySuppressions auto-suppresses minor finding with matching fingerprint', () => {
+  const findings = [findingFor(FP_A, 'minor')];
+  const memoryContext = {
+    suppressions: [suppressionFor(FP_A, { feedbackType: 'false_positive' })],
+  };
+  const r = applySuppressions(findings, memoryContext);
+  assert.equal(r.keptFindings.length, 0);
+  assert.equal(r.suppressedFindings.length, 1);
+  assert.equal(r.suppressedFindings[0].status, 'suppressed');
+  assert.equal(r.suppressedFindings[0].suppressionRef, 'suppression-' + FP_A + '-1');
+  assert.equal(r.applied.length, 1);
+  assert.equal(r.applied[0].action, 'suppressed');
+  assert.equal(r.applied[0].fingerprint, FP_A);
+  assert.equal(r.applied[0].feedbackType, 'false_positive');
+});
+
+test('applySuppressions auto-suppresses info finding too', () => {
+  const findings = [findingFor(FP_A, 'info')];
+  const memoryContext = {
+    suppressions: [suppressionFor(FP_A, { feedbackType: 'not_relevant' })],
+  };
+  const r = applySuppressions(findings, memoryContext);
+  assert.equal(r.suppressedFindings.length, 1);
+  assert.equal(r.applied[0].action, 'suppressed');
+});
+
+test('applySuppressions skips major finding when feedbackType is false_positive', () => {
+  const findings = [findingFor(FP_A, 'major')];
+  const memoryContext = {
+    suppressions: [suppressionFor(FP_A, { feedbackType: 'false_positive' })],
+  };
+  const r = applySuppressions(findings, memoryContext);
+  assert.equal(r.keptFindings.length, 1);
+  assert.equal(r.suppressedFindings.length, 0);
+  assert.equal(r.applied.length, 1);
+  assert.equal(r.applied[0].action, 'skipped');
+  assert.equal(r.applied[0].reason, 'high-severity-requires-accepted-risk');
+});
+
+test('applySuppressions skips critical finding when feedbackType is wont_fix', () => {
+  const findings = [findingFor(FP_A, 'critical')];
+  const memoryContext = {
+    suppressions: [suppressionFor(FP_A, { feedbackType: 'wont_fix' })],
+  };
+  const r = applySuppressions(findings, memoryContext);
+  assert.equal(r.keptFindings.length, 1);
+  assert.equal(r.applied[0].action, 'skipped');
+});
+
+test('applySuppressions auto-suppresses major finding when feedbackType is accepted_risk', () => {
+  const findings = [findingFor(FP_A, 'major')];
+  const memoryContext = {
+    suppressions: [suppressionFor(FP_A, { feedbackType: 'accepted_risk' })],
+  };
+  const r = applySuppressions(findings, memoryContext);
+  assert.equal(r.keptFindings.length, 0);
+  assert.equal(r.suppressedFindings.length, 1);
+  assert.equal(r.applied[0].action, 'suppressed');
+  assert.equal(r.applied[0].feedbackType, 'accepted_risk');
+});
+
+test('applySuppressions auto-suppresses critical finding when feedbackType is accepted_risk', () => {
+  const findings = [findingFor(FP_A, 'critical')];
+  const memoryContext = {
+    suppressions: [suppressionFor(FP_A, { feedbackType: 'accepted_risk' })],
+  };
+  const r = applySuppressions(findings, memoryContext);
+  assert.equal(r.suppressedFindings.length, 1);
+  assert.equal(r.applied[0].action, 'suppressed');
+});
+
+test('applySuppressions respects per-suppression minSeverityToAutoSuppress cap', () => {
+  // Suppression caps auto-suppression at `minor`. A `major` finding stays
+  // even though the global P1 guard would *also* reject it; we still want
+  // the cap to be the explicit reason recorded in `applied`.
+  const findings = [findingFor(FP_A, 'major', { severity: 'major' })];
+  const memoryContext = {
+    suppressions: [
+      suppressionFor(FP_A, {
+        feedbackType: 'accepted_risk', // would normally allow even major
+        minSeverityToAutoSuppress: 'minor',
+      }),
+    ],
+  };
+  const r = applySuppressions(findings, memoryContext);
+  assert.equal(r.keptFindings.length, 1);
+  assert.equal(r.applied[0].action, 'skipped');
+  assert.equal(r.applied[0].reason, 'severity-above-min-severity-cap');
+});
+
+test('applySuppressions per-suppression cap allows below-cap severity', () => {
+  const findings = [findingFor(FP_A, 'minor')];
+  const memoryContext = {
+    suppressions: [
+      suppressionFor(FP_A, { feedbackType: 'false_positive', minSeverityToAutoSuppress: 'minor' }),
+    ],
+  };
+  const r = applySuppressions(findings, memoryContext);
+  assert.equal(r.suppressedFindings.length, 1);
+  assert.equal(r.applied[0].action, 'suppressed');
+});
+
+test('applySuppressions ignores suppressions that lack a 16-hex fingerprint', () => {
+  // Pre-#687 PR-A entries only carried `findingHash` — they cannot gate
+  // findings safely so they must be ignored entirely.
+  const findings = [findingFor(FP_A, 'minor')];
+  const legacy = {
+    id: 'suppression-legacy-1',
+    type: 'suppression',
+    content: 'r',
+    metadata: { createdAt: '2026-01-01T00:00:00Z', author: 't' },
+    context: { scope: 'file', active: true, findingHash: FP_A }, // no fingerprint
+  };
+  const r = applySuppressions(findings, { suppressions: [legacy] });
+  assert.equal(r.keptFindings.length, 1);
+  assert.equal(r.suppressedFindings.length, 0);
+  assert.equal(r.applied.length, 0);
+});
+
+test('applySuppressions leaves findings without a fingerprint untouched', () => {
+  const findings = [{ id: 'f1', severity: 'minor', message: 'msg' }]; // no fingerprint
+  const memoryContext = {
+    suppressions: [suppressionFor(FP_A, { feedbackType: 'false_positive' })],
+  };
+  const r = applySuppressions(findings, memoryContext);
+  assert.equal(r.keptFindings.length, 1);
+  assert.equal(r.suppressedFindings.length, 0);
+  assert.equal(r.applied.length, 0);
+});
+
+test('applySuppressions leaves findings whose fingerprint does not match any suppression', () => {
+  const findings = [findingFor(FP_B, 'minor')];
+  const memoryContext = {
+    suppressions: [suppressionFor(FP_A, { feedbackType: 'false_positive' })],
+  };
+  const r = applySuppressions(findings, memoryContext);
+  assert.equal(r.keptFindings.length, 1);
+  assert.equal(r.applied.length, 0);
+});
+
+test('applySuppressions bypasses entirely when config.memory.suppressionEnabled is false', () => {
+  const findings = [findingFor(FP_A, 'minor')];
+  const memoryContext = {
+    suppressions: [suppressionFor(FP_A, { feedbackType: 'false_positive' })],
+  };
+  const r = applySuppressions(findings, memoryContext, {
+    config: { memory: { suppressionEnabled: false } },
+  });
+  assert.equal(r.keptFindings.length, 1);
+  assert.equal(r.suppressedFindings.length, 0);
+  assert.equal(r.applied.length, 0);
+});
+
+test('applySuppressions is enabled by default (suppressionEnabled !== false)', () => {
+  const findings = [findingFor(FP_A, 'minor')];
+  const memoryContext = {
+    suppressions: [suppressionFor(FP_A, { feedbackType: 'false_positive' })],
+  };
+  const r = applySuppressions(findings, memoryContext, { config: {} });
+  assert.equal(r.suppressedFindings.length, 1);
+});
+
+test('applySuppressions handles a mix of matched, P1-guarded, and unmatched findings', () => {
+  const findings = [
+    findingFor(FP_A, 'minor'),    // suppressed (false_positive ok for minor)
+    findingFor(FP_B, 'critical'), // skipped (false_positive not ok for critical)
+    findingFor(FP_C, 'major'),    // kept (no matching suppression)
+    { id: 'f4', severity: 'info', message: 'no fp' }, // kept (no fingerprint)
+  ];
+  const memoryContext = {
+    suppressions: [
+      suppressionFor(FP_A, { feedbackType: 'false_positive' }),
+      suppressionFor(FP_B, { feedbackType: 'false_positive' }),
+    ],
+  };
+  const r = applySuppressions(findings, memoryContext);
+  assert.equal(r.suppressedFindings.length, 1);
+  assert.equal(r.suppressedFindings[0].fingerprint, FP_A);
+  assert.equal(r.keptFindings.length, 3); // FP_B (skipped P1), FP_C (no match), f4 (no fp)
+  assert.equal(r.applied.length, 2); // 1 suppressed, 1 skipped
+  const skipped = r.applied.find((a) => a.action === 'skipped');
+  assert.equal(skipped.fingerprint, FP_B);
+  assert.equal(skipped.reason, 'high-severity-requires-accepted-risk');
+});
+
+test('applySuppressions does not mutate the input arrays', () => {
+  const findings = Object.freeze([findingFor(FP_A, 'minor')]);
+  const memoryContext = Object.freeze({
+    suppressions: Object.freeze([suppressionFor(FP_A, { feedbackType: 'false_positive' })]),
+  });
+  // Frozen arrays cannot be mutated; if applySuppressions tries it would throw.
+  assert.doesNotThrow(() => applySuppressions(findings, memoryContext));
+});


### PR DESCRIPTION
## Summary

PR-B of the [#687 plan](https://github.com/s977043/river-reviewer/issues/687). Adds the gate that consumes the data model from PR-A (#695). **Zero-side-effect**; PR-C of #687 will inject one call inside \`src/lib/local-runner.mjs:runLocalReview\` between \`annotateFingerprints\` and the return statement.

- New: \`src/lib/suppression-apply.mjs\` (pure function)
- New: \`tests/suppression-apply.test.mjs\` (17 cases)

## Why this is safe to merge alone

- The exported function is not yet imported by the pipeline; runtime behavior is unchanged.
- All inputs are read-only; \`Object.freeze\` test verifies no mutation of caller arrays.
- Pre-#687 PR-A entries (those that only carried \`findingHash\`) are deliberately ignored to avoid the \`hashFinding\` / \`computeFingerprint\` mismatch PR-A flagged as tech debt.

## API

\`\`\`js
applySuppressions(findings, memoryContext, { config }) ->
  { keptFindings, suppressedFindings, applied }
\`\`\`

- \`suppressedFindings\` carry \`status: 'suppressed'\` and a \`suppressionRef\` back to the suppression entry id.
- \`applied\` is the observability log; each entry: \`{ fingerprint, suppressionId, feedbackType, severity, action, reason? }\`. PR-C will surface this on \`debug.suppressionsApplied\`.

## Policy (P1 guard)

| Severity | Default | With \`feedbackType: 'accepted_risk'\` |
|---|---|---|
| info / minor | auto-suppress | auto-suppress |
| major / critical | **kept** + log \`reason: high-severity-requires-accepted-risk\` | auto-suppress |

Per-suppression \`minSeverityToAutoSuppress\` (PR-A field) caps how high this entry can suppress; the global P1 guard wins when both apply.

Bypass: \`config.memory.suppressionEnabled === false\` returns inputs unchanged.

## Verification

- \`node --test tests/suppression-apply.test.mjs\` → **17/17 pass**
- \`npm test\` → **741/741 pass**
- \`npm run lint\` → pass

## Test plan

- [ ] CI green
- [ ] Reviewer skim that the legacy-entry case (no \`fingerprint\`) is correctly ignored — confirms the migration path PR-A described
- [ ] Confirm \`Object.freeze\` test catches accidental mutation in future patches

## Follow-up PRs

- **PR-C**: \`src/lib/local-runner.mjs:runLocalReview\` integration + \`debug.suppressionsApplied\` exposure (touches live pipeline → needs explicit approval per CLAUDE.md "Always ask")
- **PR-D**: \`river suppression add\` CLI subcommand + \`config.memory.suppressionEnabled\` config surface
- **PR-E**: docs + \`runners/github-action/dist\` rebuild

Refs #687, #650, #695

🤖 Generated with [Claude Code](https://claude.com/claude-code)