### PR TITLE
test(cli): PlanGate fixture E2E for river review plan (#802 Phase 3 slice 2)

### DIFF
--- a/tests/fixtures/plangate-review-artifacts/README.md
+++ b/tests/fixtures/plangate-review-artifacts/README.md
@@ -1,0 +1,19 @@
+# plangate-review-artifacts fixture
+
+Minimal PlanGate-style upstream artifact set for the `river review plan
+--plan-only` CLI integration E2E
+(`tests/integration/review-plan-cli.test.mjs`, issue #802 Phase 3 slice 2).
+
+These are newly created rather than reused from `tests/fixtures/planner-dataset/`:
+that dataset holds `.diff` files keyed to planner-selection evaluation cases,
+not the per-artifact-ID files (`plan.md`, `todo.md`, `diff.patch`) plus a
+`.river-reviewer.json` that the artifact resolver's CLI → config → cwd-default
+precedence needs to be exercised end-to-end.
+
+Files:
+
+- `plan.md` / `todo.md` — cwd-default tier inputs (`plan.md`, `todo.md`)
+- `diff.patch` — `diff` artifact (resolver resolves the path only; no diff is
+  consumed in `--plan-only`, where no skills run)
+- `config/.river-reviewer.json` — copied to the repo root in the test to
+  exercise the config tier (`artifacts.todo` → a non-default path)

--- a/tests/fixtures/plangate-review-artifacts/config/.river-reviewer.json
+++ b/tests/fixtures/plangate-review-artifacts/config/.river-reviewer.json
@@ -1,0 +1,5 @@
+{
+  "artifacts": {
+    "todo": "todo-from-config.md"
+  }
+}

--- a/tests/fixtures/plangate-review-artifacts/diff.patch
+++ b/tests/fixtures/plangate-review-artifacts/diff.patch
@@ -1,0 +1,9 @@
+diff --git a/src/widget-cache.mjs b/src/widget-cache.mjs
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/src/widget-cache.mjs
+@@ -0,0 +1,3 @@
++export function createWidgetCache() {
++  return new Map();
++}

--- a/tests/fixtures/plangate-review-artifacts/plan.md
+++ b/tests/fixtures/plangate-review-artifacts/plan.md
@@ -1,0 +1,6 @@
+# Plan
+
+Implement the widget cache.
+
+- Add an LRU cache in `src/widget-cache.mjs`.
+- Wire it into `getWidget()`.

--- a/tests/fixtures/plangate-review-artifacts/todo-from-config.md
+++ b/tests/fixtures/plangate-review-artifacts/todo-from-config.md
@@ -1,0 +1,5 @@
+# TODO (config-tier copy)
+
+This file is referenced by `config/.river-reviewer.json` `artifacts.todo`
+to exercise the resolver's config tier (a non-default path winning over the
+cwd-default `todo.md`).

--- a/tests/fixtures/plangate-review-artifacts/todo.md
+++ b/tests/fixtures/plangate-review-artifacts/todo.md
@@ -1,0 +1,5 @@
+# TODO
+
+- [x] Add LRU cache module
+- [ ] Wire into getWidget()
+- [ ] Add tests

--- a/tests/integration/review-plan-cli.test.mjs
+++ b/tests/integration/review-plan-cli.test.mjs
@@ -1,0 +1,165 @@
+// tests/integration/review-plan-cli.test.mjs
+//
+// `river review plan --plan-only` の CLI 統合 E2E (#802 Phase 3 slice 2)。
+//
+// slice 1 (#839) で配線した公開エントリポイントを、PlanGate 風の artifact
+// fixture に対して end-to-end で検証する。skill/planner 実行・破壊的契約変更
+// は対象外。resolver の網羅的優先順テストは tests/artifact-resolver.test.mjs
+// が担い、ここは「CLI として通る」代表ケースに絞る。
+//
+// 出力捕捉の注意: src/cli.mjs の review plan は --output-file 未指定時
+// process.stdout.write で JSON を書き出す。runCliInProcess は console のみ
+// 捕捉し process.stdout.write を捕捉しない（helpers/cli.mjs 参照）ため、
+// in-process E2E は --output-file + ファイル読取で検証し、stdout 直接出力の
+// 検証は runCliAsSubprocess を 1 本使う。
+// (技術的負債: --output-file 非依存の stdout 捕捉は別 slice で扱う。)
+
+import assert from 'node:assert/strict';
+import { mkdirSync, copyFileSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+import test, { describe } from 'node:test';
+
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+import { runCliInProcess, runCliAsSubprocess } from '../helpers/cli.mjs';
+import { createTempDir, cleanupTempDir } from '../helpers/temp-dir.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = resolve(__dirname, '..', 'fixtures', 'plangate-review-artifacts');
+const schema = JSON.parse(
+  readFileSync(resolve(__dirname, '..', '..', 'schemas', 'review-artifact.schema.json'), 'utf8')
+);
+
+function makeValidator() {
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  return ajv.compile(schema);
+}
+
+/** Lay the PlanGate fixture out into a fresh temp repo root. */
+function setupRepo(t, { withConfig = false } = {}) {
+  const dir = createTempDir({ prefix: 'rr-review-plan-e2e-' });
+  t.after(() => cleanupTempDir(dir));
+  for (const f of ['plan.md', 'todo.md', 'todo-from-config.md', 'diff.patch']) {
+    copyFileSync(join(FIXTURE, f), join(dir, f));
+  }
+  if (withConfig) {
+    copyFileSync(join(FIXTURE, 'config', '.river-reviewer.json'), join(dir, '.river-reviewer.json'));
+  }
+  return dir;
+}
+
+describe('river review plan --plan-only — CLI E2E (#802 Phase 3)', () => {
+  test('emits a schema-valid v1 Review Artifact to --output-file (exit 0)', async (t) => {
+    const dir = setupRepo(t);
+    const out = join(dir, 'review-artifact.json');
+    const result = await runCliInProcess(
+      ['review', 'plan', '--plan-only', '--phase', 'upstream', '--output-file', out],
+      { cwd: dir }
+    );
+    assert.equal(result.code, 0, result.stderr);
+
+    const artifact = JSON.parse(readFileSync(out, 'utf8'));
+    const validate = makeValidator();
+    assert.equal(validate(artifact), true, JSON.stringify(validate.errors));
+    assert.equal(artifact.version, '1');
+    assert.equal(artifact.phase, 'upstream');
+    assert.equal(artifact.status, 'ok');
+    assert.deepEqual(artifact.findings, []);
+    assert.equal(artifact.plan.plannerMode, 'off');
+    assert.equal('debug' in artifact, false);
+  });
+
+  test('--debug attaches resolvedArtifacts with cwd-default resolution', async (t) => {
+    const dir = setupRepo(t);
+    const out = join(dir, 'a.json');
+    const result = await runCliInProcess(
+      ['review', 'plan', '--plan-only', '--phase', 'upstream', '--debug', '--output-file', out],
+      { cwd: dir }
+    );
+    assert.equal(result.code, 0, result.stderr);
+
+    const artifact = JSON.parse(readFileSync(out, 'utf8'));
+    assert.equal(makeValidator()(artifact), true);
+    const resolved = artifact.debug.resolvedArtifacts;
+    assert.equal(resolved.plan.source, 'cwd');
+    assert.equal(resolved.plan.exists, true);
+    assert.ok(resolved.plan.path.endsWith('plan.md'));
+    // No config, no CLI override: todo also resolves via cwd default.
+    assert.equal(resolved.todo.source, 'cwd');
+    // An unconfigured, absent artifact resolves to null/source:null.
+    assert.equal(resolved.coverage.source, null);
+    assert.equal(resolved.coverage.exists, false);
+  });
+
+  test('config tier wins over cwd default; CLI --artifact wins over config', async (t) => {
+    const dir = setupRepo(t, { withConfig: true });
+
+    // Config only: artifacts.todo → todo-from-config.md (config tier).
+    const out1 = join(dir, 'cfg.json');
+    const r1 = await runCliInProcess(
+      ['review', 'plan', '--plan-only', '--phase', 'upstream', '--debug', '--output-file', out1],
+      { cwd: dir }
+    );
+    assert.equal(r1.code, 0, r1.stderr);
+    const a1 = JSON.parse(readFileSync(out1, 'utf8'));
+    assert.equal(a1.debug.resolvedArtifacts.todo.source, 'config');
+    assert.ok(a1.debug.resolvedArtifacts.todo.path.endsWith('todo-from-config.md'));
+
+    // CLI --artifact overrides the config tier.
+    const out2 = join(dir, 'cli.json');
+    const r2 = await runCliInProcess(
+      [
+        'review',
+        'plan',
+        '--plan-only',
+        '--phase',
+        'upstream',
+        '--artifact',
+        'todo=todo.md',
+        '--debug',
+        '--output-file',
+        out2,
+      ],
+      { cwd: dir }
+    );
+    assert.equal(r2.code, 0, r2.stderr);
+    const a2 = JSON.parse(readFileSync(out2, 'utf8'));
+    assert.equal(a2.debug.resolvedArtifacts.todo.source, 'cli');
+    assert.ok(a2.debug.resolvedArtifacts.todo.path.endsWith('todo.md'));
+  });
+
+  test('invalid --phase exits 3', async (t) => {
+    const dir = setupRepo(t);
+    const result = await runCliInProcess(
+      ['review', 'plan', '--plan-only', '--phase', 'bogus'],
+      { cwd: dir }
+    );
+    assert.equal(result.code, 3);
+    assert.match(result.stderr, /Invalid --phase/);
+  });
+
+  test('missing --plan-only exits 3', async (t) => {
+    const dir = setupRepo(t);
+    const result = await runCliInProcess(['review', 'plan', '--phase', 'upstream'], { cwd: dir });
+    assert.equal(result.code, 3);
+  });
+
+  // One real-subprocess case: exercises actual process.stdout.write +
+  // process exit code (which runCliInProcess cannot observe for stdout).
+  test('writes a parseable Review Artifact to stdout via subprocess (exit 0)', async (t) => {
+    const dir = setupRepo(t);
+    const result = await runCliAsSubprocess(
+      ['review', 'plan', '--plan-only', '--phase', 'midstream'],
+      { cwd: dir }
+    );
+    assert.equal(result.code, 0, result.stderr);
+    const artifact = JSON.parse(result.stdout);
+    assert.equal(makeValidator()(artifact), true, JSON.stringify(artifact));
+    assert.equal(artifact.phase, 'midstream');
+    assert.equal(artifact.status, 'ok');
+  });
+});


### PR DESCRIPTION
## 概要

Issue #802 Phase 3 slice 2。slice 1 (#839, v0.45.0) で配線した `river review plan --plan-only` を PlanGate 風 fixture に対し **end-to-end 検証**（非破壊・テストのみ）。roadmap の「Beta (dry-run E2E)」マイルストーンを前進。

## 変更（tests/ のみ・src 非変更）

- `tests/fixtures/plangate-review-artifacts/`: plan.md / todo.md / todo-from-config.md / diff.patch / config/.river-reviewer.json。README に新規作成理由（planner-dataset 流用不可）を明記
- `tests/integration/review-plan-cli.test.mjs`（6 tests）:
  - --output-file へ schema-valid v1 Review Artifact 出力, exit 0
  - --debug の resolvedArtifacts（cwd-default 解決, 不在 artifact は source:null）
  - resolver 優先順 cwd-default < config < CLI --artifact
  - 不正 --phase / --plan-only 欠落 → exit 3
  - real-subprocess 1本（process.stdout.write + exit code）

## 設計（Codex 起案 read-only → Gemini 検証、両者「修正して採用」）

- 主検証は `--output-file` + `runCliInProcess`、stdout 直接出力は `runCliAsSubprocess` 1本（runCliInProcess は process.stdout.write 非捕捉のため）
- resolver 網羅は既存 artifact-resolver.test.mjs に委譲、E2E は代表ケースのみ
- 既知負債（runCliInProcess の stdout 非捕捉）をテストヘッダに明記、別 slice 送り

## スコープ外（後続）

skill/planner 実行、exec/verify、破壊的 --output/--format 統一、--summary-file/--quiet/--planner、PLANGATE_REVIEW_CLI_READY 切替、context.artifacts v2 schema。

## 検証（Node 22.22.2）

- `node --test tests/integration/review-plan-cli.test.mjs`: 6 pass 0 fail
- `npm run lint` exit 0 / `npm test` 998 pass 0 fail
- tests/ のみ変更のため build:action 不要

Refs #802

🤖 Generated with [Claude Code](https://claude.com/claude-code)