### PR TITLE
feat(eval): add planner-dataset coverage batch 4 (5 more never-selected skills)

### DIFF
--- a/tests/fixtures/planner-dataset/cases.json
+++ b/tests/fixtures/planner-dataset/cases.json
@@ -286,5 +286,41 @@
     "availableContexts": ["diff", "fullFile", "commitMessage", "adr"],
     "availableDependencies": ["code_search", "repo_metadata"],
     "expectedAny": ["rr-midstream-logic-torturing-001"]
+  },
+  {
+    "name": "coverage: plangate rule promotion from retrospective (batch 4)",
+    "phase": "upstream",
+    "diffFile": "diffs/upstream-plangate-rule-promotion.diff",
+    "availableContexts": ["fullFile", "repoConfig"],
+    "expectedAny": ["rr-upstream-plangate-rule-promotion-001"]
+  },
+  {
+    "name": "coverage: plangate verification audit (batch 4)",
+    "phase": "upstream",
+    "diffFile": "diffs/upstream-plangate-verification-audit.diff",
+    "availableContexts": ["diff", "fullFile"],
+    "expectedAny": ["rr-upstream-plangate-verification-audit-001"]
+  },
+  {
+    "name": "coverage: midstream config json/yaml/yml (batch 4)",
+    "phase": "midstream",
+    "diffFile": "diffs/midstream-config-json.diff",
+    "availableContexts": ["diff"],
+    "expectedAny": ["rr-midstream-config-json-001"]
+  },
+  {
+    "name": "coverage: midstream i18n unused key (batch 4)",
+    "phase": "midstream",
+    "diffFile": "diffs/midstream-i18n-unused-key.diff",
+    "availableContexts": ["diff", "fullFile"],
+    "availableDependencies": ["code_search"],
+    "expectedAny": ["rr-midstream-i18n-unused-key-001"]
+  },
+  {
+    "name": "coverage: midstream agent-skill-bridge (batch 4)",
+    "phase": "midstream",
+    "diffFile": "diffs/midstream-agent-skill-bridge.diff",
+    "availableContexts": ["diff"],
+    "expectedAny": ["rr-midstream-agent-skill-bridge-001"]
   }
 ]

--- a/tests/fixtures/planner-dataset/diffs/midstream-agent-skill-bridge.diff
+++ b/tests/fixtures/planner-dataset/diffs/midstream-agent-skill-bridge.diff
@@ -1,0 +1,17 @@
+diff --git a/src/lib/agent-skill-bridge.mjs b/src/lib/agent-skill-bridge.mjs
+index 1111111..2222222 100644
+--- a/src/lib/agent-skill-bridge.mjs
++++ b/src/lib/agent-skill-bridge.mjs
+@@ -10,7 +10,11 @@ export function loadAgentSkill(path) {
+   const raw = fs.readFileSync(path, 'utf8');
+   const fm = parseFrontmatter(raw);
+   if (!fm) {
+-    throw new Error(`No frontmatter in ${path}`);
++    return null;
+   }
+   return { metadata: fm, body: raw };
+ }
++
++export function listAgentSkills(dir) {
++  return fs.readdirSync(dir).filter((f) => f.endsWith('.md'));
++}

--- a/tests/fixtures/planner-dataset/diffs/midstream-config-json.diff
+++ b/tests/fixtures/planner-dataset/diffs/midstream-config-json.diff
@@ -1,0 +1,19 @@
+diff --git a/config/feature-flags.json b/config/feature-flags.json
+index 1111111..2222222 100644
+--- a/config/feature-flags.json
++++ b/config/feature-flags.json
+@@ -1,8 +1,12 @@
+ {
+   "features": {
+     "newCheckoutFlow": {
+-      "enabled": false
++      "enabled": true,
++      "rolloutPercent": 25
++    },
++    "experimentalRedisCache": {
++      "enabled": true
+     }
+   },
+-  "version": "1.2.0"
++  "version": "1.3.0"
+ }

