### PR TITLE
docs: correct feedbackType severity-gate descriptions

### DIFF
--- a/pages/reference/config-schema.md
+++ b/pages/reference/config-schema.md
@@ -32,11 +32,11 @@
 - `memory`（[#687](https://github.com/s977043/river-reviewer/issues/687)）
   - `suppressionEnabled`: `true`（デフォルト）。Riverbed Memory に登録された suppression entry を反映する。`false` で gate を完全バイパス（緊急対応用）。
   - **suppression entry の `feedbackType`** (`schemas/suppression-context.schema.json`):
-    - `accepted_risk`: リスクを認識した上で残すと決めた指摘。**HIGH_SEVERITY guard を通過できる唯一の値**で、`major` / `critical` の自動抑止にはこの値が必須 (`src/lib/suppression-apply.mjs:101`)。
+    - `accepted_risk`: リスクを認識した上で残すと決めた指摘。**HIGH_SEVERITY guard を通過できる唯一の値**で、`major` / `critical` の自動抑止にはこの値が必須（`src/lib/suppression-apply.mjs` の HIGH_SEVERITY guard）。
     - `false_positive`: 誤検知。`major` / `critical` は guard でブロックされ自動抑止されない（manual-handle 扱い）。`minor` / `info` は自動抑止する。
     - `wont_fix`: 修正しないと決めた指摘。`false_positive` と同じく `major` / `critical` は guard でブロックされる。
     - `not_relevant`: 当該 PR / ファイルの文脈で関連が薄い指摘。`major` / `critical` は guard でブロックされる。
-    - `duplicate`: 別エントリの fingerprint への参照（`duplicateOfFingerprint` 必須）。`major` / `critical` は guard でブロックされる。
+    - `duplicate`: 別エントリの fingerprint への参照。`duplicateOfFingerprint` フィールドで参照先を示せる（schema 上は任意だが運用上は記録推奨）。`major` / `critical` は guard でブロックされる。
   - CLI: `river suppression add` で対話的に登録できる。
     - 必須フラグ: `--fingerprint <fp>` / `--feedback <type>` / `--rationale <text>`
     - 任意フラグ: `--scope <pattern>` / `--severity <level>` / `--files <glob>` / `--expires <date>` / `--pr <num>`

--- a/pages/reference/config-schema.md
+++ b/pages/reference/config-schema.md
@@ -32,11 +32,11 @@
 - `memory`（[#687](https://github.com/s977043/river-reviewer/issues/687)）
   - `suppressionEnabled`: `true`（デフォルト）。Riverbed Memory に登録された suppression entry を反映する。`false` で gate を完全バイパス（緊急対応用）。
   - **suppression entry の `feedbackType`** (`schemas/suppression-context.schema.json`):
-    - `false_positive`: 誤検知。severity 問わず自動抑止する。
-    - `accepted_risk`: リスクを認識した上で残すと決めた指摘。`major` / `critical` の自動抑止には **この値が必須**（HIGH_SEVERITY P1 guard）。
-    - `wont_fix`: 修正しないと決めた指摘。`accepted_risk` と同様に severity gate あり。
-    - `not_relevant`: 当該 PR / ファイルの文脈で関連が薄い指摘。
-    - `duplicate`: 別エントリの fingerprint への参照（`duplicateOfFingerprint` 必須）。
+    - `accepted_risk`: リスクを認識した上で残すと決めた指摘。**HIGH_SEVERITY guard を通過できる唯一の値**で、`major` / `critical` の自動抑止にはこの値が必須 (`src/lib/suppression-apply.mjs:101`)。
+    - `false_positive`: 誤検知。`major` / `critical` は guard でブロックされ自動抑止されない（manual-handle 扱い）。`minor` / `info` は自動抑止する。
+    - `wont_fix`: 修正しないと決めた指摘。`false_positive` と同じく `major` / `critical` は guard でブロックされる。
+    - `not_relevant`: 当該 PR / ファイルの文脈で関連が薄い指摘。`major` / `critical` は guard でブロックされる。
+    - `duplicate`: 別エントリの fingerprint への参照（`duplicateOfFingerprint` 必須）。`major` / `critical` は guard でブロックされる。
   - CLI: `river suppression add` で対話的に登録できる。
     - 必須フラグ: `--fingerprint <fp>` / `--feedback <type>` / `--rationale <text>`
     - 任意フラグ: `--scope <pattern>` / `--severity <level>` / `--files <glob>` / `--expires <date>` / `--pr <num>`


### PR DESCRIPTION
## Summary

PR #730 マージ後に gemini-code-assist[bot] が指摘した 2 件のドキュメント不正確を修正:

- L35 (旧 `false_positive: 誤検知。severity 問わず自動抑止する。`) — \`suppression-apply.mjs:101\` の HIGH_SEVERITY guard により、major/critical は accepted_risk でない限り抑止されない
- L37 (旧 \`wont_fix: ... \`accepted_risk\` と同様に severity gate あり\`) — wont_fix は guard を **通過できない** ので "同様" は誤解

各 \`feedbackType\` エントリで guard の効果を明示するように書き換え。

## Why

実装と doc の挙動説明が矛盾していた状態。ユーザーが \`false_positive\` で major 指摘を抑止しようとしても guard で kept されるため、誤った期待を持つ可能性があった。

## Test plan

- [x] \`npm run lint\` green
- [ ] CI green

## Reference

- gemini comments: PR #730 (https://github.com/s977043/river-reviewer/pull/730)
- 実装: \`src/lib/suppression-apply.mjs:97-112\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)