### PR TITLE
feat(docs+skills): --reviewers auto docs, agent templates, skill version fixes

### DIFF
--- a/pages/guides/agent-workflow.en.md
+++ b/pages/guides/agent-workflow.en.md
@@ -24,6 +24,23 @@ river run . --dry-run
 river run . --output json
 ```
 
+### How `--reviewers auto` works
+
+When `auto` is specified, River Reviewer analyzes the diff content and selects reviewer roles automatically. `bug-hunter` is always included; additional roles are added based on the following signals:
+
+| Signal                                                                           | Role added         |
+| -------------------------------------------------------------------------------- | ------------------ |
+| config / schema / migration / infra files changed, or risk-escalated files exist | `security-scanner` |
+| test files changed, or 3 or more app files changed                               | `test-gap`         |
+
+To see which roles were selected, check the `autoSelectedRoles` field in the JSON output:
+
+```json
+{
+  "autoSelectedRoles": ["bug-hunter", "security-scanner", "test-gap"]
+}
+```
+
 ---
 
 ## How to Invoke by Agent
@@ -64,11 +81,15 @@ Call it as a terminal command from Cursor's Agent mode:
 river run . --reviewers auto
 ```
 
+See `templates/agent-workflow/` for ready-to-use config templates.
+
 ### Codex CLI
 
 ```bash
 codex exec "river run . --reviewers auto"
 ```
+
+See `templates/agent-workflow/` for ready-to-use config templates.
 
 ### GitHub Copilot
 

--- a/pages/guides/agent-workflow.md
+++ b/pages/guides/agent-workflow.md
@@ -24,6 +24,23 @@ river run . --dry-run
 river run . --output json
 ```
 
+### `--reviewers auto` の仕組み
+
+`auto` を指定すると、diff の内容を解析してレビュアーロールを自動選択します。常に `bug-hunter` が含まれ、以下のシグナルに基づいて追加ロールが加わります。
+
+| シグナル                                                                                             | 追加されるロール   |
+| ---------------------------------------------------------------------------------------------------- | ------------------ |
+| config / schema / migration / infra ファイルが変更されている、またはリスク評価済みファイルが存在する | `security-scanner` |
+| test ファイルが変更されている、または app ファイルが 3 件以上ある                                    | `test-gap`         |
+
+どのロールが選択されたかは、JSON 出力の `autoSelectedRoles` フィールドで確認できます。
+
+```json
+{
+  "autoSelectedRoles": ["bug-hunter", "security-scanner", "test-gap"]
+}
+```
+
 ---
 
 ## エージェント別の呼び出し方
@@ -64,11 +81,15 @@ Cursor の Agent モードからターミナルコマンドとして呼び出せ
 river run . --reviewers auto
 ```
 
+設定テンプレートは `templates/agent-workflow/` を参照してください。
+
 ### Codex CLI
 
 ```bash
 codex exec "river run . --reviewers auto"
 ```
+
+設定テンプレートは `templates/agent-workflow/` を参照してください。
 
 ### GitHub Copilot
 

--- a/pages/reference/runner-cli-reference.en.md
+++ b/pages/reference/runner-cli-reference.en.md
@@ -4,6 +4,29 @@ Use the Runner CLI to validate River Reviewer agents and skills locally or in CI
 A lightweight Python runner outputs structured review results that follow `schemas/output.schema.json`.
 Install the required dependency with `pip install jsonschema` before running the Python example.
 
+## `--reviewers` flag
+
+The `--reviewers` flag on `river run` accepts a comma-separated list of role names or the special keyword `auto`.
+
+### `auto` keyword
+
+When `--reviewers auto` is specified, River Reviewer analyzes the diff content and selects reviewer roles automatically. `bug-hunter` is always included; additional roles are added based on the following signals:
+
+| Signal                                                                           | Role added         |
+| -------------------------------------------------------------------------------- | ------------------ |
+| config / schema / migration / infra files changed, or risk-escalated files exist | `security-scanner` |
+| test files changed, or 3 or more app files changed                               | `test-gap`         |
+
+If no signals are detected, only `bug-hunter` is used.
+
+The selected roles are reported in the `autoSelectedRoles` field of the JSON output:
+
+```json
+{
+  "autoSelectedRoles": ["bug-hunter", "security-scanner"]
+}
+```
+
 ## Commands
 
 - Agents: `npm run agents:validate` (or `node scripts/validate-agents.mjs`)

