### PR TITLE
feat(scripts): offline promptfoo config validator (#929 advance, no API key)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "check:links:local": "lychee --config .lychee.toml --offline '**/*.md' --exclude-path node_modules --exclude-path '.claude/worktrees/' --exclude-path '(^|/)pages/index\\.md$' --exclude-path '(^|/)pages/index\\.en\\.md$'",
     "agents:validate": "node scripts/validate-agents.mjs",
     "skills:validate": "node scripts/validate-skills.mjs",
+    "skills:validate:promptfoo": "node scripts/validate-promptfoo-configs.mjs",
     "validate:skill-yaml": "node scripts/validate-skill-yaml.mjs",
     "agent-skills:validate": "node scripts/validate-agent-skills.mjs",
     "skills:catalog": "node scripts/generate-skill-catalog.mjs",

--- a/scripts/validate-promptfoo-configs.mjs
+++ b/scripts/validate-promptfoo-configs.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+// Offline structural validator for community skill promptfoo configs.
+// Catches schema breakage before someone burns LLM tokens on a broken yaml.
+// Does NOT call any LLM. Run by `npm run skills:validate:promptfoo` or directly.
+//
+// Validates:
+// - YAML parses
+// - `prompts`, `providers`, `tests` arrays exist and are non-empty
+// - Every `file://...` reference resolves to an existing file
+// - Every test has `description`, `vars`, `assert`
+//
+// Background: #929 (post-#868 quality gate). Lets contributors validate
+// authoring changes locally without an API key.
+
+import { readFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { globSync } from 'node:fs';
+import YAML from 'yaml';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+function resolveFileRef(ref, configPath) {
+  // file://../prompt/system.md → relative to configPath's directory
+  if (!ref.startsWith('file://')) return null;
+  const rel = ref.slice('file://'.length);
+  return path.resolve(path.dirname(configPath), rel);
+}
+
+function validateConfig(configPath) {
+  const errors = [];
+  const text = readFileSync(configPath, 'utf8');
+  let doc;
+  try {
+    doc = YAML.parse(text);
+  } catch (err) {
+    return [`YAML parse error: ${err.message}`];
+  }
+
+  for (const key of ['prompts', 'providers', 'tests']) {
+    if (!Array.isArray(doc?.[key]) || doc[key].length === 0) {
+      errors.push(`Missing or empty required array: ${key}`);
+    }
+  }
+
+  for (const ref of doc.prompts ?? []) {
+    if (typeof ref !== 'string') continue;
+    const resolved = resolveFileRef(ref, configPath);
+    if (resolved && !existsSync(resolved)) {
+      errors.push(`prompts: file reference not found: ${ref} (resolved: ${resolved})`);
+    }
+  }
+
+  for (const [i, test] of (doc.tests ?? []).entries()) {
+    if (!test || typeof test !== 'object') {
+      errors.push(`tests[${i}]: must be an object`);
+      continue;
+    }
+    if (typeof test.description !== 'string' || !test.description) {
+      errors.push(`tests[${i}]: missing description`);
+    }
+    if (!test.vars || typeof test.vars !== 'object') {
+      errors.push(`tests[${i}]: missing vars`);
+    } else {
+      for (const [k, v] of Object.entries(test.vars)) {
+        if (typeof v !== 'string' || !v.startsWith('file://')) continue;
+        const resolved = resolveFileRef(v, configPath);
+        if (resolved && !existsSync(resolved)) {
+          errors.push(`tests[${i}].vars.${k}: file reference not found: ${v}`);
+        }
+      }
+    }
+    if (!Array.isArray(test.assert) || test.assert.length === 0) {
+      errors.push(`tests[${i}]: missing or empty assert[]`);
+    }
+  }
+
+  return errors;
+}
+
+function main() {
+  const configs = globSync('skills/midstream/community/*/eval/promptfoo.yaml', {
+    cwd: REPO_ROOT,
+  });
+  if (configs.length === 0) {
+    console.error('error: no community skill promptfoo.yaml found.');
+    process.exit(1);
+  }
+
+  let total = 0;
+  let bad = 0;
+  for (const rel of configs.sort()) {
+    const full = path.join(REPO_ROOT, rel);
+    const errors = validateConfig(full);
+    total += 1;
+    if (errors.length === 0) {
+      console.log(`✅ ${rel}`);
+    } else {
+      bad += 1;
+      console.log(`❌ ${rel}`);
+      for (const e of errors) console.log(`   - ${e}`);
+    }
+  }
+
+  console.log(`\n${total - bad}/${total} configs valid.`);
+  if (bad > 0) process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary

Per Codex slice judgment for #929: API-key-free advance via offline config validation. Catches authoring drift in `eval/promptfoo.yaml` before anyone burns LLM tokens on a broken config.

`#929` itself **stays open** — the `recommended: true` promotion still requires real LLM runs with API keys, which this session does not have. This PR reduces the friction of that future work.

## Changes

- `scripts/validate-promptfoo-configs.mjs` — walks `skills/midstream/community/*/eval/promptfoo.yaml`, asserts:
  - YAML parses
  - `prompts` / `providers` / `tests` are non-empty arrays
  - every `file://...` reference (prompts + test vars) resolves
  - every test has `description` / `vars` / `assert`
- `package.json` — `npm run skills:validate:promptfoo`

Today: **7/7 configs pass**. Future drift catches a `promptfoo eval` failure pre-merge rather than at LLM-run time.

## Test plan

- [x] `npm run skills:validate:promptfoo` → 7/7 ✅
- [x] `node scripts/fix-dashes.mjs --check` clean
- [ ] CI green

## Carry-over to #929

After this PR merges I'll post a promotion-PR checklist comment on #929 (Codex slice (d)). The actual `recommended: true` flips remain blocked on API-key-bearing eval runs.