### PR TITLE
feat(orchestrator): auto team selection, diff splitting, and deduplication

### DIFF
--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -72,7 +72,8 @@ Options:
   --output <mode>   Output format: text|markdown|json|yaml. Default: text
   --context list    Comma-separated available contexts (e.g. diff,fullFile,tests). Overrides RIVER_AVAILABLE_CONTEXTS
   --dependency list Comma-separated available dependencies (e.g. code_search,test_runner). Overrides RIVER_AVAILABLE_DEPENDENCIES
-  --reviewers list  Comma-separated reviewer roles for parallel orchestration (e.g. bug-hunter,security-scanner,test-gap)
+  --reviewers list  Comma-separated reviewer roles for parallel orchestration (e.g. bug-hunter,security-scanner,test-gap).
+                    Use "auto" to select roles automatically based on diff content and risk signals.
   --baseline <path> Path to a previous review JSON (findings array) for regression comparison
   --save            Persist the review run to the project result store (.river/runs/)
 

--- a/src/lib/reviewer-orchestrator.mjs
+++ b/src/lib/reviewer-orchestrator.mjs
@@ -1,5 +1,6 @@
 import { generateReview } from './review-engine.mjs';
 import { classifyFindings } from './finding-classifier.mjs';
+import { renderDiffText } from './diff-optimizer.mjs';
 
 export const REVIEWER_ROLES = {
   'bug-hunter': {
@@ -32,11 +33,148 @@ Report only test coverage gaps. Do NOT report implementation bugs or style issue
 
 export const DEFAULT_REVIEWERS = ['bug-hunter', 'security-scanner'];
 
-export function resolveReviewerRoles(reviewers) {
+// Thresholds for diff splitting
+const SPLIT_FILE_THRESHOLD = 10;
+const SPLIT_LINE_THRESHOLD = 500;
+
+export function resolveReviewerRoles(reviewers, { fileTypes, riskAssessment } = {}) {
+  // 'auto' keyword: derive roles from diff content
+  if (reviewers?.length === 1 && reviewers[0] === 'auto') {
+    return { valid: selectRolesAuto(fileTypes, riskAssessment), invalid: [] };
+  }
   const names = reviewers ?? DEFAULT_REVIEWERS;
   const valid = names.filter((n) => REVIEWER_ROLES[n]);
   const invalid = names.filter((n) => !REVIEWER_ROLES[n]);
   return { valid, invalid };
+}
+
+/**
+ * Automatically select reviewer roles based on diff content signals.
+ * Always includes bug-hunter; adds security-scanner and test-gap when relevant.
+ */
+export function selectRolesAuto(fileTypes, riskAssessment) {
+  const roles = new Set(['bug-hunter']);
+
+  // Security: risky files or config/infra/schema changes
+  const riskyFiles =
+    (riskAssessment?.humanReviewFiles?.length ?? 0) + (riskAssessment?.escalatedFiles?.length ?? 0);
+  const infraFiles =
+    (fileTypes?.config?.length ?? 0) +
+    (fileTypes?.schema?.length ?? 0) +
+    (fileTypes?.migration?.length ?? 0) +
+    (fileTypes?.infra?.length ?? 0);
+  if (riskyFiles > 0 || infraFiles > 0) {
+    roles.add('security-scanner');
+  }
+
+  // Test gap: test files changed or new app files without accompanying tests
+  const testFiles = fileTypes?.test?.length ?? 0;
+  const appFiles = fileTypes?.app?.length ?? 0;
+  if (testFiles > 0 || appFiles > 2) {
+    roles.add('test-gap');
+  }
+
+  return [...roles];
+}
+
+/**
+ * Split diff files into groups for parallel chunk execution.
+ * Groups by directory prefix to keep related files together.
+ */
+export function splitDiffIntoChunks(diff) {
+  const files = diff.files ?? [];
+  const totalLines = files.reduce(
+    (sum, f) => sum + (f.hunks ?? []).reduce((s, h) => s + (h.lines?.length ?? 0), 0),
+    0
+  );
+
+  if (files.length <= SPLIT_FILE_THRESHOLD && totalLines <= SPLIT_LINE_THRESHOLD) {
+    return null; // No split needed
+  }
+
+  // Group files by top-level directory
+  const groups = new Map();
+  for (const file of files) {
+    const dir = file.path.split('/')[0] ?? '_root';
+    if (!groups.has(dir)) groups.set(dir, []);
+    groups.get(dir).push(file);
+  }
+
+  // Merge small groups to avoid excessive chunks (target: 2–4 chunks)
+  const targetChunks = Math.min(4, Math.ceil(files.length / SPLIT_FILE_THRESHOLD));
+  const buckets = [];
+  for (const groupFiles of groups.values()) {
+    if (buckets.length < targetChunks) {
+      buckets.push([...groupFiles]);
+    } else {
+      // Append to smallest bucket
+      buckets.sort((a, b) => a.length - b.length);
+      buckets[0].push(...groupFiles);
+    }
+  }
+
+  return buckets
+    .filter((b) => b.length > 0)
+    .map((chunkFiles) => ({
+      ...diff,
+      files: chunkFiles,
+      filesForReview: chunkFiles,
+      diffText: renderDiffText(chunkFiles),
+      _chunkLabel: chunkFiles
+        .map((f) => f.path)
+        .join(', ')
+        .slice(0, 60),
+    }));
+}
+
+/**
+ * Deduplicate findings across parallel runs.
+ * Two findings are considered duplicates if they share the same file, overlapping
+ * line range (±2 lines), and the first 80 chars of their message are similar.
+ */
+export function deduplicateFindings(findings) {
+  const seen = [];
+  const result = [];
+
+  for (const f of findings) {
+    const isDuplicate = seen.some((s) => {
+      if (s.file !== f.file) return false;
+      const lineOverlap =
+        Math.abs((s.lineStart ?? s.line ?? 0) - (f.lineStart ?? f.line ?? 0)) <= 2;
+      if (!lineOverlap) return false;
+      const msgA = (s.message ?? s.title ?? '').slice(0, 80).toLowerCase();
+      const msgB = (f.message ?? f.title ?? '').slice(0, 80).toLowerCase();
+      return editDistance(msgA, msgB) <= 10;
+    });
+
+    if (!isDuplicate) {
+      seen.push(f);
+      result.push(f);
+    }
+  }
+
+  return result;
+}
+
+function editDistance(a, b) {
+  if (a === b) return 0;
+  const m = a.length;
+  const n = b.length;
+  if (m === 0) return n;
+  if (n === 0) return m;
+  // Only compute if strings are similar enough to be worth comparing
+  if (Math.abs(m - n) > 15) return 99;
+  const dp = Array.from({ length: m + 1 }, (_, i) => [i]);
+  for (let j = 1; j <= n; j++) dp[0][j] = j;
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      dp[i][j] =
+        a[i - 1] === b[j - 1]
+          ? dp[i - 1][j - 1]
+          : 1 + Math.min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1]);
+    }
+  }
+  return dp[m][n];
 }
 
 export async function runReviewerOrchestration({
@@ -55,7 +193,7 @@ export async function runReviewerOrchestration({
   config,
   reviewers,
 } = {}) {
-  const { valid: roles, invalid } = resolveReviewerRoles(reviewers);
+  const { valid: roles, invalid } = resolveReviewerRoles(reviewers, { fileTypes, riskAssessment });
 
   if (!roles.length) {
     throw new Error(
@@ -63,8 +201,12 @@ export async function runReviewerOrchestration({
     );
   }
 
+  // Attempt diff splitting for large PRs
+  const diffChunks = splitDiffIntoChunks(diff);
+  const chunked = diffChunks !== null;
+  const diffsToProcess = chunked ? diffChunks : [diff];
+
   const generateArgs = {
-    diff,
     plan,
     phase,
     dryRun,
@@ -78,44 +220,59 @@ export async function runReviewerOrchestration({
     config,
   };
 
-  // Run each role in parallel; partial failure is tolerated
-  const settled = await Promise.allSettled(
-    roles.map((roleName) => {
+  // Fan out: each role × each diff chunk runs in parallel
+  const tasks = roles.flatMap((roleName) =>
+    diffsToProcess.map((chunkDiff, chunkIdx) => {
       const role = REVIEWER_ROLES[roleName];
       const roleRules = [role.focusInstructions, projectRules].filter(Boolean).join('\n\n');
-      return generateReview({ ...generateArgs, projectRules: roleRules }).then((result) => ({
-        ...result,
-        reviewerRole: roleName,
-      }));
+      return generateReview({ ...generateArgs, diff: chunkDiff, projectRules: roleRules }).then(
+        (result) => ({
+          ...result,
+          reviewerRole: roleName,
+          chunkIdx: chunked ? chunkIdx : null,
+          chunkLabel: chunked ? (chunkDiff._chunkLabel ?? `chunk-${chunkIdx}`) : null,
+        })
+      );
     })
   );
 
-  const succeeded = settled
-    .filter((r) => r.status === 'fulfilled')
-    .map((r) => r.value);
+  // Run each role in parallel; partial failure is tolerated
+  const settled = await Promise.allSettled(tasks);
+
+  const succeeded = settled.filter((r) => r.status === 'fulfilled').map((r) => r.value);
   const failed = settled.filter((r) => r.status === 'rejected');
 
-  // Merge findings with globally unique IDs and role tags
+  // Merge findings, deduplicate across chunks/roles, then assign stable IDs
   let nextId = 1;
-  const allFindings = succeeded.flatMap((r) =>
+  const rawFindings = succeeded.flatMap((r) =>
     (r.findings ?? []).map((f) => ({
       ...f,
-      id: `rr-${nextId++}`,
       reviewerRole: r.reviewerRole,
+      chunkLabel: r.chunkLabel ?? null,
     }))
   );
+  const deduped = deduplicateFindings(rawFindings);
+  const allFindings = deduped.map((f) => ({ ...f, id: `rr-${nextId++}` }));
 
   const allComments = succeeded.flatMap((r) => r.comments ?? []);
   const classified = classifyFindings(allFindings, { reviewMode: reviewMode ?? 'medium' });
 
-  const reviewerResults = roles.map((name, i) => ({
-    role: name,
-    label: REVIEWER_ROLES[name].label,
-    status: settled[i].status,
-    findingsCount:
-      settled[i].status === 'fulfilled' ? (settled[i].value.findings?.length ?? 0) : 0,
-    error: settled[i].status === 'rejected' ? String(settled[i].reason?.message ?? 'unknown') : null,
-  }));
+  // Summarise per-role results (aggregate across chunks)
+  const reviewerResults = roles.map((name) => {
+    const roleSettled = settled.filter(
+      (_, i) => tasks[i] && roles.flatMap((r) => diffsToProcess.map(() => r))[i] === name
+    );
+    const roleSucceeded = roleSettled.filter((r) => r.status === 'fulfilled');
+    return {
+      role: name,
+      label: REVIEWER_ROLES[name].label,
+      status: roleSucceeded.length > 0 ? 'fulfilled' : 'rejected',
+      findingsCount: roleSucceeded.reduce((sum, r) => sum + (r.value?.findings?.length ?? 0), 0),
+      chunksRun: chunked ? diffsToProcess.length : null,
+      error:
+        roleSucceeded.length === 0 ? String(roleSettled[0]?.reason?.message ?? 'unknown') : null,
+    };
+  });
 
   return {
     comments: allComments,
@@ -123,12 +280,16 @@ export async function runReviewerOrchestration({
     classified,
     reviewerResults,
     invalidRoles: invalid,
+    autoSelectedRoles: reviewers?.length === 1 && reviewers[0] === 'auto' ? roles : null,
+    chunked,
+    chunkCount: chunked ? diffsToProcess.length : null,
     prompt: succeeded[0]?.prompt ?? null,
     promptTruncated: succeeded.some((r) => r.promptTruncated),
     llmModel: succeeded[0]?.llmModel ?? null,
     debug: {
       succeededReviewers: succeeded.length,
       failedReviewers: failed.length,
+      deduplicatedCount: rawFindings.length - allFindings.length,
     },
   };
 }

--- a/tests/reviewer-orchestrator.test.mjs
+++ b/tests/reviewer-orchestrator.test.mjs
@@ -3,7 +3,13 @@ import assert from 'node:assert/strict';
 
 // Stub generateReview before importing the orchestrator
 const generateReviewStub = mock.fn(async ({ projectRules }) => ({
-  comments: [{ file: 'src/foo.mjs', line: 1, message: `Finding: issue Evidence: found in ${projectRules?.slice(0, 20) ?? ''}` }],
+  comments: [
+    {
+      file: 'src/foo.mjs',
+      line: 1,
+      message: `Finding: issue Evidence: found in ${projectRules?.slice(0, 20) ?? ''}`,
+    },
+  ],
   findings: [
     {
       id: 'rr-1',
@@ -12,7 +18,8 @@ const generateReviewStub = mock.fn(async ({ projectRules }) => ({
       lineStart: 1,
       lineEnd: 1,
       title: 'test finding',
-      message: 'Finding: issue Evidence: found in diff Impact: medium Fix: fix it Severity: major Confidence: high',
+      message:
+        'Finding: issue Evidence: found in diff Impact: medium Fix: fix it Severity: major Confidence: high',
       severity: 'major',
       confidence: 'high',
       status: 'open',
@@ -27,12 +34,19 @@ const generateReviewStub = mock.fn(async ({ projectRules }) => ({
 }));
 
 // Patch the module before import via mock.module
-const { runReviewerOrchestration, REVIEWER_ROLES, DEFAULT_REVIEWERS, resolveReviewerRoles } =
-  await (() => {
-    // We can't easily mock ESM imports in node:test without a loader.
-    // Instead, import the real module and test its observable behaviour.
-    return import('../src/lib/reviewer-orchestrator.mjs');
-  })();
+const {
+  runReviewerOrchestration,
+  REVIEWER_ROLES,
+  DEFAULT_REVIEWERS,
+  resolveReviewerRoles,
+  selectRolesAuto,
+  splitDiffIntoChunks,
+  deduplicateFindings,
+} = await (() => {
+  // We can't easily mock ESM imports in node:test without a loader.
+  // Instead, import the real module and test its observable behaviour.
+  return import('../src/lib/reviewer-orchestrator.mjs');
+})();
 
 function makeDiff() {
   return { diffText: 'diff --git a/src/foo.mjs', files: [], filesForReview: [] };
@@ -170,5 +184,159 @@ describe('runReviewerOrchestration', () => {
     });
     assert.ok(typeof result.debug.succeededReviewers === 'number');
     assert.ok(typeof result.debug.failedReviewers === 'number');
+    assert.ok(typeof result.debug.deduplicatedCount === 'number');
+  });
+
+  it('auto mode expands roles based on fileTypes', async () => {
+    const result = await runReviewerOrchestration({
+      diff: makeDiff(),
+      dryRun: true,
+      reviewers: ['auto'],
+      fileTypes: {
+        test: ['foo.test.mjs'],
+        app: ['src/foo.mjs'],
+        config: [],
+        schema: [],
+        migration: [],
+        infra: [],
+      },
+      riskAssessment: { humanReviewFiles: [], escalatedFiles: [] },
+    });
+    assert.ok(result.autoSelectedRoles !== null, 'autoSelectedRoles should be set in auto mode');
+    assert.ok(result.autoSelectedRoles.includes('bug-hunter'));
+    assert.ok(result.autoSelectedRoles.includes('test-gap'), 'test files → test-gap');
+  });
+
+  it('auto mode adds security-scanner for risky files', async () => {
+    const result = await runReviewerOrchestration({
+      diff: makeDiff(),
+      dryRun: true,
+      reviewers: ['auto'],
+      fileTypes: {
+        test: [],
+        app: [],
+        config: ['config.json'],
+        schema: [],
+        migration: [],
+        infra: [],
+      },
+      riskAssessment: { humanReviewFiles: ['config.json'], escalatedFiles: [] },
+    });
+    assert.ok(result.autoSelectedRoles.includes('security-scanner'));
+  });
+});
+
+describe('selectRolesAuto', () => {
+  it('always includes bug-hunter', () => {
+    const roles = selectRolesAuto({}, null);
+    assert.ok(roles.includes('bug-hunter'));
+  });
+
+  it('adds test-gap when test files are present', () => {
+    const roles = selectRolesAuto(
+      { test: ['foo.test.ts'], app: [], config: [], schema: [], migration: [], infra: [] },
+      null
+    );
+    assert.ok(roles.includes('test-gap'));
+  });
+
+  it('adds test-gap when many app files changed', () => {
+    const roles = selectRolesAuto(
+      { test: [], app: ['a.ts', 'b.ts', 'c.ts'], config: [], schema: [], migration: [], infra: [] },
+      null
+    );
+    assert.ok(roles.includes('test-gap'));
+  });
+
+  it('adds security-scanner for config/schema changes', () => {
+    const roles = selectRolesAuto(
+      { test: [], app: [], config: ['app.config.ts'], schema: [], migration: [], infra: [] },
+      null
+    );
+    assert.ok(roles.includes('security-scanner'));
+  });
+
+  it('adds security-scanner for escalated risk files', () => {
+    const roles = selectRolesAuto({}, { humanReviewFiles: [], escalatedFiles: ['auth.ts'] });
+    assert.ok(roles.includes('security-scanner'));
+  });
+
+  it('returns only bug-hunter when no signals', () => {
+    const roles = selectRolesAuto(
+      { test: [], app: ['a.ts', 'b.ts'], config: [], schema: [], migration: [], infra: [] },
+      { humanReviewFiles: [], escalatedFiles: [] }
+    );
+    assert.deepEqual(roles, ['bug-hunter']);
+  });
+});
+
+describe('splitDiffIntoChunks', () => {
+  function makeFile(path, lines = 10) {
+    return { path, hunks: [{ header: '@@ -1 +1 @@', lines: Array(lines).fill('+line') }] };
+  }
+
+  it('returns null for small diffs', () => {
+    const diff = { files: [makeFile('src/a.ts'), makeFile('src/b.ts')] };
+    assert.equal(splitDiffIntoChunks(diff), null);
+  });
+
+  it('splits large diffs into chunks', () => {
+    // Use distinct top-level directories so grouping produces multiple chunks
+    const dirs = ['api', 'ui', 'lib', 'tests', 'config'];
+    const files = Array.from({ length: 15 }, (_, i) =>
+      makeFile(`${dirs[i % dirs.length]}/file${i}.ts`, 20)
+    );
+    const diff = { files, filesForReview: files, diffText: '' };
+    const chunks = splitDiffIntoChunks(diff);
+    assert.ok(chunks !== null);
+    assert.ok(chunks.length >= 2, `expected ≥2 chunks, got ${chunks?.length}`);
+    // All files must appear in exactly one chunk
+    const allPaths = chunks.flatMap((c) => c.files.map((f) => f.path));
+    assert.equal(allPaths.length, files.length);
+    assert.equal(new Set(allPaths).size, files.length, 'no duplicates');
+  });
+
+  it('chunks contain diffText', () => {
+    const files = Array.from({ length: 12 }, (_, i) => makeFile(`pkg${i % 4}/f${i}.ts`, 60));
+    const diff = { files, filesForReview: files, diffText: '' };
+    const chunks = splitDiffIntoChunks(diff);
+    assert.ok(chunks !== null);
+    for (const chunk of chunks) {
+      assert.ok(typeof chunk.diffText === 'string');
+    }
+  });
+});
+
+describe('deduplicateFindings', () => {
+  function makeF(file, line, message) {
+    return { file, lineStart: line, message, title: message };
+  }
+
+  it('keeps unique findings', () => {
+    const findings = [makeF('a.ts', 1, 'bug A'), makeF('b.ts', 5, 'bug B')];
+    assert.equal(deduplicateFindings(findings).length, 2);
+  });
+
+  it('removes exact duplicates', () => {
+    const f = makeF('a.ts', 1, 'null dereference on line 1 of function foo bar');
+    assert.equal(deduplicateFindings([f, { ...f }]).length, 1);
+  });
+
+  it('removes near-duplicates same file same line', () => {
+    const f1 = makeF('a.ts', 10, 'null pointer dereference in handleRequest');
+    const f2 = makeF('a.ts', 10, 'null pointer dereference in handleRequest func');
+    assert.equal(deduplicateFindings([f1, f2]).length, 1);
+  });
+
+  it('keeps findings on different lines', () => {
+    const f1 = makeF('a.ts', 10, 'null pointer');
+    const f2 = makeF('a.ts', 50, 'null pointer');
+    assert.equal(deduplicateFindings([f1, f2]).length, 2);
+  });
+
+  it('keeps findings on different files', () => {
+    const f1 = makeF('a.ts', 10, 'null pointer dereference on handleRequest');
+    const f2 = makeF('b.ts', 10, 'null pointer dereference on handleRequest');
+    assert.equal(deduplicateFindings([f1, f2]).length, 2);
   });
 });


### PR DESCRIPTION
## Summary

「PR の規模・内容を自動判定してレビューチームを構築し、大規模 diff を分割して並列実行する」機能を実装。

## 機能詳細

### 1. Auto Team Selection — `--reviewers auto`

```bash
river run . --reviewers auto
```

diff の内容を分析して自動的にロールを選択：

| シグナル | 追加ロール |
|---------|-----------|
| テストファイルが変更 or アプリファイルが3件超 | `test-gap` |
| config/schema/infra 変更 or リスクファイルあり | `security-scanner` |
| 常時 | `bug-hunter` |

### 2. Diff Splitting — 大規模 PR の自動分割

変更ファイル数 > 10 または diff 行数 > 500 の場合、トップレベルディレクトリ単位でファイルをグループ化して並列実行（最大4チャンク）。

### 3. Cross-run Deduplication

複数ロール・複数チャンクの結果をマージする前に重複除去：
- 同一ファイル + 行範囲 ±2 + メッセージ編集距離 ≤ 10 を重複と判定

## 結果オブジェクトの変更点

| フィールド | 説明 |
|-----------|------|
| `autoSelectedRoles` | auto モード時に選択されたロール一覧 |
| `chunked` | diff 分割が発生したか |
| `chunkCount` | 分割数 |
| `debug.deduplicatedCount` | 除去された重複 finding 数 |

## Test plan

- [x] `npm test` — 1129 tests pass（+16 新規テスト）
- [x] `selectRolesAuto` の各シグナル判定
- [x] `splitDiffIntoChunks` の分割・再結合・diffText 生成
- [x] `deduplicateFindings` の重複検出・境界条件

🤖 Generated with [Claude Code](https://claude.com/claude-code)