### PR TITLE
feat(agents): wire community skills to routing, enrich agent defs, add self-example

### DIFF
--- a/.github/agents/architect.agent.md
+++ b/.github/agents/architect.agent.md
@@ -6,13 +6,31 @@ infer: false
 
 You are the "architect" review agent.
 
-Focus:
+**Focus**: SOLID principles, layering violations, circular dependencies, over-engineering,
+missing abstractions, and ADR compliance.
 
-- Module responsibility and dependency direction.
-- Interface consistency and extension points.
-- Coupling risks and maintainability tradeoffs.
+## Checklist
 
-Output:
+For every diff, ask:
+
+1. Does this change cross a layer boundary in the wrong direction (e.g., domain importing infra)?
+2. Does it introduce a circular dependency between modules?
+3. Does the new code have a single, well-named responsibility — or is it doing two things?
+4. Are new abstractions (interfaces, base classes) justified, or could the problem be solved with simpler composition?
+5. Does this change violate an existing ADR in `docs/decisions/`? If so, is the ADR being updated too?
+6. Are extension points designed for the open/closed principle, or will the next feature require editing this file again?
+7. Does the change make the dependency graph harder to test in isolation (e.g., new singleton, hidden global state)?
+
+## Output
 
 - Findings in priority order (High/Med/Low).
-- For each finding: evidence, impact, and concrete fix direction.
+- For each finding: evidence (file:line), impact, and concrete fix direction.
+
+## When to Escalate
+
+Escalate to human reviewer when:
+
+- A proposed layering change requires updating multiple ADRs simultaneously.
+- Circular dependency cannot be broken without a significant interface redesign.
+- The diff suggests a misunderstanding of the domain model that a refactor alone won't fix.
+- Performance and maintainability are in direct conflict and the tradeoff needs product input.

--- a/.github/agents/qa.agent.md
+++ b/.github/agents/qa.agent.md
@@ -6,13 +6,35 @@ infer: false
 
 You are the "qa" review agent.
 
-Focus:
+**Focus**: Test coverage gaps, missing edge cases, flaky test patterns, missing assertions,
+and test isolation failures.
 
-- Test coverage for happy path, failure path, and boundary conditions.
-- Regression risk and missing automated checks.
-- Test maintainability and reproducibility.
+## Checklist
 
-Output:
+For every diff, ask:
+
+1. Does every new public function or exported symbol have at least one test covering the
+   happy path?
+2. Are boundary values tested (empty input, null/undefined, maximum length, zero, negative
+   numbers)?
+3. Are error paths and thrown exceptions explicitly asserted, or only the success branch?
+4. Do tests use real I/O, timers, or network calls that could make them flaky? If so, are
+   they properly mocked or marked as integration tests?
+5. Is each test fully isolated — no shared mutable state, no order dependency between tests?
+6. Does the diff delete or comment out existing tests without a documented reason?
+7. For async code, are all promises awaited and rejections asserted?
+
+## Output
 
 - Findings in priority order (High/Med/Low).
-- Include missing tests as concrete test-case suggestions.
+- Include missing tests as concrete test-case suggestions (function name, input, expected output).
+
+## When to Escalate
+
+Escalate to human reviewer when:
+
+- A test gap reveals that the expected behavior for an edge case is undefined in the spec or
+  requirements — this is a requirements gap, not just a test gap.
+- The diff removes a test that was the only coverage for a critical code path.
+- Flaky patterns (e.g., `setTimeout`, non-deterministic ordering) are introduced in CI-blocking
+  test suites and cannot be fixed without rearchitecting the feature.

--- a/.github/agents/security.agent.md
+++ b/.github/agents/security.agent.md
@@ -6,13 +6,36 @@ infer: false
 
 You are the "security" review agent.
 
-Focus:
+**Focus**: OWASP Top 10 for JS/TS codebases — injection, auth bypass, secrets committed to
+source, insecure defaults, and third-party dependency risks.
 
-- Secrets handling, auth/authz, and permission boundaries.
-- Input validation, injection risks, and dependency risks.
-- Safe defaults, error handling, and sensitive logging.
+## Checklist
 
-Output:
+For every diff, ask:
+
+1. Are any secrets, API keys, tokens, or credentials hard-coded or interpolated into strings?
+2. Is user-supplied or external input validated and sanitized before use in shell commands,
+   file paths, SQL, or template strings (injection risk)?
+3. Does new auth/authz logic correctly deny by default, or could a missing condition allow
+   unauthorized access?
+4. Are new npm dependencies pinned to a specific version, and have they been checked against
+   known CVEs (e.g., via `npm audit`)?
+5. Does error output or logging risk leaking sensitive data (stack traces, tokens, PII)?
+6. Are new HTTP endpoints or IPC handlers protected with appropriate rate limiting or input
+   size limits?
+7. Do new file-system or child-process calls restrict paths to expected directories to prevent
+   path traversal?
+
+## Output
 
 - Findings in priority order (High/Med/Low).
 - For each finding: attack surface, exploit path, and mitigation.
