### PR TITLE
ci: add release-please kick workflow + script (W1+W5)

### DIFF
--- a/.github/workflows/release-please-kick.yml
+++ b/.github/workflows/release-please-kick.yml
@@ -1,0 +1,40 @@
+name: Release Please Kick
+
+# Manually advance the release-please branch by one empty commit when the
+# branch is BLOCKED (required status checks not registered on auto-generated
+# branches). Run via the GitHub UI: Actions → Release Please Kick → Run workflow.
+#
+# Background: docs/development/retrospectives/2026-05-21-25.md (W1+W5).
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'release-please branch name'
+        required: false
+        default: 'release-please--branches--main--components--river-reviewer'
+
+permissions:
+  contents: write
+
+jobs:
+  kick:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Advance release-please branch by an empty commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ inputs.branch }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          PARENT=$(gh api "repos/${REPO}/git/refs/heads/${BRANCH}" --jq '.object.sha')
+          TREE=$(gh api "repos/${REPO}/git/commits/${PARENT}" --jq '.tree.sha')
+          NEW=$(gh api "repos/${REPO}/git/commits" --method POST \
+            -f message='chore: trigger CI on release-please branch' \
+            -f tree="${TREE}" \
+            -f "parents[]=${PARENT}" \
+            --jq '.sha')
+          gh api -X PATCH "repos/${REPO}/git/refs/heads/${BRANCH}" -f sha="${NEW}"
+          echo "Advanced ${BRANCH}: ${PARENT} → ${NEW}"

--- a/docs/runbook/release-please-kick.md
+++ b/docs/runbook/release-please-kick.md
@@ -1,0 +1,32 @@
+# Release Please Kick Runbook
+
+## When to use
+
+The release-please PR is BLOCKED because required status checks were not
+registered on the auto-generated branch (a common consequence of strict
+branch protection on freshly created refs).
+
+## Preferred: `workflow_dispatch`
+
+1. Go to **Actions → Release Please Kick → Run workflow**.
+2. Leave `branch` as the default
+   (`release-please--branches--main--components--river-reviewer`) unless the
+   release-please component name differs.
+3. Confirm the new commit appears on the branch and CI starts.
+
+## Fallback: local script
+
+```bash
+scripts/release-please-kick.sh
+# or with explicit branch:
+scripts/release-please-kick.sh release-please--branches--main--components--river-reviewer
+```
+
+The script uses `gh api` to create an empty commit via the REST API
+(`POST git/commits` + `PATCH git/refs/heads/...`). It works without a clean
+local checkout, which is useful during `fs-loss` incidents.
+
+## Background
+
+See `docs/development/retrospectives/2026-05-21-25.md` (W1+W5). The empty-commit
+pattern is recorded in `AGENT_LEARNINGS.md` (2026-05-24 entry).

--- a/scripts/release-please-kick.sh
+++ b/scripts/release-please-kick.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Advance the release-please branch by an empty commit via the GitHub REST API.
+# Use when the release-please PR is BLOCKED because required status checks were
+# not registered on the auto-generated branch.
+#
+# Preferred path: trigger .github/workflows/release-please-kick.yml from the
+# Actions UI. This script is a local fallback when network/credentials make the
+# workflow path inconvenient.
+#
+# Usage:
+#   scripts/release-please-kick.sh [branch]
+#   REPO=owner/repo scripts/release-please-kick.sh [branch]
+
+set -euo pipefail
+
+REPO="${REPO:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
+BRANCH="${1:-release-please--branches--main--components--river-reviewer}"
+
+PARENT=$(gh api "repos/${REPO}/git/refs/heads/${BRANCH}" --jq '.object.sha')
+TREE=$(gh api "repos/${REPO}/git/commits/${PARENT}" --jq '.tree.sha')
+NEW=$(gh api "repos/${REPO}/git/commits" --method POST \
+  -f message='chore: trigger CI on release-please branch' \
+  -f tree="${TREE}" \
+  -f "parents[]=${PARENT}" \
+  --jq '.sha')
+gh api -X PATCH "repos/${REPO}/git/refs/heads/${BRANCH}" -f sha="${NEW}" >/dev/null
+
+echo "Advanced ${BRANCH}"
+echo "  parent: ${PARENT}"
+echo "  new:    ${NEW}"


### PR DESCRIPTION
## Summary

PR 3/3 of the P0 retrospective follow-up set (see #898 retrospective doc; companion #899 community-skills registry).

Codifies the release-please kick pattern that was applied **4 times manually** during the v0.51.0–v0.55.0 sprint:

- **Preferred**: `Actions → Release Please Kick → Run workflow` (`workflow_dispatch`)
- **Fallback**: `scripts/release-please-kick.sh` — local CLI using the same `gh api` empty-commit pattern (works during fs-loss incidents)
- Runbook: `docs/runbook/release-please-kick.md`

Per Codex's verbatim retrospective guidance: "W1/W5: release-please kick の自動化。統合して 1 件でよい。`workflow_dispatch` 優先、script は補助。empty commit script だけだと運用の本質が残る"

## Test plan

- [x] markdownlint + prettier via lint-staged pre-commit hook
- [x] `node scripts/fix-dashes.mjs --check` clean
- [ ] CI green on this PR
- [ ] Dry-run the workflow on next BLOCKED release-please PR