### PR TITLE
feat(eval): add planner-dataset coverage batch 5 + clarify agent-tag exclusion

### DIFF
--- a/tests/fixtures/planner-dataset/cases.json
+++ b/tests/fixtures/planner-dataset/cases.json
@@ -178,7 +178,7 @@
     "expectedAny": ["rr-upstream-api-design-001", "rr-upstream-failure-modes-observability-001"]
   },
   {
-    "name": "routing: architecture intent (bounded context boundaries) — Epic #743 / #746",
+    "name": "routing: architecture intent (bounded context boundaries) \u2014 Epic #743 / #746",
     "phase": "upstream",
     "diffFile": "diffs/upstream-architecture-bounded-context.diff",
     "availableContexts": ["diff", "adr"],
@@ -187,7 +187,7 @@
     "expectedTop1": ["rr-upstream-architecture-boundaries-001"]
   },
   {
-    "name": "routing: pre-mortem / adversarial design intent — Epic #743 / #746",
+    "name": "routing: pre-mortem / adversarial design intent \u2014 Epic #743 / #746",
     "phase": "upstream",
     "diffFile": "diffs/upstream-design-pre-mortem.diff",
     "availableContexts": ["diff", "adr", "fullFile", "commitMessage"],
@@ -200,7 +200,7 @@
     ]
   },
   {
-    "name": "routing: multi-skill (security + observability) — Epic #743 / #746",
+    "name": "routing: multi-skill (security + observability) \u2014 Epic #743 / #746",
     "phase": "midstream",
     "diffFile": "diffs/midstream-security-and-observability.diff",
     "availableContexts": ["diff", "fullFile"],
@@ -322,5 +322,27 @@
     "diffFile": "diffs/midstream-agent-skill-bridge.diff",
     "availableContexts": ["diff"],
     "expectedAny": ["rr-midstream-agent-skill-bridge-001"]
+  },
+  {
+    "name": "coverage: upstream create-plan (batch 5)",
+    "phase": "upstream",
+    "diffFile": "diffs/upstream-create-plan.diff",
+    "availableContexts": ["diff", "repoConfig"],
+    "expectedAny": ["rr-upstream-create-plan-001"]
+  },
+  {
+    "name": "coverage: plangate GC deterministic (batch 5)",
+    "phase": "upstream",
+    "diffFile": "diffs/upstream-plangate-gc-deterministic.diff",
+    "availableContexts": ["repoConfig", "fullFile"],
+    "expectedAny": ["rr-upstream-plangate-gc-deterministic-001"]
+  },
+  {
+    "name": "coverage: downstream test plan review (batch 5)",
+    "phase": "downstream",
+    "diffFile": "diffs/downstream-test-plan-review.diff",
+    "availableContexts": ["diff", "tests"],
+    "availableDependencies": ["test_runner", "code_search"],
+    "expectedAny": ["rr-downstream-test-plan-review-001"]
   }
 ]

--- a/tests/fixtures/planner-dataset/diffs/downstream-test-plan-review.diff
+++ b/tests/fixtures/planner-dataset/diffs/downstream-test-plan-review.diff
@@ -1,0 +1,35 @@
+diff --git a/tests/checkout-pricing.test.ts b/tests/checkout-pricing.test.ts
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/tests/checkout-pricing.test.ts
+@@ -0,0 +1,18 @@
++import { describe, it, expect } from 'vitest';
++import { computeFinalPrice } from '../src/lib/checkout-pricing';
++
++describe('computeFinalPrice', () => {
++  it('applies percent coupon correctly', () => {
++    const cart = { items: [{ price: 1000, qty: 2 }] };
++    const coupon = { type: 'percent', value: 10, isActive: true };
++    expect(computeFinalPrice(cart, coupon, { isVip: false })).toBe(1800);
++  });
++
++  it('falls back to subtotal when coupon is inactive', () => {
++    const cart = { items: [{ price: 500, qty: 1 }] };
++    const coupon = { type: 'percent', value: 50, isActive: false };
++    expect(computeFinalPrice(cart, coupon, { isVip: false })).toBe(500);
++  });
++
++  // TODO: edge cases — VIP + active coupon overlap, fixed type, zero qty
++});
+diff --git a/src/lib/checkout-pricing.ts b/src/lib/checkout-pricing.ts
+index 1111111..2222222 100644
+--- a/src/lib/checkout-pricing.ts
++++ b/src/lib/checkout-pricing.ts
+@@ -1,5 +1,5 @@
+ import { Cart, Coupon, User } from './types';
+
+ export function computeFinalPrice(cart: Cart, coupon: Coupon | null, user: User): number {
+-  return 0;
++  return cart.items.reduce((acc, it) => acc + it.price * it.qty, 0);
+ }

