### PR TITLE
feat(plugin): add self-contained format hook (official CLAUDE_PLUGIN_ROOT pattern)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -28,5 +28,6 @@
     "./.claude/commands/pr.md"
   ],
   "agents": "./.claude/agents/river-review.md",
-  "skills": "./skills/agent-skills/"
+  "skills": "./skills/agent-skills/",
+  "hooks": "./hooks/hooks.json"
 }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "description": "Optional auto-format hook for the river-review plugin. Runs the consumer project's prettier on changed files after Write/Edit; skips silently when prettier is not installed.",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/plugin-format-hook.sh\"",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/plugin-format-hook.sh
+++ b/scripts/plugin-format-hook.sh
@@ -23,12 +23,12 @@ if [ -f .claude/hooks/format.sh ]; then
   exit 0
 fi
 
-if ! command -v npm >/dev/null 2>&1; then
-  echo "[river-review:format] npm not found, skipping"
+if ! command -v npx >/dev/null 2>&1; then
+  echo "[river-review:format] npx not found, skipping"
   exit 0
 fi
 
-if [ ! -d .git ]; then
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   echo "[river-review:format] not a git repository, skipping"
   exit 0
 fi
@@ -38,7 +38,7 @@ if [ -z "$CHANGED_FILES" ]; then
   exit 0
 fi
 
-FILES_TO_FORMAT=$(echo "$CHANGED_FILES" | grep -E '\.(js|jsx|ts|tsx|json|md|yml|yaml|mjs)$' || true)
+FILES_TO_FORMAT=$(echo "$CHANGED_FILES" | grep -E '\.(js|jsx|ts|tsx|cjs|mjs|json|md|yml|yaml)$' || true)
 if [ -z "$FILES_TO_FORMAT" ]; then
   exit 0
 fi

--- a/scripts/plugin-format-hook.sh
+++ b/scripts/plugin-format-hook.sh
@@ -16,6 +16,13 @@ set -euo pipefail
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 cd "$PROJECT_DIR" || exit 0
 
+# Avoid double-formatting: if the host project already ships its own
+# repo-internal format hook (e.g. developing the river-review repo itself,
+# where .claude/settings.json wires .claude/hooks/format.sh), defer to it.
+if [ -f .claude/hooks/format.sh ]; then
+  exit 0
+fi
+
 if ! command -v npm >/dev/null 2>&1; then
   echo "[river-review:format] npm not found, skipping"
   exit 0

--- a/scripts/plugin-format-hook.sh
+++ b/scripts/plugin-format-hook.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Self-contained PostToolUse format hook for the river-review plugin.
+#
+# Bundled inside the plugin and invoked via ${CLAUDE_PLUGIN_ROOT} in
+# hooks/hooks.json, so it works when the plugin is installed into another
+# project (unlike .claude/hooks/format.sh, which assumes the river-review
+# repo layout).
+#
+# Behavior: formats the consumer project's changed files with the project's
+# own prettier. Degrades gracefully (exit 0) when npm / git / prettier are
+# unavailable, so it never blocks the host project.
+set -euo pipefail
+
+# Run in the consumer's project directory (set by Claude Code), falling back
+# to the current working directory.
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+cd "$PROJECT_DIR" || exit 0
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "[river-review:format] npm not found, skipping"
+  exit 0
+fi
+
+if [ ! -d .git ]; then
+  echo "[river-review:format] not a git repository, skipping"
+  exit 0
+fi
+
+CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB HEAD 2>/dev/null || echo "")
+if [ -z "$CHANGED_FILES" ]; then
+  exit 0
+fi
+
+FILES_TO_FORMAT=$(echo "$CHANGED_FILES" | grep -E '\.(js|jsx|ts|tsx|json|md|yml|yaml|mjs)$' || true)
+if [ -z "$FILES_TO_FORMAT" ]; then
+  exit 0
+fi
+
+# Use the consumer project's prettier only (no install). If absent, skip.
+if ! npx --no-install prettier --version >/dev/null 2>&1; then
+  echo "[river-review:format] prettier not installed in project, skipping"
+  exit 0
+fi
+
+files_array=()
+while IFS= read -r file; do
+  [ -f "$file" ] && files_array+=("$file")
+done <<<"$FILES_TO_FORMAT"
+
+if [ ${#files_array[@]} -gt 0 ]; then
+  npx --no-install prettier --write "${files_array[@]}" || true
+  echo "[river-review:format] formatted ${#files_array[@]} file(s)"
+fi


### PR DESCRIPTION
## Summary

`openai/codex-plugin-cc`（公式 Codex プラグイン）のパターンを取り込み、format フックをプラグインに同梱できるようにした。PR #981 で「未同梱」としていた課題の正しい解決策。

## 背景

`.claude/hooks/format.sh` はリポジトリルートの `hooks/format.sh` に委譲する構造で、プラグインツリー外を exec するため install 先では動作しなかった。公式プラグインは `${CLAUDE_PLUGIN_ROOT}` 変数でプラグイン内スクリプトを参照しており、これが正しいパターン。

## 変更

- `hooks/hooks.json`: PostToolUse(Write\|Edit\|MultiEdit) → `${CLAUDE_PLUGIN_ROOT}/scripts/plugin-format-hook.sh`
- `scripts/plugin-format-hook.sh`: 自己完結型フォーマッタ。消費側プロジェクトの prettier で変更ファイルを整形。npm/git/prettier が無ければ graceful skip（ホストを止めない）
- `.claude-plugin/plugin.json`: `"hooks": "./hooks/hooks.json"` を追加

## 検証

- ✅ `claude plugin validate .` — **Validation passed**
- ✅ `bash -n scripts/plugin-format-hook.sh` — 構文 OK
- ✅ hooks.json / plugin.json — JSON 妥当
- ✅ 実行ビット付与済み（100755）

🤖 Generated with [Claude Code](https://claude.com/claude-code)