### PR TITLE
chore(deps): group @opentelemetry/* in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
         patterns:
           - 'react'
           - 'react-dom'
+      opentelemetry:
+        patterns:
+          - '@opentelemetry/*'
   - package-ecosystem: 'pip'
     directory: '/'
     schedule: { interval: 'weekly' }


### PR DESCRIPTION
## 背景

OTel パッケージ（api / resources / exporter-trace-otlp-http / sdk-node 等）は版整合が必要。個別 PR (#823/#825/#826) で別々に上がるとネスト重複ツリーが発生し、strict 下で個別 rebase コストもかかる。

## 変更

`.github/dependabot.yml` の npm groups に `opentelemetry: @opentelemetry/*` を追加。既存の react/react-dom grouping (#821) と同じパターン。

## 関連

- #828（OTel 3本を手動統合）
- 今後の OTel 更新は単一のグループ PR にまとまる

🤖 Generated with [Claude Code](https://claude.com/claude-code)