### PR TITLE
chore(skills): narrow upstream **/*.md applyTo to docs/pages/specs (#762 batch 2)

### DIFF
--- a/skills/midstream/rr-midstream-gh-address-comments-001/SKILL.md
+++ b/skills/midstream/rr-midstream-gh-address-comments-001/SKILL.md
@@ -13,7 +13,6 @@ applyTo:
   - 'tests/**/*'
   - 'docs/**/*'
   - 'pages/**/*'
-  - '**/*.md'
 tags:
   - review
   - github

--- a/skills/upstream/agent-code-documentation/SKILL.md
+++ b/skills/upstream/agent-code-documentation/SKILL.md
@@ -8,8 +8,9 @@ phase: upstream
 applyTo:
   - 'docs/**/*'
   - 'pages/**/*'
-  - '**/*.md'
   - 'README*.md'
+  - 'README*.markdown'
+  - '**/README.md'
 tags:
   - agent
   - documentation

--- a/skills/upstream/rr-upstream-create-plan-001/SKILL.md
+++ b/skills/upstream/rr-upstream-create-plan-001/SKILL.md
@@ -8,7 +8,7 @@ phase: upstream
 applyTo:
   - 'docs/**/*'
   - 'pages/**/*'
-  - '**/*.md'
+  - 'docs/adr/**/*'
   - '**/*.adr'
 tags:
   - planning

--- a/skills/upstream/rr-upstream-multitenancy-isolation-001/SKILL.md
+++ b/skills/upstream/rr-upstream-multitenancy-isolation-001/SKILL.md
@@ -6,14 +6,12 @@ version: 0.1.0
 category: upstream
 phase: upstream
 applyTo:
-  - '**/*.md'
-  - '**/*.yaml'
-  - '**/*.yml'
-  - '**/*.json'
   - 'docs/**/*'
   - 'design/**/*'
   - 'architecture/**/*'
   - 'specs/**/*'
+  - 'config/**/*'
+  - 'infrastructure/**/*'
 tags:
   - multitenancy
   - isolation

--- a/skills/upstream/rr-upstream-security-privacy-design-001/SKILL.md
+++ b/skills/upstream/rr-upstream-security-privacy-design-001/SKILL.md
@@ -6,9 +6,10 @@ version: 0.1.0
 category: upstream
 phase: upstream
 applyTo:
-  - '**/*.md'
+  - 'docs/**/*.md'
   - '**/design/**/*'
   - '**/rfc/**/*'
+  - 'docs/architecture/**/*'
 tags:
   - security
   - privacy


### PR DESCRIPTION
Closes part of #762.

#762 PR-3 batch 2 (5 skills). Drops bare extension globs (`**/*.md`, `**/*.yaml`, `**/*.yml`, `**/*.json`) that pulled non-design markdown / config into upstream candidate sets. New patterns are dir-bounded per docs/development/skill-applyto-scoping.md.

## Skills modified (5)

- `skills/upstream/agent-code-documentation` — drops bare `**/*.md`, keeps `docs/`, `pages/`, `README*`
- `skills/upstream/rr-upstream-create-plan-001` — drops bare `**/*.md`, adds `docs/adr/**/*`
- `skills/upstream/rr-upstream-multitenancy-isolation-001` — drops bare `**/*.{md,yaml,yml,json}`, keeps dir-bounded
- `skills/upstream/rr-upstream-security-privacy-design-001` — drops bare `**/*.md`, adds `docs/**/*.md` and `docs/architecture/**/*`
- `skills/midstream/rr-midstream-gh-address-comments-001` — drops bare `**/*.md` (the dir-bounded patterns are sufficient)

## Validation

- [x] `npm run planner:eval:dataset`: 23 cases, **coverage=1.0, top1Match=1.0** (identical to pre-edit baseline)
- [x] `node --test tests/planner-dataset-eval.test.mjs`: 3/3 pass
- [x] `npm run skills:validate`: ✅
- [ ] CI green

## Note

`rr-upstream-review-policy-standard-001` keeps its broad applyTo. It carries the `policy` tag, which is in the planner-dataset eval `excludedTags` set, so the planner does not load it into the candidate set regardless of `applyTo` width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)