### PR TITLE
test: failing integration test for --plan replay execution (#878 A2-3-test)

### DIFF
--- a/tests/cli-review-exec-replay.test.mjs
+++ b/tests/cli-review-exec-replay.test.mjs
@@ -1,0 +1,81 @@
+// #878 A2-3-test slice — failing integration test for replay execution.
+//
+// Per docs/development/a2-3-replay-execution-design.md §"Failing test
+// specification": this test locks the silent-skip contract that A2-3-impl
+// must lift. It is marked { todo: true } so CI stays green while the test
+// is published as the contract source-of-truth. When A2-3-impl lands and
+// the assertion passes, the runner should flip this to a regular `test()`
+// in the same PR.
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test, { describe } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI = path.resolve(__dirname, '../src/cli.mjs');
+
+function makePlanFixture() {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'river-a2-3-replay-'));
+  const planPath = path.join(dir, 'plan.json');
+  const plan = {
+    version: '1',
+    timestamp: '2026-05-27T22:00:00Z',
+    phase: 'midstream',
+    status: 'ok',
+    plan: {
+      selectedSkills: [{ id: 'rr-midstream-hello-skill-001', name: 'Hello Skill (Always-On Sample)' }],
+      skippedSkills: [],
+      plannerMode: 'off',
+    },
+    debug: {
+      execution: {
+        snapshot: {
+          fileTypes: ['markdown'],
+          relatedADRs: [],
+          reviewMode: 'standard',
+          riskAssessment: { action: 'comment_only', reason: 'docs-only change' },
+        },
+      },
+    },
+  };
+  writeFileSync(planPath, JSON.stringify(plan, null, 2));
+  return { dir, planPath };
+}
+
+describe('#878 A2-3 — `river review exec --plan` replay execution', () => {
+  test(
+    'silent-skip: --plan replay returns findings: [] when execution is requested',
+    { todo: 'A2-3-impl slice will lift this. Remove the todo flag in the same PR.' },
+    () => {
+      const { dir, planPath } = makePlanFixture();
+      try {
+        const r = spawnSync(process.execPath, [CLI, 'review', 'exec', '--plan', planPath], {
+          encoding: 'utf8',
+          env: { ...process.env, NO_COLOR: '1' },
+        });
+
+        // Locate the JSON document in stdout (CLI may print human-readable
+        // preamble; the artifact JSON is the last well-formed object).
+        const jsonStart = r.stdout.lastIndexOf('{');
+        assert.ok(jsonStart >= 0, `no JSON in stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+        const artifact = JSON.parse(r.stdout.slice(jsonStart));
+
+        // Contract under A2-3-impl: replay invokes generateReview, returns
+        // findings. With the snapshot carry-over present, at least one
+        // finding (or a deliberate empty-with-explanation) must appear.
+        assert.ok(
+          Array.isArray(artifact.findings) && artifact.findings.length >= 1,
+          `expected findings >= 1 after A2-3-impl, got ${
+            Array.isArray(artifact.findings) ? artifact.findings.length : 'non-array'
+          }. Today's behavior (pre-A2-3-impl) is findings: []. This test is { todo: true } until A2-3-impl lands.`
+        );
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  );
+});


### PR DESCRIPTION
## Summary

Per `docs/development/a2-3-replay-execution-design.md` §"Failing test specification". Codex slice judgment: A2-3-test as a standalone PR with `{ todo: true }` so the failing assertion lives in the tree as the contract source-of-truth without destabilizing CI.

When A2-3-impl lands and the assertion passes, the implementer flips `{ todo: true }` to a regular `test()` in the same PR. That is the agreed graduation signal for the silent-skip contract.

## What it asserts

Spawn `node src/cli.mjs review exec --plan <fixture>`, where the fixture is a Review Artifact carrying `debug.execution.snapshot` (the schema additive from #922). The artifact's `findings.length >= 1` must hold once A2-3-impl wires `runReviewExecReplay` to `generateReview`. Today it returns `[]`.

## Test plan

- [x] `node --test tests/cli-review-exec-replay.test.mjs` → 1 todo (expected fail, doesn't break CI)
- [x] `npm test` → 1106/1106 pass + 1 todo
- [x] `node scripts/fix-dashes.mjs --check` clean
- [ ] CI green

## Self-review (per AGENTS.md from #904)

- **3 failure scenarios**:
  1. CLI output format changes such that the artifact JSON cannot be sliced from stdout → assertion includes the raw stdout in the failure message for diagnosis.
  2. `rr-midstream-hello-skill-001` is renamed / removed → fixture references it by id; pre-merge `npm run skills:validate` catches the drift.
  3. The todo never gets lifted (test stays as expected-fail forever) → A2-3-impl PR review checklist must include "flip todo flag in this PR or block".
- **Reopen / exception**: if Option A (schema v2 break) wins after team review, this fixture's `debug.execution.snapshot` shape moves to `plan.context` and the test name stays.
- **Gray zone**: drift detection is out of scope here; that lives under `debug.replay.drift` in A2-3-impl.

## Out of scope

- A2-3-runners (buildExecutionPlan populating the snapshot field). Separate slice.
- A2-3-impl (runReviewExecReplay reading the snapshot + calling generateReview). Separate slice; this PR is the failing-test contract for that work.
- Diff snapshotting (deliberately rejected in the design doc).