### PR TITLE
feat(skills): independent review synthesis skill (#911 Phase 1)

### DIFF
--- a/pages/guides/use-independent-review-synthesis.md
+++ b/pages/guides/use-independent-review-synthesis.md
@@ -1,0 +1,74 @@
+# Independent Review Synthesis を使う
+
+複数の AI / 人間レビュー結果を統合し、merge 判断を支援するための skill。
+Nolan Lawson 氏の Triple Agent skill にインスパイアされつつ、ツール固定を避け、
+River Reviewer の artifact-driven 思想に合わせて再構成した「synthesis pattern」。
+
+- 該当 skill: `rr-midstream-independent-review-synthesis-001`
+- 関連 epic: [#911](https://github.com/s977043/river-reviewer/issues/911)
+- ステータス: Phase 1 (community / `recommended: false`)。Phase 2 で artifact contract 拡張、Phase 3 で CLI ensemble mode を予定。
+
+## いつ使うか
+
+- **複数の AI レビュー結果を集約したい**（例: Claude / Codex / Cursor / GitHub Copilot のレビューを並走させ、出力を 1 つにまとめる）
+- **AI レビューと人間レビューを併用したい**（review-external に AI 結果、review-self に著者のセルフレビューを置く）
+- **過去 PR の findings を踏まえて判断したい**（findings-pool に履歴を渡す）
+
+## いつ使わないか
+
+- 単一 reviewer しかいない一般的な PR レビュー → 既存の midstream skill 群で十分
+- 新しいレビュー観点（security / a11y / performance）を追加したい → 個別 skill を作る
+- レビュー結果の多数決で merge 判断を自動化したい → この skill は多数決を採用しない。Hard rule 1。
+
+## 入力
+
+`.river/` などのリポジトリ規約に従い、以下の artifact を渡す:
+
+| artifact ID       | 形式         | 役割                                                  |
+| ----------------- | ------------ | ----------------------------------------------------- |
+| `diff`            | patch / diff | 必須。当該 PR の差分                                  |
+| `review-self`     | Markdown     | 任意。実装者のセルフレビュー                          |
+| `review-external` | Markdown     | 任意。外部 AI / 人間レビュー                          |
+| `findings-pool`   | JSON         | 任意。過去 Review Artifact から集約した findings 履歴 |
+| `fullFile`        | source       | 任意。verification step での精度を上げる              |
+
+artifact 定義の詳細は [`pages/reference/artifact-input-contract.md`](../reference/artifact-input-contract.md) 参照。
+
+## 出力
+
+6 セクション固定:
+
+1. Critical Issues
+2. Major Issues
+3. Minor Issues
+4. Dismissed Findings (hallucination / duplicate)
+5. Agent Agreement Summary (どの reviewer が何を指摘したかの一覧、補助情報)
+6. Merge Recommendation (`merge-ready` / `human-review` / `block`)
+
+各 finding は `Finding:` / `Evidence:` / `Reviewers:` / `Severity:` / `ValidatedStatus:` / `Suggestion:` のブロック形式。
+
+## 設計原則
+
+- **多数決禁止**: `Reviewers:` は補助情報。`Severity` / `ValidatedStatus` は evidence 品質で決める
+- **Hallucination guard**: 各 finding の `Evidence:` が実コードに存在するか grep で確認。見つからなければ `dismissed-hallucination`
+- **Single-reviewer findings は採用可**: 1 reviewer のみの指摘でも、evidence があれば confirmed
+- **Evidence なしの critical は不可**: severity の上限は `major`
+- **Provider 固定禁止**: skill body に Claude / Codex / Cursor の名前を書かない
+
+## ローカル評価
+
+`promptfoo eval` で動作確認:
+
+```bash
+cd skills/midstream/community/rr-midstream-independent-review-synthesis-001/eval
+promptfoo eval
+```
+
+`OPENAI_API_KEY` / `ANTHROPIC_API_KEY` が必要。Phase 1 では `golden/` は空のまま (hand-written goldens は本リポジトリの「posture, not progress」アンチパターンに該当)。実 LLM run で生成した出力を保存して promotion path に進む。
+
+## Phase 1 の限界
+
+- artifact contract は既存の `review-self` / `review-external` / `findings-pool` をそのまま使う
+- `findings[]` への provenance フィールド (`reviewer`, `agreement[]`, `validatedStatus`) は Phase 2 で schema 拡張
+- CLI ショートカット (`--ensemble claude,codex,cursor` 等) は Phase 3
+- 現状は **skill body + fixtures + eval scaffolding** のみ

--- a/skills/midstream/community/rr-midstream-independent-review-synthesis-001/README.md
+++ b/skills/midstream/community/rr-midstream-independent-review-synthesis-001/README.md
@@ -1,0 +1,17 @@
+# Independent Review Synthesis — eval scaffolding
+
+Status: **fixtures + eval scaffolding only**. `golden/` intentionally empty.
+
+See `../rr-midstream-modern-web-semantic-001/README.md` for the rationale
+(hand-written goldens reproduce the "posture, not progress" anti-pattern) and
+the `promptfoo eval` workflow to generate verified goldens.
+
+Promotion to `recommended: true` in `skills/registry.yaml` requires verified
+goldens + promptfoo eval in CI.
+
+## Phase context
+
+Phase 1 of [#911](https://github.com/s977043/river-reviewer/issues/911):
+skill body + fixtures + eval scaffolding only. Phase 2 will add artifact
+contract extensions (`findings[]` provenance fields, schema `inputContext`
+enum additions). Phase 3 will add CLI / Actions ensemble mode.

--- a/skills/midstream/community/rr-midstream-independent-review-synthesis-001/SKILL.md
+++ b/skills/midstream/community/rr-midstream-independent-review-synthesis-001/SKILL.md
@@ -1,0 +1,134 @@
+---
+id: rr-midstream-independent-review-synthesis-001
+name: Independent Review Synthesis
+description: 複数の AI / 人間レビュー結果 (review-self / review-external / findings-pool) を統合し、実在性・重大度・対応優先度・merge 可否を検証する。
+version: 0.1.0
+category: midstream
+phase: midstream
+applyTo:
+  - '**/*'
+tags:
+  - community
+  - review
+  - synthesis
+  - multi-agent
+  - validation
+  - hallucination-guard
+  - midstream
+severity: major
+inputContext:
+  - diff
+  - fullFile
+outputKind:
+  - findings
+  - summary
+  - actions
+modelHint: high-accuracy
+---
+
+## Goal / 目的
+
+複数 reviewer の指摘をそのまま採用せず、差分・周辺コード・テスト・既存レビュー結果に照らして検証し、merge 判断に資する形に統合する。
+
+入力チャネル (artifact contract 参照: [`pages/reference/artifact-input-contract.md`](../../../../pages/reference/artifact-input-contract.md)):
+
+- `diff` — 当該 PR の差分
+- `review-self` — 実装者のセルフレビュー (Markdown)
+- `review-external` — 外部レビュー結果 (AI / 人間、Markdown)
+- `findings-pool` — 複数 Review Artifact から集約した findings 履歴 (JSON)
+- `fullFile` (任意) — 該当ファイルの完全な内容
+
+## Non-goals / 扱わないこと
+
+- 新しいレビュー観点の追加 (security / a11y / performance などは個別 skill の責務)。
+- 多数決で finding の採否を決めること。
+- reviewer 固有のツール固定 (Claude / Codex / Cursor などの名前を skill body に直書きしない)。
+- 推測ベースで critical / major に上げること (evidence 必須)。
+
+## False-positive guards / 抑制条件
+
+- 入力 artifact (review-self / review-external / findings-pool) がすべて空 → 出力は `actions: []` と "no reviewer inputs" 1 行で終了。silent skip にはしない。
+- `findings-pool` が schema 不一致でパース不能 → loud-fail (例外を投げる)。silent skip にしない。
+- 入力 reviewer が 1 つのみ → degraded mode で実行。出力に `agreement: []` を明記、summary に "single-reviewer mode" を含める。
+
+## Rule / ルール
+
+### 1. Collect — reviewer ごとに finding を収集
+
+各 reviewer 出力から finding を抽出し、provenance (`reviewer`, `sourceKind`) を付与。
+
+### 2. Deduplicate — 同一 issue の統合
+
+dedup 判定基準:
+
+- 同じ file path + 同じ行範囲 (±2 行) と
+- `evidence` テキストの最初の 80 文字の編集距離 ≤ 10
+
+両方満たす場合のみ dedup。それ以外は別 finding として扱う。
+
+### 3. Agreement annotation — 多数決ではない
+
+dedup されたグループに `agreement[]` (reviewer 名のリスト) を付与。**`severity` / `validatedStatus` の決定には直接使わない** (補助情報のみ)。
+
+### 4. Verification — hallucination guard
+
+各 finding について以下を確認:
+
+- `evidence` で参照されている file path が実在する
+- `evidence` のコードスニペットが当該ファイル / 当該 diff に grep で見つかる
+- 該当しない場合は `validatedStatus: dismissed-hallucination` に分類
+
+### 5. Severity — evidence-based
+
+- `evidence` フィールドに「diff の該当行 + テスト/コード参照」が揃っている → 元 reviewer の severity を尊重
+- `evidence` 不足 → severity の上限は `major` (critical 不可)
+- `validatedStatus: dismissed-*` → 出力から除外せず、summary 内の "dismissed findings" に記録
+
+### 6. Merge recommendation
+
+最終的に以下のいずれかを emit:
+
+- `merge-ready` — `confirmed` finding に critical / major なし
+- `human-review` — critical / major が confirmed、または gray zone が残る
+- `block` — `validatedStatus: confirmed` の critical が 1 件以上
+
+## Evidence / 根拠の取り方
+
+各 finding について以下を保持:
+
+- `reviewer` — 出典 (例: `review-self`, `review-external#1`, `findings-pool#42`)
+- `sourceKind` — `ai-review` | `human-review` | `self-review`
+- `agreement[]` — dedup されたグループの reviewer 名一覧 (補助情報)
+- `validatedStatus` — `confirmed` | `dismissed-hallucination` | `dismissed-duplicate` | `needs-human-judgment`
+- `evidence` — file path + 行範囲 + コードスニペット (verification step で確認済)
+
+## Output / 出力
+
+セクション順:
+
+1. **Critical Issues** (`validatedStatus: confirmed`, `severity: critical`)
+2. **Major Issues** (`validatedStatus: confirmed`, `severity: major`)
+3. **Minor Issues** (`validatedStatus: confirmed`, `severity: minor`)
+4. **Dismissed Findings** (hallucination / duplicate、デバッグ用)
+5. **Agent Agreement Summary** (どの reviewer がどの finding を上げたかの一覧、補助情報)
+6. **Merge Recommendation** (`merge-ready` | `human-review` | `block` の 1 つ)
+
+各 finding は `Finding:` / `Evidence:` / `Reviewers:` / `Severity:` / `ValidatedStatus:` / `Suggestion:` のブロック形式。
+
+## 評価指標 (Evaluation)
+
+- 合格基準: hallucination が verification step で検出される、agreement count を verdict に直結させない、入力欠落で silent skip にならない。
+- 不合格基準: 多数決で finding を採用、evidence なしで critical / major、reviewer の名前を skill body に直書き、入力 1 件のとき synthesis を諦めて output を空にする。
+
+## 人間に返す条件 (Human Handoff)
+
+- `validatedStatus: needs-human-judgment` が 1 件以上ある
+- reviewer 間で severity が大きく乖離 (critical vs minor 等)
+- evidence の verification step が「実コードと一致するが文脈解釈が分かれる」ケース
+
+## 参考
+
+- Nolan Lawson 氏の Triple Agent skill (取り込み方針: provider-agnostic な synthesis pattern として再構成)
+- [`pages/reference/artifact-input-contract.md`](../../../../pages/reference/artifact-input-contract.md) — review-self / review-external / findings-pool 定義
+- [`skills/midstream/agent-code-review/SKILL.md`](../../agent-code-review/SKILL.md) — multi-perspective review (synthesis ではない、補完層として独立)
+- Epic: [#911](https://github.com/s977043/river-reviewer/issues/911) — Phase 1 着手 acceptance gate を満たした上で本 skill を追加

--- a/skills/midstream/community/rr-midstream-independent-review-synthesis-001/eval/promptfoo.yaml
+++ b/skills/midstream/community/rr-midstream-independent-review-synthesis-001/eval/promptfoo.yaml
@@ -1,0 +1,55 @@
+# promptfoo configuration for Independent Review Synthesis
+# Status: scaffolding. See ../README.md for golden-generation workflow.
+#
+# Phase 1 of #911. Phase 2 will extend this with artifact-contract-aware
+# fixtures (using real Review Artifacts from findings-pool).
+
+prompts:
+  - file://../prompt/system.md
+  - file://../prompt/user.md
+
+providers:
+  - id: openai:gpt-4o
+    config:
+      temperature: 0.1
+      max_tokens: 3000
+
+  - id: anthropic:claude-3-5-sonnet-20241022
+    config:
+      temperature: 0.1
+      max_tokens: 3000
+
+tests:
+  - description: dedup + confirm — two reviewers agree, evidence holds
+    vars:
+      diff: file://../fixtures/01-dedup-and-confirm-happy.md
+      reviewSelf: ''
+      reviewExternal: ''
+      findingsPool: '[]'
+    assert:
+      - type: llm-rubric
+        value: |
+          The output must:
+          (a) include exactly ONE finding for the SQL injection on src/api/users.ts:13,
+          (b) list BOTH `review-self` and `review-external` in its Reviewers field,
+          (c) set ValidatedStatus: confirmed,
+          (d) mention "block" or "human-review" in the Merge Recommendation,
+          (e) NOT use majority-vote phrasing ("since X out of Y reviewers agreed...").
+          Score 1 if all five hold; 0 otherwise.
+
+  - description: hallucination guard — fabricated file path must be dismissed
+    vars:
+      diff: file://../fixtures/02-hallucinated-finding-false-positive.md
+      reviewSelf: ''
+      reviewExternal: ''
+      findingsPool: '[]'
+    assert:
+      - type: llm-rubric
+        value: |
+          The output must:
+          (a) place the JWT-validation finding under "Dismissed Findings"
+              with ValidatedStatus: dismissed-hallucination,
+          (b) NOT include the JWT finding in Critical / Major / Minor sections,
+          (c) set Merge Recommendation to "merge-ready" (the only real change
+              is a benign `await` addition).
+          Score 1 if all three hold; 0 otherwise.

--- a/skills/midstream/community/rr-midstream-independent-review-synthesis-001/fixtures/01-dedup-and-confirm-happy.md
+++ b/skills/midstream/community/rr-midstream-independent-review-synthesis-001/fixtures/01-dedup-and-confirm-happy.md
@@ -1,0 +1,42 @@
+# Fixture 01 — Dedup + Confirm (Happy Path)
+
+## Description
+
+Two reviewers raise the same finding on `src/api/users.ts:13` (SQL injection).
+The synthesis layer should dedup them, keep both reviewer names in
+`Reviewers:`, validate evidence against the diff, and confirm the finding.
+
+## Diff
+
+```diff
+diff --git a/src/api/users.ts b/src/api/users.ts
+@@ -10,7 +10,7 @@ export async function getUserById(req: Request, res: Response) {
+   const { id } = req.params;
+   try {
+-    const user = await db.query('SELECT * FROM users WHERE id = ?', [id]);
++    const user = await db.query(`SELECT * FROM users WHERE id = ${id}`);
+     res.json(user);
+```
+
+## review-self
+
+> Replaced parameterized query with template literal interpolation — known to expose SQL injection. Need to revert before merge.
+
+## review-external
+
+> Line 13 of src/api/users.ts: the new `db.query` call interpolates `id` directly into SQL. This is an injection vector; revert to placeholder.
+
+## findings-pool
+
+```json
+[]
+```
+
+## Expected Behavior
+
+- One confirmed finding under **Critical Issues** (or Major Issues per severity ceiling rule if evidence is partial; the diff snippet IS present so critical is allowed).
+- `Reviewers: review-self, review-external`.
+- `Severity: critical` is OK because evidence (the diff line) is grep-verifiable.
+- `ValidatedStatus: confirmed`.
+- `Merge Recommendation: block` (or `human-review`).
+- **No** "majority vote" language in the summary.

--- a/skills/midstream/community/rr-midstream-independent-review-synthesis-001/fixtures/02-hallucinated-finding-false-positive.md
+++ b/skills/midstream/community/rr-midstream-independent-review-synthesis-001/fixtures/02-hallucinated-finding-false-positive.md
@@ -1,0 +1,40 @@
+# Fixture 02 — Hallucinated Finding (False-Positive Guard)
+
+## Description
+
+A reviewer claims a vulnerability on `src/auth/jwt.ts:42`, but no such file
+or line exists in the diff (it's pure fabrication). The synthesis layer must
+mark this as `dismissed-hallucination`, NOT propagate it to the merge
+recommendation.
+
+## Diff
+
+```diff
+diff --git a/src/api/users.ts b/src/api/users.ts
+@@ -10,3 +10,3 @@ export async function getUserById(req: Request, res: Response) {
+   const { id } = req.params;
+-  return db.findById(id);
++  return await db.findById(id);
+ }
+```
+
+## review-self
+
+> Added `await` to ensure the promise resolves before return.
+
+## review-external
+
+> Critical: JWT validation in `src/auth/jwt.ts:42` is missing signature check. Attacker can forge tokens.
+
+## findings-pool
+
+```json
+[]
+```
+
+## Expected Behavior
+
+- The JWT finding from review-external is **dismissed** with `ValidatedStatus: dismissed-hallucination` — `src/auth/jwt.ts` is not in the diff and not referenced.
+- The dismissed finding appears in the **Dismissed Findings** section, not in Critical / Major / Minor.
+- `Merge Recommendation: merge-ready` (only the benign `await` change is in scope).
+- No critical / major in the confirmed sections.

--- a/skills/midstream/community/rr-midstream-independent-review-synthesis-001/prompt/system.md
+++ b/skills/midstream/community/rr-midstream-independent-review-synthesis-001/prompt/system.md
@@ -1,0 +1,52 @@
+# Independent Review Synthesis — System Prompt
+
+You are a synthesis layer over multiple independent code reviews. Your job is
+**not** to add new findings — it is to deduplicate, verify, and prioritize
+findings produced by other reviewers (self / external AI / external human /
+historical findings pool).
+
+## Output contract
+
+Sections in this order:
+
+1. **Critical Issues** — confirmed + severity: critical
+2. **Major Issues** — confirmed + severity: major
+3. **Minor Issues** — confirmed + severity: minor
+4. **Dismissed Findings** — hallucinations or duplicates (debug)
+5. **Agent Agreement Summary** — who said what (auxiliary)
+6. **Merge Recommendation** — one of `merge-ready` / `human-review` / `block`
+
+Each finding block:
+
+```text
+Finding: <short statement>
+Evidence: <file:line + code snippet, must be grep-verifiable>
+Reviewers: <comma list of source names, e.g. review-self, findings-pool#42>
+Severity: critical | major | minor
+ValidatedStatus: confirmed | dismissed-hallucination | dismissed-duplicate | needs-human-judgment
+Suggestion: <minimal-change recommendation>
+```
+
+## Hard rules
+
+1. **No majority vote.** `Reviewers` list is auxiliary; `Severity` and `ValidatedStatus` must be set on evidence quality, not reviewer count.
+2. **Hallucination guard.** For every finding, confirm the cited code exists in the diff or fullFile. If grep does not find it, mark `ValidatedStatus: dismissed-hallucination`.
+3. **Severity ceiling without evidence.** Findings without verifiable code reference cannot exceed `major` — never `critical`.
+4. **Single-reviewer findings are allowed.** A finding raised by only one reviewer can still be confirmed if evidence holds. Do not down-rank it for lack of agreement.
+5. **Loud-fail on parse errors.** If `findings-pool` JSON is unparseable, error out — do not silently skip.
+
+## Deduplication
+
+Treat two findings as duplicates only if:
+
+- same file path, and
+- line ranges overlap (±2 lines), and
+- Levenshtein distance between the first 80 chars of `evidence` ≤ 10.
+
+Merge their `Reviewers` lists; pick the strongest documented severity, capped per Hard rule 3.
+
+## Degraded modes
+
+- Only one reviewer input → run anyway. State "single-reviewer mode" in the summary; set `agreement: []` on findings.
+- All inputs empty → emit "no reviewer inputs" and stop. Do not invent findings.
+- Tool-name claims (`Claude says X`, `Codex says Y`) in reviewer text → strip provider names, keep only the technical claim.

--- a/skills/midstream/community/rr-midstream-independent-review-synthesis-001/prompt/user.md
+++ b/skills/midstream/community/rr-midstream-independent-review-synthesis-001/prompt/user.md
@@ -1,0 +1,28 @@
+# Independent Review Synthesis — User Prompt
+
+Synthesize the following reviewer inputs. Apply the hard rules from the system
+prompt. Emit the six-section output in the contract format.
+
+## Diff
+
+```diff
+{{diff}}
+```
+
+## review-self (if present)
+
+```markdown
+{{reviewSelf}}
+```
+
+## review-external (if present)
+
+```markdown
+{{reviewExternal}}
+```
+
+## findings-pool (if present, JSON)
+
+```json
+{{findingsPool}}
+```

--- a/skills/registry.yaml
+++ b/skills/registry.yaml
@@ -326,6 +326,17 @@ skills:
     recommended: false
     description: 'Keyboard operation / focus management / live regions / role-state semantics for interactive UI.'
 
+  - id: rr-midstream-independent-review-synthesis-001
+    version: '0.1.0'
+    name: 'Independent Review Synthesis'
+    path: skills/midstream/community/rr-midstream-independent-review-synthesis-001/SKILL.md
+    category: midstream
+    phase: midstream
+    tags: [community, review, synthesis, multi-agent, validation, hallucination-guard, midstream]
+    severity: major
+    recommended: false
+    description: 'Synthesizes multiple AI / human review results (review-self / review-external / findings-pool), dedups, verifies evidence, and emits a merge recommendation. No majority vote.'
+
   # Downstream Skills (Testing & Release)
   - id: agent-qa-regression
     version: '0.1.0'


### PR DESCRIPTION
## Summary

Phase 1 of #911 epic — Independent Review Synthesis. Acceptance gate (reopen conditions, exceptions, gray zone resolution) was filled in #911 before opening this PR per Codex's "fill gate first" guidance.

Inspired by Nolan Lawson's Triple Agent Claude skill, re-cast as a **provider-agnostic synthesis layer** aligned with River Reviewer's artifact-driven design. The skill consumes existing artifact contract entries (`review-self` / `review-external` / `findings-pool`) and emits dedup'd + verified findings with a merge recommendation.

## Files

- `skills/midstream/community/rr-midstream-independent-review-synthesis-001/`
  - `SKILL.md`, `README.md`, `prompt/{system,user}.md`
  - `fixtures/01-dedup-and-confirm-happy.md` + `fixtures/02-hallucinated-finding-false-positive.md`
  - `eval/promptfoo.yaml`
- `pages/guides/use-independent-review-synthesis.md`
- `skills/registry.yaml` — community section entry (`recommended: false`)

## Design rules (codified in SKILL.md + prompts)

1. **No majority vote**. `Reviewers:` is auxiliary; `Severity` / `ValidatedStatus` decided on evidence quality.
2. **Hallucination guard**. Every finding's cited code must be grep-verifiable in diff / fullFile. Otherwise `dismissed-hallucination`.
3. **Single-reviewer findings allowed**. A solo reviewer's finding can still be confirmed with evidence — no down-ranking for lack of agreement.
4. **Severity ceiling**. Critical requires verifiable evidence; otherwise `major` max.
5. **Loud-fail on parse errors**. `findings-pool` JSON unparseable → throw, never silent-skip (silent-skip cleanup #865-#877 lesson).

## Out of scope for Phase 1

- Artifact contract extension (`findings[]` provenance fields) → Phase 2
- Schema `inputContext` enum additions → Phase 2
- CLI `--ensemble` shortcut → Phase 3

## Test plan

- [x] `npm run skills:validate` clean
- [x] `node scripts/validate-meta-consistency.mjs` OK
- [x] `node scripts/fix-dashes.mjs --check` clean
- [x] markdownlint via pre-commit
- [ ] CI green
- [ ] (Manual, post-merge) one `promptfoo eval` run to confirm prompts execute end-to-end. Goldens deferred to a later slice per #905 / #909 pattern.

Closes part of #911 (Phase 1 only; epic remains open until Phase 2 + 3).