### PR TITLE
chore(skills): add eval fixtures + golden + promptfoo for suppression-feedback

### DIFF
--- a/skills/midstream/rr-midstream-suppression-feedback-001/eval/promptfoo.yaml
+++ b/skills/midstream/rr-midstream-suppression-feedback-001/eval/promptfoo.yaml
@@ -1,0 +1,89 @@
+# promptfoo configuration for the Suppression Feedback Workflow skill
+# See: https://www.promptfoo.dev/docs/configuration/guide
+
+prompts:
+  - file://../prompt/system.md
+  - file://../prompt/user.md
+
+providers:
+  - id: openai:gpt-4o
+    config:
+      temperature: 0.1
+      max_tokens: 2000
+
+  - id: anthropic:claude-3-5-sonnet-20241022
+    config:
+      temperature: 0.1
+      max_tokens: 2000
+
+tests:
+  - description: Major finding without an existing suppression entry
+    vars:
+      diff: file://../fixtures/01-major-finding-without-suppression.md
+    assert:
+      - type: contains
+        value: 'accepted_risk'
+      - type: contains
+        value: 'HIGH_SEVERITY'
+      - type: contains
+        value: 'river suppression add'
+      - type: contains
+        value: 'Severity: minor'
+      - type: not-contains
+        value: 'Severity: major'
+      - type: not-contains
+        value: 'Severity: critical'
+      - type: llm-rubric
+        value: |
+          The output must present the choice between (a) implementing the fix and (b) adding a suppression with rationale.
+          Score 1 if both options are mentioned. Score 0 if only suppression is presented.
+      - type: similar
+        value: file://../golden/01-major-finding-without-suppression.md
+        threshold: 0.6
+
+  - description: Already-suppressed finding (no repeat guidance)
+    vars:
+      diff: file://../fixtures/02-already-suppressed-finding.md
+    assert:
+      - type: not-contains
+        value: 'river suppression add'
+      - type: not-contains
+        value: 'Severity: major'
+      - type: not-contains
+        value: 'Severity: minor'
+      - type: llm-rubric
+        value: |
+          The output must NOT repeat the suppression-vs-fix workflow.
+          Score 1 if it returns no findings or only a single info-level acknowledgement that the existing suppression covers the case.
+          Score 0 if it asks the reviewer to decide suppression vs fix again.
+      - type: similar
+        value: file://../golden/02-already-suppressed-finding.md
+        threshold: 0.5
+
+  - description: False positive candidate at minor severity (test fixture)
+    vars:
+      diff: file://../fixtures/03-false-positive-candidate.md
+    assert:
+      - type: contains
+        value: 'false_positive'
+      - type: not-contains
+        value: 'accepted_risk'
+      - type: contains
+        value: 'tests/'
+      - type: contains
+        value: 'Severity: minor'
+      - type: not-contains
+        value: 'Severity: major'
+      - type: llm-rubric
+        value: |
+          The output must recommend feedbackType=false_positive (not accepted_risk) and acknowledge the test-file context.
+          Score 1 if both conditions hold. Score 0 otherwise.
+      - type: similar
+        value: file://../golden/03-false-positive-candidate.md
+        threshold: 0.6
+
+defaultTest:
+  options:
+    provider: openai:gpt-4o
+
+outputPath: eval/results.json

--- a/skills/midstream/rr-midstream-suppression-feedback-001/eval/promptfoo.yaml
+++ b/skills/midstream/rr-midstream-suppression-feedback-001/eval/promptfoo.yaml
@@ -46,16 +46,18 @@ tests:
       diff: file://../fixtures/02-already-suppressed-finding.md
     assert:
       - type: not-contains
-        value: 'river suppression add'
-      - type: not-contains
         value: 'Severity: major'
       - type: not-contains
-        value: 'Severity: minor'
+        value: 'Severity: critical'
       - type: llm-rubric
         value: |
           The output must NOT repeat the suppression-vs-fix workflow.
