### PR TITLE
feat(skills): community skill fixtures slice 3/3 (#868 — a11y-interactive + nextjs)

### DIFF
--- a/skills/midstream/community/rr-midstream-modern-web-a11y-interactive-001/README.md
+++ b/skills/midstream/community/rr-midstream-modern-web-a11y-interactive-001/README.md
@@ -1,0 +1,8 @@
+# Modern Web Accessibility for Interactive UI — eval scaffolding
+
+Status: **fixtures + eval scaffolding only**. `golden/` intentionally empty.
+
+See `../rr-midstream-modern-web-semantic-001/README.md` for the rationale and
+the `promptfoo eval` workflow to generate verified goldens.
+
+Promotion to `recommended: true` requires verified goldens + promptfoo eval in CI.

--- a/skills/midstream/community/rr-midstream-modern-web-a11y-interactive-001/eval/promptfoo.yaml
+++ b/skills/midstream/community/rr-midstream-modern-web-a11y-interactive-001/eval/promptfoo.yaml
@@ -1,0 +1,42 @@
+# promptfoo configuration for Modern Web Accessibility for Interactive UI
+# Status: scaffolding. See ../README.md for golden-generation workflow.
+
+prompts:
+  - file://../prompt/system.md
+  - file://../prompt/user.md
+
+providers:
+  - id: openai:gpt-4o
+    config:
+      temperature: 0.1
+      max_tokens: 2000
+
+  - id: anthropic:claude-3-5-sonnet-20241022
+    config:
+      temperature: 0.1
+      max_tokens: 2000
+
+tests:
+  - description: clickable div without keyboard handler must be flagged
+    vars:
+      diff: file://../fixtures/01-div-onclick-no-keyboard-happy.md
+    assert:
+      - type: llm-rubric
+        value: |
+          The output must include `Aspect: Keyboard`, identify the `<div onClick>`
+          as missing keyboard support, and suggest either reverting to `<button>`
+          or adding `tabIndex` + `onKeyDown` for Enter/Space.
+          Score 1 if all three are present; 0 otherwise.
+      - type: contains
+        value: 'Severity: minor'
+
+  - description: Radix Dialog must NOT be flagged (library guard)
+    vars:
+      diff: file://../fixtures/02-library-radix-dialog-false-positive.md
+    assert:
+      - type: llm-rubric
+        value: |
+          The output must NOT propose focus management / keyboard handlers /
+          ARIA changes on the Radix Dialog. Acceptable outputs include
+          "No findings" or an explicit reference to the library-component guard.
+          Score 1 if no finding on the Dialog is produced; 0 otherwise.

--- a/skills/midstream/community/rr-midstream-modern-web-a11y-interactive-001/fixtures/01-div-onclick-no-keyboard-happy.md
+++ b/skills/midstream/community/rr-midstream-modern-web-a11y-interactive-001/fixtures/01-div-onclick-no-keyboard-happy.md
@@ -1,0 +1,27 @@
+# Fixture 01 — Clickable `<div>` with no keyboard handler (Happy Path)
+
+## Description
+
+A clickable `<div>` is added with `onClick` but no `onKeyDown` and no `tabIndex`.
+The skill should flag missing keyboard support and recommend a `<button>` or
+explicit key handlers + `tabIndex`.
+
+## Input Diff
+
+```diff
+diff --git a/src/components/MenuItem.tsx b/src/components/MenuItem.tsx
+@@ -1,4 +1,7 @@
+ export function MenuItem({ label, onSelect }: Props) {
+-  return <button onClick={onSelect}>{label}</button>;
++  return (
++    <div onClick={onSelect} className="menu-item">{label}</div>
++  );
+ }
+```
+
+## Expected Behavior
+
+- `Aspect: Keyboard`.
+- Suggestion: revert to `<button>` or add `tabIndex={0}` + `onKeyDown` for Enter/Space.
+- `Severity: minor`.
+- `Confidence: high`.

--- a/skills/midstream/community/rr-midstream-modern-web-a11y-interactive-001/fixtures/02-library-radix-dialog-false-positive.md
+++ b/skills/midstream/community/rr-midstream-modern-web-a11y-interactive-001/fixtures/02-library-radix-dialog-false-positive.md
@@ -1,0 +1,31 @@
+# Fixture 02 — Library-provided dialog (False-Positive Guard)
+
+## Description
+
+Diff uses Radix UI's `<Dialog>` which provides focus management internally.
+The skill must NOT propose adding focus traps or key handlers — the
+library-component guard applies.
+
+## Input Diff
+
+```diff
+diff --git a/src/components/SettingsDialog.tsx b/src/components/SettingsDialog.tsx
+@@ -3,9 +3,10 @@ import * as Dialog from '@radix-ui/react-dialog';
+ export function SettingsDialog() {
+   return (
+     <Dialog.Root>
+       <Dialog.Trigger>Open Settings</Dialog.Trigger>
++      <Dialog.Overlay />
+       <Dialog.Content>
+         <Dialog.Title>Settings</Dialog.Title>
+       </Dialog.Content>
+     </Dialog.Root>
+   );
+ }
+```
+
+## Expected Behavior
+
+- No finding. Library boundary guard applies; Radix Dialog handles focus,
+  Esc, and ARIA roles internally.
+- Output references the library-component guard explicitly.

--- a/skills/midstream/community/rr-midstream-modern-web-a11y-interactive-001/prompt/system.md
+++ b/skills/midstream/community/rr-midstream-modern-web-a11y-interactive-001/prompt/system.md
@@ -1,0 +1,44 @@
+# Modern Web Accessibility for Interactive UI — System Prompt
+
+You are a code reviewer focused on **interactive** UI accessibility: keyboard
+operation, focus management, dynamic role/state semantics. Static labelling
+is covered by the sibling skill `rr-midstream-a11y-accessible-name-001`.
+
+## Goal
+
+- Flag missing keyboard support, focus traps, and role/state regressions on
+  modal / popover / menu / tabs / live-region patterns.
+- Suggestion-only. Severity `minor`.
+
+## Non-goals
+
+- `alt` / `aria-label` checks (sibling skill).
+- Contrast ratio / visual a11y.
+- Full WCAG grading.
+
+## False-positive guards
+
+- Library-provided interactive components (`<Dialog>`, `<Popover>`,
+  `<MenuButton>` from Radix / Headless UI / shadcn) → respect library boundary.
+- `tabIndex` / `aria-*` already set deliberately in the diff → suppress.
+- CSS-only style tweaks with no interaction change → suppress.
+- `:focus-visible` / `outline` already explicit → suppress new focus findings.
+
+## Rules
+
+- **Keyboard**: click handlers on non-`<button>` / non-`<a>` interactive
+  elements must support `Enter` / `Space`. Flag missing key handlers.
+- **Focus management**: opening a modal / popover should move focus into it;
+  closing should restore focus. Live updates of focused content should not
+  silently steal focus.
+- **Role / state**: `role="tab"` needs `aria-selected`; `role="menuitem"`
+  needs the parent `role="menu"`; expand/collapse toggles need `aria-expanded`.
+
+## Output contract
+
+- `Finding:` short statement
+- `Evidence:` diff snippet with line number
+- `Aspect:` Keyboard | Focus | Role/State
+- `Suggestion:` minimal change (key handler, focus call, ARIA attribute)
+- `Severity:` `minor`
+- `Confidence:` `low` | `medium` | `high`

--- a/skills/midstream/community/rr-midstream-modern-web-a11y-interactive-001/prompt/user.md
+++ b/skills/midstream/community/rr-midstream-modern-web-a11y-interactive-001/prompt/user.md
@@ -1,0 +1,11 @@
+# Modern Web Accessibility for Interactive UI — User Prompt
+
+Review the provided code diff. Apply the rules and false-positive guards from
+the system prompt. Emit one Output block per finding. If suppressed, say
+"No findings" and name the guard.
+
+## Input
+
+```diff
+{{diff}}
+```

--- a/skills/midstream/community/rr-midstream-nextjs-app-router-boundary-001/README.md
+++ b/skills/midstream/community/rr-midstream-nextjs-app-router-boundary-001/README.md
@@ -1,0 +1,6 @@
+# Next.js App Router Client/Server Boundary — eval scaffolding
+
+Status: **fixtures + eval scaffolding only**. `golden/` intentionally empty.
+
+See `../rr-midstream-modern-web-semantic-001/README.md` for golden-generation
+workflow. Promotion to `recommended: true` requires verified goldens.

--- a/skills/midstream/community/rr-midstream-nextjs-app-router-boundary-001/eval/promptfoo.yaml
+++ b/skills/midstream/community/rr-midstream-nextjs-app-router-boundary-001/eval/promptfoo.yaml
@@ -1,0 +1,41 @@
+# promptfoo configuration for Next.js App Router Client/Server Boundary
+# Status: scaffolding. See ../README.md for golden-generation workflow.
+
+prompts:
+  - file://../prompt/system.md
+  - file://../prompt/user.md
+
+providers:
+  - id: openai:gpt-4o
+    config:
+      temperature: 0.1
+      max_tokens: 2000
+
+  - id: anthropic:claude-3-5-sonnet-20241022
+    config:
+      temperature: 0.1
+      max_tokens: 2000
+
+tests:
+  - description: useState in server component must be flagged
+    vars:
+      diff: file://../fixtures/01-usestate-in-server-component-happy.md
+    assert:
+      - type: llm-rubric
+        value: |
+          The output must reference `useState` as the offending API, include
+          `BoundaryViolation: client-API in server component`, and suggest
+          adding `'use client'` to the top of the file.
+          Score 1 if all three are present; 0 otherwise.
+      - type: contains
+        value: 'Severity: major'
+
+  - description: file with `'use client'` must NOT be flagged
+    vars:
+      diff: file://../fixtures/02-use-client-directive-false-positive.md
+    assert:
+      - type: llm-rubric
+        value: |
+          The output must NOT flag the useState usage. Acceptable outputs include
+          "No findings" or an explicit reference to the `'use client'` guard.
+          Score 1 if no finding is produced; 0 otherwise.

--- a/skills/midstream/community/rr-midstream-nextjs-app-router-boundary-001/fixtures/01-usestate-in-server-component-happy.md
+++ b/skills/midstream/community/rr-midstream-nextjs-app-router-boundary-001/fixtures/01-usestate-in-server-component-happy.md
@@ -1,0 +1,29 @@
+# Fixture 01 — `useState` in Server Component (Happy Path)
+
+## Description
+
+A file under `app/` has no `'use client'` directive but adds `useState`.
+The skill should flag the boundary violation and suggest adding `'use client'`
+or extracting the state to a child client component.
+
+## Input Diff
+
+```diff
+diff --git a/app/dashboard/Filter.tsx b/app/dashboard/Filter.tsx
+@@ -1,5 +1,7 @@
+ import { Card } from '@/components/Card';
++import { useState } from 'react';
+
+ export function Filter() {
++  const [query, setQuery] = useState('');
+   return <Card><input /></Card>;
+ }
+```
+
+## Expected Behavior
+
+- `Finding:` boundary violation referencing `useState`.
+- `BoundaryViolation: client-API in server component`.
+- Suggestion proposes adding `'use client'` at top of file.
+- `Severity: major`.
+- `Confidence: high`.

--- a/skills/midstream/community/rr-midstream-nextjs-app-router-boundary-001/fixtures/02-use-client-directive-false-positive.md
+++ b/skills/midstream/community/rr-midstream-nextjs-app-router-boundary-001/fixtures/02-use-client-directive-false-positive.md
@@ -1,0 +1,26 @@
+# Fixture 02 — File has `'use client'` (False-Positive Guard)
+
+## Description
+
+A client component declares `'use client'` at the top and uses `useState`.
+This is correct App Router usage — the skill must NOT flag it.
+
+## Input Diff
+
+```diff
+diff --git a/app/dashboard/SearchBox.tsx b/app/dashboard/SearchBox.tsx
+@@ -1,5 +1,7 @@
+ 'use client';
+
++import { useState } from 'react';
++
+ export function SearchBox() {
++  const [q, setQ] = useState('');
+   return <input value={q} onChange={(e) => setQ(e.target.value)} />;
+ }
+```
+
+## Expected Behavior
+
+- No finding. `'use client'` directive guard applies.
+- Output references the `'use client'` guard explicitly.

--- a/skills/midstream/community/rr-midstream-nextjs-app-router-boundary-001/prompt/system.md
+++ b/skills/midstream/community/rr-midstream-nextjs-app-router-boundary-001/prompt/system.md
@@ -1,0 +1,40 @@
+# Next.js App Router Client/Server Boundary — System Prompt
+
+You are a code reviewer enforcing the Next.js App Router client/server
+boundary. Flag files that use client-only APIs but lack a `'use client'`
+directive.
+
+## Goal
+
+- Detect Server Component files using React hooks or browser globals.
+- Severity `major` — these break the build or fail at runtime.
+
+## Non-goals
+
+- UI/UX critique.
+- Non-App-Router frameworks.
+- Async data-fetching optimization.
+
+## False-positive guards
+
+- File begins with `'use client'` → suppress.
+- Existing comment annotation explaining intentional bypass → suppress
+  (handle skeptically, only when the comment is explicit).
+
+## Rules
+
+- Server Component (no `'use client'`) MUST NOT use:
+  - React hooks: `useState`, `useEffect`, `useLayoutEffect`, `useReducer`,
+    `useRef`, `useContext`, `useMemo`, `useCallback`
+  - Browser globals: `window`, `document`, `localStorage`, `sessionStorage`,
+    `navigator`
+
+## Output contract
+
+- `Finding:` short statement
+- `Evidence:` diff snippet with line number, naming the offending API
+- `BoundaryViolation:` "client-API in server component"
+- `Suggestion:` add `'use client'` at top of file OR extract the client logic
+  to a child component
+- `Severity:` `major`
+- `Confidence:` `high` (boundary check is mechanical)

--- a/skills/midstream/community/rr-midstream-nextjs-app-router-boundary-001/prompt/user.md
+++ b/skills/midstream/community/rr-midstream-nextjs-app-router-boundary-001/prompt/user.md
@@ -1,0 +1,11 @@
+# Next.js App Router Client/Server Boundary — User Prompt
+
+Review the provided code diff. Apply the rules and false-positive guards from
+the system prompt. Emit one Output block per finding. If suppressed, say
+"No findings" and name the guard.
+
+## Input
+
+```diff
+{{diff}}
+```


### PR DESCRIPTION
## Summary

Final slice of #868 (Modern Web Guidance Phase 2). Codex slice judgment: **1 PR で完走、過剰リリースより #868 の閉鎖性を優先**.

### Skills (last 2 of 6)

- `rr-midstream-modern-web-a11y-interactive-001` — div onClick no-keyboard happy + Radix Dialog false-positive
- `rr-midstream-nextjs-app-router-boundary-001` — `useState` in server component happy + `'use client'` directive false-positive

Pattern matches #905 / #909 / #910: `prompt/{system,user}.md` + 2 fixtures + `eval/promptfoo.yaml` + `README.md`. `golden/` intentionally empty.

### #868 Phase 2 — closed

All 6 community skills (semantic / a11y-accessible-name / browser-compat / performance / a11y-interactive / nextjs) now have eval scaffolding. Phase 3 (`recommended: true` promotion via verified goldens) deferred per Codex — needs `promptfoo eval` runs in next session.

## Test plan

- [x] `npm run skills:validate` clean
- [x] `node scripts/validate-meta-consistency.mjs` OK
- [x] `node scripts/fix-dashes.mjs --check` clean
- [ ] CI green