### PR TITLE
feat(skills): promote 7 community skills to recommended:true (#929)

### DIFF
--- a/skills/midstream/community/rr-midstream-a11y-accessible-name-001/golden/01-icon-button-happy.md
+++ b/skills/midstream/community/rr-midstream-a11y-accessible-name-001/golden/01-icon-button-happy.md
@@ -1,0 +1,23 @@
+Finding: The `<button>` in `CloseButton.tsx` lost its `aria-label="Close"` and now contains only an icon with no accessible name.
+
+Evidence:
+
+```diff
+-  return <button onClick={onClose} aria-label="Close">{/* icon */}<XIcon /></button>;
++  return <button onClick={onClose}><XIcon /></button>;
+```
+
+Line 15 of the diff removes the `aria-label` attribute, leaving the button with no visible text and no ARIA label.
+
+Impact: Screen reader users will hear an unlabeled or ambiguously named button (e.g., "button") instead of a meaningful name. This makes the close action undiscoverable for assistive technology users.
+
+Fix: Restore `aria-label="Close"` on the button, or add visible text describing the action.
+
+```tsx
+<button onClick={onClose} aria-label="Close">
+  <XIcon />
+</button>
+```
+
+Severity: minor
+Confidence: high

--- a/skills/midstream/community/rr-midstream-a11y-accessible-name-001/golden/02-decorative-img-false-positive.md
+++ b/skills/midstream/community/rr-midstream-a11y-accessible-name-001/golden/02-decorative-img-false-positive.md
@@ -1,0 +1,3 @@
+No findings.
+
+The added `<img>` element has `aria-hidden="true"`, which triggers the decorative-element false-positive guard. Elements explicitly marked `aria-hidden="true"` are intentionally hidden from the accessibility tree and do not require an accessible name. No action is needed.

--- a/skills/midstream/community/rr-midstream-independent-review-synthesis-001/golden/01-dedup-and-confirm-happy.md
+++ b/skills/midstream/community/rr-midstream-independent-review-synthesis-001/golden/01-dedup-and-confirm-happy.md
@@ -1,0 +1,44 @@
+## Critical Issues
+
+Finding: Parameterized query replaced with template literal interpolation, introducing SQL injection
+Evidence: src/api/users.ts:13 — `const user = await db.query(\`SELECT _ FROM users WHERE id = ${id}\`);`(diff line`+ const user = await db.query(\`SELECT _ FROM users WHERE id = ${id}\`);`)
+Reviewers: review-self, review-external
+Severity: critical
+ValidatedStatus: confirmed
+Suggestion: Revert to the parameterized form:`db.query('SELECT \* FROM users WHERE id = ?', [id])`. Never interpolate untrusted request parameters directly into SQL strings.
+
+---
+
+## Major Issues
+
+(none)
+
+---
+
+## Minor Issues
+
+(none)
+
+---
+
+## Dismissed Findings
+
+(none)
+
+---
+
+## Agent Agreement Summary
+
+| Finding                              | Reviewers                    | Deduplicated                                                              |
+| ------------------------------------ | ---------------------------- | ------------------------------------------------------------------------- |
+| SQL injection on src/api/users.ts:13 | review-self, review-external | yes — same file path, overlapping line range, evidence text distance ≤ 10 |
+
+Both inputs describe the same root cause (direct interpolation of `id` into the SQL string). They were merged into one confirmed finding; the `Reviewers` list carries both sources as provenance.
+
+---
+
+## Merge Recommendation
+
+block
+
+Rationale: There is one `confirmed` finding with `severity: critical`. The diff replaces a parameterized query with an unsanitized template-literal interpolation of a user-supplied request parameter (`req.params.id`), which is a textbook SQL injection vector. This must be reverted before the PR is merged.

--- a/skills/midstream/community/rr-midstream-independent-review-synthesis-001/golden/02-hallucinated-finding-false-positive.md
+++ b/skills/midstream/community/rr-midstream-independent-review-synthesis-001/golden/02-hallucinated-finding-false-positive.md
@@ -1,0 +1,45 @@
+## Critical Issues
+
+(none)
+
+---
+
+## Major Issues
+
+(none)
+
+---
+
+## Minor Issues
+
+(none)
+
+---
+
+## Dismissed Findings
+
+Finding: JWT validation is missing a signature check, allowing token forgery
+Evidence: Claimed file `src/auth/jwt.ts:42` — snippet "JWT validation … missing signature check" — **not found in diff or any referenced file**. The diff touches only `src/api/users.ts` (adding `await` to `db.findById`). `src/auth/jwt.ts` does not appear anywhere in the provided diff.
+Reviewers: review-external
+Severity: (originally claimed critical)
+ValidatedStatus: dismissed-hallucination
+Suggestion: N/A — finding is not grounded in the actual change. If a real concern about JWT validation exists it should be filed as a separate issue with a pointer to the actual source location.
+
+---
+
+## Agent Agreement Summary
+
+| Finding                                                     | Reviewers       | Outcome                                        |
+| ----------------------------------------------------------- | --------------- | ---------------------------------------------- |
+| JWT validation missing signature check (src/auth/jwt.ts:42) | review-external | dismissed-hallucination — file not in diff     |
+| `await` added to `db.findById` (src/api/users.ts)           | review-self     | no actionable finding raised; change is benign |
+
+The only confirmed change in scope is the addition of `await` before `db.findById(id)` in `src/api/users.ts`. The self-reviewer described this accurately and raised no concern. The external reviewer's claim about `src/auth/jwt.ts:42` references a file and line that do not appear in the diff; it is dismissed as a hallucination.
+
+---
+
+## Merge Recommendation
+
+merge-ready
+
+Rationale: No `confirmed` findings with `severity: critical`, `major`, or `minor` exist. The sole dismissed finding was a hallucination (fabricated file reference). The actual diff — adding `await` to ensure the promise resolves before returning — is a benign correctness fix with no identified risk.

--- a/skills/midstream/community/rr-midstream-modern-web-a11y-interactive-001/golden/01-div-onclick-no-keyboard-happy.md
+++ b/skills/midstream/community/rr-midstream-modern-web-a11y-interactive-001/golden/01-div-onclick-no-keyboard-happy.md
@@ -1,0 +1,47 @@
+Finding: Clickable `<div>` lacks keyboard support — previously a `<button>`, now a generic element with `onClick` only.
+
+Evidence:
+
+```diff
+-  return <button onClick={onSelect}>{label}</button>;
++  return (
++    <div onClick={onSelect} className="menu-item">{label}</div>
++  );
+```
+
+`src/components/MenuItem.tsx` — the original `<button>` was removed in favour of a `<div>` that carries no implicit keyboard role, no `tabIndex`, and no `onKeyDown` handler. Keyboard users and AT users navigating by Tab / Enter / Space cannot activate this element. The library-component guard does not apply — this is a custom `<div>`, and no `tabIndex` / `aria-*` attributes have been set deliberately.
+
+Aspect: Keyboard
+
+Suggestion: Revert to `<button>` (preferred — keyboard, focus, and implicit `role="button"` are provided for free):
+
+```tsx
+return (
+  <button onClick={onSelect} className="menu-item">
+    {label}
+  </button>
+);
+```
+
+If a non-button element is required for styling reasons, add `role="button"`, `tabIndex={0}`, and an `onKeyDown` handler that calls `onSelect` on `Enter` / `Space`:
+
+```tsx
+return (
+  <div
+    role="button"
+    tabIndex={0}
+    onClick={onSelect}
+    onKeyDown={(e) => {
+      if (e.key === 'Enter' || e.key === ' ') onSelect();
+    }}
+    className="menu-item"
+  >
+    {label}
+  </div>
+);
+```
+
+Reference: WAI-ARIA Authoring Practices — Button Pattern; WCAG SC 2.1.1 Keyboard.
+
+Severity: minor
+Confidence: high

--- a/skills/midstream/community/rr-midstream-modern-web-a11y-interactive-001/golden/02-library-radix-dialog-false-positive.md
+++ b/skills/midstream/community/rr-midstream-modern-web-a11y-interactive-001/golden/02-library-radix-dialog-false-positive.md
@@ -1,0 +1,3 @@
+No findings.
+
+The diff adds a `<Dialog.Overlay />` inside a Radix UI `<Dialog.Root>` structure. The **library-component guard** applies: Radix UI's `Dialog` primitive handles focus trapping, initial focus placement, return-focus on close, `Escape` key dismissal, and the required `role="dialog"` / `aria-modal` ARIA attributes internally. Proposing additional focus management, keyboard handlers, or ARIA attributes on top of this library would be a false positive.

--- a/skills/midstream/community/rr-midstream-modern-web-browser-compat-001/golden/01-popover-api-happy.md
+++ b/skills/midstream/community/rr-midstream-modern-web-browser-compat-001/golden/01-popover-api-happy.md
@@ -1,0 +1,43 @@
+Finding: Popover API (`popover` attribute) introduced without feature detection
+
+Evidence:
+
+```diff
+-      <div role="tooltip">{children}</div>
++      <div popover="auto" id={id}>{children}</div>
+```
+
+File: `src/components/HelpTooltip.tsx` — the `popover="auto"` attribute (and the
+paired `popovertarget` on the button) use the Popover API, which reached all
+modern browsers in 2024.
+
+Baseline: Newly available (2024) — Safari 17, Chrome 114, Firefox 125. Older
+Safari versions (< 17) and any non-evergreen browser do not support the
+`popover` attribute; the element will render as a static, always-visible `<div>`
+with no show/hide behaviour.
+
+Suggestion: Add a JavaScript feature-detection guard before relying on the
+Popover API behaviour, for example:
+
+```ts
+if ('popover' in HTMLElement.prototype) {
+  // Popover API path — already handled by the JSX above
+} else {
+  // fallback: e.g. aria-expanded toggle or CSS-only show/hide
+}
+```
+
+Alternatively, if only the CSS anchor/display aspect matters, gate styles with:
+
+```css
+@supports selector([popover]) {
+  /* popover-specific styles */
+}
+```
+
+If your repo targets evergreen / modern browsers only (documented in
+`package.json` `browserslist`, `.browserslistrc`, or `.river/rules.md`), this
+suggestion can be dismissed.
+
+Severity: minor
+Confidence: high

--- a/skills/midstream/community/rr-midstream-modern-web-browser-compat-001/golden/02-supports-guard-false-positive.md
+++ b/skills/midstream/community/rr-midstream-modern-web-browser-compat-001/golden/02-supports-guard-false-positive.md
@@ -1,0 +1,20 @@
+No findings.
+
+Guard applied: **`@supports` feature-detection guard** — the diff already wraps
+the Container Query rules inside `@supports (container-type: inline-size) { … }`,
+so the false-positive suppression condition is met. No additional suggestion is
+needed.
+
+```diff
++@supports (container-type: inline-size) {
++  .card-container {
++    container-type: inline-size;
++  }
++  @container (min-width: 400px) {
++    .card { padding: 2rem; }
++  }
++}
+```
+
+Browsers that do not support Container Queries will ignore the entire block,
+providing the intended graceful degradation.

--- a/skills/midstream/community/rr-midstream-modern-web-performance-001/golden/01-lcp-lazy-hero-happy.md
+++ b/skills/midstream/community/rr-midstream-modern-web-performance-001/golden/01-lcp-lazy-hero-happy.md
@@ -1,0 +1,23 @@
+Finding: Hero image has `loading="lazy"` — this defers the browser's fetch and is a likely LCP regression for above-the-fold content.
+
+Evidence:
+
+```diff
+-      <img src="/hero.jpg" alt="..." width="1200" height="600" fetchpriority="high" />
++      <img src="/hero.jpg" alt="..." width="1200" height="600" loading="lazy" />
+```
+
+The diff removes `fetchpriority="high"` and adds `loading="lazy"`. For a hero image that is visible on initial load, `loading="lazy"` instructs the browser to delay the fetch until the image is near the viewport — but it is already in the viewport, so this serves no benefit and directly delays LCP.
+
+Metric: LCP
+
+Suggestion: Remove `loading="lazy"` and restore `fetchpriority="high"`. Optionally add `decoding="async"` to avoid blocking the main thread during image decode:
+
+```html
+<img src="/hero.jpg" alt="..." width="1200" height="600" fetchpriority="high" decoding="async" />
+```
+
+Reference: [MDN — HTMLImageElement.loading](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/loading), [web.dev — LCP](https://web.dev/lcp/)
+
+Severity: minor
+Confidence: high

--- a/skills/midstream/community/rr-midstream-modern-web-performance-001/golden/02-already-sized-img-false-positive.md
+++ b/skills/midstream/community/rr-midstream-modern-web-performance-001/golden/02-already-sized-img-false-positive.md
@@ -1,0 +1,3 @@
+No findings.
+
+The diff only adds an `alt` attribute to an image that already has `width="200"`, `height="200"`, `loading="lazy"`, and `decoding="async"`. All relevant performance attributes are present and correct for a below-the-fold thumbnail. The false-positive guard applies: because `loading="lazy"` and `decoding` are already specified, no attribute finding is raised. The `alt` addition is outside the scope of this skill.

--- a/skills/midstream/community/rr-midstream-modern-web-semantic-001/golden/01-div-onclick-happy.md
+++ b/skills/midstream/community/rr-midstream-modern-web-semantic-001/golden/01-div-onclick-happy.md
@@ -1,0 +1,19 @@
+Finding: A `<div>` with an `onClick` handler and `tabIndex` is used where a `<button>` element would provide the same interaction natively.
+
+Evidence:
+
+```diff
+-      <button onClick={onSave}>Save</button>
++      <div onClick={onSave} tabIndex={0} className="save-btn">
++        Save
++      </div>
+```
+
+The diff replaces a `<button>` with a `<div>` that manually re-implements keyboard focus via `tabIndex={0}`. This loses the built-in Enter/Space key activation, implicit `role="button"` ARIA semantics, and native focus styling that `<button>` provides automatically.
+
+Suggestion: Revert to `<button onClick={onSave} className="save-btn">Save</button>`. The HTML `<button>` element (MDN: [HTMLButtonElement](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button)) provides focus management, keyboard activation (Enter and Space), and `role="button"` at zero cost. The manual `tabIndex` on `<div>` does not restore Enter/Space handling without an additional `onKeyDown` guard. If custom styling is the concern, CSS resets (`all: unset` or targeted overrides) on `<button>` are the recommended approach.
+
+Note: No false-positive guard applies — this is not a library-provided component, not a typo/rename diff, and no legacy browser support policy was detected.
+
+Severity: minor
+Confidence: high

--- a/skills/midstream/community/rr-midstream-modern-web-semantic-001/golden/02-library-dialog-false-positive.md
+++ b/skills/midstream/community/rr-midstream-modern-web-semantic-001/golden/02-library-dialog-false-positive.md
@@ -1,0 +1,5 @@
+No findings.
+
+**Guard applied:** Library-component false-positive guard.
+
+The diff changes only the trigger label text from `"Open"` to `"Settings"` inside a `@radix-ui/react-dialog` component tree. Because the dialog implementation is fully owned by the Radix UI library (`Dialog.Root`, `Dialog.Trigger`, `Dialog.Portal`, `Dialog.Content`), the library boundary guard applies: suggesting a replacement with the native HTML `<dialog>` element would constitute a framework-level change that is outside this skill's scope. The diff itself carries no semantic meaning change — it is a label rename — and therefore does not warrant a finding under any rule.

--- a/skills/midstream/community/rr-midstream-nextjs-app-router-boundary-001/golden/01-usestate-in-server-component-happy.md
+++ b/skills/midstream/community/rr-midstream-nextjs-app-router-boundary-001/golden/01-usestate-in-server-component-happy.md
@@ -1,0 +1,11 @@
+Finding: `app/dashboard/Filter.tsx` uses `useState` without a `'use client'` directive, making it an invalid Server Component.
+
+Evidence: Line `+import { useState } from 'react';` and `+  const [query, setQuery] = useState('');` are added to a file under `app/` that has no `'use client'` directive at the top. React hooks are client-only APIs and cannot run in a Server Component.
+
+BoundaryViolation: client-API in server component
+
+Suggestion: Add `'use client';` as the very first line of `app/dashboard/Filter.tsx`. Alternatively, extract the stateful logic into a new child component (e.g. `FilterClient.tsx`) that begins with `'use client';`, and render it from the existing `Filter` server component.
+
+Severity: major
+
+Confidence: high

--- a/skills/midstream/community/rr-midstream-nextjs-app-router-boundary-001/golden/02-use-client-directive-false-positive.md
+++ b/skills/midstream/community/rr-midstream-nextjs-app-router-boundary-001/golden/02-use-client-directive-false-positive.md
@@ -1,0 +1,3 @@
+No findings.
+
+Guard applied: `'use client'` directive is present at the top of `app/dashboard/SearchBox.tsx` (line 1 of the diff context: `'use client';`). The file is a Client Component by declaration, so using `useState` is valid App Router usage. The false-positive guard suppresses this finding.

--- a/skills/registry.yaml
+++ b/skills/registry.yaml
@@ -268,7 +268,7 @@ skills:
     phase: midstream
     tags: [community, accessibility, ui, midstream]
     severity: minor
-    recommended: false
+    recommended: true
     description: 'Checks images, buttons, and form controls for accessible names (alt / aria-label / label association).'
 
   - id: rr-midstream-nextjs-app-router-boundary-001
@@ -279,7 +279,7 @@ skills:
     phase: midstream
     tags: [community, nextjs, app-router, ui, midstream]
     severity: minor
-    recommended: false
+    recommended: true
     description: 'Surfaces Next.js App Router boundary issues (server vs client component placement, "use client" misuse).'
 
   - id: rr-midstream-modern-web-semantic-001
@@ -290,7 +290,7 @@ skills:
     phase: midstream
     tags: [community, modern-web, semantic-html, accessibility, ui, midstream]
     severity: minor
-    recommended: false
+    recommended: true
     description: 'Suggests semantic HTML / Web Platform Native APIs / modern CSS over legacy workarounds.'
 
   - id: rr-midstream-modern-web-performance-001
@@ -301,7 +301,7 @@ skills:
     phase: midstream
     tags: [community, modern-web, performance, core-web-vitals, ui, midstream]
     severity: minor
-    recommended: false
+    recommended: true
     description: 'Surfaces LCP / INP / CLS / resource-cost implications of frontend diffs.'
 
   - id: rr-midstream-modern-web-browser-compat-001
@@ -312,7 +312,7 @@ skills:
     phase: midstream
     tags: [community, modern-web, browser-compatibility, baseline, midstream]
     severity: minor
-    recommended: false
+    recommended: true
     description: 'Prompts Baseline status / feature detection / progressive enhancement for new Web APIs and CSS.'
 
   - id: rr-midstream-modern-web-a11y-interactive-001
@@ -323,7 +323,7 @@ skills:
     phase: midstream
     tags: [community, modern-web, accessibility, a11y, ui, midstream]
     severity: minor
-    recommended: false
+    recommended: true
     description: 'Keyboard operation / focus management / live regions / role-state semantics for interactive UI.'
 
   - id: rr-midstream-independent-review-synthesis-001
@@ -334,7 +334,7 @@ skills:
     phase: midstream
     tags: [community, review, synthesis, multi-agent, validation, hallucination-guard, midstream]
     severity: major
-    recommended: false
+    recommended: true
     description: 'Synthesizes multiple AI / human review results (review-self / review-external / findings-pool), dedups, verifies evidence, and emits a merge recommendation. No majority vote.'
 
   # Downstream Skills (Testing & Release)


### PR DESCRIPTION
## Summary

- 7 community skills の golden output (14 ファイル) を生成し、`skills/registry.yaml` の `recommended: false → true` に変更
- eval は Claude Code エージェントがレビュアー LLM として直接実行（promptfoo / API キー不要）
- 全ルーブリック条件を各スキルで検証済み

## Promoted skills

| Skill | Happy fixture | False-positive fixture |
|---|---|---|
| a11y-accessible-name-001 | icon-button (aria-label missing) | decorative img (aria-hidden guard) |
| nextjs-app-router-boundary-001 | useState in server component | use-client directive guard |
| modern-web-semantic-001 | div onClick → button | library dialog false-positive |
| modern-web-performance-001 | LCP lazy hero | already-sized img |
| modern-web-browser-compat-001 | Popover API | @supports guard |
| modern-web-a11y-interactive-001 | div onClick no keyboard | Radix dialog library guard |
| independent-review-synthesis-001 | dedup + confirmed SQL injection | hallucinated JWT finding dismissed |

## Test plan

- [x] `npm test` — 1113 tests pass, 0 fail
- [x] lint-staged (markdownlint / prettier / skills:validate) — all pass
- [x] Each golden passes the rubric assertions defined in `eval/promptfoo.yaml`

Closes #929

🤖 Generated with [Claude Code](https://claude.com/claude-code)