### PR TITLE
chore(skills): reclassify rr-upstream-create-plan-001 major→minor (rubric)

### DIFF
--- a/skills/registry.yaml
+++ b/skills/registry.yaml
@@ -668,7 +668,7 @@ skills:
     category: upstream
     phase: upstream
     tags: [planning, upstream]
-    severity: major
+    severity: minor
     recommended: true
     description: '課題のゴールと制約を整理し、仮説・リスク付きの実行計画を段階的に提示して人間レビューにかける'
 

--- a/skills/upstream/rr-upstream-create-plan-001/SKILL.md
+++ b/skills/upstream/rr-upstream-create-plan-001/SKILL.md
@@ -13,7 +13,7 @@ applyTo:
 tags:
   - planning
   - upstream
-severity: major
+severity: minor
 inputContext:
   - diff
   - repoConfig


### PR DESCRIPTION
Second severity reclassification under [`docs/development/skill-severity-rubric.md`](https://github.com/s977043/river-reviewer/blob/main/docs/development/skill-severity-rubric.md).

| skill | from | to |
|---|---|---|
| `rr-upstream-create-plan-001` (計画作成とレビュー) | `major` | `minor` |

## Rationale (3 lines per rubric rule)

1. **Worst-case finding match**: Skill output is `[summary, actions, questions]` — advisory artifacts for human review, not merge-blocking findings. Rubric `minor` includes "教育・案内目的のスキル".
2. **HIGH_SEVERITY guard**: minor is not gated; reviewers can acknowledge or apply guard fixtures without needing `accepted_risk`.
3. **Neighbor calibration**: `rr-upstream-architecture-traceability-001` (major) detects governance gaps with functional implications; create-plan is a planning-stage advisor without such implications, so minor preserves the relative ordering.

## Eval evidence

| metric | before | after |
|---|---|---|
| cases | 38 | 38 |
| coverage | 1.0 | 1.0 |
| top1Match | 1.0 | 1.0 |

(severity is metadata-only — no planner-ranking effect)

## Test plan

- [x] `npm run planner:eval:dataset` no regression
- [x] `npm run skills:validate` ✅
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)