### PR TITLE
docs(skills): add canonical sections to 9 agent-* skills

### DIFF
--- a/skills/downstream/agent-qa-regression/SKILL.md
+++ b/skills/downstream/agent-qa-regression/SKILL.md
@@ -27,6 +27,22 @@ dependencies:
   - code_search
 ---
 
+## Pattern declaration
+
+Primary pattern: Reviewer
+Secondary patterns: Inversion
+Why: Playwright を使った回帰テストの設計と実行をガイドする。
+
+## Goal / 目的
+
+- Playwright を使った回帰テストの設計と実行をガイドする。
+- 既存の方針に沿った差分は追加コストなく通し、領域固有の高シグナル指摘のみ返す。
+
+## Pre-execution Gate / 実行前ゲート
+
+- 差分が `tests/e2e/**/*` / `tests/**/*regression*` / `playwright.config.*` のいずれか に該当する場合のみ起動する。
+- 差分がドキュメント/フィクスチャのみで本スキルの対象範囲外の場合は `NO_REVIEW: agent-qa-regression — 対象差分なし` を返す。
+
 ## Guidance
 
 - Ensure critical flows (auth/dashboard/CRUD) have regression specs for success and failure cases.
@@ -41,3 +57,17 @@ dependencies:
 ## False-positive guards
 
 - 既存の回帰スイートが同フローをカバーし、変更が文書のみなら指摘しない。
+
+## Output / 出力例
+
+```yaml
+findings:
+  - severity: major
+    file: <対象ファイル>
+    line: <行番号>
+    issue: <Goal で述べた観点に該当する問題の 1 文要約>
+    suggestion: <次の最小一手>
+actions: []
+```
+
+出力種別: actions / findings。Severity は本スキルの metadata 既定値（`major`）を上限とし、root cause を伴わないものは `info` に下げる。

--- a/skills/downstream/agent-webapp-testing/SKILL.md
+++ b/skills/downstream/agent-webapp-testing/SKILL.md
@@ -27,6 +27,22 @@ dependencies:
   - code_search
 ---
 
+## Pattern declaration
+
+Primary pattern: Reviewer
+Secondary patterns: Inversion
+Why: Playwright でローカル/プレビュー環境の Web アプリを操作・検証するための手順をまとめる。
+
+## Goal / 目的
+
+- Playwright でローカル/プレビュー環境の Web アプリを操作・検証するための手順をまとめる。
+- 既存の方針に沿った差分は追加コストなく通し、領域固有の高シグナル指摘のみ返す。
+
+## Pre-execution Gate / 実行前ゲート
+
+- 差分が `src/**/*.{ts,tsx,js,jsx}` または `tests/**/*` の web 関連いずれか に該当する場合のみ起動する。
+- 差分がドキュメント/フィクスチャのみで本スキルの対象範囲外の場合は `NO_REVIEW: agent-webapp-testing — 対象差分なし` を返す。
+
 ## Guidance
 
 - Outline key UI flows to automate with Playwright and prefer role/test-id selectors.
@@ -41,3 +57,17 @@ dependencies:
 ## False-positive guards
 
 - 既に安定した E2E 基盤があり変更が非 UI 設定のみなら指摘しない。
+
+## Output / 出力例
+
+```yaml
+findings:
+  - severity: major
+    file: <対象ファイル>
+    line: <行番号>
+    issue: <Goal で述べた観点に該当する問題の 1 文要約>
+    suggestion: <次の最小一手>
+actions: []
+```
+
+出力種別: actions / findings。Severity は本スキルの metadata 既定値（`major`）を上限とし、root cause を伴わないものは `info` に下げる。

--- a/skills/midstream/agent-agentcheck-code-review/SKILL.md
+++ b/skills/midstream/agent-agentcheck-code-review/SKILL.md
@@ -28,6 +28,22 @@ dependencies:
   - code_search
 ---
 
+## Pattern declaration
+
+Primary pattern: Reviewer
+Secondary patterns: Inversion
+Why: AgentCheck ベースでローカルリポジトリを走査し、PR 前のコードレビューを実行するスキル。
+
+## Goal / 目的
+
+- AgentCheck ベースでローカルリポジトリを走査し、PR 前のコードレビューを実行するスキル。
+- 既存の方針に沿った差分は追加コストなく通し、領域固有の高シグナル指摘のみ返す。
+
+## Pre-execution Gate / 実行前ゲート
+
+- 差分が `src/**/*` / `app/**/*` / `lib/**/*` / `packages/**/*` の TS/JS いずれか に該当する場合のみ起動する。
+- 差分がドキュメント/フィクスチャのみで本スキルの対象範囲外の場合は `NO_REVIEW: agent-agentcheck-code-review — 対象差分なし` を返す。
+
 ## Guidance
 
 - Use AgentCheck rules to scan high-impact files first and classify findings by severity with file:line.