-          Score 1 if it returns no findings or only a single info-level acknowledgement that the existing suppression covers the case.
-          Score 0 if it asks the reviewer to decide suppression vs fix again.
+          Score 1 if the output (a) returns NO_REVIEW, or (b) returns only a single
+          `Severity: info` acknowledgement that the existing suppression covers the case
+          and does NOT prescribe a new `river suppression add` CLI invocation for the reviewer.
+          Score 0 if it emits a `minor` finding that asks the reviewer to choose suppression
+          vs fix, or if it prescribes new CLI input even though an active entry already
+          covers the fingerprint.
       - type: similar
         value: file://../golden/02-already-suppressed-finding.md
         threshold: 0.5
@@ -66,17 +68,19 @@ tests:
     assert:
       - type: contains
         value: 'false_positive'
-      - type: not-contains
-        value: 'accepted_risk'
       - type: contains
         value: 'tests/'
       - type: contains
         value: 'Severity: minor'
       - type: not-contains
         value: 'Severity: major'
+      - type: not-contains
+        value: 'Severity: critical'
       - type: llm-rubric
         value: |
-          The output must recommend feedbackType=false_positive (not accepted_risk) and acknowledge the test-file context.
+          The output must recommend feedbackType=false_positive as the action and acknowledge the test-file context.
+          The output may mention `accepted_risk` for contrast (e.g. "use false_positive, not accepted_risk")
+          but the recommended `--feedback` value passed to `river suppression add` must be `false_positive`.
           Score 1 if both conditions hold. Score 0 otherwise.
       - type: similar
         value: file://../golden/03-false-positive-candidate.md

--- a/skills/midstream/rr-midstream-suppression-feedback-001/fixtures/01-major-finding-without-suppression.md
+++ b/skills/midstream/rr-midstream-suppression-feedback-001/fixtures/01-major-finding-without-suppression.md
@@ -1,0 +1,50 @@
+# Test Case: Major Finding Without Suppression Entry
+
+## Description
+
+A `major` severity finding is detected by another midstream skill, and there is **no existing suppression entry** for the corresponding fingerprint in Riverbed Memory. The skill should explain the suppression vs. fix decision and surface the HIGH_SEVERITY guard so reviewers know that anything other than `accepted_risk` will not auto-suppress the finding on later PRs.
+
+## Input Diff
+
+```diff
+diff --git a/src/api/users.ts b/src/api/users.ts
+index 1234567..89abcdef 100644
+--- a/src/api/users.ts
++++ b/src/api/users.ts
+@@ -10,7 +10,11 @@ export async function getUserById(req: Request, res: Response) {
+   const { id } = req.params;
+
+   try {
+-    const user = await db.query('SELECT * FROM users WHERE id = ?', [id]);
++    const user = await db.query('SELECT * FROM users WHERE id = ?', [id]);
++    if (!user) {
++      return res.status(404).json({ error: 'not found' });
++    }
+     res.json(user);
+   } catch (error) {
++    // upstream logger already records this; deliberately swallow
+     res.status(500).json({ error: 'Internal server error' });
+```
+
+## Companion finding (out of band)
+
+`rr-midstream-logging-observability-001` has emitted (in the same PR):
+
+```text
+**Finding:** try / catch swallows the upstream error without re-throwing or logging
+**Evidence:** src/api/users.ts:18
+**Severity:** major
+**Confidence:** medium
+```
+
+There is **no `type: 'suppression'` entry** in Riverbed Memory for this fingerprint.
+
+## Expected Behavior
+
+The skill should:
+
+1. Recognize that a `major` finding has been raised in the same PR with no existing suppression.
+2. Surface the HIGH_SEVERITY guard rule: `major`/`critical` findings can only be auto-suppressed via `feedbackType=accepted_risk`.
+3. Frame the choice as `(a) implement the fix` vs. `(b) add a suppression with explicit rationale`, **not** "always suppress".
+4. Quote the `river suppression add` CLI form with `--feedback accepted_risk` and require a non-empty `--rationale`.
+5. Severity of the skill's own finding stays `minor` (this is a workflow nudge, not a security claim).

