### PR TITLE
fix(ci): kick workflow requires RELEASE_KICK_PAT + loud failure mode (closes #906)

### DIFF
--- a/.github/workflows/release-please-kick.yml
+++ b/.github/workflows/release-please-kick.yml
@@ -4,7 +4,15 @@ name: Release Please Kick
 # branch is BLOCKED (required status checks not registered on auto-generated
 # branches). Run via the GitHub UI: Actions → Release Please Kick → Run workflow.
 #
-# Background: docs/development/retrospectives/2026-05-21-25.md (W1+W5).
+# IMPORTANT: This workflow requires a `RELEASE_KICK_PAT` secret to actually
+# trigger downstream CI. Pushes authored by `GITHUB_TOKEN` do NOT trigger
+# `pull_request: synchronize` workflows by GitHub design (no-recursion safety).
+# Without `RELEASE_KICK_PAT`, the commit will land but downstream checks will
+# never run — the workflow detects this and fails loudly.
+#
+# Setup: see docs/runbook/release-please-kick.md.
+# Background: docs/development/retrospectives/2026-05-21-25.md (W1+W5),
+# issue #906 (defect discovered during v0.57.0 release).
 
 on:
   workflow_dispatch:
@@ -17,6 +25,7 @@ on:
 permissions:
   contents: write
   pull-requests: read
+  checks: read
 
 concurrency:
   group: release-please-kick
@@ -25,15 +34,29 @@ concurrency:
 jobs:
   kick:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Advance release-please branch by an empty commit
+        id: advance
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Prefer RELEASE_KICK_PAT (user/app PAT with contents:write) so the
+          # push can trigger downstream pull_request workflows. Falls back to
+          # GITHUB_TOKEN with a loud warning — the fallback path is known to
+          # produce a "successful kick with zero CI" silent failure (#906).
+          GH_TOKEN: ${{ secrets.RELEASE_KICK_PAT || secrets.GITHUB_TOKEN }}
+          USING_PAT: ${{ secrets.RELEASE_KICK_PAT != '' }}
           BRANCH_INPUT: ${{ inputs.branch }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+
+          if [ "${USING_PAT}" != "true" ]; then
+            echo "::warning::RELEASE_KICK_PAT secret is not set. Falling back to GITHUB_TOKEN."
+            echo "::warning::GitHub blocks GITHUB_TOKEN pushes from triggering downstream workflows (no-recursion safety)."
+            echo "::warning::The kick will succeed but downstream pull_request checks will NOT re-run, leaving the release PR BLOCKED."
+            echo "::warning::See docs/runbook/release-please-kick.md for RELEASE_KICK_PAT setup."
+          fi
+
           if [ -z "${BRANCH_INPUT}" ]; then
             BRANCH=$(gh pr list --repo "${REPO}" --state open --search 'in:title "chore(main): release"' --json headRefName --jq '.[0].headRefName')
             if [ -z "${BRANCH}" ] || [ "${BRANCH}" = "null" ]; then
@@ -44,6 +67,7 @@ jobs:
           else
             BRANCH="${BRANCH_INPUT}"
           fi
+
           PARENT=$(gh api "repos/${REPO}/git/refs/heads/${BRANCH}" --jq '.object.sha')
           TREE=$(gh api "repos/${REPO}/git/commits/${PARENT}" --jq '.tree.sha')
           NEW=$(gh api "repos/${REPO}/git/commits" --method POST \
@@ -52,4 +76,38 @@ jobs:
             -f "parents[]=${PARENT}" \
             --jq '.sha')
           gh api -X PATCH "repos/${REPO}/git/refs/heads/${BRANCH}" -f sha="${NEW}"
+
           echo "Advanced ${BRANCH}: ${PARENT} → ${NEW}"
+          echo "branch=${BRANCH}" >> "${GITHUB_OUTPUT}"
+          echo "sha=${NEW}" >> "${GITHUB_OUTPUT}"
+
+      - name: Verify downstream CI actually started (loud failure mode)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.advance.outputs.branch }}
+          SHA: ${{ steps.advance.outputs.sha }}
+          REPO: ${{ github.repository }}
+          USING_PAT: ${{ secrets.RELEASE_KICK_PAT != '' }}
+        run: |
+          set -euo pipefail
+          if [ "${USING_PAT}" != "true" ]; then
+            echo "::error::RELEASE_KICK_PAT not configured — skipping CI-started verification because we already know it will fail."
+            echo "::error::Use scripts/release-please-kick.sh from a local machine (user PAT) until the secret is added."
+            exit 1
+          fi
+
+          echo "Waiting up to 90s for non-Vercel checks to start on ${SHA}..."
+          for i in $(seq 1 9); do
+            sleep 10
+            COUNT=$(gh api "repos/${REPO}/commits/${SHA}/check-runs" --jq '[.check_runs[] | select(.name | test("Vercel"; "i") | not)] | length')
+            if [ "${COUNT}" -gt 0 ]; then
+              echo "Detected ${COUNT} non-Vercel check-run(s) started. Kick succeeded."
+              exit 0
+            fi
+            echo "  attempt ${i}/9: still 0 non-Vercel checks..."
+          done
+
+          echo "::error::No non-Vercel checks started within 90s on ${SHA}."
+          echo "::error::This is the #906 failure mode — kick landed but downstream CI did not fire."
+          echo "::error::Verify RELEASE_KICK_PAT scope (needs contents:write) or use the local script as fallback."
+          exit 1

