### PR TITLE
feat(registry): add community section with recommended:false (S3 from retrospective)

### DIFF
--- a/skills/registry.yaml
+++ b/skills/registry.yaml
@@ -250,6 +250,82 @@ skills:
     recommended: true
     description: 'Meta-review skill: detects review findings that belong in CI/lint/formatter rather than human review'
 
+  # ------------------------------------------------------------------
+  # Community Skills (Experimental tier; recommended: false)
+  # ------------------------------------------------------------------
+  # These skills live under skills/midstream/community/ and are intentionally
+  # marked `recommended: false` so the catalog distinguishes "core / curated"
+  # from "experimental / not yet eval-backed". A community skill becomes a
+  # candidate for `recommended: true` when it gains good/bad fixtures and a
+  # golden output (the S1 convention from the 2026-05-21..25 retrospective).
+  # Until then, treat them as opt-in suggestions, not first-line gates.
+
+  - id: rr-midstream-a11y-accessible-name-001
+    version: '0.1.0'
+    name: 'a11y Accessible Name Basics'
+    path: skills/midstream/community/rr-midstream-a11y-accessible-name-001/SKILL.md
+    category: midstream
+    phase: midstream
+    tags: [community, accessibility, ui, midstream]
+    severity: minor
+    recommended: false
+    description: 'Checks images, buttons, and form controls for accessible names (alt / aria-label / label association).'
+
+  - id: rr-midstream-nextjs-app-router-boundary-001
+    version: '0.1.0'
+    name: 'Next.js App Router Boundary Guard'
+    path: skills/midstream/community/rr-midstream-nextjs-app-router-boundary-001/SKILL.md
+    category: midstream
+    phase: midstream
+    tags: [community, nextjs, app-router, ui, midstream]
+    severity: minor
+    recommended: false
+    description: 'Surfaces Next.js App Router boundary issues (server vs client component placement, "use client" misuse).'
+
+  - id: rr-midstream-modern-web-semantic-001
+    version: '0.1.0'
+    name: 'Modern Web Semantic + Platform-Native'
+    path: skills/midstream/community/rr-midstream-modern-web-semantic-001/SKILL.md
+    category: midstream
+    phase: midstream
+    tags: [community, modern-web, semantic-html, accessibility, ui, midstream]
+    severity: minor
+    recommended: false
+    description: 'Suggests semantic HTML / Web Platform Native APIs / modern CSS over legacy workarounds.'
+
+  - id: rr-midstream-modern-web-performance-001
+    version: '0.1.0'
+    name: 'Modern Web Performance + Core Web Vitals'
+    path: skills/midstream/community/rr-midstream-modern-web-performance-001/SKILL.md
+    category: midstream
+    phase: midstream
+    tags: [community, modern-web, performance, core-web-vitals, ui, midstream]
+    severity: minor
+    recommended: false
+    description: 'Surfaces LCP / INP / CLS / resource-cost implications of frontend diffs.'
+
+  - id: rr-midstream-modern-web-browser-compat-001
+    version: '0.1.0'
+    name: 'Modern Web Browser Compatibility + Baseline Awareness'
+    path: skills/midstream/community/rr-midstream-modern-web-browser-compat-001/SKILL.md
+    category: midstream
+    phase: midstream
+    tags: [community, modern-web, browser-compatibility, baseline, midstream]
+    severity: minor
+    recommended: false
+    description: 'Prompts Baseline status / feature detection / progressive enhancement for new Web APIs and CSS.'
+
+  - id: rr-midstream-modern-web-a11y-interactive-001
+    version: '0.1.0'
+    name: 'Modern Web Accessibility for Interactive UI'
+    path: skills/midstream/community/rr-midstream-modern-web-a11y-interactive-001/SKILL.md
+    category: midstream
+    phase: midstream
+    tags: [community, modern-web, accessibility, a11y, ui, midstream]
+    severity: minor
+    recommended: false
+    description: 'Keyboard operation / focus management / live regions / role-state semantics for interactive UI.'
+
   # Downstream Skills (Testing & Release)
   - id: agent-qa-regression
     version: '0.1.0'


### PR DESCRIPTION
## Summary

**PR 2 of 3** in the retrospective follow-up (foundation: [#898](https://github.com/s977043/river-reviewer/pull/898)). Implement S3: surface the community tier in `skills/registry.yaml` with explicit `recommended: false`. Until now community skills were loaded at runtime but invisible in the catalog, which Codex flagged in the multi-perspective review as a scaling risk.

## What changed

Add a new "Community Skills (Experimental)" subsection between the core midstream block and the downstream block. Six skills listed:

| Skill | Origin |
|---|---|
| `rr-midstream-a11y-accessible-name-001` | pre-existing |
| `rr-midstream-nextjs-app-router-boundary-001` | pre-existing |
| `rr-midstream-modern-web-semantic-001` | #873 |
| `rr-midstream-modern-web-performance-001` | #875 |
| `rr-midstream-modern-web-browser-compat-001` | #881 |
| `rr-midstream-modern-web-a11y-interactive-001` | #884 |

All six carry `recommended: false`. The section also carries a header comment defining the convention: a community skill becomes a `recommended: true` candidate when it gains good/bad fixtures + golden output (the S1 follow-up).

## Test plan

- [x] `node scripts/validate-meta-consistency.mjs` → "Meta consistency: OK"
- [x] `npm run skills:validate` → all SKILL.md valid
- [x] `npm test` → 1087/1087 green
- [x] prettier + markdownlint + dashes green
- [ ] CI green

## Refs

- [`docs/development/retrospectives/2026-05-21-25.md`](docs/development/retrospectives/2026-05-21-25.md) — S3 entry in the priority table.
- [#898](https://github.com/s977043/river-reviewer/pull/898) — retrospective doc that proposed this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)