### PR TITLE
fix(docs): correct ESLint refs in agent yaml, add agent-skills:validate to EN

### DIFF
--- a/CONTRIBUTING.en.md
+++ b/CONTRIBUTING.en.md
@@ -88,6 +88,7 @@ npm run lint
 Depending on what you change:
 
 - If you changed skills (`skills/`): `npm run skills:validate`
+- If you changed Agent Skills (`skills/agent-skills/`): `npm run agent-skills:validate`
 - If you changed agent definitions: `npm run agents:validate`
 - If you changed tracing functionality: `npm run trace:validate` (when OpenTelemetry validation is needed)
 

--- a/agents/examples/river-review-self.agent.yaml
+++ b/agents/examples/river-review-self.agent.yaml
@@ -64,7 +64,7 @@ tooling:
     - name: Lint
       category: quality
       run: npm run lint
-      description: 'ESLint による静的解析'
+      description: 'Prettier format check / markdownlint / textlint による静的解析'
       expectation: '警告ゼロでパスすること'
     - name: Unit tests
       category: quality
@@ -88,7 +88,7 @@ tooling:
   definitionOfDone:
     - title: 実装完了条件
       items:
-        - 'TypeScript strict / ESLint / テストがすべて Green'
+        - 'lint（format / dash / markdownlint / textlint）/ テストがすべて Green'
         - 'agents/examples/*.agent.yaml がスキーマ検証をパス'
         - 'dist/ の再ビルドが必要な変更では build:action を実行済み'
         - 'CHANGELOG.md は release-please に委ねる（手動編集禁止）'


### PR DESCRIPTION
## Summary

PR #979 の2巡目レビュー（Codex + セルフレビュー）で発見した既存の軽微な不整合を修正。

## 修正
- `river-review-self.agent.yaml`: lint の説明「ESLint による静的解析」→ 実際のスタック（Prettier format / markdownlint / textlint）に修正（2箇所）
- `CONTRIBUTING.en.md`: `npm run agent-skills:validate` の行を追加（JA との parity）

## Test plan
- [x] `agents:validate` — 両 yaml ✅
- [x] lint-staged — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)