--- a/pages/reference/runner-cli-reference.md
+++ b/pages/reference/runner-cli-reference.md
@@ -4,6 +4,29 @@ Runner CLI を使用して、River Reviewer のエージェントとスキルを
 軽量な Python ランナーが `schemas/output.schema.json` に従う構造化されたレビュー結果を出力します。
 Python の例を実行する前に、`pip install jsonschema` で必要な依存関係をインストールしてください。
 
+## `--reviewers` フラグ
+
+`river run` の `--reviewers` フラグにはロール名のリスト（カンマ区切り）または特殊キーワード `auto` を指定できます。
+
+### `auto` キーワード
+
+`--reviewers auto` を指定すると、diff の内容を解析してレビュアーロールを自動選択します。`bug-hunter` は常に含まれ、以下のシグナルに基づいて追加ロールが加わります。
+
+| シグナル                                                                                             | 追加されるロール   |
+| ---------------------------------------------------------------------------------------------------- | ------------------ |
+| config / schema / migration / infra ファイルが変更されている、またはリスク評価済みファイルが存在する | `security-scanner` |
+| test ファイルが変更されている、または app ファイルが 3 件以上ある                                    | `test-gap`         |
+
+シグナルが何もない場合は `bug-hunter` のみが使われます。
+
+JSON 出力の `autoSelectedRoles` フィールドで選択されたロールを確認できます。
+
+```json
+{
+  "autoSelectedRoles": ["bug-hunter", "security-scanner"]
+}
+```
+
 ## コマンド
 
 - Agents: `npm run agents:validate` (または `node scripts/validate-agents.mjs`)

