### PR TITLE
docs(eng-practices): add google/eng-practices mapping + policy skill alignment

### DIFF
--- a/docs/development/google-eng-practices-mapping.md
+++ b/docs/development/google-eng-practices-mapping.md
@@ -1,6 +1,6 @@
 # `google/eng-practices` Mapping
 
-[`google/eng-practices`](https://google.github.io/eng-practices/) は Google が社内で長年運用してきたコードレビュー文化を公開したドキュメント集です。River Reviewer は別の組織で動く OSS なので **そのままコピーするのではなく、既存の `severity` 語彙 / skill registry / review policy にどう翻訳されるか** を整理します。
+[`google/eng-practices`](https://google.github.io/eng-practices/) は Google が社内で長年運用してきたコードレビュー文化を公開したドキュメント集です。River Reviewer は Google 以外の組織でも利用される汎用 OSS なので **そのままコピーするのではなく、既存の `severity` 語彙 / skill registry / review policy にどう翻訳されるか** を整理します。
 
 このページは River Reviewer 利用者と skill 作者向けで、Google の用語が出てきたときに River Reviewer のどの仕組みで等価のことが扱えるかを引きやすくするのが目的です。
 
@@ -38,13 +38,13 @@
 
 `google/eng-practices` のうち、River Reviewer の汎用 skill に直接持ち込むと scope が崩れるものは以下です。これらは別レイヤで扱います。
 
-| 要素                                              | 理由                                               | 該当レイヤ                                                   |
-| ------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------ |
-| Speed of Code Reviews（SLA）                      | diff から判断不能、組織 metric の領域              | DORA metrics / CI dashboard / 別 epic                        |
-| Reviewer role（Gatekeeper + Mentor）              | 役割定義であって per-PR 評価ではない               | onboarding doc / org culture                                 |
-| Readability approval 制度                         | Google 固有の認定制度。汎用化が困難                | スコープ外（必要な組織は独自 skill / policy で扱う）         |
-| Comment hierarchy を新 taxonomy として導入        | 既存 `severity` ladder と競合し、運用が二重化する  | 上の対応表で吸収するのみ                                     |
-| Design > Functionality > ... 絶対順の機械ルール化 | 個別 PR の重みは domain 依存。固定順は誤指摘を生む | 参考順位として skill prompt に存在、ただし強制ルールにしない |
+| 要素                                                                      | 理由                                               | 該当レイヤ                                                   |
+| ------------------------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------ |
+| Speed of Code Reviews（SLA）                                              | diff から判断不能、組織 metric の領域              | DORA metrics / CI dashboard / 別 epic                        |
+| Reviewer role（Gatekeeper + Mentor）                                      | 役割定義であって per-PR 評価ではない               | onboarding doc / org culture                                 |
+| Readability approval 制度                                                 | Google 固有の認定制度。汎用化が困難                | スコープ外（必要な組織は独自 skill / policy で扱う）         |
+| Comment hierarchy を新 taxonomy として導入                                | 既存 `severity` ladder と競合し、運用が二重化する  | 上の対応表で吸収するのみ                                     |
+| Design > Functionality > Complexity > Tests > Naming 絶対順の機械ルール化 | 個別 PR の重みは domain 依存。固定順は誤指摘を生む | 参考順位として skill prompt に存在、ただし強制ルールにしない |
 
 ## PR size 警告（将来エピック）
 

--- a/docs/development/google-eng-practices-mapping.md
+++ b/docs/development/google-eng-practices-mapping.md
@@ -1,0 +1,62 @@
+# `google/eng-practices` Mapping
+
+[`google/eng-practices`](https://google.github.io/eng-practices/) は Google が社内で長年運用してきたコードレビュー文化を公開したドキュメント集です。River Reviewer は別の組織で動く OSS なので **そのままコピーするのではなく、既存の `severity` 語彙 / skill registry / review policy にどう翻訳されるか** を整理します。
+
+このページは River Reviewer 利用者と skill 作者向けで、Google の用語が出てきたときに River Reviewer のどの仕組みで等価のことが扱えるかを引きやすくするのが目的です。
+
+## 取り込み方針（要約）
+
+- **思想**: 完璧主義禁止 / "Improve the overall code health" は `review-policy-standard` skill (upstream / midstream / downstream) の prompt に取り込み済み。
+- **語彙**: must / should / nit / optional は River Reviewer の `severity: critical | major | minor | info` に対応表で吸収（新 taxonomy は導入しない）。
+- **レビュー観点の優先順** (Design > Functionality > Complexity > Tests > Naming) は River Reviewer の phase (upstream / midstream / downstream) + 既存 skill カタログにマップ可能。
+- **PR size** / **review speed SLA** / **Readability approval 制度** などの組織運用面は skill では扱わず、CI metric / docs / org policy 側へ送る。
+
+## Comment hierarchy ↔ `severity` ladder
+
+| `google/eng-practices` | River Reviewer `severity`       | 意味                        |
+| ---------------------- | ------------------------------- | --------------------------- |
+| must                   | `critical` あるいは強い `major` | merge 前に対処すべき実害    |
+| should                 | `major`                         | 残すと debt になる強い推奨  |
+| nit                    | `minor`                         | polish / 好み寄り、見送り可 |
+| optional / FYI         | `info`                          | 情報共有のみ、対応不要      |
+
+詳細な `severity` の付け方は [`skill-severity-rubric.md`](./skill-severity-rubric.md) を参照してください。**この表は外部語彙との対応であって、River Reviewer の rubric 本体ではありません**。
+
+## レビュー観点優先順 ↔ phase / skill カテゴリ
+
+`google/eng-practices` の "What to look for in a code review" は Design > Functionality > Complexity > Tests > Naming の優先順を提示しています。River Reviewer ではこれを **phase + 既存 skill** に分解します。
+
+| Google 観点   | River Reviewer 上の主担当                                                                                                                                                                         |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Design        | `phase: upstream` の skill（`rr-upstream-architecture-*`, `rr-upstream-api-*`, `rr-upstream-plangate-*` ほか）。`review-policy-standard` の upstream 版が「設計フェーズの重点」を prompt で明示。 |
+| Functionality | `phase: midstream` の `review-policy-standard` が「壊れる/漏れる/回復できない」順を prompt で固定。                                                                                               |
+| Complexity    | `phase: midstream` の中で `rr-midstream-logic-torturing-001` / `rr-midstream-type-driven-design-001` などが cognitive load / clever code を扱う。                                                 |
+| Tests         | `phase: downstream` の skill 群（`rr-downstream-coverage-gap-001`, `rr-downstream-flaky-test-001`, `rr-downstream-test-existence-001` ほか）と `rr-upstream-test-code-*`。                        |
+| Naming        | 各 phase の policy skill が prompt で軽量な命名ガイドを持ち、`rr-midstream-normalization-consistency-001` が一貫性視点を補完。                                                                    |
+
+## 採用しない（取り込まない）要素
+
+`google/eng-practices` のうち、River Reviewer の汎用 skill に直接持ち込むと scope が崩れるものは以下です。これらは別レイヤで扱います。
+
+| 要素                                              | 理由                                               | 該当レイヤ                                                   |
+| ------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------ |
+| Speed of Code Reviews（SLA）                      | diff から判断不能、組織 metric の領域              | DORA metrics / CI dashboard / 別 epic                        |
+| Reviewer role（Gatekeeper + Mentor）              | 役割定義であって per-PR 評価ではない               | onboarding doc / org culture                                 |
+| Readability approval 制度                         | Google 固有の認定制度。汎用化が困難                | スコープ外（必要な組織は独自 skill / policy で扱う）         |
+| Comment hierarchy を新 taxonomy として導入        | 既存 `severity` ladder と競合し、運用が二重化する  | 上の対応表で吸収するのみ                                     |
+| Design > Functionality > ... 絶対順の機械ルール化 | 個別 PR の重みは domain 依存。固定順は誤指摘を生む | 参考順位として skill prompt に存在、ただし強制ルールにしない |
+
+## PR size 警告（将来エピック）
+
+`google/eng-practices` の "Small CLs" 原則は River Reviewer でも価値が高いですが、これは **per-PR の LLM finding ではなく diff metric** として扱うべきです。
+
+現状 `runners/core/review-runner.mjs` の `buildExecutionPlan` は `extractDiffMeta` 経由で `reviewMode: tiny | medium | large` を返しています。将来この閾値判定を拡張し、CI annotation / GitHub Action soft warning 経由で PR size を adopter に提示できます。実装は別エピックで扱い、本 mapping doc では「思想として吸収済み」とだけ位置付けます。
+
+## 参考リンク
+
+- [`google/eng-practices` Code Review Standard](https://google.github.io/eng-practices/review/reviewer/standard.html)
+- [`google/eng-practices` What to look for](https://google.github.io/eng-practices/review/reviewer/looking-for.html)
+- [`google/eng-practices` Speed of Code Reviews](https://google.github.io/eng-practices/review/reviewer/speed.html)
+- [`google/eng-practices` Small CLs](https://google.github.io/eng-practices/review/developer/small-cls.html)
+- [`skill-severity-rubric.md`](./skill-severity-rubric.md)—River Reviewer の `severity` 定義（本対応表の親ドキュメント）
+- [`execution-context-contract.md`](./execution-context-contract.md)—`runReviewPlan` → `generateReview` の context contract

--- a/skills/downstream/review-policy-standard/SKILL.md
+++ b/skills/downstream/review-policy-standard/SKILL.md
@@ -81,3 +81,9 @@ severity: 'info'
 
 - 仕様や意図が不明確で解釈が分かれる場合は質問として返す。
 - 影響範囲が広い設計判断やトレードオフは人間レビューへ返す。
+
+## レビュー姿勢（Standard of Code Review）
+
+- テスト / QA レビューでも完璧を求めず、「このテスト追加 / 修正が回帰検出と保守性を改善するか」を判断軸にする (`google/eng-practices` の "Improve the overall code health" 原則)。
+- テスト観点では「意味のある assertion」「flaky 回避」「適切な scope (unit / integration / e2e)」を最優先する。命名やフォーマットは nit 扱い。
+- nit / 好み相当の指摘は `severity: minor` 以下に留める。詳しい対応表は [`docs/development/google-eng-practices-mapping.md`](../../../docs/development/google-eng-practices-mapping.md) を参照する。

--- a/skills/midstream/review-policy-standard/SKILL.md
+++ b/skills/midstream/review-policy-standard/SKILL.md
@@ -82,3 +82,9 @@ severity: 'info'
 
 - 仕様や意図が不明確で解釈が分かれる場合は質問として返す。
 - 影響範囲が広い設計判断やトレードオフは人間レビューへ返す。
+
+## レビュー姿勢（Standard of Code Review）
+
+- 完璧なコードを求めず、「PR を入れることでコードベース全体の健全性が改善するか」を判断軸にする (`google/eng-practices` の "Improve the overall code health" 原則)。
+- 完璧主義的な書き直し要求や、好みベースの reformat 要求はしない。
+- nit / 好み相当の指摘は `severity: minor` 以下に留め、`major` / `critical` は実害ベースの指摘に限定する。詳しい対応表は [`docs/development/google-eng-practices-mapping.md`](../../../docs/development/google-eng-practices-mapping.md) を参照する。

--- a/skills/upstream/review-policy-standard/SKILL.md
+++ b/skills/upstream/review-policy-standard/SKILL.md
@@ -71,3 +71,9 @@ severity: 'info'
 
 - 仕様や意図が不明確で解釈が分かれる場合は質問として返す。
 - 影響範囲が広い設計判断やトレードオフは人間レビューへ返す。
+
+## レビュー姿勢（Standard of Code Review）
+
+- 設計フェーズでも完璧な設計を求めず、「この plan / ADR がコードベース全体の方向性を改善するか」を判断軸にする (`google/eng-practices` の "Improve the overall code health" 原則)。
+- 上流レビューは Design > Functionality > Complexity > Tests > Naming の順で重点を置く（`google/eng-practices` "What to look for in a code review"）。
+- nit / 好み相当の指摘は `severity: minor` 以下に留める。詳しい対応表は [`docs/development/google-eng-practices-mapping.md`](../../../docs/development/google-eng-practices-mapping.md) を参照する。


### PR DESCRIPTION
## Summary

Absorb the google/eng-practices content (Standard of Code Review, What to look for, Small CLs, Speed of Code Reviews, How to Write Code Review Comments) into River Reviewer through the smallest non-redundant surface: a mapping doc + three short additions to the existing `review-policy-standard` skill prompts.

The shape was chosen after a Codex consultation that ruled out a full new skill pack (would duplicate the existing severity ladder and policy skills without buying new diff-level signal).

## Changes

### `docs/development/google-eng-practices-mapping.md` (new)

| Section | Content |
|---|---|
| Comment hierarchy ↔ severity | must → critical/major, should → major, nit → minor, optional → info. References [`skill-severity-rubric.md`](docs/development/skill-severity-rubric.md) as canonical |
| Review priority ↔ phase / skill | Design / Functionality / Complexity / Tests / Naming each mapped to a phase + concrete skill IDs in the existing registry |
| Not adopted | Speed SLA, Reviewer role, Readability approval, hierarchy as new taxonomy, strict priority order as a machine rule |
| PR size note | Treated as a future `reviewMode` threshold / CI annotation epic, not a skill |

### `skills/{upstream,midstream,downstream}/review-policy-standard/SKILL.md`

Short "Standard of Code Review" section added per file. Each variant adapts the framing to the phase:
- **upstream**: design-fitness over plan perfection, Design-first priority
- **midstream**: implementation overall-code-health, severity ladder discipline
- **downstream**: tests overall-code-health, "meaningful assertion / flaky-avoidance / appropriate scope" priority

All three link to the mapping doc for the full vocabulary.

## Behaviour change

None at the skill schema / artifact level. The policy skill prompts gain ~3 lines each, so the LLM has a slightly stronger framing for "improve overall code health" / "don't enforce perfection". Severity ladder, schemas, and outputs are unchanged.

## Out of scope (intentionally not adopted)

- New skill for PR size: deferred to a `reviewMode` threshold epic.
- New skill for clever-code / complexity: existing midstream skills cover it; not duplicating.
- New taxonomy for must/should/nit/optional: covered by mapping table only.
- Reviewer role / Readability approval / Speed SLA: org policy / metrics layer, not skills.

## Test plan

- [x] `npm run skills:validate` passes the modified policy skills
- [x] `npm test` (1087/1087 green; no behavioural change)
- [x] markdownlint + prettier + dashes + link-check green (1006 links, 0 errors)
- [ ] CI green

## Refs

- [`google/eng-practices`](https://google.github.io/eng-practices/) (Standard of Code Review / What to look for / Small CLs / Speed of Code Reviews / How to Write Code Review Comments)
- [`skill-severity-rubric.md`](docs/development/skill-severity-rubric.md) — canonical severity rubric this PR cross-references
- Predecessor: review-policy-standard skill set (upstream / midstream / downstream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)