### PR TITLE
feat(eval): add planner-dataset coverage batch 3 (5 more never-selected skills)

### DIFF
--- a/tests/fixtures/planner-dataset/cases.json
+++ b/tests/fixtures/planner-dataset/cases.json
@@ -247,5 +247,44 @@
     "availableContexts": ["diff", "adr"],
     "availableDependencies": ["adr_lookup", "repo_metadata"],
     "expectedAny": ["rr-upstream-architecture-traceability-001"]
+  },
+  {
+    "name": "coverage: plangate plan integrity (batch 3)",
+    "phase": "upstream",
+    "diffFile": "diffs/upstream-plangate-plan-integrity.diff",
+    "availableContexts": ["diff", "fullFile"],
+    "expectedAny": ["rr-upstream-plangate-plan-integrity-001"]
+  },
+  {
+    "name": "coverage: API versioning compatibility (batch 3)",
+    "phase": "upstream",
+    "diffFile": "diffs/upstream-api-versioning-compat.diff",
+    "availableContexts": ["diff", "fullFile", "adr"],
+    "availableDependencies": ["repo_metadata"],
+    "expectedAny": ["rr-upstream-api-versioning-compat-001"]
+  },
+  {
+    "name": "coverage: DR multi-region design (batch 3)",
+    "phase": "upstream",
+    "diffFile": "diffs/upstream-dr-multiregion.diff",
+    "availableContexts": ["diff", "adr"],
+    "availableDependencies": ["repo_metadata"],
+    "expectedAny": ["rr-upstream-dr-multiregion-001"]
+  },
+  {
+    "name": "coverage: integration contracts (batch 3)",
+    "phase": "upstream",
+    "diffFile": "diffs/upstream-integration-contracts.diff",
+    "availableContexts": ["diff", "fullFile", "adr"],
+    "availableDependencies": ["repo_metadata"],
+    "expectedAny": ["rr-upstream-integration-contracts-001"]
+  },
+  {
+    "name": "coverage: midstream logic torturing / adversarial (batch 3)",
+    "phase": "midstream",
+    "diffFile": "diffs/midstream-logic-torturing.diff",
+    "availableContexts": ["diff", "fullFile", "commitMessage", "adr"],
+    "availableDependencies": ["code_search", "repo_metadata"],
+    "expectedAny": ["rr-midstream-logic-torturing-001"]
   }
 ]