--- a/scripts/validate-agent-skills.mjs
+++ b/scripts/validate-agent-skills.mjs
@@ -25,7 +25,7 @@ async function hasReferencesDir(dirPath) {
 async function listSkillPackages(dirPath) {
   const entries = await fs.readdir(dirPath, { withFileTypes: true });
   const packageGroups = await Promise.all(
-    entries.map(async entry => {
+    entries.map(async (entry) => {
       if (!entry.isDirectory()) return [];
       const entryPath = path.join(dirPath, entry.name);
       const skillPath = path.join(entryPath, 'SKILL.md');
@@ -38,7 +38,7 @@ async function listSkillPackages(dirPath) {
         // Continue to nested directories.
       }
       return listSkillPackages(entryPath);
-    }),
+    })
   );
 
   return packageGroups.flat().sort();
@@ -83,6 +83,18 @@ async function validateSkill(skillPath) {
       console.error(`  - ${error}`);
     }
     return false;
+  }
+
+  // Warn about missing recommended fields (non-blocking).
+  const missingRecommended = [];
+  if (!metadata?.version) missingRecommended.push('version');
+  if (!metadata?.tags) missingRecommended.push('tags');
+  if (!metadata?.severity && !metadata?.outputKind)
+    missingRecommended.push('severity or outputKind');
+  if (missingRecommended.length) {
+    console.warn(
+      `⚠  ${relativePath} — missing recommended fields: ${missingRecommended.join(', ')}`
+    );
   }
 
   console.log(`✅ ${relativePath}`);

--- a/skills/agent-skills/adversarial-review/SKILL.md
+++ b/skills/agent-skills/adversarial-review/SKILL.md
@@ -17,6 +17,7 @@ applyTo:
 inputContext: [diff, fullFile]
 outputKind: [findings, questions, actions]
 tags: [adversarial, pre-mortem, war-game, logic-torturing, cognitive-bias, entry, routing]
+version: '0.1.0'
 license: MIT
 ---
 

--- a/skills/agent-skills/river-reviewer/SKILL.md
+++ b/skills/agent-skills/river-reviewer/SKILL.md
@@ -10,6 +10,7 @@ phase: [upstream, midstream, downstream]
 severity: minor
 applyTo: ['**/*']
 tags: [entry, routing, orchestrator, improvement-loop]
+version: '0.1.0'
 license: MIT
 ---
 

--- a/templates/agent-workflow/README.md
+++ b/templates/agent-workflow/README.md
@@ -1,0 +1,28 @@
+# Agent Workflow Templates
+
+Ready-to-use config files for integrating River Reviewer into AI agent workflows.
+
+## Templates
+
+| Directory | File           | Purpose                                               |
+| --------- | -------------- | ----------------------------------------------------- |
+| `cursor/` | `.cursorrules` | Tells Cursor when and how to invoke River Reviewer    |
+| `codex/`  | `AGENTS.md`    | Tells Codex CLI when and how to invoke River Reviewer |
+
+## Usage
+
+Copy the relevant file into your project root:
+
+```bash
+# Cursor
+cp templates/agent-workflow/cursor/.cursorrules /your-project/.cursorrules
+
+# Codex CLI
+cp templates/agent-workflow/codex/AGENTS.md /your-project/AGENTS.md
+```
+
+If your project already has a `.cursorrules` or `AGENTS.md`, append the River Reviewer section to it.
+
+## Further reading
+
+See [pages/guides/agent-workflow.md](../../pages/guides/agent-workflow.md) for the full agent integration guide.

--- a/templates/agent-workflow/codex/AGENTS.md
+++ b/templates/agent-workflow/codex/AGENTS.md
@@ -1,0 +1,36 @@
+# AGENTS.md — River Reviewer integration
+
+## Code review
+
+Before finalizing any code change, run River Reviewer to catch issues:
+
+```bash
+river run . --reviewers auto
+```
+
+If the `ANTHROPIC_API_KEY` environment variable is not set, use dry-run mode:
+
+```bash
+river run . --dry-run
+```
+
+## When to invoke
+
+- After implementing a feature or fix, before committing.
+- When the user explicitly requests a review.
+- Before opening or updating a pull request.
+
+## Interpreting results
+
+| Severity | Action                                     |
+| -------- | ------------------------------------------ |
+| Critical | Must fix before merging. Report to user.   |
+| Major    | Should fix before merging. Report to user. |
+| Minor    | Advisory. Surface to user; does not block. |
+| Info     | Informational only.                        |
+
+Output in JSON for programmatic use:
+
+```bash
+river run . --reviewers auto --output json
+```

--- a/templates/agent-workflow/cursor/.cursorrules
+++ b/templates/agent-workflow/cursor/.cursorrules
@@ -1,0 +1,24 @@
+# River Reviewer — Cursor Agent Rules
+
+## When to run River Reviewer
+
+- Before committing: run a code review on staged changes.
+- When the user asks to "review", "check", or "audit" the current diff or a file.
+
+## Command
+
+```bash
+river run . --reviewers auto
+```
+
+If no API key is configured, use dry-run mode to validate the setup without making API calls:
+
+```bash
+river run . --dry-run
+```
+
+## Interpreting results
+
+- **Critical / Major**: Block the commit or merge. Explain the issue to the user and suggest a fix.
+- **Minor**: Advisory. Surface to the user but do not block.
+- **Info**: Informational only.


### PR DESCRIPTION
## Summary

Codex が提案した3件を実装。

## 変更内容

### 1. `--reviewers auto` ドキュメント追加

- `agent-workflow.md/.en.md` — シグナルテーブル（どの条件でどのロールが選ばれるか）と `autoSelectedRoles` 出力例を追加
- `runner-cli-reference.md/.en.md` — `--reviewers auto` 専用セクションを追加

| シグナル | 追加ロール |
|---------|-----------|
| テストファイル変更 / アプリファイル3件超 | `test-gap` |
| config/schema/infra 変更 / リスクファイルあり | `security-scanner` |
| 常時 | `bug-hunter` |

### 2. エージェント設定テンプレート追加

- `templates/agent-workflow/cursor/.cursorrules` — Cursor 向けコピペテンプレート
- `templates/agent-workflow/codex/AGENTS.md` — Codex CLI 向けコピペテンプレート
- `templates/agent-workflow/README.md` — 使い方説明

`agent-workflow.md` の Cursor / Codex 各セクションからリンク。

### 3. Agent Skills version フィールド修正

- `adversarial-review/SKILL.md` / `river-reviewer/SKILL.md` — `version: '0.1.0'` を追加
- `scripts/validate-agent-skills.mjs` — 推奨フィールド（version, tags, severity/outputKind）欠落時に警告を追加（エラーではない）

## Test plan
- [x] `npm test` — 1129 tests pass
- [x] `agent-skills:validate` — 全7スキル ✅、警告なし
- [x] textlint / lint-staged — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)