### PR TITLE
docs(readme): add roadmap status column (multi-perspective review follow-up)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -280,15 +280,19 @@ We organize content into four types, mapped by directory under `pages/` and serv
 
 ## Roadmap
 
-Following the concept refresh (2026-05), the roadmap is organized into the following seven epics. Issues will be opened progressively.
+Following the concept refresh (2026-05), the roadmap is organized into the following seven epics. The Status column reflects v0.53.0 implementation reality.
 
-- **Epic 0**: Official Skill Pack and Minimal Registry (security / a11y / migration-safety / dependency-policy / plan-conformance)
-- **Epic 1**: First-Run Adoption (npm distribution, `npx river try`, 10-minute Quick Start, [#800](https://github.com/s977043/river-reviewer/issues/800))
-- **Epic 2**: SDLC Gates (stabilize `plan` / `exec` / `verify` CLI, artifact-input-contract v1, [#802](https://github.com/s977043/river-reviewer/issues/802))
-- **Epic 3**: Concept Refresh (README / vision / intro)
-- **Epic 4**: Skill Authoring and Governance (`npx river create skill`, catalog, contribution policy)
-- **Epic 5**: Evaluation Observability (CI regression, skill badges, dashboard)
-- **Epic 6**: Docs IA and Onboarding (first-run / skill authoring / CI operation paths)
+| Epic                                       | Description                                                                                                          | Status                                                                                                                                                                                                                                                        |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Epic 0**: Official Skill Pack            | Official skill pack and minimal registry (security / a11y / migration-safety / dependency-policy / plan-conformance) | Partial — community-tier modern-web-semantic / modern-web-performance landed ([#873](https://github.com/s977043/river-reviewer/pull/873) / [#875](https://github.com/s977043/river-reviewer/pull/875)). Official-tier registry not yet wired                  |
+| **Epic 1**: First-Run Adoption             | npm distribution, `npx river try`, 10-minute Quick Start                                                             | Planned — tracked at [#800](https://github.com/s977043/river-reviewer/issues/800), not started                                                                                                                                                                |
+| **Epic 2**: SDLC Gates                     | Stabilize `plan` / `exec` / `verify` CLI, artifact-input-contract v1                                                 | Partial — `plan` / `exec` stable as of v0.53.0 (silent-skip 5/6 closed). `exec --plan` replay execution tracked at [#878](https://github.com/s977043/river-reviewer/issues/878). `verify` execution not implemented                                           |
+| **Epic 3**: Concept Refresh                | README / vision / intro overhaul                                                                                     | Implemented — landed in v0.51.0 ([#860](https://github.com/s977043/river-reviewer/pull/860))                                                                                                                                                                  |
+| **Epic 4**: Skill Authoring and Governance | `npx river create skill`, catalog, contribution policy                                                               | Planned — registry.yaml extensions and contribution policy untouched                                                                                                                                                                                          |
+| **Epic 5**: Evaluation Observability       | CI regression, skill badges, dashboard                                                                               | Planned — per-skill promptfoo eval scaffold in place, dashboard / aggregation not yet                                                                                                                                                                         |
+| **Epic 6**: Docs IA and Onboarding         | First-run / skill authoring / CI operation onboarding paths                                                          | Partial — `docs/review/troubleshooting.md` covers silent-skip diagnosis ([#866](https://github.com/s977043/river-reviewer/pull/866), [#872](https://github.com/s977043/river-reviewer/pull/872)). Quick Start / skill-authoring onboarding tracks with Epic 1 |
+
+Legend: **Implemented** = primary acceptance criteria met / **Partial** = some scope landed, more remaining / **Planned** = not yet started.
 
 Earlier pillars (phase-aware review, Riverbed Memory, Evals/CI integration) remain in scope and are absorbed by the epics above.
 

--- a/README.md
+++ b/README.md
@@ -560,15 +560,19 @@ River Reviewer の技術ドキュメントは、[Diátaxis ドキュメントフ
 
 ## ロードマップ
 
-コンセプト刷新（2026-05）に伴い、Roadmap は以下の 7 Epic で構成する方針です。各 Epic の Issue は順次起票します。
+コンセプト刷新（2026-05）に伴い、Roadmap は以下の 7 Epic で構成しています。状態列は v0.53.0 時点の実装到達点を示します。
 
-- **Epic 0**: 公式 Skill Pack と最小 Registry（security / a11y / migration-safety / dependency-policy / plan-conformance）
-- **Epic 1**: First-Run Adoption（npm 配布、`npx river try`、10 分 Quick Start、[#800](https://github.com/s977043/river-reviewer/issues/800)）
-- **Epic 2**: SDLC Gates（`plan` / `exec` / `verify` CLI 安定化、artifact-input-contract v1、[#802](https://github.com/s977043/river-reviewer/issues/802)）
-- **Epic 3**: Concept Refresh（README / vision / intro 刷新）
-- **Epic 4**: Skill Authoring and Governance（`npx river create skill`、catalog、contribution policy）
-- **Epic 5**: Evaluation Observability（CI 回帰、skill バッジ、dashboard）
-- **Epic 6**: Docs IA and Onboarding（first-run / skill authoring / CI operation の動線再設計）
+| Epic                                       | 内容                                                                                                         | 状態                                                                                                                                                                                                                                                   |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Epic 0**: Official Skill Pack            | 公式 Skill Pack と最小 Registry（security / a11y / migration-safety / dependency-policy / plan-conformance） | Partial — community tier で modern-web-semantic / modern-web-performance が landed ([#873](https://github.com/s977043/river-reviewer/pull/873) / [#875](https://github.com/s977043/river-reviewer/pull/875))。公式 Skill Pack の registry 整備は未着手 |
+| **Epic 1**: First-Run Adoption             | npm 配布、`npx river try`、10 分 Quick Start                                                                 | Planned — [#800](https://github.com/s977043/river-reviewer/issues/800) で追跡中、未着手                                                                                                                                                                |
+| **Epic 2**: SDLC Gates                     | `plan` / `exec` / `verify` CLI 安定化、artifact-input-contract v1                                            | Partial — `plan` / `exec` は v0.53.0 で安定（silent-skip 5/6 解消済み）。`exec --plan` replay execution は [#878](https://github.com/s977043/river-reviewer/issues/878) で追跡。`verify` 実行は未実装                                                  |
+| **Epic 3**: Concept Refresh                | README / vision / intro 刷新                                                                                 | Implemented — v0.51.0 でランディング ([#860](https://github.com/s977043/river-reviewer/pull/860))                                                                                                                                                      |
+| **Epic 4**: Skill Authoring and Governance | `npx river create skill`、catalog、contribution policy                                                       | Planned — registry.yaml 拡張と contribution policy が未着手                                                                                                                                                                                            |
+| **Epic 5**: Evaluation Observability       | CI 回帰、skill バッジ、dashboard                                                                             | Planned — promptfoo eval は per-skill 基盤あり、全体 dashboard 化は未着手                                                                                                                                                                              |
+| **Epic 6**: Docs IA and Onboarding         | first-run / skill authoring / CI operation の動線再設計                                                      | Partial — `docs/review/troubleshooting.md` 整備済み ([#866](https://github.com/s977043/river-reviewer/pull/866), [#872](https://github.com/s977043/river-reviewer/pull/872))。Quick Start / Skill authoring の動線は Epic 1 と並行                     |
+
+凡例: **Implemented** = 主要受け入れ条件を達成 / **Partial** = 一部到達、残スコープあり / **Planned** = 着手予定。
 
 従来の柱（フェーズ別レビュー拡張、Riverbed Memory、Evals/CI 連携）は引き続き有効で、上記 Epic に吸収されます。
 


### PR DESCRIPTION
## Summary

Multi-perspective session review flagged the README roadmap as a list of epic names with no implementation status, making it hard for adopters to tell which slice was **Implemented** vs **Partial** vs **Planned**.

| Reviewer | Comment |
|---|---|
| Codex (86/100) | "Roadmap Epic 0-6 と実 PR の対応は、読めば推測できるが追跡表はない。README Roadmap に状態列を追加するべき" |
| Gemini (95/100) | "Vision drift のリスク。README で 5 軸比較表まで出した以上、状態の透明性が必要" |

## Change

Convert the 7-epic list to a table with an explicit **状態** column showing v0.53.0 reality:

| Epic | Status |
|---|---|
| 0 Official Skill Pack | Partial (#873 / #875 landed, registry pending) |
| 1 First-Run Adoption | Planned (#800) |
| 2 SDLC Gates | Partial (plan/exec stable, replay #878, verify pending) |
| 3 Concept Refresh | Implemented (#860) |
| 4 Skill Authoring and Governance | Planned |
| 5 Evaluation Observability | Planned |
| 6 Docs IA and Onboarding | Partial (#866 / #872) |

Adds a 凡例 line so the status column is self-explanatory.

No code changes.

## Test plan

- [x] markdownlint + prettier + dashes green
- [x] `npm run check:links:local` (981 links, 0 errors)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)