### PR TITLE
feat(eval): add planner-dataset coverage for 5 never-selected upstream skills

### DIFF
--- a/tests/fixtures/planner-dataset/cases.json
+++ b/tests/fixtures/planner-dataset/cases.json
@@ -207,5 +207,45 @@
     "availableDependencies": ["code_search", "tracing"],
     "expectedAny": ["rr-midstream-security-basic-001", "rr-midstream-logging-observability-001"],
     "expectedTop1": ["rr-midstream-security-basic-001", "rr-midstream-logging-observability-001"]
+  },
+  {
+    "name": "coverage: ADR decision quality (#762 audit follow-up)",
+    "phase": "upstream",
+    "diffFile": "diffs/upstream-adr-decision-quality.diff",
+    "availableContexts": ["diff", "adr"],
+    "availableDependencies": ["adr_lookup", "repo_metadata"],
+    "expectedAny": ["rr-upstream-adr-decision-quality-001"]
+  },
+  {
+    "name": "coverage: DB schema migration design (#762 audit follow-up)",
+    "phase": "upstream",
+    "diffFile": "diffs/upstream-db-schema-migration.diff",
+    "availableContexts": ["diff", "fullFile", "adr"],
+    "availableDependencies": ["repo_metadata"],
+    "expectedAny": ["rr-upstream-data-model-db-design-001"]
+  },
+  {
+    "name": "coverage: OpenAPI contract change (#762 audit follow-up)",
+    "phase": "upstream",
+    "diffFile": "diffs/upstream-openapi-contract.diff",
+    "availableContexts": ["diff", "fullFile", "adr"],
+    "availableDependencies": ["repo_metadata"],
+    "expectedAny": ["rr-upstream-openapi-contract-001"]
+  },
+  {
+    "name": "coverage: event-driven design (#762 audit follow-up)",
+    "phase": "upstream",
+    "diffFile": "diffs/upstream-event-driven-design.diff",
+    "availableContexts": ["diff", "adr"],
+    "availableDependencies": ["repo_metadata"],
+    "expectedAny": ["rr-upstream-event-driven-semantics-001"]
+  },
+  {
+    "name": "coverage: architecture traceability (#762 audit follow-up)",
+    "phase": "upstream",
+    "diffFile": "diffs/upstream-architecture-traceability.diff",
+    "availableContexts": ["diff", "adr"],
+    "availableDependencies": ["adr_lookup", "repo_metadata"],
+    "expectedAny": ["rr-upstream-architecture-traceability-001"]
   }
 ]

--- a/tests/fixtures/planner-dataset/diffs/upstream-adr-decision-quality.diff
+++ b/tests/fixtures/planner-dataset/diffs/upstream-adr-decision-quality.diff
@@ -1,0 +1,24 @@
+diff --git a/docs/adr/0042-payment-retry-policy.md b/docs/adr/0042-payment-retry-policy.md
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/docs/adr/0042-payment-retry-policy.md
+@@ -0,0 +1,18 @@
++# ADR 0042: Payment retry policy
++
++## Status
++
++Proposed
++
++## Context
++
++We need to retry failed payment authorizations.
++
++## Decision
++
++Retry up to 3 times with exponential backoff.
++
++## Consequences
++
++- Idempotency keys must be passed.
++- The provider rate limit caps at 100 req/s, so retry storms must be jittered.

--- a/tests/fixtures/planner-dataset/diffs/upstream-architecture-traceability.diff
+++ b/tests/fixtures/planner-dataset/diffs/upstream-architecture-traceability.diff
@@ -1,0 +1,22 @@
+diff --git a/docs/architecture/order-context-design.md b/docs/architecture/order-context-design.md
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/docs/architecture/order-context-design.md
+@@ -0,0 +1,16 @@
++# Order context design
++
++## Decisions traced from ADRs
++
++- ADR 0042 (payment retry policy) → idempotency key flow on `Order.create`
++- ADR 0038 (event delivery semantics) → at-least-once + revision counter
++
++## Component diagram
++
++See `docs/architecture/diagrams/order-c4.svg`.
++
++## Open questions
++
++- Does the inventory context need to know the cancellation reason?
++- Should `OrderCancelled` carry the original `OrderPlaced` payload, or just the
++  `orderId` and a timestamp?