--- a/skills/midstream/rr-midstream-suppression-feedback-001/fixtures/02-already-suppressed-finding.md
+++ b/skills/midstream/rr-midstream-suppression-feedback-001/fixtures/02-already-suppressed-finding.md
@@ -1,0 +1,53 @@
+# Test Case: Already-Suppressed Finding (Avoid Duplicate Guidance)
+
+## Description
+
+A finding is detected whose 16-hex fingerprint already has an active `type: 'suppression'` entry in Riverbed Memory. The skill should **not** re-issue the suppression workflow guidance — that would be noise. The False-positive guards section of the SKILL says: "do not surface suppression workflow when the same fingerprint is already suppressed."
+
+## Input Diff
+
+```diff
+diff --git a/src/lib/legacy-adapter.ts b/src/lib/legacy-adapter.ts
+index 1234567..89abcdef 100644
+--- a/src/lib/legacy-adapter.ts
++++ b/src/lib/legacy-adapter.ts
+@@ -42,6 +42,7 @@ export function callLegacyService(payload: Payload): Promise<Result> {
+   if (!payload?.userId) {
+     throw new Error('missing userId');
+   }
++  metrics.increment('legacy.calls');
+   return legacyClient.invoke(payload);
+ }
+```
+
+## Companion finding (out of band)
+
+`rr-midstream-logging-observability-001` raised:
+
+```text
+**Finding:** counter increment is not awaited; failure cannot be observed
+**Evidence:** src/lib/legacy-adapter.ts:45
+**Fingerprint:** 9f3c1a8b2d4e7f01
+**Severity:** minor
+**Confidence:** medium
+```
+
+Riverbed Memory contains an active entry:
+
+```text
+type: suppression
+fingerprint: 9f3c1a8b2d4e7f01
+feedbackType: accepted_risk
+rationale: 'metrics client is fire-and-forget by design (PR #612)'
+scope: file
+files: ['src/lib/legacy-adapter.ts']
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. Detect the active suppression entry for fingerprint `9f3c1a8b2d4e7f01` and the matching companion finding.
+2. **Not** repeat the suppression-vs-fix workflow guidance. Re-emitting it duplicates user-facing noise.
+3. Either return no findings, or return at most one `info` finding noting the existing suppression's rationale (one-line acknowledgement only).
+4. If a finding is emitted, severity must not exceed `info`, and the message must reference the existing rationale rather than asking the reviewer to re-decide.

--- a/skills/midstream/rr-midstream-suppression-feedback-001/fixtures/03-false-positive-candidate.md
+++ b/skills/midstream/rr-midstream-suppression-feedback-001/fixtures/03-false-positive-candidate.md
@@ -1,0 +1,52 @@
+# Test Case: False Positive Candidate (Minor Severity)
+
+## Description
+
+A `minor` severity finding looks plausibly like a misdetection: the diff is in a `tests/` file with deliberately mock-shaped data. The skill should suggest `feedbackType=false_positive` (rather than `accepted_risk`) for low-severity, test-context findings, and remind the reviewer that the HIGH_SEVERITY guard does **not** apply at `minor` severity, so manual handling is fine.
+
+## Input Diff
+
+```diff
+diff --git a/tests/auth.test.ts b/tests/auth.test.ts
+index 1234567..89abcdef 100644
+--- a/tests/auth.test.ts
++++ b/tests/auth.test.ts
+@@ -5,9 +5,11 @@ describe('Authentication', () => {
+   it('should authenticate user with valid credentials', async () => {
+     const testUser = {
+       email: 'test@example.com',
+-      password: 'test-password-123',
++      password: 'test-password-123-rotated',
+       apiKey: 'test-api-key-mock-value',
++      sessionId: 'test-session-id-stub',
+     };
+
+     const response = await request(app)
+       .post('/auth/login')
++      .set('Authorization', 'Bearer test-token-do-not-use-in-prod')
+       .send(testUser);
+```
+
+## Companion finding (out of band)
+
+`rr-midstream-security-basic-001` raised:
+
+```text
+**Finding:** hardcoded credential in source
+**Evidence:** tests/auth.test.ts:11 password='test-password-123-rotated'
+**Fingerprint:** 4a2b9d1e6c8f0357
+**Severity:** minor
+**Confidence:** low
+```
+
+There is **no** existing suppression for this fingerprint.
+
+## Expected Behavior
+
+The skill should:
+
+1. Recognize the diff is in a `tests/` file with `test-`-prefixed mock values, which is the canonical false-positive shape for credential checks.
+2. Recommend `feedbackType=false_positive` (not `accepted_risk`) — the value is not a real risk; it is a misdetection.
+3. Note that the HIGH_SEVERITY guard does **not** kick in at `minor` severity, so a `false_positive` suppression here is fine and will not bypass safety checks.
+4. Provide the `river suppression add --feedback false_positive --rationale "test fixture, no production secret"` form as a concrete next step.
+5. Severity of the skill's own finding stays `minor`; do not promote to `major`.

--- a/skills/midstream/rr-midstream-suppression-feedback-001/golden/01-major-finding-without-suppression.md
+++ b/skills/midstream/rr-midstream-suppression-feedback-001/golden/01-major-finding-without-suppression.md
@@ -1,0 +1,26 @@
+# Expected Output: Major Finding Without Suppression Entry
+
+**Finding:** A `major` severity finding from `rr-midstream-logging-observability-001` (try / catch swallow at `src/api/users.ts:18`) has no active suppression entry; the suppression-vs-fix decision must be made explicitly before merge.
+
+**Evidence:** Companion finding at `src/api/users.ts:18` is `Severity: major`. Riverbed Memory has no `type: 'suppression'` entry for the matching fingerprint.
+
+**Impact:** `major` and `critical` findings are auto-suppressed only when `feedbackType=accepted_risk`. Choosing `false_positive`, `wont_fix`, `not_relevant`, or `duplicate` is blocked by the HIGH_SEVERITY guard, so the same finding will surface on every subsequent PR until the reviewer either fixes the code or registers an `accepted_risk` entry with rationale.
+
+**Fix:** Decide explicitly before merge:
+
+- (a) Remove the swallow and re-raise / log the original error, **or**
+- (b) Add a suppression with explicit rationale:
+
+  ```bash
+  river suppression add \
+    --fingerprint <fp from --debug or reviewDebug.suppressionsApplied> \
+    --feedback accepted_risk \
+    --rationale "upstream logger already records this error; deliberate swallow" \
+    --pr <this PR number>
+  ```
+
+**Severity:** minor
+
+**Confidence:** medium
+
+**Skill ID:** rr-midstream-suppression-feedback-001

--- a/skills/midstream/rr-midstream-suppression-feedback-001/golden/02-already-suppressed-finding.md
+++ b/skills/midstream/rr-midstream-suppression-feedback-001/golden/02-already-suppressed-finding.md
@@ -1,0 +1,13 @@
+# Expected Output: Already-Suppressed Finding (No Repeat Guidance)
+
+No suppression workflow guidance.
+
+**Rationale:** Riverbed Memory already has an active `type: 'suppression'` entry for fingerprint `9f3c1a8b2d4e7f01` (`feedbackType: accepted_risk`, `rationale: 'metrics client is fire-and-forget by design (PR #612)'`, scope: file). The skill's False-positive guards section explicitly prevents re-issuing the suppression workflow when the same fingerprint is already suppressed; doing so would duplicate user-facing noise.
+
+**Optional info-level acknowledgement (only if emitted at all):**
+
+> **Note:** Existing suppression covers this finding (`accepted_risk`, "metrics client is fire-and-forget by design (PR #612)"). No reviewer action required.
+>
+> **Severity:** info
+
+Do not emit a `minor` or higher finding. Do not repeat the `river suppression add` CLI form. Do not ask the reviewer to choose suppression vs. fix again.

--- a/skills/midstream/rr-midstream-suppression-feedback-001/golden/03-false-positive-candidate.md
+++ b/skills/midstream/rr-midstream-suppression-feedback-001/golden/03-false-positive-candidate.md
@@ -1,0 +1,26 @@
+# Expected Output: False Positive Candidate (Minor Severity)
+
+**Finding:** A `minor` severity credential finding from `rr-midstream-security-basic-001` is in `tests/auth.test.ts` with `test-`-prefixed mock values; this is the canonical false-positive shape for credential checks. Recommend `feedbackType=false_positive`, not `accepted_risk`.
+
+**Evidence:** Companion finding at `tests/auth.test.ts:11` is `Severity: minor`, `Confidence: low`. The diff is entirely in a `tests/` path and the values are `test-password-123-rotated`, `test-api-key-mock-value`, `test-session-id-stub`, and `test-token-do-not-use-in-prod` — all visibly mock-shaped.
+
+**Impact:** Choosing `accepted_risk` for a misdetection conflates "real risk we accept" with "the tool is wrong here," making future audits noisier. The HIGH_SEVERITY guard does **not** apply at `minor` severity, so `false_positive` suppression is safe — it will not bypass `major` / `critical` checks.
+
+**Fix:** Use `false_positive` (not `accepted_risk`) for this fingerprint:
+
+```bash
+river suppression add \
+  --fingerprint <fp from --debug or reviewDebug.suppressionsApplied> \
+  --feedback false_positive \
+  --rationale "test fixture; values are visibly mock and not a production secret" \
+  --files tests/auth.test.ts \
+  --pr <this PR number>
+```
+
+If similar test fixtures recur, prefer adding a guard fixture under `skills/midstream/rr-midstream-security-basic-001/fixtures/` so the underlying detector stops misfiring instead of suppressing every instance.
+
+**Severity:** minor
+
+**Confidence:** medium
+
+**Skill ID:** rr-midstream-suppression-feedback-001

--- a/skills/midstream/rr-midstream-suppression-feedback-001/prompt/system.md
+++ b/skills/midstream/rr-midstream-suppression-feedback-001/prompt/system.md
@@ -1,0 +1,62 @@
+# Suppression Feedback Workflow - System Prompt
+
+You are a midstream code reviewer that helps human + AI reviewers decide what to do with findings emitted by other midstream skills: **fix the code, register a suppression entry, or do nothing**. You are not a security or correctness reviewer; you do not re-evaluate findings on their merits.
+
+## Goal
+
+Give the reviewer the smallest possible nudge so they can make one decision:
+
+- (a) implement the underlying fix, **or**
+- (b) write a `river suppression add` entry with explicit rationale, **or**
+- (c) recognize that the finding is already suppressed and avoid re-asking.
+
+## Pre-execution Gate
+
+Stay quiet (`NO_REVIEW`) unless **all** of the following hold:
+
+- The diff touches application code under `src/`, `app/`, `lib/`, or `packages/` (not docs / fixtures / generated artifacts only).
+- A companion finding exists in the same PR from another midstream skill at `info` severity or higher, **or** the PR body / commit message mentions `accepted_risk`, `false_positive`, `wont_fix`, `suppress`, `Riverbed Memory`, or `fingerprint`.
+
+If gate fails, output exactly:
+
+```text
+NO_REVIEW: rr-midstream-suppression-feedback-001 — suppression workflow に関連する変更や指摘が検出されない
+```
+
+## HIGH_SEVERITY guard
+
+`major` and `critical` findings are auto-suppressed **only** when `feedbackType=accepted_risk`. The other feedback types (`false_positive`, `wont_fix`, `not_relevant`, `duplicate`) are blocked by the guard at high severity, so the finding will resurface on every later PR until either the code is fixed or an `accepted_risk` entry is registered.
+
+At `minor` / `info` severity, the guard does not apply; any feedback type is acceptable.
+
+## feedbackType selection
+
+| feedbackType     | When to recommend                                                                                       |
+| ---------------- | ------------------------------------------------------------------------------------------------------- |
+| `accepted_risk`  | Real risk the team consciously accepts; rationale must explain why the residual risk is tolerable.      |
+| `false_positive` | The detector is wrong (test fixture, generated file, mock value, intentional pattern outside the rule). |
+| `wont_fix`       | Real issue, low priority, fix cost > value. Allowed only at `minor` / `info`.                           |
+| `not_relevant`   | The rule does not apply to this codebase or this PR.                                                    |
+| `duplicate`      | Equivalent to an existing suppression; pass `--duplicate-of <fingerprint>`.                             |
+
+## False-positive guards (workflow guidance, not findings)
+
+- If the fingerprint already has an active `type: 'suppression'` entry, **do not** repeat suppression workflow guidance. Either return no findings, or one `info` line acknowledging the existing rationale.
+- If the PR is entirely `info` / `minor` severity, do not surface the HIGH_SEVERITY guard text — it is noise.
+- Recommend `accepted_risk` only when the PR body or commit message contains a rationale; never invite the reviewer to suppress without reason.
+
+## Output Format
+
+Per finding:
+
+```text
+**Finding:** <one sentence: which companion finding, what decision is needed>
+**Evidence:** <file:line of the companion finding + presence/absence of suppression entry>
+**Impact:** <what happens on later PRs if no decision is made — focus on the HIGH_SEVERITY guard at major/critical>
+**Fix:** <either (a) implement-the-fix outline, or (b) the river suppression add CLI with the right --feedback>
+**Severity:** minor   (this skill never claims major or critical itself)
+**Confidence:** <low|medium|high>
+**Skill ID:** rr-midstream-suppression-feedback-001
+```
+
+Do **not** introduce new vulnerabilities, performance claims, or design assertions. This skill exists only to route reviewers toward the correct workflow.

--- a/skills/midstream/rr-midstream-suppression-feedback-001/prompt/system.md
+++ b/skills/midstream/rr-midstream-suppression-feedback-001/prompt/system.md
@@ -12,10 +12,13 @@ Give the reviewer the smallest possible nudge so they can make one decision:
 
 ## Pre-execution Gate
 
-Stay quiet (`NO_REVIEW`) unless **all** of the following hold:
+Stay quiet (`NO_REVIEW`) unless **at least one** of the following holds:
 
-- The diff touches application code under `src/`, `app/`, `lib/`, or `packages/` (not docs / fixtures / generated artifacts only).
-- A companion finding exists in the same PR from another midstream skill at `info` severity or higher, **or** the PR body / commit message mentions `accepted_risk`, `false_positive`, `wont_fix`, `suppress`, `Riverbed Memory`, or `fingerprint`.
+- A companion finding exists in the same PR from another midstream skill at `info` severity or higher. The companion finding is the trigger; the diff path does not need to be application code (`tests/` is acceptable when the companion finding is real, e.g. a security misdetection on a test fixture).
+- The PR body / commit message mentions `accepted_risk`, `false_positive`, `wont_fix`, `suppress`, `Riverbed Memory`, or `fingerprint`.
+- The diff touches application code under `src/`, `app/`, `lib/`, or `packages/` and the PR involves at least one finding.
+
+A diff that is purely docs / generated artifacts and has no companion finding and no suppression-related text in the PR body must return `NO_REVIEW`.
 
 If gate fails, output exactly:
 
@@ -41,7 +44,7 @@ At `minor` / `info` severity, the guard does not apply; any feedback type is acc
 
 ## False-positive guards (workflow guidance, not findings)
 
-- If the fingerprint already has an active `type: 'suppression'` entry, **do not** repeat suppression workflow guidance. Either return no findings, or one `info` line acknowledging the existing rationale.
+- If the fingerprint already has an active `type: 'suppression'` entry, **do not** repeat the suppression workflow. Prefer returning `NO_REVIEW`. If you do emit a finding, it must be `Severity: info` and one line that re-states the existing rationale; never `minor` for an already-suppressed case.
 - If the PR is entirely `info` / `minor` severity, do not surface the HIGH_SEVERITY guard text — it is noise.
 - Recommend `accepted_risk` only when the PR body or commit message contains a rationale; never invite the reviewer to suppress without reason.
 
@@ -54,9 +57,14 @@ Per finding:
 **Evidence:** <file:line of the companion finding + presence/absence of suppression entry>
 **Impact:** <what happens on later PRs if no decision is made — focus on the HIGH_SEVERITY guard at major/critical>
 **Fix:** <either (a) implement-the-fix outline, or (b) the river suppression add CLI with the right --feedback>
-**Severity:** minor   (this skill never claims major or critical itself)
+**Severity:** <minor|info>
 **Confidence:** <low|medium|high>
 **Skill ID:** rr-midstream-suppression-feedback-001
 ```
+
+Severity rules (the skill never claims `major` or `critical`):
+
+- `minor` — a workflow nudge that asks the reviewer to choose between fix and suppression for a companion finding that has no active suppression entry.
+- `info` — a one-line acknowledgement that an already-active suppression entry covers the companion finding. Prefer `NO_REVIEW` over `info` if the acknowledgement adds no information beyond what the suppression entry already says.
 
 Do **not** introduce new vulnerabilities, performance claims, or design assertions. This skill exists only to route reviewers toward the correct workflow.

--- a/skills/midstream/rr-midstream-suppression-feedback-001/prompt/user.md
+++ b/skills/midstream/rr-midstream-suppression-feedback-001/prompt/user.md
@@ -29,7 +29,7 @@ For each companion finding decide which of these three states applies and emit a
 
 ## Output Format
 
-Use the format from the system prompt for every finding. The skill's own `Severity` is always `minor`; never `major` or `critical`. Always end with `**Skill ID:** rr-midstream-suppression-feedback-001`.
+Use the format from the system prompt for every finding. The skill's own `Severity` is `minor` for workflow nudges (case 2 — suppression workflow needed) and `info` for already-suppressed acknowledgements (case 1 — but prefer `NO_REVIEW` when the acknowledgement adds no information); never `major` or `critical`. Always end with `**Skill ID:** rr-midstream-suppression-feedback-001`.
 
 If no finding is emitted, output exactly:
 

--- a/skills/midstream/rr-midstream-suppression-feedback-001/prompt/user.md
+++ b/skills/midstream/rr-midstream-suppression-feedback-001/prompt/user.md
@@ -1,0 +1,38 @@
+# Suppression Feedback Workflow - User Prompt
+
+You will receive:
+
+- The current PR diff.
+- One or more companion findings from other midstream skills, each with `Severity`, optional `Confidence`, optional `Fingerprint`, and the `file:line` of the offending location.
+- Optional Riverbed Memory state: a list of active `type: 'suppression'` entries with `fingerprint`, `feedbackType`, `rationale`, `scope`, and `files`.
+- Optional PR body / commit messages that may already contain rationale text.
+
+## Task
+
+For each companion finding decide which of these three states applies and emit at most one finding per companion:
+
+1. **Already suppressed** — fingerprint matches an active suppression entry.
+   → Emit no finding, or one `info` acknowledgement that re-states the existing rationale in one line. Do not repeat the suppression workflow.
+
+2. **Suppression workflow needed** — companion finding has no matching suppression entry.
+   → Emit one `minor` finding telling the reviewer to choose: implement the fix, or `river suppression add` with the appropriate `--feedback`. If the companion finding is `major` / `critical`, surface the HIGH_SEVERITY guard explicitly so the reviewer knows only `accepted_risk` will auto-suppress.
+
+3. **Out of scope** — the companion finding does not require a workflow nudge (e.g. the diff is doc-only, or the Pre-execution Gate did not fire).
+   → Return `NO_REVIEW`.
+
+## Selection rules
+
+- For `major` / `critical` companions without rationale in the PR body, recommend implementing the fix as the **first** option; suppression is the second option only if the rationale is genuine.
+- For `minor` / `info` companions in obvious test / fixture / mock contexts, recommend `false_positive` (not `accepted_risk`).
+- Never recommend `accepted_risk` without a rationale visible in the PR body or commit message.
+- Never re-emit suppression workflow guidance for a fingerprint that is already in an active `type: 'suppression'` entry.
+
+## Output Format
+
+Use the format from the system prompt for every finding. The skill's own `Severity` is always `minor`; never `major` or `critical`. Always end with `**Skill ID:** rr-midstream-suppression-feedback-001`.
+
+If no finding is emitted, output exactly:
+
+```text
+NO_REVIEW: rr-midstream-suppression-feedback-001 — suppression workflow に関連する変更や指摘が検出されない
+```


### PR DESCRIPTION
## Summary

Closes #739 (PR #735 follow-up).

PR #735 shipped \`rr-midstream-suppression-feedback-001/SKILL.md\` only and intentionally deferred eval fixtures, golden files, and the prompt template. This PR completes the structural parity with \`rr-midstream-security-basic-001\`.

## Files

| Path | Purpose |
| ---- | ------- |
| \`fixtures/01-major-finding-without-suppression.md\` | HIGH_SEVERITY guard: major companion finding with no entry → recommend fix vs. \`accepted_risk\` |
| \`fixtures/02-already-suppressed-finding.md\` | Active suppression entry exists → skill must stay quiet (no repeat workflow) |
| \`fixtures/03-false-positive-candidate.md\` | Minor severity in \`tests/\` → recommend \`false_positive\`, not \`accepted_risk\` |
| \`golden/01..03\` | Representative expected outputs per fixture |
| \`prompt/system.md\` | Pre-execution Gate, HIGH_SEVERITY guard, feedbackType selection, False-positive guards |
| \`prompt/user.md\` | Per-finding decision rules and output format |
| \`eval/promptfoo.yaml\` | \`contains\` / \`not-contains\` / \`llm-rubric\` / \`similar\` assertions per case |

## Why these three cases

The three fixtures encode the SKILL's three operating regimes:

1. **Workflow needed** — companion finding has no suppression entry, so the skill must surface the suppression-vs-fix decision **and** the HIGH_SEVERITY guard at \`major\`/\`critical\`.
2. **Already covered** — the False-positive guards section explicitly forbids re-emitting workflow when an active \`type: 'suppression'\` entry exists.
3. **Misdetection at minor severity** — guides reviewers to \`false_positive\` (not \`accepted_risk\`) so the audit trail stays clean and \`accepted_risk\` keeps its meaning.

## Test plan

- [x] \`npm run skills:validate\` ✅
- [x] \`npm run eval:fixtures\` (exit 0, "All review fixtures passed.")
- [x] \`node --test\` — 863/863 pass
- [x] \`npm run lint\` — clean
- [ ] CI green

## Out of scope

- Changes to \`scripts/evaluate-review-fixtures.mjs\` or \`tests/fixtures/review-eval/cases.json\` — \`promptfoo\` per-skill eval is the path established by \`rr-midstream-security-basic-001\`; no other skill is wired into \`cases.json\` either.
- SKILL.md content — already in main; this PR adds eval surface only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)