### PR TITLE
docs(troubleshooting): close out silent-skip cleanup through v0.51.1

### DIFF
--- a/docs/review/troubleshooting.md
+++ b/docs/review/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting: `river review exec`
 
-This page captures the silent-skip failure modes fixed across `v0.51.0` and `v0.51.1`, plus the one residual replay-side gap that is still open as #802 A2-3.
+This page captures the silent-skip failure modes fixed across `v0.51.0` and `v0.51.1`, plus the one residual replay-side gap that is still open as [#802](https://github.com/s977043/river-reviewer/issues/802) A2-3.
 
 ## `river review exec` returns no findings despite a non-empty diff
 

--- a/docs/review/troubleshooting.md
+++ b/docs/review/troubleshooting.md
@@ -1,5 +1,7 @@
 # Troubleshooting: `river review exec`
 
+This page captures the silent-skip failure modes fixed across `v0.51.0` and `v0.51.1`, plus the one residual replay-side gap that is still open as #802 A2-3.
+
 ## `river review exec` returns no findings despite a non-empty diff
 
 **Symptom:** The CLI exits with `status: ok` but `findings.length === 0` and `plan.selectedSkills.length === 0`, even though the diff has real changes and skills exist.
@@ -21,11 +23,11 @@ If `selected` is `0` and `skipped` is large, run:
 jq '[.plan.skippedSkills[] | select(.reasons[] | contains("missing inputContext"))]' /tmp/review.json
 ```
 
-If that returns a non-empty list on v0.50.0 or earlier, you hit this issue.
+If that returns a non-empty list on `v0.50.0` or earlier, you hit this issue.
 
 ### Fix
 
-Upgrade to v0.51.0 or later. The plan layer now defaults `availableContexts` to `['diff']` whenever a diff artifact is resolved, so all skills with `inputContext: ['diff']` are selected without extra configuration.
+Upgrade to `v0.51.0` or later. The plan layer now defaults `availableContexts` to `['diff']` whenever a diff artifact is resolved, so all skills with `inputContext: ['diff']` are selected without extra configuration.
 
 ### CI environments with additional artifact contexts
 
@@ -54,6 +56,65 @@ A skill declares `inputContext: ['<X>']` but `<X>` is not in the effective `avai
 1. Add `<X>` to `RIVER_AVAILABLE_CONTEXTS` or `--context` if the artifact is genuinely available in this environment.
 2. Drop the `inputContext` constraint from the skill metadata if it should always run.
 3. Leave the skill skipped—`skippedSkills` is the correct outcome when the input is missing.
+
+---
+
+## Skill appears in `skippedSkills` with reason `missing dependency: <X>` (v0.51.1+)
+
+A skill declares `dependencies: ['<X>']` (for example `code_search`, `test_runner`, `coverage_report`) but `<X>` is not in the effective `availableDependencies`.
+
+**Fixed in:** `v0.51.1` ([#869](https://github.com/s977043/river-reviewer/pull/869))
+
+Prior to `v0.51.1`, `river review exec` never forwarded `availableDependencies` to the plan layer at all, so dependency-based skip was effectively disabled on exec. The fix wires the same flow that `river run` has always used.
+
+**Resolution options (now that the flow is honored):**
+
+1. Pass `--dependency code_search,test_runner` on the CLI when the runner actually provides those capabilities.
+2. Set `RIVER_AVAILABLE_DEPENDENCIES=code_search,test_runner` in the environment.
+3. Set `RIVER_DEPENDENCY_STUBS=1` to enable the default stub set (`code_search`, `test_runner`, `coverage_report`, `adr_lookup`, `repo_metadata`, `tracing`). Useful for local dry-run experiments where you only want to confirm a skill _would_ be selected.
+4. Leave the skill skipped—`skippedSkills` is the correct outcome when the dependency is unavailable.
+
+The CLI's default is `null` (= dependency-based skipping disabled), preserving the legacy behaviour for callers that do not opt in.
+
+---
+
+## Finding output looks generic / missing ADR references (v0.51.1+)
+
+**Symptom:** Findings appear, but ADR cross-references that worked on `river run` are missing, or phase-mismatch checks behave differently than `river run`.
+
+**Fixed in:** `v0.51.1` ([#871](https://github.com/s977043/river-reviewer/pull/871))
+
+Prior to `v0.51.1`, `river review exec` did not read the derived analysis context (`fileTypes`, `relatedADRs`, `reviewMode`) that `buildExecutionPlan` had already computed, and it did not pass them to the LLM call. Three effects were silent rather than failing:
+
+- `fileTypes` missing → the verifier's file-phase coherence check fell back to lenient.
+- `relatedADRs` missing → ADR cross-references were dropped from the prompt.
+- `reviewMode` missing → the context budget preset (`tiny | medium | large`) was always the generateReview default rather than the calibrated value.
+
+The fix is automatic in `v0.51.1+`; no configuration change is required.
+
+---
+
+## Where the plan layer forwards each context (reference)
+
+This is the current contract between `runReviewPlan` and `buildExecutionPlan` / `generateReview` on the `river review exec` path:
+
+| Source                                                                         | Field                                        | Forwarded since  |
+| ------------------------------------------------------------------------------ | -------------------------------------------- | ---------------- |
+| CLI `--context` / `RIVER_AVAILABLE_CONTEXTS`                                   | `availableContexts`                          | `v0.51.0` (#865) |
+| CLI `--dependency` / `RIVER_AVAILABLE_DEPENDENCIES` / `RIVER_DEPENDENCY_STUBS` | `availableDependencies`                      | `v0.51.1` (#869) |
+| Derived by `buildExecutionPlan`                                                | `fileTypes` (from changed files)             | `v0.51.1` (#871) |
+| Derived by `buildExecutionPlan`                                                | `relatedADRs` (from impact tags + ADR index) | `v0.51.1` (#871) |
+| Derived by `buildExecutionPlan`                                                | `reviewMode` (from diff size)                | `v0.51.1` (#871) |
+
+`config` (loaded from `.river-reviewer.{json,yaml}`) is already forwarded to `generateReview` since `v0.51.0`.
+
+---
+
+## Residual gap: `--plan` replay does not yet run skills
+
+`river review exec --plan <path>` still echoes the source plan as a Review Artifact with `findings: []` and does not invoke the execution adapter. This is intentional in `v0.51.x`—it locks the "replay does not re-plan" contract from PR #861 (B')—and is tracked as the next slice ([#802](https://github.com/s977043/river-reviewer/issues/802) A2-3).
+
+If you need findings, run `river review exec` without `--plan` so the internal plan path executes.
 
 ---
 


### PR DESCRIPTION
## Summary

Codex-recommended docs follow-up after the `v0.51.1` release. The troubleshooting page only documented the `v0.51.0` `availableContexts` fix; this PR adds the two remaining silent-skip cleanup items (#869, #871) and a forwarding reference table so adopters can quickly verify which plan-layer field is honored on which version.

## Additions

- **"missing dependency"** section: documents the `v0.51.1` (#869) fix and the `--dependency` / `RIVER_AVAILABLE_DEPENDENCIES` / `RIVER_DEPENDENCY_STUBS=1` knobs.
- **"Finding output looks generic / missing ADR references"** section: explains the three derived-context fields (`fileTypes`, `relatedADRs`, `reviewMode`) that the exec path was silently dropping, fixed in `v0.51.1` (#871).
- **"Where the plan layer forwards each context"** reference table: maps each forwarded field to the PR / release that wired it.
- **"Residual gap"** section: explicitly points at `--plan` replay (A2-3) so adopters know the boundary of `v0.51.x`.

## Out of scope

- No code changes
- `--plan` replay execution (A2-3) — separate slice

## Test plan

- [x] markdownlint + prettier + dashes green
- [x] `npm run check:links:local` (967 links, 0 errors)
- [ ] CI green
- [ ] Vercel preview renders the new sections

Follows: #864 (A2-1), #865 (A2-fix-1), #869 (A2-fix-2), #871 (A2-fix-3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)