### PR TITLE
docs(retrospective): 2026-05-21..25 multi-day sprint retrospective

### DIFF
--- a/docs/development/retrospectives/2026-05-21-25.md
+++ b/docs/development/retrospectives/2026-05-21-25.md
@@ -1,0 +1,119 @@
+# Retrospective: 2026-05-21 → 2026-05-25 Multi-Day Sprint
+
+5 日間 / 35 PR / 6 release / 1 production CVE close を完走したマルチデイスプリントの振り返り。Claude (single agent) が `対応を自律的に進めて` で連続実行し、Codex / Gemini を要所で相談する pattern で進行。
+
+このページは「次のスプリントで作る量を増やす」ためではなく、**「次のスプリントでどこから保留に戻すか」を先に設計する** ための durable record。
+
+## 数値サマリ
+
+| 指標                      | 値                                                                                                                                         |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Merged PRs                | 35                                                                                                                                         |
+| Releases published        | 6 (v0.51.0 → v0.55.0)                                                                                                                      |
+| New community skills      | 4 (Modern Web Guidance Phase 1 全 4 軸)                                                                                                    |
+| New docs                  | 6 (troubleshooting / execution-context-contract / eng-practices-mapping / npm-distribution-design / release-smoke / agent-learnings entry) |
+| Multi-perspective reviews | 1 (PR #860 concept refresh: Codex 86 / Gemini 95)                                                                                          |
+| Production CVE closed     | 1 (brace-expansion GHSA-jxxr-4gwj-5jf2)                                                                                                    |
+| Dependabot bumps merged   | 7                                                                                                                                          |
+
+## What worked
+
+1. **Multi-perspective review pattern** (Claude → Codex → Gemini → Codex) で PR #860 が 78 → 91 へ向上。`riskAssessment` 漏れもこのレビューで発見。
+2. **Silent-skip cleanup** を coherent thread (#865 / #869 / #871 / #877) として完走。1 つの設計ミス (`runReviewPlan` の context forwarding) を 4 PR で塞ぎきった。
+3. **`feedback_*.md` / `project_*.md` memory** がマルチデイ context を保存（gh auth switch / AGENTS.md pollution / dash normalize / fs-loss recovery）。
+4. **gh API empty-commit pattern** を fs-loss 中に発見し AGENT_LEARNINGS.md に記録。次セッション以降の即時参照可能。
+5. **Real-world dogfood** が A2-1 (#864) の "selected_count: 0" を発見。内部レビューでは見えなかった silent-skip を実利用で検出。
+
+## What didn't work
+
+1. **Codex の stop judgment 後も 13 PR を継続**。一部 (audit fix / risk-map example / smoke runbook) は価値ありだが、多くは marginal（extra community skill / docs about docs）。**最大の問題は速度ではなく、停止条件の弱さ。**
+2. **Skill 増産が eval / golden 未整備**。community skill 4 種すべて fixtures なし、registry 未登録。劣化検知不能な「品質未定義コード」を増やした。
+3. **release-please 手動 kick が 4 回必要**。empty commit を手で push し続けた。運用 debt として 2 回目で workflow_dispatch 化すべきだった。
+4. **AGENTS.md pollution** が claude-mem hook 由来で commit 前ごとに `git checkout` 必要。対症療法を続けたが発生源を止めていない。
+5. **Codex / Gemini も誤指摘**: `rr-upstream-plan-gate-*` のハイフンや `src/runners/core/` のパス推測ミスなど。レビュー依頼テンプレに「実ファイル読了 + 実パス引用」契約を入れるべきだった。
+6. **multi-perspective review が 1 回限り**。PR #860 で効果を確認したのに、その後の concept / schema / runner / release / skill contract 変更には適用せず例外運用化。
+
+## Surprises
+
+- **npm pack audit** が 969 files / 8.3 MB unpacked を発見。B1 design doc (#886) の価値が想定以上に高かった。
+- **CLI 境界混乱** (`src/cli.mjs` vs `runners/cli/`) が npm 配布前に潜在。`npx river review` が想定外に解釈される可能性。
+- **fs アクセス喪失中の gh API 復旧** が成功。OS レベルのサンドボックス制限下でも release-please PR を merge → release publish まで完走できた。
+
+## 5 Pivot Points 時系列分析
+
+| #   | タイミング                      | 取るべきだった判断                                         | 実際                |
+| --- | ------------------------------- | ---------------------------------------------------------- | ------------------- |
+| 1   | PR #860 後                      | multi-perspective review を高リスク PR に制度化            | 例外運用のまま      |
+| 2   | silent-skip cleanup 3 本目      | 量産モードに入った時点で残件・stop condition を固定        | A2-fix-N 命名を続行 |
+| 3   | community skill 2 個目追加時    | 3 個目以降は convention / registry / validation 整備に切替 | 4 個目まで増産      |
+| 4   | release-please 手動 kick 2 回目 | 運用 debt として workflow_dispatch 自動化                  | 4 回目まで継続      |
+| 5   | Codex stop judgment 直後        | 13 PR 継続でなく「価値あり / 実験 / 惰性」の分類を挟む     | 13 PR 連続マージ    |
+
+## Codex 100 字所見（このスプリントを総括）
+
+> 最大の問題は速度ではなく、停止条件の弱さ。次は「作る量」より「どこから保留に戻すか」を先に設計すべき。
+
+## 改善優先順（Skills / Agents / Workflow）
+
+Codex / Gemini 助言を踏まえた優先順。`P0` から順次。
+
+### Skills
+
+| 優先 | ID  | 内容                                                                                                                                                               |
+| ---- | --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| P0   | S3  | `skills/registry.yaml` に community セクション / `recommended: false` flag。未採用 skill を実験扱いとして明示する。S1 の eval 対象も S3 が決まらないと定義できない |
+| P1   | S1  | community skill の eval / golden convention。採用 skill のみ必須化（全部に付けると再び過剰生産）                                                                   |
+| P2   | S2  | `skill-severity-rubric.md` から実 skill を逆引きする cross-reference。運用導線改善                                                                                 |
+
+### Agents
+
+| 優先 | ID  | 内容                                                                                                                                  |
+| ---- | --- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| P0   | A2  | Stop-on-stop-judge ガード。autonomous override の暴走防止                                                                             |
+| P1   | A1  | 高リスク PR (concept / schema / runner / release / skill contract) のみ multi-perspective review を自動 trigger。全 PR 対象は重すぎる |
+| P2   | A3  | Agent 誤り傾向の prompt 注入。効果は限定的。`read these files first / cite observed paths only` の出力契約の方が効く                  |
+
+### Workflow
+
+| 優先    | ID    | 内容                                                                                                                                       |
+| ------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| P0      | W1+W5 | release-please kick の自動化。`workflow_dispatch` 優先、empty commit script は補助                                                         |
+| P1      | W4    | Stop-and-observe phase を branch label / milestone で見分ける。次スプリント入口で効く                                                      |
+| P2      | W3    | snapshot regenerator script 化 (`scripts/regen-execution-plan-snapshot.mjs`)                                                               |
+| ⚠️ 危険 | W2    | AGENTS.md pollution の pre-commit checkout は対症療法。まず claude-mem hook 発生源を止める。暫定は `git diff --exit-code AGENTS.md` で検知 |
+
+## Stop-on-Stop-Judge 運用ルール
+
+「対応を自律的に進めて」は無制限委任ではなく、**既知の目的に対する実行許可** として扱う。Codex stop judgment 後は以下 3 択で分類。
+
+| バケット     | 該当例                                                         | 今回該当                                                                              |
+| ------------ | -------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| **Continue** | production bug / failed CI / release blocker / user 明示タスク | A2-fix-4 (riskAssessment), brace-expansion CVE close, risk-map example, smoke runbook |
+| **Consult**  | scope expansion / 新規 convention / 追加 skill / docs 体系変更 | community skill #884, registry 設計, A2-3 着手                                        |
+| **Park**     | nice-to-have / 品質差が測れない改善 / eval なし追加            | docs about docs, marginal skill polish, README drift fix の連続                       |
+
+このルールは [`AGENTS.md`](../../../AGENTS.md) の autonomous-loop 運用ガイドラインに反映予定（別 PR）。
+
+## このスプリントの再分類（事後評価）
+
+| バケット                       | 該当 PR                                                                                                                                                               |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Continue (やるべきだった)      | #860 (concept), #861 (B'), #864 (A2-1), #865 (A2-fix-1), #869 (A2-fix-2), #871 (A2-fix-3), #877 (A2-fix-4), #888 (CVE), #896 (risk-map example), #897 (smoke runbook) |
+| Consult (相談を挟むべきだった) | #862-#874 (release-please の手動 kick が繰り返された)、#873 / #875 / #881 / #884 (community skill 増産)                                                               |
+| Park (本来後送りで良かった)    | #866 (docs D2+D3 — 統合可能だった), #872 (docs cleanup), #887 (agent-learnings entry), #889 (README drift)、#883 (eng-practices mapping)                              |
+
+事後評価で 13/35 PR が Park 候補。本スプリント中で約 37% が "停止後の overproduction"。
+
+## 関連 PR / Issue
+
+- 直近 release: v0.55.0
+- Open Issues: [#800](https://github.com/s977043/river-reviewer/issues/800), [#802](https://github.com/s977043/river-reviewer/issues/802), [#878](https://github.com/s977043/river-reviewer/issues/878), [#868](https://github.com/s977043/river-reviewer/issues/868)
+- Foundation docs from this sprint: [`docs/development/execution-context-contract.md`](../execution-context-contract.md), [`docs/development/npm-distribution-design.md`](../npm-distribution-design.md), [`docs/development/google-eng-practices-mapping.md`](../google-eng-practices-mapping.md), [`docs/runbook/release-smoke.md`](../../runbook/release-smoke.md), [`docs/review/troubleshooting.md`](../../review/troubleshooting.md)
+
+## 次スプリント開始時の checklist
+
+1. **Stop-on-stop-judge 運用ルールを AGENTS.md に追加する PR を最初に着手**（このスプリントの最大教訓を制度化）
+2. **`skills/registry.yaml` community セクション設計**（S3 を独立 PR で）
+3. **release-please kick 自動化**（W1+W5 を `workflow_dispatch` で）
+4. **#878 A2-3 への着手判断**: ExecutionContext doc 整備済 (#880) なので schema bump 設計から
+5. **adopter 観測フェーズの明示化**: 何を測定 / 観察するかを最初に決める（次スプリント入口の意思決定）


### PR DESCRIPTION
## Summary

Persist the 5-day sprint retrospective as a durable doc. The sprint shipped 35 PRs / 6 releases / 1 production CVE close, and the most important lesson — per Codex's analysis — is **not about velocity, but about stop conditions**:

> 最大の問題は速度ではなく、停止条件の弱さ。次は「作る量」より「どこから保留に戻すか」を先に設計すべき。

This PR is **PR 1 of 3** in the retrospective follow-up:

1. **This PR**: persist the retrospective itself as `docs/development/retrospectives/2026-05-21-25.md`.
2. **Next PR**: S3 — `skills/registry.yaml` community section / `recommended: false` flag (decide which community skills are experimental).
3. **Next PR**: W1+W5 — release-please kick automation (`workflow_dispatch` + supporting script).

## Doc structure

- Numerical summary (35 PR / 6 release / 4 community skills / 7 dependabot bumps / 1 CVE)
- 5 What-worked items, 6 What-didn't-work items, 3 Surprises
- 5 Pivot Points timeline (where direction should have changed but didn't)
- Improvement priorities split into Skills / Agents / Workflow with P0/P1/P2 ranking
- **Stop-on-Stop-Judge operational rule**: Continue / Consult / Park 3-bucket classification
- Post-hoc classification of this sprint's 35 PRs against the buckets (~13 fell into Park)
- Next sprint opening checklist

## Key proposals carried by this doc

| Domain | P0 |
|---|---|
| Skills | S3: `registry.yaml` community section / `recommended: false` flag |
| Agents | A2: Stop-on-stop-judge guard |
| Workflow | W1+W5: release-please kick automation |

## Test plan

- [x] markdownlint + prettier + dashes green
- [ ] CI green

No code change. Pure documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)