### PR TITLE
docs: add severity rubric learnings + registry sync rule

### DIFF
--- a/docs/development/skill-severity-rubric.md
+++ b/docs/development/skill-severity-rubric.md
@@ -96,6 +96,33 @@ A skill's `severity` is decided by the **worst case finding it is allowed to emi
 - 1 PR で **同時に 2 つ以上の skill の severity を上げ下げしない**（影響の切り分けが困難になる）
 - severity を変える PR は本書の該当節に明示的にリンクし、判断根拠を 3 行で書く
 - 変更前後で `npm run eval:all` の主要メトリクスを記録し、PR 本文に before / after を残す
+- **registry.yaml の同期を忘れない**: `skills/registry.yaml` にエントリがある skill は、SKILL.md の severity と registry の severity を同 PR 内で揃える（不揃いだと skill カタログ表示が誤る）
+
+## 既往の再分類事例（learnings）
+
+本書に基づいて完了した再分類:
+
+| skill                                        | from  | to    | PR   | rubric criterion                                                                                                       |
+| -------------------------------------------- | ----- | ----- | ---- | ---------------------------------------------------------------------------------------------------------------------- |
+| `rr-midstream-normalization-consistency-001` | major | minor | #777 | minor の "naming, formatting, dead code, 軽微な inconsistency" に該当。normalization drift は merge blocker ではない。 |
+| `rr-upstream-create-plan-001`                | major | minor | #781 | minor の "教育・案内目的のスキル" に該当。outputKind が `[summary, actions, questions]` で advisory artifacts のみ。   |
+
+### 共通パターン（観察）
+
+1. **outputKind が `summary` / `questions` / `actions` のみの skill は minor 候補**: 直接の修正提案ではなく議論や次の一手の提示なので merge blocker にならない
+2. **「教育・案内」「formatting drift」のような soft 領域 skill が major のまま放置されているケースが多い**: 過去の severity 設計が "全 skill major" 寄りで、後続の「目立つ findings のみ出す」要件にズレている
+3. **registry.yaml の同期漏れは Copilot review で検出される**: PR 本体だけでなく registry も同 PR で touch するのを習慣化する（#781 で実例）
+
+### 再分類を避けるべきケース
+
+以下は安易な major → minor を行わない:
+
+- セキュリティ系（`rr-midstream-security-basic-001`, `rr-upstream-trust-boundaries-authz-001`）— 検知対象が直接的な脆弱性
+- API 互換性破壊系（`rr-midstream-api-compatibility-001`, `rr-upstream-api-versioning-compat-001`）— 既存クライアントを壊す可能性
+- 失敗モード / 観測性系（`rr-upstream-failure-modes-observability-001`, `rr-midstream-logging-observability-001`）— 本番運用での復旧能力に直結
+- 実装ガード系（`rr-midstream-typescript-strict-001`, `rr-midstream-nullability-contract-001`）— type-unsafety は実害につながる
+
+これらは検知される問題そのものが major 級なので severity も major のままが妥当。
 
 ## References
 

--- a/docs/development/skill-severity-rubric.md
+++ b/docs/development/skill-severity-rubric.md
@@ -96,7 +96,7 @@ A skill's `severity` is decided by the **worst case finding it is allowed to emi
 - 1 PR で **同時に 2 つ以上の skill の severity を上げ下げしない**（影響の切り分けが困難になる）
 - severity を変える PR は本書の該当節に明示的にリンクし、判断根拠を 3 行で書く
 - 変更前後で `npm run eval:all` の主要メトリクスを記録し、PR 本文に before / after を残す
-- **registry.yaml の同期を忘れない**: `skills/registry.yaml` にエントリがある skill は、SKILL.md の severity と registry の severity を同 PR 内で揃える（不揃いだと skill カタログ表示が誤る）
+- **registry.yaml の同期を忘れない**: `skills/registry.yaml` にエントリがある skill は、SKILL.md の severity と registry の severity を同 PR 内で揃える。`registry.yaml` 自体は `loadSkills()` から無視される（`runners/core/skill-loader.mjs:59` の `ignoredFileNames` に含まれる）が、`skills/README.md` / `docs/skills-structure.md` / `docs/migration/skill-migration-guide.md` などの human-readable カタログから参照されるため、不揃いだと SKILL.md と registry の値が食い違うドキュメント矛盾が発生する。
 
 ## 既往の再分類事例（learnings）
 
@@ -111,7 +111,7 @@ A skill's `severity` is decided by the **worst case finding it is allowed to emi
 
 1. **outputKind が `summary` / `questions` / `actions` のみの skill は minor 候補**: 直接の修正提案ではなく議論や次の一手の提示なので merge blocker にならない
 2. **「教育・案内」「formatting drift」のような soft 領域 skill が major のまま放置されているケースが多い**: 過去の severity 設計が "全 skill major" 寄りで、後続の「目立つ findings のみ出す」要件にズレている
-3. **registry.yaml の同期漏れは Copilot review で検出される**: PR 本体だけでなく registry も同 PR で touch するのを習慣化する（#781 で実例）
+3. **registry.yaml の同期漏れが PR review で検出されることがある**: #781 では Copilot review が SKILL.md と registry.yaml の severity 不一致を検出した。将来も常に検出される保証はないため、severity を変える PR では **`grep -A 8 <skill-id> skills/registry.yaml` で registry エントリの有無を能動的に確認** することを推奨する（自動化されるまでの自衛策）。
 
 ### 再分類を避けるべきケース
 


### PR DESCRIPTION
Enriches `docs/development/skill-severity-rubric.md` after the first 2 reclassifications (#777, #781) under the rubric.

## Additions

1. **Operational rule** — registry.yaml sync requirement. Codified after Copilot review caught severity drift between SKILL.md and registry.yaml in PR #781.

2. **既往の再分類事例 table** — Records both completed downgrades with their rubric criterion as worked examples for future authors.

3. **共通パターン** observed across the 2 cases:
   - outputKind ∈ {summary, questions, actions} only → minor candidate
   - "教育・案内" / formatting drift often left as major from earlier "all major" defaults
   - registry.yaml drift is caught by Copilot review

4. **再分類を避けるべきケース** — Lists 8 representative skills (security / API-compat / failure-modes / type-safety) that must keep major.

## Behavioral note

This PR adds policy documentation only. No individual skill's severity is changed.

## Test plan

- [x] npm run lint clean
- [x] npm run check:bilingual: 73 paired / 0 missing / 0 orphaned
- [ ] CI green

🤖 Generated with Claude Code