### PR TITLE
feat(schemas): debug.execution.snapshot carry-over field (#878 A2-3-pre)

### DIFF
--- a/schemas/review-artifact.schema.json
+++ b/schemas/review-artifact.schema.json
@@ -160,7 +160,42 @@
     "debug": {
       "type": "object",
       "additionalProperties": true,
-      "description": "Free-form debug information. Structure is not guaranteed across versions."
+      "description": "Free-form debug information. Structure is not guaranteed across versions.",
+      "properties": {
+        "execution": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Execution-stage diagnostics. Additive over time.",
+          "properties": {
+            "snapshot": {
+              "type": "object",
+              "additionalProperties": true,
+              "description": "Carry-over context written by buildExecutionPlan and consumed by --plan replay execution (#878 A2-3). Used to avoid context-snapshot drift between plan and replay time. Optional; absent on older artifacts.",
+              "properties": {
+                "fileTypes": {
+                  "type": "array",
+                  "items": { "type": "string" },
+                  "description": "File-type tags derived at plan creation time."
+                },
+                "relatedADRs": {
+                  "type": "array",
+                  "items": { "type": "string" },
+                  "description": "Architecture Decision Records related to the change at plan creation time."
+                },
+                "reviewMode": {
+                  "type": "string",
+                  "description": "Review mode resolved at plan creation time."
+                },
+                "riskAssessment": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "description": "Risk-map evaluation result captured at plan creation time."
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "$defs": {

--- a/tests/review-artifact-schema.test.mjs
+++ b/tests/review-artifact-schema.test.mjs
@@ -193,4 +193,49 @@ describe('review-artifact.schema.json', () => {
       assert.equal(ok, false);
     });
   });
+
+  describe('debug.execution.snapshot (#878 A2-3-pre — additive carry-over)', () => {
+    test('artifact without debug.execution.snapshot stays valid (backward compat)', () => {
+      const ok = validate(minimalArtifact());
+      assert.equal(ok, true, JSON.stringify(validate.errors));
+    });
+
+    test('round-trips fileTypes / relatedADRs / reviewMode / riskAssessment', () => {
+      const ok = validate(
+        minimalArtifact({
+          debug: {
+            execution: {
+              snapshot: {
+                fileTypes: ['typescript', 'react'],
+                relatedADRs: ['adr-007-auth-boundary'],
+                reviewMode: 'standard',
+                riskAssessment: { action: 'require_human_review', reason: 'auth code' },
+              },
+            },
+          },
+        })
+      );
+      assert.equal(ok, true, JSON.stringify(validate.errors));
+    });
+
+    test('accepts partial snapshot (any subset of fields)', () => {
+      const ok = validate(
+        minimalArtifact({ debug: { execution: { snapshot: { reviewMode: 'lite' } } } })
+      );
+      assert.equal(ok, true, JSON.stringify(validate.errors));
+    });
+
+    test('accepts unrelated debug.* keys alongside execution (additionalProperties)', () => {
+      const ok = validate(
+        minimalArtifact({
+          debug: {
+            execution: { snapshot: { fileTypes: ['md'] } },
+            resolvedArtifacts: { diff: '/tmp/diff.patch' },
+            replay: { sourceTimestamp: '2026-05-25T03:48:53Z' },
+          },
+        })
+      );
+      assert.equal(ok, true, JSON.stringify(validate.errors));
+    });
+  });
 });


### PR DESCRIPTION
## Summary

A2-3-pre slice of #878 per the design doc (#910). Additive schema extension to carry the analysis context across plan → replay execution, avoiding the "context snapshot drift" bug Codex and Gemini flagged on multi-perspective review.

### Field added

`debug.execution.snapshot`:

| Field | Type | Purpose |
| ----- | ---- | ------- |
| `fileTypes` | string[] | File-type tags at plan-creation time |
| `relatedADRs` | string[] | ADRs related to the change at plan-creation time |
| `reviewMode` | string | Review mode resolved at plan-creation time |
| `riskAssessment` | object | Risk-map evaluation captured at plan-creation time |

All optional. `additionalProperties: true` preserved so future fields can land additively without breaking consumers.

### Scope boundary

- Schema + schema unit tests only.
- `buildExecutionPlan` wiring (`runners/core/` change to populate the field) is **deferred** to a separate PR per AGENTS.md "Ask before editing".
- A2-3-test (failing integration test) is also a separate PR — kept apart so a deliberately-failing test does not destabilize the schema PR's CI signal.

## Test plan

- [x] `node --test tests/review-artifact-schema.test.mjs` → 24/24 pass (4 new tests in `debug.execution.snapshot` describe block: backward compat, full round-trip, partial round-trip, additive coexistence with other debug.* keys)
- [x] `npm test` → 1106/1106 pass
- [x] `node scripts/fix-dashes.mjs --check` clean
- [ ] CI green

## Self-review (per AGENTS.md from #904)

- **3 failure scenarios**: (a) old artifact without the field → backward compat test, (b) consumer reads field strictly → optional, must handle absence, (c) drift between snapshot and actual repo state → reported via `debug.replay.drift` (next slice).
- **Reopen / exception**: integration test (A2-3-test PR) is the source of truth. If the assertion needs Option A (schema v2 break) instead, update the design doc rather than this PR.
- **Gray zone**: "how stale is too stale" for replay — out of scope; drift is reported, user decides.