### PR TITLE
feat(plugin): add Codex-native plugin manifest (.codex-plugin/plugin.json)

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "river-review",
+  "version": "1.1.0",
+  "description": "Skill-routed code review for Codex: an orchestrator plus specialist skills (code, security, performance, architecture, testing) and an adversarial pre-mortem/war-game pass. Classifies review intent, routes to the right specialist, and verifies findings.",
+  "author": {
+    "name": "river-review maintainers",
+    "url": "https://github.com/s977043/river-review"
+  },
+  "homepage": "https://github.com/s977043/river-review",
+  "repository": "https://github.com/s977043/river-review",
+  "license": "MIT",
+  "keywords": [
+    "code-review",
+    "security-review",
+    "performance",
+    "architecture",
+    "testing",
+    "adversarial-review",
+    "skills"
+  ],
+  "skills": "./skills/agent-skills/",
+  "interface": {
+    "displayName": "River Review",
+    "shortDescription": "Skill-routed code review: specialist skills plus an adversarial pass",
+    "longDescription": "River Review executes your team's review criteria as versioned skills. It classifies review intent, routes to specialist skills (code, security, performance, architecture, testing), runs an adversarial pre-mortem/war-game pass, and verifies findings against the diff so human reviewers can focus on high-risk judgment.",
+    "developerName": "river-review maintainers",
+    "category": "Developer Tools",
+    "capabilities": ["Read"],
+    "websiteURL": "https://river-review.the3396.com/"
+  }
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -18,6 +18,11 @@
           "type": "json",
           "path": ".claude-plugin/plugin.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".codex-plugin/plugin.json",
+          "jsonpath": "$.version"
         }
       ]
     }


### PR DESCRIPTION
## 背景（plugin 配布監査 gap #1, major）

Codex は skills 登録と interface メタデータを **`.codex-plugin/plugin.json`**（`.claude-plugin/` ではない）から読み込む。river-review は Claude Code 用 manifest しか持たず、`codex plugin marketplace add s977043/river-review` はマーケットプレイス追加までは成功するものの、specialist review skills を登録できなかった。

## 変更内容

- **新規** `.codex-plugin/plugin.json` — 実 OpenAI Codex plugin のフォーマットに準拠
  - `name` / `version` / `description` / `author` / `license` / `keywords`
  - `"skills": "./skills/agent-skills/"`
  - `interface` ブロック（displayName / shortDescription / longDescription / category `Developer Tools` / capabilities `["Read"]` / websiteURL）
- `release-please-config.json` の extra-files に `.codex-plugin/plugin.json` `$.version` を追加し、リリースで自動追従

## 検証

- JSON 構文 valid
- `claude plugin validate .` → ✔ Validation passed（.codex-plugin は無視され影響なし）
- `codex plugin marketplace add <repo path>` がリポジトリを受理（"Added marketplace river-review-marketplace"）→ 検証後 remove で副作用なし
- フォーマットはインストール済み OpenAI Codex plugin（github / build-web-apps 等、`skills` + `interface`）と突合

Refs #966

🤖 Generated with [Claude Code](https://claude.com/claude-code)