@@ -42,3 +58,17 @@ dependencies:
 ## False-positive guards
 
 - 変更が無い領域や設定でスキャン対象外と明記されている箇所は報告しない。
+
+## Output / 出力例
+
+```yaml
+findings:
+  - severity: major
+    file: <対象ファイル>
+    line: <行番号>
+    issue: <Goal で述べた観点に該当する問題の 1 文要約>
+    suggestion: <次の最小一手>
+actions: []
+```
+
+出力種別: findings / actions。Severity は本スキルの metadata 既定値（`major`）を上限とし、root cause を伴わないものは `info` に下げる。

--- a/skills/midstream/agent-code-quality/SKILL.md
+++ b/skills/midstream/agent-code-quality/SKILL.md
@@ -25,6 +25,22 @@ outputKind:
 modelHint: balanced
 ---
 
+## Pattern declaration
+
+Primary pattern: Reviewer
+Secondary patterns: Inversion
+Why: 可読性と保守性を中心に、コード品質の基本的な劣化を検知する。
+
+## Goal / 目的
+
+- 可読性と保守性を中心に、コード品質の基本的な劣化を検知する。
+- 既存の方針に沿った差分は追加コストなく通し、領域固有の高シグナル指摘のみ返す。
+
+## Pre-execution Gate / 実行前ゲート
+
+- 差分が `src/**/*` / `app/**/*` / `lib/**/*` / `packages/**/*` の TS/JS いずれか に該当する場合のみ起動する。
+- 差分がドキュメント/フィクスチャのみで本スキルの対象範囲外の場合は `NO_REVIEW: agent-code-quality — 対象差分なし` を返す。
+
 ## Guidance
 
 - Check names and boundaries keep responsibilities clear; flatten deep nesting with guard clauses.
@@ -39,3 +55,17 @@ modelHint: balanced
 ## False-positive guards
 
 - フォーマット変更や既に周辺と一貫している命名の場合は黙る。
+
+## Output / 出力例
+
+```yaml
+findings:
+  - severity: minor
+    file: <対象ファイル>
+    line: <行番号>
+    issue: <Goal で述べた観点に該当する問題の 1 文要約>
+    suggestion: <次の最小一手>
+actions: []
+```
+
+出力種別: findings / actions。Severity は本スキルの metadata 既定値（`minor`）を上限とし、root cause を伴わないものは `info` に下げる。

--- a/skills/midstream/agent-code-refactoring/SKILL.md
+++ b/skills/midstream/agent-code-refactoring/SKILL.md
@@ -28,6 +28,22 @@ dependencies:
   - code_search
 ---
 
+## Pattern declaration
+
+Primary pattern: Reviewer
+Secondary patterns: Inversion
+Why: 挙動を変えずに設計を整えるためのリファクタリング手順をガイドする。
+
+## Goal / 目的
+
+- 挙動を変えずに設計を整えるためのリファクタリング手順をガイドする。
+- 既存の方針に沿った差分は追加コストなく通し、領域固有の高シグナル指摘のみ返す。
+
+## Pre-execution Gate / 実行前ゲート
+
+- 差分が `src/**/*` / `app/**/*` / `lib/**/*` / `packages/**/*` の TS/JS いずれか に該当する場合のみ起動する。
+- 差分がドキュメント/フィクスチャのみで本スキルの対象範囲外の場合は `NO_REVIEW: agent-code-refactoring — 対象差分なし` を返す。
+
 ## Guidance
 
 - Plan safety nets (tests/smoke) before refactors; keep steps small and reversible.
@@ -42,3 +58,17 @@ dependencies:
 ## False-positive guards
 
 - 一時的コードや短命な実験ならコストに見合う最小の提案にとどめる。
+
+## Output / 出力例
+
+```yaml
+findings:
+  - severity: minor
+    file: <対象ファイル>
+    line: <行番号>
+    issue: <Goal で述べた観点に該当する問題の 1 文要約>
+    suggestion: <次の最小一手>
+actions: []
+```
+
+出力種別: actions / findings。Severity は本スキルの metadata 既定値（`minor`）を上限とし、root cause を伴わないものは `info` に下げる。