--- a/tests/fixtures/planner-dataset/diffs/midstream-i18n-unused-key.diff
+++ b/tests/fixtures/planner-dataset/diffs/midstream-i18n-unused-key.diff
@@ -1,0 +1,28 @@
+diff --git a/src/i18n/keys.ts b/src/i18n/keys.ts
+index 1111111..2222222 100644
+--- a/src/i18n/keys.ts
++++ b/src/i18n/keys.ts
+@@ -3,8 +3,7 @@ export const messageKeys = {
+   common: {
+     confirm: 'common.confirm',
+     cancel: 'common.cancel',
+-    welcome: 'common.welcome',
+-    legacyHelp: 'common.legacyHelp',
++    welcome: 'common.welcome'
+   },
+   checkout: {
+     placeOrder: 'checkout.placeOrder',
+diff --git a/locales/en.json b/locales/en.json
+index 1111111..2222222 100644
+--- a/locales/en.json
++++ b/locales/en.json
+@@ -3,8 +3,7 @@
+     "confirm": "Confirm",
+     "cancel": "Cancel",
+     "welcome": "Welcome",
+-    "legacyHelp": "Need help? Click the help icon.",
+-    "deprecatedFooter": "Old footer text"
++    "welcome2": "Welcome v2"
+   },
+   "checkout": {
+     "placeOrder": "Place order"

--- a/tests/fixtures/planner-dataset/diffs/upstream-plangate-rule-promotion.diff
+++ b/tests/fixtures/planner-dataset/diffs/upstream-plangate-rule-promotion.diff
@@ -1,0 +1,22 @@
+diff --git a/docs/retrospective.md b/docs/retrospective.md
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/docs/retrospective.md
+@@ -0,0 +1,16 @@
++# Retrospective: orders checkout latency reduction
++
++## What worked
++
++- Redis cache wiring landed without regression.
++- Parallel DB calls cut p95 latency by 38%.
++
++## What needs improvement
++
++- 3 minor findings repeated across PRs (same auth check pattern). Should
++  promote the rule into the skill body, not rely on PR-by-PR catches.
++
++## Recommendations
++
++- Add a guard fixture for the duplicated auth-check pattern.
++- Promote the "verify session before write" rule into the security skill.

--- a/tests/fixtures/planner-dataset/diffs/upstream-plangate-verification-audit.diff
+++ b/tests/fixtures/planner-dataset/diffs/upstream-plangate-verification-audit.diff
@@ -1,0 +1,18 @@
+diff --git a/artifacts/sample/review-self.md b/artifacts/sample/review-self.md
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/artifacts/sample/review-self.md
+@@ -0,0 +1,12 @@
++# Self review (sample for verify audit)
++
++## Findings
++
++- src/api/auth.ts:42 hardcoded token (Severity: major, Confidence: high)
++- src/lib/cache.ts:18 missing TTL on Redis set (Severity: minor, Confidence: medium)
++
++## Coverage check
++
++- All planned skills ran.
++- 1 finding lacks `Evidence:` line (auth.ts:42 — only "see line" reference).
++- 1 finding restates the rule rather than the diff impact.


### PR DESCRIPTION
Multi-axis audit follow-up batch 4. Adds 5 cases bringing previously never-selected skills into measurable routing coverage.

## Cases added (5)

| skill | diff |
|---|---|
| `rr-upstream-plangate-rule-promotion-001` | `docs/retrospective.md` (strict applyTo: `**/retrospective.md`) |
| `rr-upstream-plangate-verification-audit-001` | `artifacts/sample/review-self.md` |
| `rr-midstream-config-json-001` | `config/feature-flags.json` |
| `rr-midstream-i18n-unused-key-001` | `src/i18n/keys.ts` + `locales/en.json` |
| `rr-midstream-agent-skill-bridge-001` | `src/lib/agent-skill-bridge.mjs` |

## Validation

- [x] `npm run planner:eval:dataset`: **38 cases** (was 33), coverage=1.0, top1Match=1.0
- [x] `node --test tests/planner-dataset-eval.test.mjs` 3/3 pass
- [ ] CI green

## Audit progression

- never-selected planner-loadable skills: **30 → 24 → 19 → 14**
- planner-dataset cases: **23 → 28 → 33 → 38**

🤖 Generated with [Claude Code](https://claude.com/claude-code)