### PR TITLE
docs: add Node.js engine learning for local/CI checks

### DIFF
--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -37,3 +37,7 @@
 - `2026-04-30`: Secret redaction is **multi-stage** by design. Deny-glob runs BEFORE files are read (`.env*` / `*.pem` / `*.key` / `secrets.*` never enter process memory). Content-level redaction runs AFTER read with named categories plus an entropy fallback (default 4.5 bits / char, 24-char minimum). Replacements use length-stable `<REDACTED:category>` so suppression fingerprints stay deterministic across redaction. Final boundary redaction in `review-engine.mjs` covers prompt previews and debug output. Allowlist is for fixed test fixtures only.
   - `Applies to`: any change touching repo-wide context, prompt construction, or debug observability.
   - `Evidence`: `src/lib/secret-redactor.mjs`, wiring at `src/lib/repo-context.mjs` / `local-runner.mjs` / `review-engine.mjs`, `pages/guides/repo-wide-review.md` "secret redaction" section.
+
+- `2026-05-03`: Root scripts assume Node.js 22.x; running validations on older Node versions can fail before repo logic executes.
+  - `Applies to`: local/CI execution of `npm run lint`, `npm test`, and validation scripts.
+  - `Evidence`: `package.json` `engines.node` is pinned to `22.x`.

--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -38,6 +38,6 @@
   - `Applies to`: any change touching repo-wide context, prompt construction, or debug observability.
   - `Evidence`: `src/lib/secret-redactor.mjs`, wiring at `src/lib/repo-context.mjs` / `local-runner.mjs` / `review-engine.mjs`, `pages/guides/repo-wide-review.md` "secret redaction" section.
 
-- `2026-05-03`: Root scripts assume Node.js 22.x; running validations on older Node versions can fail before repo logic executes.
+- `2026-05-03`: Root scripts assume Node.js `22.x`; running validations on older Node versions can fail before repo logic executes.
   - `Applies to`: local/CI execution of `npm run lint`, `npm test`, and validation scripts.
   - `Evidence`: `package.json` `engines.node` is pinned to `22.x`.


### PR DESCRIPTION
### Motivation
- Record a durable repository learning that root scripts assume Node.js `22.x` because `package.json` pins `engines.node`, to prevent contributors/CI from running validations with incompatible Node versions.

### Description
- Add a `2026-05-03` entry to `AGENT_LEARNINGS.md` documenting the Node.js `22.x` requirement with `package.json` referenced as evidence and commit the change (`docs: add node runtime learning`).

### Testing
- Ran `npm run lint` and `npm test`, and both completed successfully with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f70f2247c4832a8fa40cbac76f7317)