--- a/docs/runbook/release-please-kick.md
+++ b/docs/runbook/release-please-kick.md
@@ -6,13 +6,25 @@ The release-please PR is BLOCKED because required status checks were not
 registered on the auto-generated branch (a common consequence of strict
 branch protection on freshly created refs).
 
+## Setup (one-time): `RELEASE_KICK_PAT` secret
+
+The workflow requires a Personal Access Token to actually unblock downstream CI.
+GitHub blocks `GITHUB_TOKEN`-authored pushes from triggering `pull_request: synchronize`
+workflows (no-recursion safety), so the default token cannot do this job (#906).
+
+1. Create a fine-grained PAT with **Contents: Read and write** on this repo.
+   (Or use a GitHub App installation token if you prefer.)
+2. Add it as repo secret `RELEASE_KICK_PAT` under **Settings → Secrets and variables → Actions**.
+3. The workflow auto-detects the secret. Without it, the workflow exits 1 with a clear error
+   pointing back to this runbook.
+
 ## Preferred: `workflow_dispatch`
 
-1. Go to **Actions → Release Please Kick → Run workflow**.
-2. Leave `branch` as the default
-   (`release-please--branches--main--components--river-reviewer`) unless the
-   release-please component name differs.
-3. Confirm the new commit appears on the branch and CI starts.
+1. Confirm `RELEASE_KICK_PAT` secret is configured (above).
+2. Go to **Actions → Release Please Kick → Run workflow**.
+3. Leave `branch` blank—the workflow auto-detects the open release-please PR.
+4. The workflow also verifies a non-Vercel check started within 90s; if not, it fails loudly
+   so the silent #906 failure mode cannot recur.
 
 ## Fallback: local script
 


### PR DESCRIPTION
## Summary

Fixes #906 — defect discovered during v0.57.0 release. The kick workflow's `GITHUB_TOKEN`-authored push cannot trigger downstream `pull_request` workflows (GitHub no-recursion safety), so the release PR stays BLOCKED despite the kick appearing successful.

Applies Code-gen self-review (AGENTS.md from #904) — specifically the "Failure mode" point that was meant to prevent exactly this kind of silent success.

## Changes

- **Failure mode (loud)**: new verify step polls `commits/{sha}/check-runs` for 90s and fails the workflow if no non-Vercel checks start. The silent success was the #906 pattern.
- **PAT support**: `RELEASE_KICK_PAT` secret preferred; fallback to `GITHUB_TOKEN` emits warnings and then exits 1 in the verify step (rather than completing green with zero effect).
- **Runbook**: PAT setup steps added at the top.
- Concurrency + auto-detect preserved from #902.

Local `scripts/release-please-kick.sh` remains the unconditional fallback — it pushes via gh OAuth (user PAT), so it bypasses the no-recursion limit. Used to unblock #903 (v0.57.0).

## Test plan

- [x] `node scripts/fix-dashes.mjs --check` clean
- [x] markdownlint via pre-commit
- [ ] CI green
- [ ] Add `RELEASE_KICK_PAT` secret (manual, post-merge)
- [ ] Validate against next release-please BLOCKED PR

## Codify-then-validate self-check

1. Failure scenarios: (a) PAT missing → exit 1 with runbook link, (b) PAT expired → 401 surfaces in step output, (c) PAT under-scoped → check-runs poll fails, hits loud-failure path.
2. Reopen condition: N/A (not a rule).
3. Gray zone: Vercel-only checks are insufficient signal; the poll filters them out explicitly.