### PR TITLE
docs: skill-selection troubleshooting guide + executionDeferred deprecation (D2+D3)

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -92,3 +92,46 @@ If you have questions about migration, please:
 1. Check the [Migration Guide](migration/runners-migration-guide.md)
 2. Review [Epic #242](https://github.com/s977043/river-reviewer/issues/242)
 3. Open an issue with the `migration-help` label
+
+## Output artifact field executionDeferred (v0.51.0)
+
+### artifact.executionDeferred -> use artifact.plan.skippedSkills
+
+**Deprecated in:** v0.51.0  
+**Planned removal:** v0.53.0
+
+The boolean executionDeferred field on the review artifact was added during Phase 3
+to signal that some skills were deferred/skipped. It is superseded by the richer
+plan.skippedSkills array, which carries a per-skill skip reason.
+
+
+#### Migration
+
+**Before:**
+
+```js
+if (artifact.executionDeferred) {
+  console.warn("some skills were skipped");
+}
+```
+
+
+**After:**
+
+```js
+const skipped = artifact.plan?.skippedSkills ?? [];
+if (skipped.length > 0) {
+  console.warn(skipped.length + " skills skipped:", skipped.map(s => s.reason));
+}
+```
+
+
+plan.skippedSkills is available on all artifacts from river review plan
+and river review exec (v0.45.0+).
+
+
+#### Related
+
+- [Troubleshooting: skill selection](review/troubleshooting.md)
+
+- Issue [#802](https://github.com/s977043/river-reviewer/issues/802) Phase 3 A2-fix-1

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -93,45 +93,63 @@ If you have questions about migration, please:
 2. Review [Epic #242](https://github.com/s977043/river-reviewer/issues/242)
 3. Open an issue with the `migration-help` label
 
-## Output artifact field executionDeferred (v0.51.0)
+## Output artifact field `debug.executionDeferred` (v0.51.0)
 
-### artifact.executionDeferred -> use artifact.plan.skippedSkills
+### `artifact.debug.executionDeferred` → use `debug.execution` trace
 
-**Deprecated in:** v0.51.0  
+**Deprecated in:** v0.51.0
 **Planned removal:** v0.53.0
 
-The boolean executionDeferred field on the review artifact was added during Phase 3
-to signal that some skills were deferred/skipped. It is superseded by the richer
-plan.skippedSkills array, which carries a per-skill skip reason.
+The boolean `debug.executionDeferred` flag was introduced in v0.50.0 (#802 Phase 3 A1)
+to signal that `river review exec` had accepted the contract but had not yet wired
+the skill execution adapter. v0.51.0 (#802 Phase 3 A2-1) actually wires the
+adapter via `generateReview`, so the flag is no longer set and is being retired.
 
+It is superseded by the `debug.execution` trace, which reports whether and how
+findings were produced:
+
+| Field                            | Meaning                                                                         |
+| -------------------------------- | ------------------------------------------------------------------------------- |
+| `debug.execution.skillsExecuted` | Number of skills the adapter actually invoked                                   |
+| `debug.execution.findingsCount`  | Findings written to `artifact.findings`                                         |
+| `debug.execution.llmUsed`        | `true` when an LLM call succeeded                                               |
+| `debug.execution.llmSkipped`     | Reason string when the LLM call was skipped (e.g. `OPENAI_API_KEY ... not set`) |
+| `debug.execution.heuristicsUsed` | `true` when the heuristic fallback ran                                          |
+
+For "which skills did not run", continue to use `artifact.plan.skippedSkills`
+(each entry has `id` and a `reasons` array). That field is unchanged.
 
 #### Migration
 
-**Before:**
+**Before (v0.50.0 only):**
 
 ```js
-if (artifact.executionDeferred) {
-  console.warn("some skills were skipped");
+if (artifact.debug?.executionDeferred) {
+  console.warn('river review exec did not execute skills yet');
 }
 ```
 
-
-**After:**
+**After (v0.51.0+):**
 
 ```js
+const exec = artifact.debug?.execution;
+if (exec && !exec.llmUsed && !exec.heuristicsUsed) {
+  console.warn('river review exec did not produce findings:', exec.llmSkipped);
+}
+
 const skipped = artifact.plan?.skippedSkills ?? [];
 if (skipped.length > 0) {
-  console.warn(skipped.length + " skills skipped:", skipped.map(s => s.reason));
+  console.warn(
+    skipped.length + ' skills skipped:',
+    skipped.map((s) => ({ id: s.id, reasons: s.reasons }))
+  );
 }
 ```
 
-
-plan.skippedSkills is available on all artifacts from river review plan
-and river review exec (v0.45.0+).
-
+`plan.skippedSkills` has been present since v0.45.0; `debug.execution` is
+new in v0.51.0.
 
 #### Related
 
 - [Troubleshooting: skill selection](review/troubleshooting.md)
-
-- Issue [#802](https://github.com/s977043/river-reviewer/issues/802) Phase 3 A2-fix-1
+- Issue [#802](https://github.com/s977043/river-reviewer/issues/802) Phase 3 (A1 → A2-1 → A2-fix-1)

--- a/docs/review/troubleshooting.md
+++ b/docs/review/troubleshooting.md
@@ -1,60 +1,63 @@
-# Troubleshooting: river review exec
+# Troubleshooting: `river review exec`
 
-## river review exec returns no findings despite a non-empty diff
+## `river review exec` returns no findings despite a non-empty diff
 
-**Symptom:** The CLI exits status: ok with findings_count: 0 and
-selected_count: 0 even though the diff has real changes and skills exist.
+**Symptom:** The CLI exits with `status: ok` but `findings.length === 0` and `plan.selectedSkills.length === 0`, even though the diff has real changes and skills exist.
 
-**Root cause (fixed in v0.51.0):** Prior to v0.51.0, river review exec never
-forwarded availableContexts to the plan layer. Every skill with
-inputContext: [diff] was silently moved into skippedSkills -- the review ran
-and returned empty findings with no visible error.
+**Root cause (fixed in v0.51.0):** Prior to v0.51.0, `river review exec` never forwarded `availableContexts` to the plan layer. Every skill that declared `inputContext: ['diff']` was silently moved into `plan.skippedSkills` with the reason `missing inputContext: diff`—the review ran and returned empty findings with no visible error.
 
 ### How to diagnose
 
-Run with --debug --output json and inspect plan.skippedSkills:
+Run with `--debug --output json` and inspect `plan.skippedSkills`:
 
 ```bash
 river review exec --phase midstream --debug --output json --output-file /tmp/review.json
-jq "{selected: (.plan.selectedSkills|length), skipped: (.plan.skippedSkills|length)}" /tmp/review.json
+jq '{ selected: (.plan.selectedSkills | length), skipped: (.plan.skippedSkills | length) }' /tmp/review.json
 ```
 
-If selected is 0 and skipped is large, you hit this issue.
+If `selected` is `0` and `skipped` is large, run:
+
+```bash
+jq '[.plan.skippedSkills[] | select(.reasons[] | contains("missing inputContext"))]' /tmp/review.json
+```
+
+If that returns a non-empty list on v0.50.0 or earlier, you hit this issue.
 
 ### Fix
 
-Upgrade to v0.51.0+. The plan layer now defaults availableContexts to [diff]
-whenever a diff artifact is resolved, so all skills with inputContext: [diff]
-are selected without extra configuration.
+Upgrade to v0.51.0 or later. The plan layer now defaults `availableContexts` to `['diff']` whenever a diff artifact is resolved, so all skills with `inputContext: ['diff']` are selected without extra configuration.
 
 ### CI environments with additional artifact contexts
 
-Set RIVER_AVAILABLE_CONTEXTS before invoking the CLI:
+Set `RIVER_AVAILABLE_CONTEXTS` before invoking the CLI:
 
 ```bash
 RIVER_AVAILABLE_CONTEXTS=diff,junit,coverage river review exec --phase midstream
 ```
 
-Or pass --context directly:
+Or pass `--context` directly:
 
 ```bash
 river review exec --phase midstream --context diff,junit,coverage
 ```
 
+The `'diff'` context is always retained when a diff artifact is resolved, so `--context tests` does not strip it.
+
 ---
 
-## Skill appears in skippedSkills with reason: missing inputContext X
+## Skill appears in `skippedSkills` with reason `missing inputContext: <X>`
 
-A skill declares inputContext: [X] but X is not in availableContexts.
+A skill declares `inputContext: ['<X>']` but `<X>` is not in the effective `availableContexts`.
 
 **Resolution options:**
 
-1. Add X to RIVER_AVAILABLE_CONTEXTS / --context if the artifact is genuinely available.
-2. Remove the inputContext constraint from the skill if it should always run.
+1. Add `<X>` to `RIVER_AVAILABLE_CONTEXTS` or `--context` if the artifact is genuinely available in this environment.
+2. Drop the `inputContext` constraint from the skill metadata if it should always run.
+3. Leave the skill skipped—`skippedSkills` is the correct outcome when the input is missing.
 
 ---
 
 ## See also
 
-- [CLI reference: river review exec](../pages/reference/cli-review-exec-spec.md)
-- [Deprecated: executionDeferred](deprecated.md#output-artifact-field-executiondeferred-v0510)
+- [CLI reference: `river review exec`](../../pages/reference/cli-review-exec-spec.md)
+- [Deprecated: `debug.executionDeferred`](../deprecated.md#output-artifact-field-debugexecutiondeferred-v0510)

--- a/docs/review/troubleshooting.md
+++ b/docs/review/troubleshooting.md
@@ -1,0 +1,60 @@
+# Troubleshooting: river review exec
+
+## river review exec returns no findings despite a non-empty diff
+
+**Symptom:** The CLI exits status: ok with findings_count: 0 and
+selected_count: 0 even though the diff has real changes and skills exist.
+
+**Root cause (fixed in v0.51.0):** Prior to v0.51.0, river review exec never
+forwarded availableContexts to the plan layer. Every skill with
+inputContext: [diff] was silently moved into skippedSkills -- the review ran
+and returned empty findings with no visible error.
+
+### How to diagnose
+
+Run with --debug --output json and inspect plan.skippedSkills:
+
+```bash
+river review exec --phase midstream --debug --output json --output-file /tmp/review.json
+jq "{selected: (.plan.selectedSkills|length), skipped: (.plan.skippedSkills|length)}" /tmp/review.json
+```
+
+If selected is 0 and skipped is large, you hit this issue.
+
+### Fix
+
+Upgrade to v0.51.0+. The plan layer now defaults availableContexts to [diff]
+whenever a diff artifact is resolved, so all skills with inputContext: [diff]
+are selected without extra configuration.
+
+### CI environments with additional artifact contexts
+
+Set RIVER_AVAILABLE_CONTEXTS before invoking the CLI:
+
+```bash
+RIVER_AVAILABLE_CONTEXTS=diff,junit,coverage river review exec --phase midstream
+```
+
+Or pass --context directly:
+
+```bash
+river review exec --phase midstream --context diff,junit,coverage
+```
+
+---
+
+## Skill appears in skippedSkills with reason: missing inputContext X
+
+A skill declares inputContext: [X] but X is not in availableContexts.
+
+**Resolution options:**
+
+1. Add X to RIVER_AVAILABLE_CONTEXTS / --context if the artifact is genuinely available.
+2. Remove the inputContext constraint from the skill if it should always run.
+
+---
+
+## See also
+
+- [CLI reference: river review exec](../pages/reference/cli-review-exec-spec.md)
+- [Deprecated: executionDeferred](deprecated.md#output-artifact-field-executiondeferred-v0510)


### PR DESCRIPTION
## Summary

Documentation follow-up for #865 (A2-fix-1). Covers two items from the session plan:

**D3 -- docs/review/troubleshooting.md (new file)**
Explains the silent-skip problem fixed in v0.51.0: river review exec returned
empty findings with no error when availableContexts was not forwarded to
buildExecutionPlan. Includes: diagnosis with --debug, the fix, RIVER_AVAILABLE_CONTEXTS
usage, and how to handle per-skill skippedSkills reasons.

**D2 -- docs/deprecated.md (append)**
Marks artifact.executionDeferred as deprecated in v0.51.0 (planned removal v0.53.0).
Points to plan.skippedSkills as the richer replacement with per-skill reasons.

## Changes

| File | What |
|---|---|
| docs/review/troubleshooting.md | New file: river review exec troubleshooting guide |
| docs/deprecated.md | Append: executionDeferred deprecation notice |

## No code changes

Pure documentation. All tests continue to pass unchanged.

Closes documentation gap for: #865 (A2-fix-1), #802 Phase 3.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>