### PR TITLE
feat(plugin): package river-review as a Claude Code plugin + Codex setup

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "name": "river-review-marketplace",
+  "owner": {
+    "name": "s977043",
+    "email": "masatake.komine@proni.co.jp"
+  },
+  "description": "Marketplace distributing the river-review code-review plugin for Claude Code.",
+  "plugins": [
+    {
+      "name": "river-review",
+      "source": "./",
+      "description": "Skill-routed code review: orchestrator agent + specialist review skills + adversarial pass.",
+      "category": "code-review",
+      "tags": ["code-review", "security", "performance", "architecture", "testing"]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "river-review",
+  "displayName": "River Review",
+  "version": "1.0.0",
+  "description": "Skill-routed code review for Claude Code: an orchestrator agent plus specialist skills (code, security, performance, architecture, testing) and an adversarial pre-mortem/war-game pass. Classifies review intent, routes to the right specialist, and verifies findings.",
+  "author": {
+    "name": "river-review maintainers",
+    "url": "https://github.com/s977043/river-review"
+  },
+  "homepage": "https://github.com/s977043/river-review",
+  "repository": "https://github.com/s977043/river-review",
+  "license": "MIT",
+  "keywords": [
+    "code-review",
+    "security-review",
+    "performance",
+    "architecture",
+    "testing",
+    "adversarial-review",
+    "skills"
+  ],
+  "commands": [
+    "./.claude/commands/review-local.md",
+    "./.claude/commands/challenge.md",
+    "./.claude/commands/skill.md",
+    "./.claude/commands/check.md",
+    "./.claude/commands/pr.md"
+  ],
+  "agents": "./.claude/agents/river-review.md",
+  "skills": "./skills/agent-skills/"
+}

--- a/README.en.md
+++ b/README.en.md
@@ -256,6 +256,66 @@ severity: minor
 - Known limitations: `pages/reference/known-limitations.md`
 - Troubleshooting: `pages/guides/troubleshooting.md`
 
+## Installing the river-review plugin
+
+### Claude Code
+
+river-review ships as a Claude Code plugin from a same-repo marketplace.
+
+1. Add the marketplace (GitHub shorthand):
+
+   ```text
+   /plugin marketplace add s977043/river-review
+   ```
+
+   Pin to a tag if you want reproducible installs: `/plugin marketplace add s977043/river-review@v1.0.0`.
+
+2. Install the plugin:
+
+   ```text
+   /plugin install river-review@river-review-marketplace
+   ```
+
+3. Activate without restarting:
+
+   ```text
+   /reload-plugins
+   ```
+
+What you get (namespaced by plugin name):
+
+- Commands: `/river-review:review-local`, `/river-review:challenge`, `/river-review:skill`, `/river-review:check`, `/river-review:pr`
+- Agent: `river-review` (skill-routed code-review orchestrator)
+- Skills: the orchestrator plus `river-review-code`, `river-review-security`, `river-review-performance`, `river-review-architecture`, `river-review-testing`, and `adversarial-review` — addressable as `/river-review:<skill-name>`
+
+Manage: `/plugin enable|disable|uninstall river-review@river-review-marketplace`.
+
+Local development / testing without installing:
+
+```text
+claude --plugin-dir .
+```
+
+### Codex
+
+Codex has no plugin marketplace; integration is copy-in.
+
+1. Copy the Codex integration template into your project:
+
+   ```text
+   cp templates/agent-workflow/codex/AGENTS.md ./AGENTS.md
+   ```
+
+2. Make the review skills available to Codex by copying the skills directory into your project (or pointing Codex at a checkout of this repo):
+
+   ```text
+   cp -R skills/agent-skills ./skills
+   ```
+
+3. Reference the skills from your `AGENTS.md` and add your own `.codex/config.toml` (`approval_policy`, `sandbox`) to taste — the repo's `.codex/` config is environment-specific and not shipped as a template.
+
+See `templates/agent-workflow/README.md` for the full Codex (and Cursor) setup. The Codex side is versioned by git only; re-copy on upgrade.
+
 ## AI Review Standard Policy
 
 River Review follows a standard review policy to maintain consistent quality and reproducibility. The policy defines evaluation principles, output format, and prohibited actions to ensure constructive and specific feedback.

--- a/README.md
+++ b/README.md
@@ -368,6 +368,66 @@ GitHub Actions では:
 
 詳細は [`pages/guides/repo-wide-review.md`](pages/guides/repo-wide-review.md) および [`pages/reference/config-schema.md`](pages/reference/config-schema.md) を参照。
 
+## river-review プラグインの導入
+
+### Claude Code
+
+river-review は同一リポジトリ内のマーケットプレイスから Claude Code プラグインとして配布されます。
+
+1. マーケットプレイスを追加（GitHub ショートハンド）:
+
+   ```text
+   /plugin marketplace add s977043/river-review
+   ```
+
+   再現可能なインストールが必要ならタグを固定: `/plugin marketplace add s977043/river-review@v1.0.0`。
+
+2. プラグインをインストール:
+
+   ```text
+   /plugin install river-review@river-review-marketplace
+   ```
+
+3. 再起動せずに有効化:
+
+   ```text
+   /reload-plugins
+   ```
+
+得られるもの（プラグイン名で名前空間化されます）:
+
+- コマンド: `/river-review:review-local`, `/river-review:challenge`, `/river-review:skill`, `/river-review:check`, `/river-review:pr`
+- エージェント: `river-review`（スキルルーティング型のコードレビュー・オーケストレーター）
+- スキル: オーケストレーターに加えて `river-review-code`, `river-review-security`, `river-review-performance`, `river-review-architecture`, `river-review-testing`, `adversarial-review`—`/river-review:<skill-name>` で呼び出せます
+
+管理: `/plugin enable|disable|uninstall river-review@river-review-marketplace`。
+
+インストールせずにローカルで開発・テストする場合:
+
+```text
+claude --plugin-dir .
+```
+
+### Codex
+
+Codex にはプラグインマーケットプレイスがないため、連携はコピーインで行います。
+
+1. Codex 連携テンプレートをプロジェクトにコピー:
+
+   ```text
+   cp templates/agent-workflow/codex/AGENTS.md ./AGENTS.md
+   ```
+
+2. レビュースキルを Codex から利用できるよう、スキルディレクトリをプロジェクトにコピー（または本リポジトリのチェックアウトを Codex に参照させる）:
+
+   ```text
+   cp -R skills/agent-skills ./skills
+   ```
+
+3. `AGENTS.md` からスキルを参照し、自分用の `.codex/config.toml`（`approval_policy`, `sandbox`）を追加します—本リポジトリの `.codex/` 設定は環境依存のためテンプレートとしては配布されません。
+
+Codex（および Cursor）の完全なセットアップは `templates/agent-workflow/README.md` を参照してください。Codex 側は git のみでバージョン管理されるため、アップグレード時は再コピーが必要です。
+
 ## AI エージェント運用
 
 - ルートの `AGENTS.md` が AI コーディングエージェント向けの SSOT です。

--- a/templates/agent-workflow/README.md
+++ b/templates/agent-workflow/README.md
@@ -23,6 +23,23 @@ cp templates/agent-workflow/codex/AGENTS.md /your-project/AGENTS.md
 
 If your project already has a `.cursorrules` or `AGENTS.md`, append the River Review section to it.
 
+### Making the review skills available to Codex
+
+Codex has no plugin marketplace, so the river-review skills are vendored as plain
+skill docs that Codex reads. Copy the skills directory into your project (or point
+Codex at a checkout of this repo via `CODEX_HOME`):
+
+```bash
+cp -R skills/agent-skills /your-project/skills
+```
+
+Then reference the skills from your `AGENTS.md`. Add your own `.codex/config.toml`
+(`approval_policy`, `sandbox`) to taste — the repo's `.codex/` config is
+environment-specific and is intentionally not shipped as a template.
+
+The Codex integration is versioned by git only; there is no auto-update. Re-copy
+`AGENTS.md` and `skills/agent-skills/` when you upgrade.
+
 ## Further reading
 
 See [pages/guides/agent-workflow.md](../../pages/guides/agent-workflow.md) for the full agent integration guide.


### PR DESCRIPTION
## Summary

river-review を Claude Code プラグインとして正式配布できるよう整備（ultracode ワークフローで仕様調査 → 設計 → 実装）。これまで手動コピーが必要だった導入を `/plugin` コマンド一発に。

## 追加内容

### Claude Code Plugin
- `.claude-plugin/plugin.json` — マニフェスト（v1.0.0、配布対象5コマンド・river-review オーケストレーターエージェント・`skills/agent-skills/`）。リポジトリ保守用コマンド（propose-issue / plan-merge-order / preflight）は除外
- `.claude-plugin/marketplace.json` — 同一リポジトリ marketplace（`source: ./`）

導入手順:
```text
/plugin marketplace add s977043/river-review
/plugin install river-review@river-review-marketplace
```

### Codex
- `templates/agent-workflow/README.md` に Codex 向けスキルコピーイン手順を整備（Codex には marketplace がないためコピーイン方式）

### ドキュメント
- `README.md` / `README.en.md` に導入セクション追加（Claude Code + Codex）

## 検証
- ✅ `claude plugin validate .` — **Validation passed**（公式バリデーター）
- ✅ 両 manifest JSON 妥当
- ✅ `npm test` — 1129 pass
- ✅ 既存 `.claude/` 作業設定は未変更

## フォローアップ（別途）
- `.claude/hooks/format.sh` はプラグインツリー外を exec するため未同梱。自己完結型 prettier hook として再実装する場合は次イテレーションで対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)