--- a/tests/fixtures/planner-dataset/diffs/midstream-logic-torturing.diff
+++ b/tests/fixtures/planner-dataset/diffs/midstream-logic-torturing.diff
@@ -1,0 +1,37 @@
+diff --git a/src/lib/checkout-pricing.ts b/src/lib/checkout-pricing.ts
+index 1111111..2222222 100644
+--- a/src/lib/checkout-pricing.ts
++++ b/src/lib/checkout-pricing.ts
+@@ -3,12 +3,28 @@ import { Cart, Coupon, User } from './types';
+ export function computeFinalPrice(cart: Cart, coupon: Coupon | null, user: User): number {
+   const subtotal = cart.items.reduce((acc, it) => acc + it.price * it.qty, 0);
+
+-  if (coupon) {
+-    return subtotal - coupon.discountAmount;
++  if (coupon && coupon.isActive) {
++    if (coupon.type === 'percent') {
++      return subtotal * (1 - coupon.value / 100);
++    }
++    if (coupon.type === 'fixed') {
++      return Math.max(0, subtotal - coupon.value);
++    }
+   }
+
+   if (user.isVip) {
+-    return subtotal * 0.9;
++    return subtotal * 0.9;
++  }
++
++  return subtotal;
++}
++
++export function applyTax(price: number, country: string): number {
++  if (country === 'JP') return price * 1.1;
++  if (country === 'US') return price; // US handles tax at next step
++  if (country) {
++    return price * 1.2; // EU default
+   }
+
+-  return subtotal;
++  return price;
+ }

--- a/tests/fixtures/planner-dataset/diffs/upstream-api-versioning-compat.diff
+++ b/tests/fixtures/planner-dataset/diffs/upstream-api-versioning-compat.diff
@@ -1,0 +1,23 @@
+diff --git a/docs/api/orders-v2-contract.md b/docs/api/orders-v2-contract.md
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/docs/api/orders-v2-contract.md
+@@ -0,0 +1,18 @@
++# Orders API v2 contract
++
++## Breaking changes from v1
++
++- `POST /orders` now requires `idempotencyKey` (was optional).
++- Response envelope renamed `data` → `result`.
++- Removed deprecated `cancellationReason` field.
++
++## Versioning policy
++
++v1 will be sunset 90 days after v2 GA. Clients must send `Accept: application/vnd.acme.orders.v2+json`.
++
++## Compatibility considerations
++
++- v1 callers receive `406 Not Acceptable` if they request v2 without the header.
++- The deprecated `cancellationReason` is mirrored under `metadata.legacy_cancellation_reason` for one minor version only.
++- SDK auto-upgrade flag must default to `false` to avoid silent client behavior changes.

--- a/tests/fixtures/planner-dataset/diffs/upstream-dr-multiregion.diff
+++ b/tests/fixtures/planner-dataset/diffs/upstream-dr-multiregion.diff
@@ -1,0 +1,26 @@
+diff --git a/docs/architecture/order-dr-multi-region.md b/docs/architecture/order-dr-multi-region.md
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/docs/architecture/order-dr-multi-region.md
+@@ -0,0 +1,20 @@
++# Order context: multi-region disaster recovery
++
++## Active region topology
++
++Primary: ap-northeast-1 (tokyo). Secondary: us-east-1 (warm standby).
++
++## RPO / RTO targets
++
++- RPO: 30 seconds (cross-region replication for orders DB)
++- RTO: 5 minutes (DNS failover + warm-pool scale-out)
++
++## Failover triggers
++
++- p99 latency > 2s for 3 consecutive minutes
++- Health check fail rate > 50% in primary region
++
++## Open questions
++
++- Does the inventory context need RPO/RTO matched to orders, or can it tolerate weaker SLOs?
++- Where is the runbook? Is the on-call team trained on it?

--- a/tests/fixtures/planner-dataset/diffs/upstream-integration-contracts.diff
+++ b/tests/fixtures/planner-dataset/diffs/upstream-integration-contracts.diff
@@ -1,0 +1,24 @@
+diff --git a/docs/integration/payment-provider-contract.md b/docs/integration/payment-provider-contract.md
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/docs/integration/payment-provider-contract.md
+@@ -0,0 +1,18 @@
++# Payment provider integration contract
++
++## Inbound: webhook
++
++- `POST /webhooks/payment-provider`
++- HMAC-SHA256 signature in `X-Provider-Signature`
++- Retries up to 5x with exponential backoff
++
++## Outbound: charge API
++
++- `POST <provider>/v1/charges` with idempotency key
++- 30s timeout, no retry on 4xx, retry on 5xx with jitter
++
++## Ownership
++
++- Provider-side schema: vendor managed, version pinned in `payment-provider.openapi.yaml`
++- Inbound webhook payload: must validate against `webhook-payment.schema.json` before persisting
++- Failed validation increments `webhook_validation_failures{type="payment"}` and drops to DLQ

--- a/tests/fixtures/planner-dataset/diffs/upstream-plangate-plan-integrity.diff
+++ b/tests/fixtures/planner-dataset/diffs/upstream-plangate-plan-integrity.diff
@@ -1,0 +1,38 @@
+diff --git a/docs/plangate/sample/plan.md b/docs/plangate/sample/plan.md
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/docs/plangate/sample/plan.md
+@@ -0,0 +1,18 @@
++# Plan
++
++## Goal
++
++Reduce checkout latency from p95=420ms to p95<200ms.
++
++## Steps
++
++1. Add Redis cache for session lookup (Step 1).
++2. Convert sync DB calls in `OrderService.place` to parallel (Step 2).
++3. Move PII redaction to background queue (Step 3).
++
++## Acceptance criteria
++
++- p95 < 200ms over 24h sample
++- error rate unchanged
++
++## Open questions
++
++- Does Step 3 affect downstream audit pipelines?
+diff --git a/docs/plangate/sample/todo.md b/docs/plangate/sample/todo.md
+new file mode 100644
+index 0000000..2222222
+--- /dev/null
++++ b/docs/plangate/sample/todo.md
+@@ -0,0 +1,6 @@
++# TODO
++
++- [ ] Step 1: Redis cache wired in
++- [ ] Step 2: parallel calls in OrderService.place
++- [ ] (Step 3 not in TODO — drift)
++- [ ] Step 4: emit metrics (not in plan — drift)


### PR DESCRIPTION
Multi-axis audit follow-up batch 3.

## Cases added (5)

| skill | diff | applyTo match |
|---|---|---|
| `rr-upstream-plangate-plan-integrity-001` | `docs/plangate/sample/{plan,todo}.md` | plan/todo files (drift detection target) |
| `rr-upstream-api-versioning-compat-001` | `docs/api/orders-v2-contract.md` | api/contract md |
| `rr-upstream-dr-multiregion-001` | `docs/architecture/order-dr-multi-region.md` | dr/multi-region md |
| `rr-upstream-integration-contracts-001` | `docs/integration/payment-provider-contract.md` | integration md |
| `rr-midstream-logic-torturing-001` | `src/lib/checkout-pricing.ts` | source ts with branch logic |

## Validation

- [x] `npm run planner:eval:dataset`: **33 cases** (was 28), coverage=1.0, top1Match=1.0
- [x] `node --test tests/planner-dataset-eval.test.mjs` 3/3 pass
- [ ] CI green

## Audit progression

- never-selected planner-loadable skills: **30 → 24 → 19** (batch 1+2+3)
- planner-dataset cases: **23 → 28 → 33**

## Out of scope (deferred)

19 remaining never-selected (architecture-* family / availability / capacity-cost / change-comm / data-flow / failure-modes-observability / multitenancy-isolation / operability-slo / trust-boundaries / etc.) — each requires a custom diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)