--- a/tests/fixtures/planner-dataset/diffs/upstream-db-schema-migration.diff
+++ b/tests/fixtures/planner-dataset/diffs/upstream-db-schema-migration.diff
@@ -1,0 +1,35 @@
+diff --git a/db/migrations/2026-05-07-add-orders-table.sql b/db/migrations/2026-05-07-add-orders-table.sql
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/db/migrations/2026-05-07-add-orders-table.sql
+@@ -0,0 +1,12 @@
++-- migration: add orders table
++CREATE TABLE orders (
++  id BIGSERIAL PRIMARY KEY,
++  user_id BIGINT NOT NULL,
++  total_amount NUMERIC(12, 2) NOT NULL,
++  currency VARCHAR(3) NOT NULL DEFAULT 'JPY',
++  status VARCHAR(32) NOT NULL,
++  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
++  updated_at TIMESTAMPTZ
++);
++
++CREATE INDEX idx_orders_user_id ON orders(user_id);
+diff --git a/prisma/schema.prisma b/prisma/schema.prisma
+index 1111111..2222222 100644
+--- a/prisma/schema.prisma
++++ b/prisma/schema.prisma
+@@ -8,3 +8,12 @@ model User {
+   id    BigInt @id @default(autoincrement())
+   email String @unique
+ }
++
++model Order {
++  id          BigInt   @id @default(autoincrement())
++  userId      BigInt
++  totalAmount Decimal  @db.Decimal(12, 2)
++  currency    String   @default("JPY") @db.VarChar(3)
++  status      String   @db.VarChar(32)
++  createdAt   DateTime @default(now())
++}

--- a/tests/fixtures/planner-dataset/diffs/upstream-event-driven-design.diff
+++ b/tests/fixtures/planner-dataset/diffs/upstream-event-driven-design.diff
@@ -1,0 +1,26 @@
+diff --git a/docs/architecture/order-event-design.md b/docs/architecture/order-event-design.md
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/docs/architecture/order-event-design.md
+@@ -0,0 +1,20 @@
++# Order event design
++
++## Events
++
++- `OrderPlaced` — emitted by the order context after a successful checkout.
++- `OrderCancelled` — emitted when the user cancels within the cancellation window.
++
++## Topic / queue
++
++| Event           | Topic                | Partitioning key | Retention |
++| --------------- | -------------------- | ---------------- | --------- |
++| `OrderPlaced`   | `orders.placed.v1`   | `orderId`        | 7d        |
++| `OrderCancelled`| `orders.cancelled.v1`| `orderId`        | 7d        |
++
++## Delivery semantics
++
++At-least-once. Consumers must be idempotent on `orderId`.
++
++The `OrderPlaced` payload includes `revision: number` so out-of-order
++delivery can be detected and ignored on the consumer side.

--- a/tests/fixtures/planner-dataset/diffs/upstream-openapi-contract.diff
+++ b/tests/fixtures/planner-dataset/diffs/upstream-openapi-contract.diff
@@ -1,0 +1,35 @@
+diff --git a/openapi/orders.yaml b/openapi/orders.yaml
+index 1111111..2222222 100644
+--- a/openapi/orders.yaml
++++ b/openapi/orders.yaml
+@@ -10,6 +10,18 @@ paths:
+       responses:
+         '200':
+           description: list of orders
++    post:
++      summary: create a new order
++      requestBody:
++        required: true
++        content:
++          application/json:
++            schema:
++              $ref: '#/components/schemas/CreateOrderRequest'
++      responses:
++        '201':
++          description: created
++
+ components:
+   schemas:
+     Order:
+@@ -19,3 +31,11 @@ components:
+           type: integer
+         status:
+           type: string
++    CreateOrderRequest:
++      type: object
++      required:
++        - userId
++        - totalAmount
++      properties:
++        userId:
++          type: integer


### PR DESCRIPTION
Multi-axis skills/agents/workflows audit (Phase 1) found 30 planner-loadable skills that are never selected in any planner-dataset case (42% gap).

This PR adds 5 cases to bring high-value upstream skills into measurable routing coverage.

## Cases added

| skill | diff |
|---|---|
| `rr-upstream-adr-decision-quality-001` | `docs/adr/0042-payment-retry-policy.md` |
| `rr-upstream-data-model-db-design-001` | `db/migrations` + `prisma/schema.prisma` |
| `rr-upstream-openapi-contract-001` | `openapi/orders.yaml` |
| `rr-upstream-event-driven-semantics-001` | `docs/architecture/order-event-design.md` |
| `rr-upstream-architecture-traceability-001` | `docs/architecture/order-context-design.md` |

## Validation

- [x] `npm run planner:eval:dataset` — 28 cases (was 23), coverage=1.0, top1Match=1.0
- [x] `node --test tests/planner-dataset-eval.test.mjs` — 3/3 pass
- [x] `npm run lint` — clean
- [ ] CI green

## Out of scope

- 25 remaining never-selected skills (plangate-* / multi-tenancy / DR / capacity-cost / etc.) — each requires a custom diff and is best filed as separate batches
- Verification-family skills covered separately via `cli-review-verify-spec`

🤖 Generated with [Claude Code](https://claude.com/claude-code)