### PR TITLE
chore(plugin): sync plugin.json to 1.1.0 + auto-track version

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "river-review",
   "displayName": "River Review",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Skill-routed code review for Claude Code: an orchestrator agent plus specialist skills (code, security, performance, architecture, testing) and an adversarial pre-mortem/war-game pass. Classifies review intent, routes to the right specialist, and verifies findings.",
   "author": {
     "name": "river-review maintainers",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,6 +13,11 @@
         {
           "type": "generic",
           "path": "README.en.md"
+        },
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
         }
       ]
     }


### PR DESCRIPTION
## 背景

ClaudeCode / Codex 用 Plugin の整合確認の一環。`.claude-plugin/plugin.json` の `version` が `1.0.0` のまま残っており、リリース済みの npm package (`1.1.0`) とズレていた。

## 変更内容

- `.claude-plugin/plugin.json` の `version` を `1.1.0` に更新（package.json と一致）
- `release-please-config.json` の `extra-files` に `.claude-plugin/plugin.json`（`json` updater, `$.version`）を追加し、今後のリリースで自動追従させる

## 検証

- `claude plugin validate .` → ✔ Validation passed
- 両 JSON の構文チェック pass
- Plugin が参照する commands / agents / hooks / skills の実在を確認済み

## 補足: Plugin の用意状況（ClaudeCode / Codex）

- ClaudeCode: `.claude-plugin/plugin.json` + `marketplace.json` 完備、`/plugin marketplace add s977043/river-review` → install 動作確認済み
- Codex: `codex plugin marketplace add s977043/river-review` で同じ `marketplace.json` を読む（CLI 確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)