### PR TITLE
docs(reference): PlanGate CLI 安定化ロードマップ (#802)

### DIFF
--- a/pages/reference/plangate-cli-roadmap.en.md
+++ b/pages/reference/plangate-cli-roadmap.en.md
@@ -1,0 +1,83 @@
+---
+title: PlanGate CLI Stabilization Roadmap
+---
+
+`river review plan` / `river review exec` / `river review verify` are the CLI subcommands that take artifacts produced by upstream workflows such as PlanGate and run review planning, execution, and re-audit. They are River Reviewer's biggest differentiator, but **there is drift between the spec and the implementation, CI, and distribution**, so adopters cannot use them in a stable manner.
+
+This document addresses [Issue #802](https://github.com/s977043/river-reviewer/issues/802) and defines (1) an inventory of the current contract drift, (2) the decision on the public entrypoint, (3) the stabilization target-version roadmap, and (4) the spec inconsistencies to resolve and the recommended unified contract.
+
+> Related: [Artifact Input Contract](./artifact-input-contract.en.md) / [Stable Interfaces](./stable-interfaces.en.md) / [`river review plan` spec](./cli-review-plan-spec.en.md) / [`river review exec` spec](./cli-review-exec-spec.en.md) / [`river review verify` spec](./cli-review-verify-spec.en.md) / `docs/CLI-architecture.md`
+
+## Contract drift inventory
+
+The following is the gap between the contract the specs declare and the reality of the implementation, CI, and distribution.
+
+| Item                         | What the spec declares                                                                                                                   | Reality of implementation / distribution                                                                                                             | Impact                                                                                      |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Location of `river review *` | All 3 specs describe it as "a contract that can be called stably from CI"                                                                | The `review` subcommand exists only in the **Runner CLI** (`runners/cli/`, npm-unpublished / private bin). See `docs/CLI-architecture.md`            | `npx river review …` is **resolved to the main CLI and errors as unknown command**          |
+| Public entrypoint            | Implicitly presents `river review plan/exec/verify` as a public contract                                                                 | The main CLI (`src/cli.mjs`, registered in `package.json#bin`) has no `review` command                                                               | No stable path for adopters to call from `npx` / CI                                         |
+| Artifact config path         | [Artifact Input Contract](./artifact-input-contract.en.md) describes the `artifacts` section under `river.config.*` as "already defined" | `src/config/schema.mjs` has no `artifacts` key                                                                                                       | Artifact path specification via config file does not actually work                          |
+| `--output` semantics         | `plan` spec: `--output <format>` (`text`/`markdown`/`json`) + `--output-file <path>`                                                     | `exec` / `verify` spec: `--output <path>` (output path, `-`=stdout) + `--format <value>`                                                             | **The same flag has opposite meanings in plan vs exec/verify**. CI scripts cannot be shared |
+| Exit codes                   | `plan` spec: `0`/`1`/`2`/`3` (4 values, `3`=config error)                                                                                | `exec` / `verify` spec: `0`/`1`/`2` (3 values, `2`=config error)                                                                                     | The config-error exit code is inconsistent across subcommands                               |
+| GitHub Action mapping        | `plan` spec: "provides a mapping from `action.yml` inputs to this CLI"                                                                   | The spec body explicitly states "not implemented, to be addressed separately"                                                                        | No stable path established via the Action                                                   |
+| CI job                       | —                                                                                                                                        | `.github/workflows/plangate-review.yml` runs placeholder behavior gated by the `PLANGATE_REVIEW_CLI_READY` flag (can pass even with CLI unconnected) | CI green does not guarantee the CLI works (false-positive risk)                             |
+
+## Public entrypoint decision (fixed)
+
+**The stable public entrypoint for `river review plan` / `river review exec` / `river review verify` will be implemented on the main CLI (`src/cli.mjs`, the `river` / `river-reviewer` `package.json#bin`).**
+
+Rationale:
+
+- The main CLI is the only stable path registered in the npm `bin` and used in the GitHub Action production path (`runners/github-action` → `src/cli.mjs`).
+- The Runner CLI (`runners/cli/`) is npm-unpublished, an experimental interface for skill developers, and `docs/CLI-architecture.md` explicitly states there is no replacement plan. The Runner CLI's `review` keeps its **quick-check** positioning and does not bear the stable CI contract.
+- This decision **uniquely fixes the location of the public API** when [Issue #801](https://github.com/s977043/river-reviewer/issues/801) (separating the review engine and docs site into packages) designs the separation boundary. #801 must not break this boundary (the `review` subcommand on `src/cli.mjs` and the import boundary of the `src/lib/*` it depends on).
+
+> This entrypoint decision only makes the "decision" within the scope of #802. The implementation (adding the `review` subcommand to the main CLI) is done in a later phase (Phase 3 below) with design approval.
+
+## Stabilization target-version roadmap
+
+Stability labels follow the vocabulary in [Stable Interfaces](./stable-interfaces.en.md). The target for each subcommand is defined in 3 stages.
+
+| Subcommand            | Current                 | Alpha (contract fixed)                                                              | Beta (dry-run E2E)                                 | Stable (CI-integratable)                                           |
+| --------------------- | ----------------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------------ |
+| `river review plan`   | spec only (unconnected) | spec inconsistencies resolved + main CLI impl + `--plan-only --output json`         | E2E with PlanGate sample fixtures (dry-run)        | switch the `plangate-review.yml` feature flag to a live connection |
+| `river review exec`   | spec only (unconnected) | spec inconsistencies resolved (unify to the same output/exit-code contract as plan) | linked plan→exec E2E (advisory)                    | provide Action inputs mapping                                      |
+| `river review verify` | spec only (unconnected) | spec inconsistencies resolved (same shape as exec)                                  | linked exec→verify E2E (META finding verification) | publish CI integration guide                                       |
+
+Integration into the ai-agent-template C-1 / C-2 workflows is "plannable" once each subcommand reaches **Beta (dry-run E2E passing)**, and "executable for integration" at **Stable**.
+
+## Spec inconsistencies to resolve and recommended unified contract
+
+The following are the inconsistencies across specs and the recommended unification, which are prerequisites for stabilization (Alpha). **Because they involve breaking contract changes, the finalization and spec revisions will be done in a later PR with design approval** (this document only presents the recommended proposals).
+
+### 1. Unify `--output` / `--format` semantics
+
+- Current: `plan` uses `--output <format>` + `--output-file <path>`; `exec`/`verify` use `--output <path>` + `--format <value>`.
+- Recommendation: **unify to the `exec`/`verify` side** (`--output <path>` = destination, `--format <json|markdown>` = format, `-` = stdout). The reason is that writing out a [Review Artifact](./review-artifact.en.md) is the shared primary use case across plan/exec/verify, and separating destination and format lets CI scripts be shared across all 3 subcommands. The `plan` spec's `--output-file` migrates to `--output`, and `--output <format>` migrates to `--format`.
+
+### 2. Unify exit codes
+
+- Current: `plan` uses `0`/`1`/`2`/`3` (`2`=warnings only, `3`=config error); `exec`/`verify` use `0`/`1`/`2` (`2`=config error).
+- Recommendation: **unify to 4 values (`0`/`1`/`2`/`3`)**. `2`=warnings only, `3`=config error. `exec`/`verify` currently use `2`=config error, but as long as CI treats `!= 0` as failure, backward compatibility is preserved (and it is not incompatible with the minimal `0`/`1` contract in [Stable Interfaces](./stable-interfaces.en.md)). Making `plan`'s `--warn-on`/`advisory` distinction common across all 3 subcommands unifies the gating logic.
+
+### 3. Artifact config schema
+
+- Current: [Artifact Input Contract](./artifact-input-contract.en.md) presumes the `artifacts` section under `river.config.*`, but it is undefined in `src/config/schema.mjs`.
+- Recommendation: **add a generic `artifacts.<artifactId>` to `src/config/schema.mjs`, not a PlanGate-specific `plangate.artifacts.*`**. The Artifact Input Contract itself states PlanGate independence, so a PlanGate-specific key runs counter to the design. If a default path set for PlanGate is needed, add it later as an optional profile such as `artifacts.profiles.plangate`.
+
+## Phase plan
+
+| Phase   | Content                                                                                                                   | Autonomous-executable?                     |
+| ------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| Phase 1 | Publish this roadmap (drift inventory, entrypoint decision, stabilization-version definition, proposals)                  | Yes (docs only, additive)                  |
+| Phase 2 | Add a generic `artifacts.*` schema to `src/config/schema.mjs` + artifact resolver + unit tests                            | Requires design approval (schema)          |
+| Phase 3 | Minimal `river review plan --plan-only --output json` impl on the main CLI + PlanGate fixture E2E + workflow flag cleanup | Requires design approval (`src/` CLI impl) |
+
+From Phase 2 onward, work proceeds on the premise of the policy fixed in this roadmap (entrypoint, unified contract), presenting the design and obtaining approval in each PR before starting. Each PR passes `npm run lint && npm test` on its own, and runs `npm run check:links:local` when `pages/` changes.
+
+## Related documents
+
+- [Artifact Input Contract](./artifact-input-contract.en.md) — the input artifact contract
+- [`river review plan` spec](./cli-review-plan-spec.en.md) / [`river review exec` spec](./cli-review-exec-spec.en.md) / [`river review verify` spec](./cli-review-verify-spec.en.md)
+- [Stable Interfaces](./stable-interfaces.en.md) — vocabulary and versioning of stable contracts
+- [Review Artifact](./review-artifact.en.md) — output JSON schema

--- a/pages/reference/plangate-cli-roadmap.md
+++ b/pages/reference/plangate-cli-roadmap.md
@@ -1,0 +1,83 @@
+---
+title: PlanGate CLI 安定化ロードマップ
+---
+
+`river review plan` / `river review exec` / `river review verify` は、PlanGate をはじめとする上流ワークフローが生成した artifact を入力として、レビュー計画・実行・再監査を行う CLI サブコマンド群です。これらは River Reviewer の最大の差別化要素ですが、**仕様（spec）と実装・CI・配布の間にドリフトがあり**、導入側が安定的に利用できる状態にありません。
+
+本ドキュメントは [Issue #802](https://github.com/s977043/river-reviewer/issues/802) に対応し、(1) 現状の契約ドリフトの棚卸し、(2) 公開エントリポイントの方針確定、(3) 安定化目標バージョンのロードマップ、(4) 解消すべき仕様不整合と推奨統一契約を定義します。
+
+> 関連: [Artifact Input Contract](./artifact-input-contract.md) / [Stable Interfaces](./stable-interfaces.md) / [`river review plan` 仕様](./cli-review-plan-spec.md) / [`river review exec` 仕様](./cli-review-exec-spec.md) / [`river review verify` 仕様](./cli-review-verify-spec.md) / `docs/CLI-architecture.md`
+
+## 現状の契約ドリフト棚卸し
+
+以下は spec が宣言する契約と、実装・CI・配布の実態の差分です。
+
+| 項目                     | spec の宣言                                                                                                               | 実装・配布の実態                                                                                                             | 影響                                                                     |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `river review *` の所在  | 3 spec とも「CI から安定して呼び出せる契約」と記述                                                                        | `review` サブコマンドは **Runner CLI**（`runners/cli/`、npm 未公開・private bin）にのみ存在。`docs/CLI-architecture.md` 参照 | `npx river review …` は **メイン CLI に解釈され unknown command エラー** |
+| 公開エントリポイント     | 暗黙に `river review plan/exec/verify` を公開契約として提示                                                               | メイン CLI（`src/cli.mjs`、`package.json#bin` 登録）に `review` コマンドは未実装                                             | 導入側が `npx`/CI から安定して呼べる動線が存在しない                     |
+| artifact 設定経路        | [Artifact Input Contract](./artifact-input-contract.md) が `river.config.*` の `artifacts` セクションを「定義済み」と記述 | `src/config/schema.mjs` に `artifacts` キーが存在しない                                                                      | 設定ファイル経由の artifact パス指定が実際には機能しない                 |
+| `--output` の意味論      | `plan` spec: `--output <format>`（`text`/`markdown`/`json`）+ `--output-file <path>`                                      | `exec` / `verify` spec: `--output <path>`（出力先パス、`-`=stdout）+ `--format <value>`                                      | **同名フラグが plan と exec/verify で逆の意味**。CI スクリプトが共有不能 |
+| 終了コード               | `plan` spec: `0`/`1`/`2`/`3`（4 値、`3`=設定エラー）                                                                      | `exec` / `verify` spec: `0`/`1`/`2`（3 値、`2`=設定エラー）                                                                  | 設定エラーの exit code がサブコマンド間で不一致                          |
+| GitHub Action マッピング | `plan` spec: 「`action.yml` inputs から本 CLI へのマッピングを提供する」                                                  | spec 本文に「未実装、別途対応予定」と明記                                                                                    | Action 経由の安定動線が未確立                                            |
+| CI ジョブ                | —                                                                                                                         | `.github/workflows/plangate-review.yml` が `PLANGATE_REVIEW_CLI_READY` フラグで placeholder 動作（CLI 未接続でも成功しうる） | CI green が「CLI が動く」ことを保証しない（偽陽性リスク）                |
+
+## 公開エントリポイントの方針（確定）
+
+**`river review plan` / `river review exec` / `river review verify` の安定版公開エントリポイントは、メイン CLI（`src/cli.mjs`、`package.json#bin` の `river` / `river-reviewer`）に実装する。**
+
+理由:
+
+- メイン CLI は npm `bin` に登録され、GitHub Action 本番経路（`runners/github-action` → `src/cli.mjs`）でも使われる唯一の安定動線である。
+- Runner CLI（`runners/cli/`）は npm 未公開・スキル開発者向け実験的インターフェースであり、`docs/CLI-architecture.md` でも置き換え計画は無いと明記されている。Runner CLI 側の `review` は **簡易確認用** の位置づけを維持し、安定 CI 契約は担わない。
+- この方針により、[Issue #801](https://github.com/s977043/river-reviewer/issues/801)（レビューエンジンとドキュメントサイトのパッケージ分離）が分離境界を設計する際の **public API の所在が一意に固定**される。#801 はこの境界（`src/cli.mjs` 上の `review` サブコマンドと、それが依存する `src/lib/*` の import 境界）を壊してはならない。
+
+> このエントリポイント決定は #802 のスコープ内で「決定」のみを行う。実装（メイン CLI への `review` サブコマンド追加）は後続フェーズ（下記 Phase 3）で設計承認のうえ着手する。
+
+## 安定化目標バージョンのロードマップ
+
+安定性ラベルは [Stable Interfaces](./stable-interfaces.md) の語彙に従う。各サブコマンドの目標を 3 段階で定義する。
+
+| サブコマンド          | 現状                | Alpha（契約固定）                                               | Beta（dry-run E2E）                         | Stable（CI 組込み可）                                |
+| --------------------- | ------------------- | --------------------------------------------------------------- | ------------------------------------------- | ---------------------------------------------------- |
+| `river review plan`   | spec のみ（未接続） | spec 不整合解消 + メイン CLI 実装 + `--plan-only --output json` | PlanGate sample fixture での E2E（dry-run） | `plangate-review.yml` の feature flag を実接続へ切替 |
+| `river review exec`   | spec のみ（未接続） | spec 不整合解消（plan と同一の出力/終了コード契約に統一）       | plan→exec の連結 E2E（advisory）            | Action inputs マッピング提供                         |
+| `river review verify` | spec のみ（未接続） | spec 不整合解消（exec と同一 shape）                            | exec→verify の連結 E2E（META finding 検証） | CI 組込みガイド公開                                  |
+
+AI-agent-template の C-1 / C-2 ワークフローへの組込みは、各サブコマンドが **Beta（dry-run E2E 通過）** に到達した時点で「計画可能」、**Stable** で「組込み実行可能」とする。
+
+## 解消すべき仕様不整合と推奨統一契約
+
+以下は安定化（Alpha）の前提となる、spec 間の不整合と推奨される統一方針です。**契約の破壊的変更を伴うため、確定・spec 改訂は後続 PR で設計承認のうえ実施する**（本ドキュメントは推奨案の提示まで）。
+
+### 1. `--output` / `--format` の意味論統一
+
+- 現状: `plan` は `--output <format>` + `--output-file <path>`、`exec`/`verify` は `--output <path>` + `--format <value>`。
+- 推奨: **`exec`/`verify` 側に統一**（`--output <path>` = 出力先、`--format <json|markdown>` = 形式、`-` = stdout）。理由は [Review Artifact](./review-artifact.md) を伴う書き出しが plan/exec/verify 共通の主用途であり、出力先と形式を分離する方が CI スクリプトを 3 サブコマンドで共有できるため。`plan` spec の `--output-file` は `--output` に、`--output <format>` は `--format` に移行する。
+
+### 2. 終了コードの統一
+
+- 現状: `plan` は `0`/`1`/`2`/`3`（`2`=警告のみ、`3`=設定エラー）、`exec`/`verify` は `0`/`1`/`2`（`2`=設定エラー）。
+- 推奨: **4 値（`0`/`1`/`2`/`3`）に統一**。`2`=警告のみ、`3`=設定エラー。`exec`/`verify` は現状 `2`=設定エラーだが、CI が `!= 0` を失敗として扱う限り後方互換は保たれる（[Stable Interfaces](./stable-interfaces.md) の最小契約 `0`/`1` とも非互換ではない）。`plan` の `--warn-on`/`advisory` 区分を 3 サブコマンド共通にすることで、ゲート判定ロジックを統一できる。
+
+### 3. artifact 設定スキーマ
+
+- 現状: [Artifact Input Contract](./artifact-input-contract.md) は `river.config.*` の `artifacts` セクションを前提化しているが `src/config/schema.mjs` に未定義。
+- 推奨: **PlanGate 固有の `plangate.artifacts.*` ではなく、汎用 `artifacts.<artifactId>` を `src/config/schema.mjs` に追加**。Artifact Input Contract 自体が PlanGate 非依存を明示しているため、PlanGate 専用キーは設計と逆行する。PlanGate 向けの既定パス集合が必要であれば `artifacts.profiles.plangate` のような optional profile として後付けする。
+
+## フェーズ計画
+
+| Phase   | 内容                                                                                                               | 自律実行可否                      |
+| ------- | ------------------------------------------------------------------------------------------------------------------ | --------------------------------- |
+| Phase 1 | 本ロードマップ公開（契約ドリフト棚卸し・エントリポイント方針確定・安定化バージョン定義・統一案提示）               | 可（doc のみ・追加型）            |
+| Phase 2 | 汎用 `artifacts.*` スキーマを `src/config/schema.mjs` に追加 + artifact resolver + unit test                       | 設計承認が必要（schema 変更）     |
+| Phase 3 | メイン CLI への `river review plan --plan-only --output json` 最小実装 + PlanGate fixture E2E + workflow flag 整理 | 設計承認が必要（`src/` CLI 実装） |
+
+Phase 2 以降は本ロードマップで確定した方針（エントリポイント・統一契約）を前提に、各 PR で設計を提示して承認を得たうえで着手する。各 PR は単独で `npm run lint && npm test` を通し、`pages/` 変更時は `npm run check:links:local` を実行する。
+
+## 関連ドキュメント
+
+- [Artifact Input Contract](./artifact-input-contract.md) — 入力アーティファクトの契約
+- [`river review plan` 仕様](./cli-review-plan-spec.md) / [`river review exec` 仕様](./cli-review-exec-spec.md) / [`river review verify` 仕様](./cli-review-verify-spec.md)
+- [Stable Interfaces](./stable-interfaces.md) — 安定契約の語彙とバージョニング
+- [Review Artifact](./review-artifact.md) — 出力 JSON スキーマ


### PR DESCRIPTION
## 概要

[Issue #802](https://github.com/s977043/river-reviewer/issues/802) の deliverable 1（ロードマップ公開）と deliverable 2-4 の前提となる reconciliation を実施。

`pages/reference/plangate-cli-roadmap.md`（+ `.en.md`）を新規追加し、以下を文書化:

1. **契約ドリフト棚卸し** — `river review plan/exec/verify` の spec が宣言する契約と、実装・CI・配布の実態の差分表（7 項目）
2. **公開エントリポイント方針の確定** — 安定版は **メイン CLI (`src/cli.mjs`)** に実装。Runner CLI の `review` は簡易確認用のまま。#801 の分離境界を一意に固定
3. **安定化目標バージョン** — plan/exec/verify を Alpha（契約固定）/ Beta（dry-run E2E）/ Stable（CI 組込み可）の 3 段階で定義。ai-agent-template C-1/C-2 組込み判断基準を明記
4. **仕様不整合と推奨統一契約** — `--output`/`--format` 意味論、終了コード（3値 vs 4値）、artifact 設定スキーマの不整合と推奨統一案を提示

## 検証で確認した実在のドリフト

- `npx river review …` は Runner CLI でなくメイン CLI に解釈され unknown command エラー（`docs/CLI-architecture.md:51`）
- `artifact-input-contract.md:121` は `river.config.artifacts` を前提化するが `src/config/schema.mjs` に該当キー無し
- `plan` spec は `--output <format>`、`exec`/`verify` spec は `--output <path>`（同名フラグが逆の意味）
- 終了コードが plan=4値 / exec・verify=3値で不一致

## スコープ

本 PR は **追加型の doc のみ**（既存 Beta 契約は一方的に書き換えない）。Phase 2（汎用 `artifacts.*` schema + resolver）/ Phase 3（メイン CLI への `review` 実装）は本ロードマップ確定後、設計承認のうえ別 PR で着手。

## 検証

- `npm run lint` exit 0 / `npm test` fail 0 / `npm run check:links:local` 0 errors / `npm run check:docs` bilingual+placement OK
- 検証プロセス: Codex 起案 → Codex 自己反証 → リポジトリ実コード照合で全 claim 確認

Refs #802

🤖 Generated with [Claude Code](https://claude.com/claude-code)