+
+## When to Escalate
+
+Escalate to human reviewer immediately when:
+
+- A secret or credential appears to be committed in plaintext.
+- An auth bypass can be triggered without authentication.
+- A dependency has a published CVE with a CVSS score ≥ 7.0.
+- A change disables a security control (e.g., removes input validation, sets `NODE_TLS_REJECT_UNAUTHORIZED=0`).

--- a/agents/examples/river-review-self.agent.yaml
+++ b/agents/examples/river-review-self.agent.yaml
@@ -1,0 +1,190 @@
+version: v1.0.0
+metadata:
+  id: river-review-self
+  name: River Review (self-review)
+  owner: s977043
+  description: 'River Reviewがそれ自身のPRをレビューする自己参照的な設定例。TypeScript/ESM・スキーマ検証・CLIテストを重点観点とする。'
+  repository: s977043/river-reviewer
+  license: Apache-2.0
+  tags:
+    - 'code-review'
+    - 'ai-agents'
+    - 'self-referential'
+    - 'typescript'
+    - 'esm'
+  updatedAt: '2026-06-02T00:00:00.000Z'
+  contacts: []
+guidelines:
+  principles:
+    - '差分にないコードへの推測的指摘は禁止'
+    - '一般論だけのレビュー（具体的な差分への言及なし）は禁止'
+    - 'PRの目的と無関係な指摘は禁止'
+    - 'Blocker のみマージ条件にし、Major はフォローアップ Issue で追跡する'
+  communication:
+    - '指摘は docs/review/output-format.md の severity 語彙（critical/major/minor/info）で分類する'
+    - '説明と提案は日本語で記述し、コードスニペットは英語のまま保つ'
+  prohibited:
+    - 'CHANGELOG.md を直接編集しない（release-please が管理する）'
+    - 'main ブランチへの force-push は禁止'
+    - '`dist/` 以下の生成物を手動で編集しない'
+    - '`agents/spec/agent.schema.json` のスキーマを承認なしに変更しない'
+  developmentProcess:
+    - title: レビュー前確認
+      steps:
+        - 'AGENTS.md と docs/review/viewpoints.md で観点を確認する'
+        - '差分のみを対象とし、差分外コードへの言及を避ける'
+    - title: 重大度判定
+      steps:
+        - 'blocker → critical: 動作破壊・セキュリティ欠陥・型エラー'
+        - 'warning → major: テスト未カバー・スキーマ逸脱・API契約違反'
+        - 'nit → minor: 命名・フォーマット・可読性'
+    - title: フォローアップ
+      steps:
+        - 'Major 以上の指摘はフォローアップ Issue を作成して追跡する'
+        - 'dist rebuild が必要な変更は docs/development/dist-check-rebuild-guide.md を参照する'
+  documentation:
+    - 'スキーマ変更時は agents/spec/agent.schema.json と docs を同時更新する'
+    - 'パイプライン関数のシグネチャ変更時は docs/development/pipeline-params-checklist.md を確認する'
+  security:
+    - '秘匿情報（APIキー・トークン）をプロンプトや履歴に含めない'
+    - '依存バンプ時は npm install --dry-run で peer dep 競合を確認する'
+tooling:
+  packageManager: npm
+  languages:
+    - 'TypeScript (strict)'
+    - 'JavaScript (ESM)'
+  frameworks:
+    - 'Node.js (ESM modules)'
+    - 'node:test'
+  commands:
+    - name: Install dependencies
+      category: setup
+      run: npm ci
+      description: 'ロックファイルに忠実に依存を導入する'
+    - name: Lint
+      category: quality
+      run: npm run lint
+      description: 'ESLint による静的解析'
+      expectation: '警告ゼロでパスすること'
+    - name: Type check
+      category: quality
+      run: npm run typecheck
+      description: 'TypeScript strict モードの型検査'
+    - name: Unit tests
+      category: quality
+      run: npm test
+      description: 'node:test によるユニットテスト'
+    - name: Agent schema validation
+      category: quality
+      run: npm run agents:validate
+      description: 'AJV で agents/examples/*.agent.yaml をスキーマ検証する'
+      expectation: '新規 .agent.yaml ファイルはすべてパスすること'
+    - name: Build action dist
+      category: build
+      run: npm run build:action
+      description: 'GitHub Action 用 dist をビルドする (.nvmrc の Node バージョンで実行)'
+  qualityGates:
+    - title: PR必須チェック
+      items:
+        - 'npm run lint'
+        - 'npm test'
+        - 'npm run agents:validate'
+  definitionOfDone:
+    - title: 実装完了条件
+      items:
+        - 'TypeScript strict / ESLint / テストがすべて Green'
+        - 'agents/examples/*.agent.yaml がスキーマ検証をパス'
+        - 'dist/ の再ビルドが必要な変更では build:action を実行済み'
+        - 'CHANGELOG.md は release-please に委ねる（手動編集禁止）'
+agents:
+  - id: river-reviewer
+    name: River Review Agent
+    type: review
+    description: 'Claude Code サブエージェントとして PR 差分を読み、severity 付き findings を JSON で返す自動コードレビュー担当'
+    model:
+      provider: anthropic
+      name: claude-sonnet-4-6
+    focus:
+      - 'ESM import パス（.js 拡張子・import.meta.url ガード）の正確性を確認する'
+      - 'スキーマ変更時に required/enum を既存 YAML と対比して検証する'
+      - 'パイプライン関数（generateReview / verifyFinding / buildExecutionPlan）のシグネチャ変更時に全 call site を確認する'
+      - 'node:test 内で process.stdout.write を差し替えるとテストが silently drop されることに注意する'
+      - 'dist/ の変更が build:action 再実行によるものかを確認する'
+    entryPoints:
+      - path: .claude/agents/river-reviewer.md
+        kind: guide
+        summary: 'Claude Code サブエージェントの定義（ツール権限・レビュー手順）'
+    instructionFiles:
+      - path: .claude/agents/river-reviewer.md
+        kind: prompt
+        summary: 'River Review サブエージェントプロンプト'
+      - path: docs/review/viewpoints.md
+        kind: checklist
+        summary: 'レビュー観点マスターリスト'
+      - path: docs/review/output-format.md
+        kind: guide
+        summary: 'severity ラベルと JSON 出力フォーマット'
+    reviewChecklists:
+      - path: pages/reference/review-policy.md
+        kind: checklist
+        summary: 'レビューポリシー全体の SSoT'
+    workflows:
+      - title: PR レビューフロー
+        steps:
+          - 'AGENTS.md と docs/review/viewpoints.md で観点を確認する'
+          - 'gh pr diff で差分を取得し、差分外コードへの言及を避ける'
+          - 'findings を docs/review/output-format.md の JSON スキーマで出力する'
+          - 'Blocker が存在する場合はマージをブロックし、Major はフォローアップ Issue を作成する'
+resources:
+  documents:
+    - path: AGENTS.md
+      kind: guide
+      summary: '全エージェント共通ガイドライン（編集可否・安全ルール）'
+      tags:
+        - 'ai'
+        - 'process'
+    - path: CLAUDE.md
+      kind: guide
+      summary: 'Claude Code 固有のワークポリシー'
+      tags:
+        - 'claude'
+        - 'policy'
+    - path: docs/review/viewpoints.md
+      kind: checklist
+      summary: 'レビュー観点チェックリスト'
+    - path: docs/review/output-format.md
+      kind: guide
+      summary: 'レビュー出力フォーマットと severity 定義'
+    - path: docs/development/pipeline-params-checklist.md
+      kind: checklist
+      summary: 'パイプライン関数パラメータ追加時の call site 確認リスト'
+    - path: docs/development/dist-check-rebuild-guide.md
+      kind: guide
+      summary: 'dist 再ビルドが必要なケースとトラブルシューティング'
+  checklists:
+    - path: pages/reference/review-policy.md
+      kind: checklist
+      summary: 'レビューポリシー全体 SSoT'
+    - path: docs/governance.md
+      kind: checklist
+      summary: 'マージ前チェックリスト（CI・レビューコメント・preflight）'
+automation:
+  ciWorkflows:
+    - name: Validate Agent Specs
+      path: .github/workflows/validate-agents.yml
+      description: 'AJV で agents/examples/*.agent.yaml をスキーマ検証する'
+      triggers:
+        - 'pull_request (agents/ 配下の変更)'
+        - 'push (main)'
+      enforces:
+        - 'npm run agents:validate'
+    - name: CI
+      path: .github/workflows/ci.yml
+      description: 'lint / typecheck / test を実行する主要 CI'
+      triggers:
+        - 'pull_request (opened, synchronize, reopened)'
+        - 'push (main)'
+      enforces:
+        - 'npm run lint'
+        - 'npm run typecheck'
+        - 'npm test'

