### PR TITLE
docs(agent-learnings): record gh-api empty-commit pattern for release-please recovery

### DIFF
--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -42,6 +42,24 @@
   - `Applies to`: local/CI execution of `npm run lint`, `npm test`, and validation scripts.
   - `Evidence`: `package.json` `engines.node` is pinned to `22.x`.
 
-- `2026-05-24`: release-please often leaves a PR in `mergeStateStatus: BLOCKED` because the required CI checks were not registered on the auto-generated branch (only `Vercel` appears). The fix is to kick CI with a single empty commit on the branch. When local `git push` is not available (e.g. macOS Full Disk Access has revoked the working tree), the same effect can be achieved via the gh REST API: `gh api repos/<owner>/<repo>/git/commits` with the existing tree SHA plus parent, then `gh api -X PATCH repos/<owner>/<repo>/git/refs/heads/<branch>` to fast-forward the ref. Once CI re-runs the required checks register and the PR transitions to CLEAN.
+- `2026-05-24`: release-please often leaves a PR in `mergeStateStatus: BLOCKED` because the required CI checks did not register on the auto-generated branch (only `Vercel` appears). Fix: advance the branch by one empty commit. When local `git push` is unavailable (e.g. macOS Full Disk Access revoked the working tree), do it entirely via the gh REST API:
+
+  ```bash
+  REPO=s977043/river-reviewer
+  BRANCH=release-please--branches--main--components--river-reviewer
+  PARENT=$(gh api repos/$REPO/git/refs/heads/$BRANCH --jq '.object.sha')
+  TREE=$(gh api repos/$REPO/git/commits/$PARENT --jq '.tree.sha')
+
+  NEW=$(gh api repos/$REPO/git/commits --method POST --input - <<EOF | jq -r .sha
+  { "message": "chore: trigger CI", "tree": "$TREE", "parents": ["$PARENT"] }
+  EOF
+  )
+
+  gh api -X PATCH repos/$REPO/git/refs/heads/$BRANCH --input - <<EOF
+  { "sha": "$NEW" }
+  EOF
+  ```
+
+  Once the ref advances, the required status checks re-register and the PR transitions BLOCKED → CLEAN.
   - `Applies to`: release-please workflow recovery, fs-loss / sandbox-restricted environments, any case where the branch head must advance without a local checkout.
   - `Evidence`: validated on PR #876 (v0.53.0) during a session where the working tree was inaccessible; the BLOCKED → CLEAN → squash-merge → release-publish flow completed entirely via gh API.

--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -41,3 +41,7 @@
 - `2026-05-03`: Root scripts assume Node.js `22.x`; running validations on older Node versions can fail before repo logic executes.
   - `Applies to`: local/CI execution of `npm run lint`, `npm test`, and validation scripts.
   - `Evidence`: `package.json` `engines.node` is pinned to `22.x`.
+
+- `2026-05-24`: release-please often leaves a PR in `mergeStateStatus: BLOCKED` because the required CI checks were not registered on the auto-generated branch (only `Vercel` appears). The fix is to kick CI with a single empty commit on the branch. When local `git push` is not available (e.g. macOS Full Disk Access has revoked the working tree), the same effect can be achieved via the gh REST API: `gh api repos/<owner>/<repo>/git/commits` with the existing tree SHA plus parent, then `gh api -X PATCH repos/<owner>/<repo>/git/refs/heads/<branch>` to fast-forward the ref. Once CI re-runs the required checks register and the PR transitions to CLEAN.
+  - `Applies to`: release-please workflow recovery, fs-loss / sandbox-restricted environments, any case where the branch head must advance without a local checkout.
+  - `Evidence`: validated on PR #876 (v0.53.0) during a session where the working tree was inaccessible; the BLOCKED → CLEAN → squash-merge → release-publish flow completed entirely via gh API.


### PR DESCRIPTION
## Summary

Add one durable operational learning to `AGENT_LEARNINGS.md`: the gh-api empty-commit pattern that recovered release-please PR [#876](https://github.com/s977043/river-reviewer/pull/876) (v0.53.0) during a session when local fs access was revoked.

## The pattern

```
1. POST gh api repos/<owner>/<repo>/git/commits
   - tree: existing tree SHA
   - parents: [current branch HEAD]
   - message: "chore: trigger CI for release ..."
   -> returns new commit SHA

2. PATCH gh api -X PATCH repos/<owner>/<repo>/git/refs/heads/<branch>
   - sha: new commit SHA
   -> fast-forwards the branch ref
```

Once the branch advances by one commit, GitHub re-runs the required status checks, the PR transitions BLOCKED → CLEAN, and the normal squash-merge / release publish flow completes.

## Why this fits AGENT_LEARNINGS

Per the file's own README:

> Do not duplicate facts already stated in `AGENTS.md`. Only record what is not obvious from the canonical instructions.

This pattern is:
- Not duplicated anywhere in `AGENTS.md` or `docs/`.
- Applies to multiple future situations (release-please recovery, sandbox / fs-loss environments, branch-ref advance without a local checkout).
- Validated end-to-end on a real PR (#876, v0.53.0).

## Changes

| File | What |
|---|---|
| `AGENT_LEARNINGS.md` | +1 entry under "Current Learnings" |

No other content changes.

## Test plan

- [x] markdownlint + prettier + dashes green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)