--- a/tests/fixtures/planner-dataset/diffs/upstream-create-plan.diff
+++ b/tests/fixtures/planner-dataset/diffs/upstream-create-plan.diff
@@ -1,0 +1,22 @@
+diff --git a/docs/plan/2026-checkout-latency-cut.md b/docs/plan/2026-checkout-latency-cut.md
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/docs/plan/2026-checkout-latency-cut.md
+@@ -0,0 +1,16 @@
++# Plan: cut checkout latency
++
++## Goal
++
++Reduce p95 latency from 420ms to <200ms.
++
++## Steps
++
++1. Wire Redis cache for session lookup.
++2. Parallelize OrderService.place DB calls.
++3. Move PII redaction to background queue.
++
++## Risks
++
++- Redis outage compounds checkout failure.
++- Step 3 may break audit pipeline.

--- a/tests/fixtures/planner-dataset/diffs/upstream-plangate-gc-deterministic.diff
+++ b/tests/fixtures/planner-dataset/diffs/upstream-plangate-gc-deterministic.diff
@@ -1,0 +1,11 @@
+diff --git a/.river/memory/suppressions.jsonl b/.river/memory/suppressions.jsonl
+index 1111111..2222222 100644
+--- a/.river/memory/suppressions.jsonl
++++ b/.river/memory/suppressions.jsonl
+@@ -1,3 +1,5 @@
+ {"type":"suppression","fingerprint":"a1b2c3d4e5f60718","feedbackType":"accepted_risk","rationale":"legacy adapter, fire-and-forget metrics","createdAt":"2026-01-15T00:00:00Z"}
+ {"type":"suppression","fingerprint":"f0e1d2c3b4a59687","feedbackType":"false_positive","rationale":"test fixture password","createdAt":"2026-02-20T00:00:00Z","scope":"file","files":["tests/auth.test.ts"]}
+-{"type":"suppression","fingerprint":"9876543210abcdef","feedbackType":"wont_fix","rationale":"low priority","createdAt":"2025-09-10T00:00:00Z"}
++{"type":"suppression","fingerprint":"9876543210abcdef","feedbackType":"wont_fix","rationale":"low priority","createdAt":"2025-09-10T00:00:00Z","expiresAt":"2026-12-31T00:00:00Z"}
++{"type":"suppression","fingerprint":"deadbeefcafe0123","feedbackType":"accepted_risk","rationale":"compliance review pending","createdAt":"2026-05-01T00:00:00Z"}
++{"type":"suppression","fingerprint":"abcdef0123456789","feedbackType":"duplicate","duplicateOfFingerprint":"a1b2c3d4e5f60718","createdAt":"2026-05-07T00:00:00Z"}


### PR DESCRIPTION
Multi-axis audit follow-up batch 5 — final batch for non-agent skills.

## Discovery during audit

The previous "never-selected 14 skills" count included 9 `agent-*` skills that are intentionally excluded by `loadSkills()` via the default `excludedTags: ['agent']` filter (`runners/core/skill-loader.mjs:374`). These skills are NOT planner-loadable by design — they belong to a separate agent orchestration layer, not the workflow review pipeline.

The actual never-selected **planner-loadable** skills after batch 4 were 5, not 14. This batch covers 3 of those 5.

## Cases added (3)

| skill | diff |
|---|---|
| `rr-upstream-create-plan-001` | `docs/plan/2026-checkout-latency-cut.md` |
| `rr-upstream-plangate-gc-deterministic-001` | `.river/memory/suppressions.jsonl` (GC reasoning) |
| `rr-downstream-test-plan-review-001` | `tests/checkout-pricing.test.ts` |

## Validation

- [x] `npm run planner:eval:dataset`: **41 cases** (was 38), coverage=1.0, top1Match=1.0
- [x] `node --test tests/planner-dataset-eval.test.mjs` — 3/3 pass
- [ ] CI green

## Audit progression (corrected)

- planner-dataset cases: 23 → 28 → 33 → 38 → **41**
- non-agent never-selected planner-loadable skills: 5 → **1** (only `rr-upstream-plangate-exec-conformance-001` with `'**/*'` applyTo, which is meta-gate semantics, not a content-routing target)

## Remaining

- 9 `agent-*` tagged skills are loader-excluded by design — covered by canonical-sections work (#773), not planner coverage
- 1 `rr-upstream-plangate-exec-conformance-001` has `'**/*'` applyTo and is selected on every diff via the meta-gate path; explicit case adds noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)