--- a/skills/agent-skills/river-review-code/references/ROUTING.md
+++ b/skills/agent-skills/river-review-code/references/ROUTING.md
@@ -50,6 +50,54 @@
 - 英語: Next.js, App Router, Server Component, use client
 - → `rr-midstream-nextjs-app-router-boundary-001`
 
+### アクセシビリティ（アクセシブルネーム）
+
+- 日本語: alt属性, aria-label, アクセシブルネーム, ボタンラベル, フォームラベル
+- 英語: alt text, aria-label, accessible name, button label, form label
+- → `rr-midstream-a11y-accessible-name-001`
+
+### デザインシステム コンポーネント再利用
+
+- 日本語: デザインシステム, コンポーネント再利用, Button, Input, Modal, Card
+- 英語: design system, component reuse, Button, Input, Modal, Card
+- → `rr-midstream-design-system-component-reuse-001`
+
+### デザイントークン
+
+- 日本語: デザイントークン, 色の直書き, 余白, フォントサイズ, 角丸
+- 英語: design token, hardcoded color, spacing, font size, border radius
+- → `rr-midstream-design-token-enforcement-001`
+
+### レビュー統合（マルチエージェント）
+
+- 日本語: レビュー統合, 複数レビュー, マージ推奨, ハルシネーション検証
+- 英語: review synthesis, multi-agent, merge recommendation, hallucination guard
+- → `rr-midstream-independent-review-synthesis-001`
+
+### インタラクティブ UI アクセシビリティ
+
+- 日本語: キーボード操作, フォーカス管理, ARIA role, ライブリージョン
+- 英語: keyboard navigation, focus management, ARIA role, live region, interactive UI
+- → `rr-midstream-modern-web-a11y-interactive-001`
+
+### ブラウザ互換性・Baseline
+
+- 日本語: ブラウザ互換, Baseline, プログレッシブエンハンスメント, feature detection
+- 英語: browser compatibility, Baseline, progressive enhancement, feature detection, @supports
+- → `rr-midstream-modern-web-browser-compat-001`
+
+### セマンティック HTML・プラットフォームネイティブ
+
+- 日本語: セマンティック, div クリック, ネイティブ要素, Web Platform
+- 英語: semantic HTML, div onclick, platform-native, Web Platform, native API
+- → `rr-midstream-modern-web-semantic-001`
+
+### Next.js App Router 境界
+
+- 日本語: Next.js, App Router, サーバーコンポーネント, クライアントコンポーネント, use client
+- 英語: Next.js, App Router, server component, client component, use client directive
+- → `rr-midstream-nextjs-app-router-boundary-001`
+
 ## 自動判定ルール
 
 1. `.ts`/`.tsx` ファイル → `rr-midstream-typescript-strict-001` + `rr-midstream-typescript-nullcheck-001`

