### PR TITLE
chore(skills): reclassify rr-midstream-normalization-consistency-001 major→minor (rubric)

### DIFF
--- a/skills/midstream/rr-midstream-normalization-consistency-001/SKILL.md
+++ b/skills/midstream/rr-midstream-normalization-consistency-001/SKILL.md
@@ -15,7 +15,7 @@ tags:
   - normalization
   - formatting
   - midstream
-severity: major
+severity: minor
 inputContext:
   - diff
   - fullFile


### PR DESCRIPTION
First severity reclassification under [`docs/development/skill-severity-rubric.md`](https://github.com/s977043/river-reviewer/blob/main/docs/development/skill-severity-rubric.md) (#775).

## Reclassification

| skill | from | to |
|---|---|---|
| `rr-midstream-normalization-consistency-001` | `major` | `minor` |

## Rationale (3 lines per rubric rule)

1. **Worst-case finding match**: The skill detects normalization / formatting drift (ID format, date display, monetary amounts, enum labels) — exactly the rubric `minor` criterion ("naming, formatting, dead code, 軽微な inconsistency").
2. **HIGH_SEVERITY guard**: minor is not gated, so reviewers can use guard fixtures for false-positives without needing `accepted_risk`.
3. **Neighbor calibration**: `rr-midstream-typescript-strict-001` (major) detects type unsafety which is functionally riskier; dropping normalization to minor preserves the relative severity ordering.

## Eval evidence

| metric | before | after |
|---|---|---|
| cases | 33 | 33 |
| coverage | 1.0 | 1.0 |
| top1Match | 1.0 | 1.0 |
| top1MatchCases | 13 | 13 |

(severity does not affect planner ranking — change is metadata-only)

## Test plan

- [x] `npm run planner:eval:dataset` — no regression
- [x] `node --test tests/planner-dataset-eval.test.mjs` — 3/3 pass
- [x] `npm run skills:validate` — ✅
- [x] `npm run lint` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)