### PR TITLE
feat(schemas): synthesis provenance fields + reviewer input contexts (#911 Phase 2)

### DIFF
--- a/schemas/review-artifact.schema.json
+++ b/schemas/review-artifact.schema.json
@@ -237,6 +237,27 @@
         "suggestion": {
           "type": "string",
           "description": "Optional fix or follow-up hint."
+        },
+        "sourceKind": {
+          "type": "string",
+          "description": "Provenance kind for synthesis layers (e.g. Independent Review Synthesis). Optional; absent for findings produced by core skills.",
+          "enum": ["ai-review", "human-review", "self-review"]
+        },
+        "agreement": {
+          "type": "array",
+          "description": "Auxiliary metadata listing reviewer identifiers that independently raised this finding (after dedup). Synthesis layers MUST NOT use this for majority-vote decisions; severity is decided on evidence quality.",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "validatedStatus": {
+          "type": "string",
+          "description": "Synthesis verdict for the finding. Distinct from `status` (which tracks lifecycle: open/suppressed/verified).",
+          "enum": [
+            "confirmed",
+            "dismissed-hallucination",
+            "dismissed-duplicate",
+            "needs-human-judgment"
+          ]
         }
       }
     }

--- a/schemas/skill.schema.json
+++ b/schemas/skill.schema.json
@@ -39,7 +39,17 @@
     },
     "inputContext": {
       "type": "string",
-      "enum": ["diff", "fullFile", "tests", "adr", "commitMessage", "repoConfig"]
+      "enum": [
+        "diff",
+        "fullFile",
+        "tests",
+        "adr",
+        "commitMessage",
+        "repoConfig",
+        "reviewSelf",
+        "reviewExternal",
+        "findingsPool"
+      ]
     },
     "outputKind": {
       "type": "string",

--- a/skills/midstream/community/rr-midstream-independent-review-synthesis-001/SKILL.md
+++ b/skills/midstream/community/rr-midstream-independent-review-synthesis-001/SKILL.md
@@ -19,6 +19,9 @@ severity: major
 inputContext:
   - diff
   - fullFile
+  - reviewSelf
+  - reviewExternal
+  - findingsPool
 outputKind:
   - findings
   - summary

--- a/tests/review-artifact-schema.test.mjs
+++ b/tests/review-artifact-schema.test.mjs
@@ -133,4 +133,64 @@ describe('review-artifact.schema.json', () => {
     );
     assert.equal(ok, true, JSON.stringify(validate.errors));
   });
+
+  describe('synthesis fields (#911 Phase 2 — additive)', () => {
+    test('finding without sourceKind / agreement / validatedStatus stays valid (backward compat)', () => {
+      const ok = validate(minimalArtifact({ findings: [validFinding()] }));
+      assert.equal(ok, true, JSON.stringify(validate.errors));
+    });
+
+    test('accepts finding with sourceKind enum values', () => {
+      for (const kind of ['ai-review', 'human-review', 'self-review']) {
+        const ok = validate(minimalArtifact({ findings: [validFinding({ sourceKind: kind })] }));
+        assert.equal(ok, true, `${kind}: ${JSON.stringify(validate.errors)}`);
+      }
+    });
+
+    test('rejects unknown sourceKind', () => {
+      const ok = validate(
+        minimalArtifact({ findings: [validFinding({ sourceKind: 'pinned-by-claude' })] })
+      );
+      assert.equal(ok, false);
+    });
+
+    test('accepts agreement array of reviewer ids', () => {
+      const ok = validate(
+        minimalArtifact({
+          findings: [
+            validFinding({ agreement: ['review-self', 'review-external', 'findings-pool#42'] }),
+          ],
+        })
+      );
+      assert.equal(ok, true, JSON.stringify(validate.errors));
+    });
+
+    test('rejects agreement with duplicate reviewer names', () => {
+      const ok = validate(
+        minimalArtifact({
+          findings: [validFinding({ agreement: ['a', 'a'] })],
+        })
+      );
+      assert.equal(ok, false);
+    });
+
+    test('accepts validatedStatus enum values', () => {
+      for (const v of [
+        'confirmed',
+        'dismissed-hallucination',
+        'dismissed-duplicate',
+        'needs-human-judgment',
+      ]) {
+        const ok = validate(minimalArtifact({ findings: [validFinding({ validatedStatus: v })] }));
+        assert.equal(ok, true, `${v}: ${JSON.stringify(validate.errors)}`);
+      }
+    });
+
+    test('rejects unknown validatedStatus', () => {
+      const ok = validate(
+        minimalArtifact({ findings: [validFinding({ validatedStatus: 'maybe' })] })
+      );
+      assert.equal(ok, false);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Phase 2 of #911 epic — additive schema extensions to support the Independent Review Synthesis skill (#912). Per the epic plan, this is **additive only**: v1 artifacts and existing skills without the new fields keep validating.

### `schemas/review-artifact.schema.json` — `finding` additions

| Field | Type | Purpose |
| ----- | ---- | ------- |
| `sourceKind` | enum: `ai-review` / `human-review` / `self-review` | Provenance kind |
| `agreement` | unique array of reviewer ids | Auxiliary metadata only — MUST NOT drive majority-vote severity (Hard rule from #912) |
| `validatedStatus` | enum: `confirmed` / `dismissed-hallucination` / `dismissed-duplicate` / `needs-human-judgment` | Synthesis verdict, distinct from existing `status` (lifecycle) |

`status` (open / suppressed / verified) and `validatedStatus` coexist — different concerns (lifecycle vs synthesis), per Codex sanity check.

### `schemas/skill.schema.json` — `inputContext` enum additions

- `reviewSelf`
- `reviewExternal`
- `findingsPool`

Match the artifact IDs defined in `pages/reference/artifact-input-contract.md`.

### Knock-on changes

- `skills/midstream/community/rr-midstream-independent-review-synthesis-001/SKILL.md`: declares the 3 new inputContexts (previously limited to `diff` / `fullFile` because the enum hadn't shipped yet).

### Tests

New `synthesis fields (#911 Phase 2 — additive)` describe block in `tests/review-artifact-schema.test.mjs`:

- backward compat: finding without any new field is still valid
- accept each enum value of `sourceKind` / `validatedStatus`
- reject unknown enum values
- `agreement` accepts reviewer-id list, rejects duplicates (uniqueItems)

All 1093+ unit tests still pass.

## Out of scope

- Phase 3 (CLI `--ensemble` shortcut + GitHub Action wiring) — separate slice of #911.
- Populating `sourceKind` / `agreement` / `validatedStatus` from the synthesis skill at runtime — that's a downstream consumer behavior; this PR ships the schema only.

## Self-review

- **Codify-then-validate (per AGENTS.md from #904):**
  1. Failure scenarios: (a) v1 artifact without new fields → covered by backward-compat test, (b) consumer reads new field strictly → optional, must handle absence, (c) tool name leaks into `agreement` → handled by skill prompt, not schema.
  2. Reopen / exception: enum values are forward-compatible; new entries can be added without breaking existing consumers as long as they default to "unknown → reject" (matches current behavior).
  3. Gray zone: relationship between `status` and `validatedStatus` is documented inline in the schema description.

## Test plan

- [x] `node --test tests/review-artifact-schema.test.mjs` → 20/20 pass
- [x] `npm test` → 1087/1087+ (pre-existing) pass, new tests included
- [x] `npm run skills:validate` clean
- [x] `node scripts/validate-meta-consistency.mjs` OK
- [x] `node scripts/fix-dashes.mjs --check` clean
- [ ] CI green