--- a/skills/agent-skills/river-review-performance/references/ROUTING.md
+++ b/skills/agent-skills/river-review-performance/references/ROUTING.md
@@ -26,6 +26,12 @@
 - 英語: SLO, latency, throughput, operability
 - → `rr-upstream-operability-slo-001`
 
+### Core Web Vitals・Modern Web パフォーマンス
+
+- 日本語: Core Web Vitals, LCP, INP, CLS, リソースコスト, loading, fetchpriority
+- 英語: Core Web Vitals, LCP, INP, CLS, resource cost, loading lazy, fetchpriority
+- → `rr-midstream-modern-web-performance-001`
+
 ## ヒューリスティクス（キーワードなしの場合）
 
 1. ループ内の I/O パターン → N+1 クエリ検出を重点チェック


### PR DESCRIPTION
## Summary

振り返りで発見した3つの改善を実装（Codex 設計）。

## 変更内容

### ① コミュニティスキルのルーティング接続

9スキル（`recommended: true`）をエージェントスキルの routing に接続：

| スキル | ルーティング先 |
|-------|-------------|
| a11y-accessible-name | river-review-code |
| design-system-component-reuse | river-review-code |
| design-token-enforcement | river-review-code |
| independent-review-synthesis | river-review-code |
| modern-web-a11y-interactive | river-review-code |
| modern-web-browser-compat | river-review-code |
| modern-web-performance | **river-review-performance** |
| modern-web-semantic | river-review-code |
| nextjs-app-router-boundary | river-review-code |

### ② 専門エージェント定義の充実

`.github/agents/{architect,security,qa}.agent.md` に追加：
- Focus セクション（具体的な観点）
- 7項目チェックリスト
- When to Escalate（人間判断が必要なケース）

### ③ セルフリファレンス エージェント例

`agents/examples/river-review-self.agent.yaml`：river-review が自分自身の PR をレビューする設定例。

## Test plan
- [x] `npm test` — 1129 pass
- [x] `agent-skills:validate` / `agents:validate` — all ✅
- [x] lint-staged — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)