### PR TITLE
chore(skills): add missing modelHint=balanced to 3 skills

### DIFF
--- a/skills/downstream/rr-downstream-test-naming-001/SKILL.md
+++ b/skills/downstream/rr-downstream-test-naming-001/SKILL.md
@@ -12,6 +12,7 @@ tags: [tests, naming, downstream]
 severity: minor
 inputContext: [tests, diff]
 outputKind: [tests, findings, summary]
+modelHint: balanced
 ---
 
 ## Pattern declaration

--- a/skills/midstream/rr-midstream-typescript-strict-001/SKILL.md
+++ b/skills/midstream/rr-midstream-typescript-strict-001/SKILL.md
@@ -14,6 +14,7 @@ tags: [typescript, type-safety, midstream]
 severity: major
 inputContext: [diff, fullFile]
 outputKind: [findings, actions]
+modelHint: balanced
 dependencies: [code_search]
 ---
 

--- a/skills/upstream/rr-upstream-api-design-001/SKILL.md
+++ b/skills/upstream/rr-upstream-api-design-001/SKILL.md
@@ -12,6 +12,7 @@ tags: [api, design, upstream]
 severity: major
 inputContext: [diff, adr]
 outputKind: [findings, summary, actions]
+modelHint: balanced
 dependencies: [repo_metadata]
 ---
 


### PR DESCRIPTION
Multi-axis audit (skills/agents/workflows) flagged 3 skills missing the optional but recommended `modelHint` frontmatter key.

## Files (3)

- `skills/upstream/rr-upstream-api-design-001`
- `skills/midstream/rr-midstream-typescript-strict-001`
- `skills/downstream/rr-downstream-test-naming-001`

All three are set to `modelHint: balanced` to match the dominant pattern (62 / 80 other skills) and to make planner ranking deterministic against the default `preferredModelHint=balanced`.

## Why

`rankByModelHint` in `runners/core/review-runner.mjs` falls back to `balanced` weight when a skill omits `modelHint`, so behavior was already correct. But the audit treats the missing field as **metadata inconsistency** — explicit values make the field a contract instead of an implicit default, so future ranking-strategy changes don't silently affect the 3 skills.

## Test plan

- [x] `npm run skills:validate` ✅
- [x] `node --test tests/planner-dataset-eval.test.mjs` 3/3 pass (no routing regression)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)