### PR TITLE
feat(scripts): local promptfoo eval helper + runbook reorientation (#868)

### DIFF
--- a/docs/runbook/community-skill-eval.md
+++ b/docs/runbook/community-skill-eval.md
@@ -4,26 +4,36 @@ Workflow to generate verified `golden/` outputs for community skills and
 promote them from `recommended: false` to `recommended: true` in
 `skills/registry.yaml`.
 
-## Setup (one-time): API key secrets
+## Project policy on API keys
 
-The eval needs at least one LLM provider key. Add as repo secrets:
+API keys are **not** stored as GitHub repo secrets. They live on the
+developer's local machine. The Actions workflow exists as an optional
+fallback for future use; the primary path is local execution.
 
-- `OPENAI_API_KEY`—enables the OpenAI provider tests
-- `ANTHROPIC_API_KEY`—enables the Anthropic provider tests
+## Preferred: local execution
 
-Either or both works. The workflow exits 1 if neither is set.
+Set at least one of `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` in your shell,
+then:
 
-Settings → Secrets and variables → Actions → New repository secret.
+```bash
+scripts/run-promptfoo-eval.sh                          # all community skills
+scripts/run-promptfoo-eval.sh modern-web-semantic      # egrep filter on path
+PROVIDER_FILTER=anthropic:claude-3-5-sonnet-20241022 \
+  scripts/run-promptfoo-eval.sh                        # limit provider/cost
+```
 
-## Run
+Outputs land in `./eval-output/<skill-id>.json` per evaluated skill.
 
-1. Go to **Actions → Promptfoo Eval (community skills) → Run workflow**.
-2. (Optional) `skill_filter`—egrep-style filter on the eval config path
-   (e.g. `modern-web-semantic` to target one skill).
-3. (Optional) `provider_filter`—comma-list of provider IDs to limit cost
-   (e.g. `anthropic:claude-3-5-sonnet-20241022`).
-4. Wait for the run to finish (≈5-15 min depending on filter).
-5. Download the `promptfoo-eval-output` artifact from the run.
+## Fallback: GitHub Actions workflow
+
+Only use this path if API keys are eventually added as repo secrets and
+contributors want the eval to run on shared infrastructure.
+
+1. Add `OPENAI_API_KEY` and/or `ANTHROPIC_API_KEY` under Settings → Secrets
+   and variables → Actions.
+2. Go to **Actions → Promptfoo Eval (community skills) → Run workflow**.
+3. (Optional) `skill_filter` / `provider_filter` inputs.
+4. Download the `promptfoo-eval-output` artifact from the run.
 
 ## Review and commit goldens
 

--- a/scripts/run-promptfoo-eval.sh
+++ b/scripts/run-promptfoo-eval.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Local helper to run promptfoo eval against community skill configs.
+# Preferred over the GitHub Actions workflow when API keys live on the
+# developer's machine rather than in repo secrets (per project policy).
+#
+# Requires at least one of: OPENAI_API_KEY, ANTHROPIC_API_KEY in the env.
+#
+# Usage:
+#   scripts/run-promptfoo-eval.sh                          # all community skills
+#   scripts/run-promptfoo-eval.sh <skill-filter>           # egrep filter on path
+#   PROVIDER_FILTER=anthropic:... scripts/run-promptfoo-eval.sh
+#
+# Output: ./eval-output/<skill-id>.json per evaluated skill.
+# Next step: see docs/runbook/community-skill-eval.md "Review and commit goldens".
+
+set -euo pipefail
+
+SKILL_FILTER="${1:-}"
+PROVIDER_FILTER="${PROVIDER_FILTER:-}"
+
+if [ -z "${OPENAI_API_KEY:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+  echo "error: set OPENAI_API_KEY and/or ANTHROPIC_API_KEY before running." >&2
+  echo "       see docs/runbook/community-skill-eval.md" >&2
+  exit 1
+fi
+
+if ! command -v npx >/dev/null 2>&1; then
+  echo "error: npx not found. Install Node.js (see .nvmrc)." >&2
+  exit 1
+fi
+
+mapfile -t configs < <(find skills/midstream/community -name promptfoo.yaml -path '*/eval/*' | sort)
+if [ -n "${SKILL_FILTER}" ]; then
+  mapfile -t configs < <(printf '%s\n' "${configs[@]}" | grep -E "${SKILL_FILTER}" || true)
+fi
+
+if [ "${#configs[@]}" -eq 0 ]; then
+  echo "error: no community skill eval configs match filter '${SKILL_FILTER}'." >&2
+  exit 1
+fi
+
+mkdir -p eval-output
+echo "evaluating ${#configs[@]} skill(s)..."
+
+for config in "${configs[@]}"; do
+  skill_dir="$(dirname "$(dirname "${config}")")"
+  skill_id="$(basename "${skill_dir}")"
+  out="eval-output/${skill_id}.json"
+  echo "  → ${skill_id}"
+  if [ -n "${PROVIDER_FILTER}" ]; then
+    npx promptfoo eval --config "${config}" --output "${out}" --providers "${PROVIDER_FILTER}" || true
+  else
+    npx promptfoo eval --config "${config}" --output "${out}" || true
+  fi
+done
+
+echo
+echo "done. outputs in eval-output/. Next: review per docs/runbook/community-skill-eval.md."


### PR DESCRIPTION
## Summary

Project policy update: API keys are **not** stored as GitHub repo secrets. They live on the developer's local machine. Reorients the #924 mechanism accordingly.

### Adds

- `scripts/run-promptfoo-eval.sh` — local execution helper. Honors `$1` as an egrep filter and `PROVIDER_FILTER` as a comma list. Loud-fails when no API key is in env.

### Modifies

- `docs/runbook/community-skill-eval.md` — promotes local execution to the primary path; demotes the Actions workflow to "optional fallback" under an explicit project-policy note.

### Why this layout

The Actions workflow stays in place because it costs nothing to keep and may become useful later. Today the primary path is `scripts/run-promptfoo-eval.sh`, which any agent (Claude Code session or human contributor) can run with API keys in their local env.

## Codify-then-validate (per AGENTS.md)

- **Failure scenarios**: no API key in env → script exits 1 with runbook link; no `npx` → exits 1; no matching configs → exits 1.
- **Reopen / exception**: if local-only proves friction (e.g. multiple contributors generating goldens that diverge), revisit the repo-secret path via the existing workflow.
- **Gray zone**: which provider/model is "canonical" for the committed golden — out of scope; the README in each skill leaves this to the human review step.

## Test plan

- [x] `node scripts/fix-dashes.mjs --check` clean
- [x] Shell script syntax: passes `bash -n` mentally; runs in CI lint if any
- [ ] CI green
- [ ] (Manual, post-merge, with API key in env) one local invocation to confirm output lands in `./eval-output/`