### PR TITLE
docs(retrospective): addendum — post-#930 arc + #877 silent-skip lesson

### DIFF
--- a/docs/development/retrospectives/2026-05-25-28.md
+++ b/docs/development/retrospectives/2026-05-25-28.md
@@ -115,3 +115,55 @@ Where the prior retro asked "next sprint should be slower, not bigger", this spr
 - **3 PRs** were Slice B / dogfood / runbook elaborations that arguably could have been Park-bucketed.
 
 Net: ~3 PRs of "stop condition weakness" surface, vs ~13 of last sprint. The rule helped. Codify-then-validate caught its own gap. The next iteration of the rule is in A8 / A9.
+
+## Addendum—post-#930 arc (#878 epic + #868/#929/#921 closeout)
+
+The retrospective above was written mid-session (#930). The remaining work that
+session—#878 A2-3 epic completion, #868 closure, #921/#929 advancement —
+surfaced one durable lesson worth persisting.
+
+### Durable lesson: "completed" report ≠ wired-through
+
+A2-3-runners (#933) discovered that `riskAssessment` was computed in
+`buildExecutionPlan` but **never returned**—so every `plan.riskAssessment`
+consumer silently received `undefined`. The prior retrospective listed
+A2-fix-4 (#877) as having closed this silent-skip. It had not: the field was
+forwarded at the _call site_ (`generateReview` received `plan.riskAssessment`)
+but the _source_ never emitted it. The forwarding was wired to a value that
+was always undefined.
+
+**Why it slipped**: the #877 work added the consumer side and a test that the
+consumer _forwards_ the value, but no test asserted the _producer_ emits it.
+A "forwards X" test passes whether X is a real value or `undefined`.
+
+**Rule (new, P1 for next sprint)**: a silent-skip fix is not complete until a
+test asserts the value is **returned by the producer AND consumed by the
+consumer**—not just "forwarded if present". The `review-runner-snapshot-field`
+test (#933) now covers the producer side for these four fields; back-fill the
+same assertion shape for any future forwarded field.
+
+### Delivery shape that worked
+
+The #878 epic shipped as 4 independently-mergeable slices following the
+design doc (#910): schema → todo-marked failing test → producer → consumer.
+The todo-marked test (#927) acted as an executable contract; flipping
+`{ todo: true }` to a real test in the impl PR (#935) was the objective
+"done" signal. Recommend this pattern for future multi-slice features.
+
+### Design-only discipline held twice
+
+Both #910 (A2-3 design) and #938 (cost control design) shipped as design docs
+with explicit implementation-hold conditions rather than speculative code. The
+cost-control doc (#921) went further: it named telemetry—not the workflow —
+as the real first deliverable, because the 3-mode branching cannot be validated
+without cost data. This is the prior retro's "stop condition" discipline
+applied at design time.
+
+### Session totals (full session, superseding the mid-session count above)
+
+- **38 PRs merged** (#898–#938)
+- **13 releases** (v0.56.0 → v0.68.0)
+- **4 issues closed**: #906, #911, #868, #878
+- **5 issues opened**: #906, #911, #921, #929, #936
+- Stop-on-Stop-Judge invoked 11+ times; A9 (cached judgment) applied in the
+  later half to avoid re-consulting Codex on unchanged situations.


### PR DESCRIPTION
## Summary

Appends an addendum to the 2026-05-25..28 retrospective (the original #930 was written mid-session). Captures the remaining arc and one durable lesson.

## The durable lesson

**"completed" report ≠ wired-through.** A2-3-runners (#933) found that `riskAssessment` was computed in `buildExecutionPlan` but never returned — every `plan.riskAssessment` consumer silently got `undefined`. #877 had claimed to fix this silent-skip but only wired the *consumer* side; the *producer* never emitted the value.

**Why it slipped**: #877 added a "forwards X" test, which passes whether X is real or `undefined`.

**New P1 rule**: a silent-skip fix is not complete until a test asserts the value is RETURNED by the producer AND consumed — not just "forwarded if present". The #933 producer-side test now covers it for these four fields.

## Also recorded

- The 4-slice design-doc-first delivery shape worked well for #878 (schema → todo test → producer → consumer; flipping `{todo:true}` = objective "done").
- Design-only discipline held twice (#910, #938) — cost control (#921) named telemetry, not the workflow, as the real first deliverable.

## Session totals (full)

38 PRs / 13 releases (v0.56.0→v0.68.0) / 4 issues closed (#906, #911, #868, #878) / 5 opened.

## Test plan

- [x] `node scripts/fix-dashes.mjs --check` clean
- [ ] CI green

Doc only.