--- a/skills/midstream/agent-code-review/SKILL.md
+++ b/skills/midstream/agent-code-review/SKILL.md
@@ -27,6 +27,22 @@ outputKind:
 modelHint: balanced
 ---
 
+## Pattern declaration
+
+Primary pattern: Reviewer
+Secondary patterns: Inversion
+Why: PR 向けの自動コードレビュー。セキュリティ・性能・品質・テスト観点で差分を評価する。
+
+## Goal / 目的
+
+- PR 向けの自動コードレビュー。セキュリティ・性能・品質・テスト観点で差分を評価する。
+- 既存の方針に沿った差分は追加コストなく通し、領域固有の高シグナル指摘のみ返す。
+
+## Pre-execution Gate / 実行前ゲート
+
+- 差分が `src/**/*` / `app/**/*` / `lib/**/*` / `packages/**/*` の TS/JS いずれか に該当する場合のみ起動する。
+- 差分がドキュメント/フィクスチャのみで本スキルの対象範囲外の場合は `NO_REVIEW: agent-code-review — 対象差分なし` を返す。
+
 ## Guidance
 
 - Scan the diff for security risks (injection/auth), performance hotspots, and risky coupling.
@@ -85,3 +101,17 @@ modelHint: balanced
 - `O(n*m)`パターン、ループ内のDB/APIコール → performance
 - `any`型、型アサーション(`as`)、未使用import → quality
 - 新規export関数にテストファイル内の対応する`describe`/`test`がない → testing
+
+## Output / 出力例
+
+```yaml
+findings:
+  - severity: major
+    file: <対象ファイル>
+    line: <行番号>
+    issue: <Goal で述べた観点に該当する問題の 1 文要約>
+    suggestion: <次の最小一手>
+actions: []
+```
+
+出力種別: findings / actions。Severity は本スキルの metadata 既定値（`major`）を上限とし、root cause を伴わないものは `info` に下げる。

--- a/skills/midstream/agent-test-coverage/SKILL.md
+++ b/skills/midstream/agent-test-coverage/SKILL.md
@@ -26,6 +26,22 @@ dependencies:
   - code_search
 ---
 
+## Pattern declaration
+
+Primary pattern: Reviewer
+Secondary patterns: Inversion
+Why: 変更に対するテスト不足を検知し、最低限の補完方針を提示する。
+
+## Goal / 目的
+
+- 変更に対するテスト不足を検知し、最低限の補完方針を提示する。
+- 既存の方針に沿った差分は追加コストなく通し、領域固有の高シグナル指摘のみ返す。
+
+## Pre-execution Gate / 実行前ゲート
+
+- 差分が `src/**/*` / `app/**/*` の TS/JS、または `tests/**/*` の対応テストいずれか に該当する場合のみ起動する。
+- 差分がドキュメント/フィクスチャのみで本スキルの対象範囲外の場合は `NO_REVIEW: agent-test-coverage — 対象差分なし` を返す。
+
 ## Guidance
 
 - Summarize behaviour changes and check matching unit/e2e tests exist.
@@ -40,3 +56,17 @@ dependencies:
 ## False-positive guards
 
 - 既存テストが同じ経路をカバーしていると確認できる場合は指摘しない。
+
+## Output / 出力例
+
+```yaml
+findings:
+  - severity: major
+    file: <対象ファイル>
+    line: <行番号>
+    issue: <Goal で述べた観点に該当する問題の 1 文要約>
+    suggestion: <次の最小一手>
+actions: []
+```
+
+出力種別: actions / findings。Severity は本スキルの metadata 既定値（`major`）を上限とし、root cause を伴わないものは `info` に下げる。

--- a/skills/upstream/agent-architecture-review/SKILL.md
+++ b/skills/upstream/agent-architecture-review/SKILL.md
@@ -24,6 +24,22 @@ outputKind:
 modelHint: balanced
 ---
 
+## Pattern declaration
+
+Primary pattern: Reviewer
+Secondary patterns: Inversion
+Why: 変更の全体設計、責務分離、境界の破綻を検知するためのレビュー手順。
+
+## Goal / 目的
+
+- 変更の全体設計、責務分離、境界の破綻を検知するためのレビュー手順。
+- 既存の方針に沿った差分は追加コストなく通し、領域固有の高シグナル指摘のみ返す。
+
+## Pre-execution Gate / 実行前ゲート
+
+- 差分が `docs/architecture/**/*.md` / `docs/adr/**/*` / `pages/**/*architecture*.md` / `**/*.adr` のいずれか に該当する場合のみ起動する。
+- 差分がドキュメント/フィクスチャのみで本スキルの対象範囲外の場合は `NO_REVIEW: agent-architecture-review — 対象差分なし` を返す。
+
 ## Guidance
 
 - Summarize impacted components and boundaries; flag unclear responsibilities or new cycles.
@@ -38,3 +54,17 @@ modelHint: balanced
 ## False-positive guards
 
 - 既存ガイドラインに沿った小変更や差分外で根拠が示されている場合は指摘しない。
+
+## Output / 出力例
+
+```yaml
+findings:
+  - severity: major
+    file: <対象ファイル>
+    line: <行番号>
+    issue: <Goal で述べた観点に該当する問題の 1 文要約>
+    suggestion: <次の最小一手>
+actions: []
+```
+
+出力種別: findings / actions。Severity は本スキルの metadata 既定値（`major`）を上限とし、root cause を伴わないものは `info` に下げる。

--- a/skills/upstream/agent-code-documentation/SKILL.md
+++ b/skills/upstream/agent-code-documentation/SKILL.md
@@ -25,6 +25,22 @@ dependencies:
   - code_search
 ---
 
+## Pattern declaration
+
+Primary pattern: Reviewer
+Secondary patterns: Inversion
+Why: コードや API の意図を短時間で共有できるドキュメントの書き方をガイドする。
+
+## Goal / 目的
+
+- コードや API の意図を短時間で共有できるドキュメントの書き方をガイドする。
+- 既存の方針に沿った差分は追加コストなく通し、領域固有の高シグナル指摘のみ返す。
+
+## Pre-execution Gate / 実行前ゲート
+
+- 差分が `docs/**/*` / `pages/**/*` / `README*.md` のいずれか に該当する場合のみ起動する。
+- 差分がドキュメント/フィクスチャのみで本スキルの対象範囲外の場合は `NO_REVIEW: agent-code-documentation — 対象差分なし` を返す。
+
 ## Guidance
 
 - Clarify audience and purpose first; provide runnable quickstart/usage with dummy secrets.
@@ -39,3 +55,17 @@ dependencies:
 ## False-positive guards
 
 - 既に最新の README/ドキュメントで目的と手順が明確な場合は指摘しない。
+
+## Output / 出力例
+
+```yaml
+findings:
+  - severity: minor
+    file: <対象ファイル>
+    line: <行番号>
+    issue: <Goal で述べた観点に該当する問題の 1 文要約>
+    suggestion: <次の最小一手>
+actions: []
+```
+
+出力種別: actions / findings。Severity は本スキルの metadata 既定値（`minor`）を上限とし、root cause を伴わないものは `info` に下げる。


### PR DESCRIPTION
Multi-axis skill audit (Phase 1) flagged 9 `agent-*` SKILL.md files missing canonical sections.

## Sections added (per skill)

- `## Pattern declaration` — Primary / Secondary patterns + Why (derived from `description`)
- `## Goal / 目的` — 1-2 line summary + a generic high-signal-only line
- `## Pre-execution Gate / 実行前ゲート` — `NO_REVIEW` fallback whose hint mirrors the skill's `applyTo`
- `## Output / 出力例` — `yaml` finding template using the skill's declared `severity` and `outputKind`

## Files (9)

- `skills/upstream/agent-architecture-review`
- `skills/upstream/agent-code-documentation`
- `skills/midstream/agent-agentcheck-code-review`
- `skills/midstream/agent-code-quality`
- `skills/midstream/agent-code-refactoring`
- `skills/midstream/agent-code-review`
- `skills/midstream/agent-test-coverage`
- `skills/downstream/agent-qa-regression`
- `skills/downstream/agent-webapp-testing`

## Behavioral note

The new sections describe what the skill **already** does according to its frontmatter. No changes to `applyTo` / `inputContext` / `dependencies` / `severity` / `outputKind`. Pre-execution Gate text is a `NO_REVIEW` fallback that mirrors `applyTo` semantics, not a stricter filter.

## Test plan

- [x] `npm run skills:validate` — all 83 skills ✅
- [x] `node --test tests/planner-dataset-eval.test.mjs` — 3/3 pass
- [x] `npm run lint` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)