### PR TITLE
fix(codex): vendor full agent-skills (with references/) in setup fallback

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -5,9 +5,15 @@
 
 ## スクリプト一覧
 
-| スクリプト  | 用途                         | 呼び出し元                |
-| ----------- | ---------------------------- | ------------------------- |
-| `format.sh` | 変更ファイルにPrettierを実行 | `.claude/hooks/format.sh` |
+| スクリプト              | 用途                                   | 呼び出し元                              |
+| ----------------------- | -------------------------------------- | --------------------------------------- |
+| `format.sh`             | 変更ファイルにPrettierを実行           | `.claude/hooks/format.sh`               |
+| `hooks.json`            | プラグイン配布用 PostToolUse hook 定義 | プラグインインストール先（Claude Code） |
+| `plugin-format-hook.sh` | プラグイン同梱の自己完結フォーマッター | `hooks.json`（`${CLAUDE_PLUGIN_ROOT}`） |
+
+### `plugin-format-hook.sh` の defer 挙動
+
+`plugin-format-hook.sh` は、インストール先プロジェクトに `.claude/hooks/format.sh` が存在する場合、二重整形を避けるために何もせず exit 0 で抜けます（river-review リポジトリ自身を開発する際の二重実行を防ぐための条件）。そのため、インストール先が独自に `.claude/hooks/format.sh` を持つ場合、プラグイン同梱のフォーマッターは意図的に no-op になります（プロジェクト側のフォーマッターが優先されます）。
 
 ## 各ツールでの強制方法
 

--- a/scripts/setup-codex.sh
+++ b/scripts/setup-codex.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
-# River Review — one-command setup for Codex CLI.
+# River Review — non-marketplace fallback setup for Codex CLI.
 #
-# Codex has no plugin marketplace, so this script vendors the River Review
-# integration (AGENTS.md guidance + agent-skills) directly into your project.
-# It is the Codex equivalent of `/plugin install` in Claude Code.
+# Preferred install path is the Codex plugin marketplace:
+#   codex plugin marketplace add s977043/river-review
+# (Codex reads the same .claude-plugin/marketplace.json + .codex-plugin/plugin.json.)
+#
+# This script is a FALLBACK for environments that cannot use the marketplace.
+# It vendors the River Review integration (AGENTS.md guidance + the full
+# agent-skills directory, including each skill's references/) directly into
+# your project.
 #
 # Usage (from your project root):
 #   curl -fsSL https://raw.githubusercontent.com/s977043/river-review/main/scripts/setup-codex.sh | bash
@@ -11,13 +16,14 @@
 # Or after cloning river-review:
 #   bash scripts/setup-codex.sh [target-project-dir]
 #
-# Idempotent: re-running updates the vendored skills and refreshes the
-# AGENTS.md River Review section without duplicating it.
+# Idempotent: re-running refreshes the vendored skills and the AGENTS.md
+# River Review section without duplicating it.
 set -euo pipefail
 
 REPO="s977043/river-review"
 REF="${RIVER_REVIEW_REF:-main}"
 RAW_BASE="https://raw.githubusercontent.com/${REPO}/${REF}"
+TARBALL_URL="https://codeload.github.com/${REPO}/tar.gz/refs/heads/${REF}"
 TARGET_DIR="${1:-$(pwd)}"
 MARKER_BEGIN="<!-- river-review:begin -->"
 MARKER_END="<!-- river-review:end -->"
@@ -57,27 +63,36 @@ else
   log "appended River Review section to existing AGENTS.md"
 fi
 
-# --- 3. Vendor the agent-skills via sparse git archive --------------------
-log "vendoring river-review agent-skills..."
-SKILLS=(adversarial-review river-review river-review-architecture \
-  river-review-code river-review-performance river-review-security \
-  river-review-testing)
-
-mkdir -p skills/agent-skills
+# --- 3. Vendor the full agent-skills directory (including references/) -----
+# Download a repo tarball and extract only skills/agent-skills/**, so every
+# skill ships its SKILL.md AND its references/ rubric files. The skill list is
+# derived from the tarball, never hardcoded.
+log "vendoring river-review agent-skills (full directories)..."
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
-# Download each skill's SKILL.md (and references/) from raw GitHub.
-for skill in "${SKILLS[@]}"; do
-  mkdir -p "skills/agent-skills/${skill}"
-  if curl -fsSL "${RAW_BASE}/skills/agent-skills/${skill}/SKILL.md" \
-      -o "skills/agent-skills/${skill}/SKILL.md" 2>/dev/null; then
-    :
+if curl -fsSL "$TARBALL_URL" -o "$TMP/river-review.tar.gz"; then
+  # The tarball top-level dir is river-review-<ref>; strip it and keep only
+  # the agent-skills subtree.
+  mkdir -p skills/agent-skills
+  tar -xzf "$TMP/river-review.tar.gz" -C "$TMP"
+  SRC_DIR="$(find "$TMP" -maxdepth 4 -type d -path '*/skills/agent-skills' | head -1)"
+  if [ -n "$SRC_DIR" ]; then
+    # Copy the full agent-skills tree (SKILL.md + references/ + any assets).
+    cp -R "$SRC_DIR/." skills/agent-skills/
+    COUNT="$(find skills/agent-skills -maxdepth 1 -mindepth 1 -type d | wc -l | tr -d ' ')"
+    log "vendored ${COUNT} skill(s) with references/ into skills/agent-skills/"
   else
-    log "warning: could not fetch ${skill}/SKILL.md (skipped)"
+    log "error: skills/agent-skills not found in tarball" >&2
+    exit 1
   fi
-done
+else
+  log "error: could not download repo tarball from ${TARBALL_URL}" >&2
+  exit 1
+fi
 
 log "done."
 log "Codex will read AGENTS.md and skills/agent-skills/ on its next run."
 log "Add a .codex/config.toml (approval_policy, sandbox) to taste."
+log "Note: the agent workflow runs the 'river' CLI — install it (npm/npx) or"
+log "      use the skills directly if the CLI is not on PATH."

--- a/templates/agent-workflow/codex/AGENTS.md
+++ b/templates/agent-workflow/codex/AGENTS.md
@@ -1,5 +1,12 @@
 # AGENTS.md — River Review integration
 
+## Prerequisite: the `river` CLI
+
+The commands below invoke the `river` CLI. Make sure it is available on `PATH`
+first — install it (`npm install -g river-review`) or run it via `npx river ...`.
+If the CLI is not installed, use the agent-skills under `skills/agent-skills/`
+directly instead of the CLI commands.
+
 ## Code review
 
 Before finalizing any code change, run River Review to catch issues:


### PR DESCRIPTION
## 背景（plugin 配布監査 gap #2 major, #8 #16 #17）

Codex setup script は「マーケットプレイスを使わない場合のフォールバック」と位置づけられているが、各 skill の `SKILL.md` のみを curl し、**specialist skill が依存する `references/`（ROUTING.md / VERIFICATION.md / FEEDBACK.md 等）を取りこぼし**、リンク切れの劣化コピーを配っていた。

## 変更内容

- **#2**: `skills/agent-skills/` サブツリーをリポジトリ tarball（curl + tar）で**references/ 込みの完全 vendoring** に変更。skill list はハードコード配列を廃し tarball から動的導出
- **#8**: header を書き換え。「Codex has no plugin marketplace」の誤記述を削除し、`codex plugin marketplace add` を使えない環境向けのフォールバックと明記
- **#17**: Codex AGENTS.md テンプレートに `river` CLI の precondition（npm/npx インストール、または skills 直接利用）を追記
- **#16**: `plugin-format-hook.sh` の `.claude/hooks/format.sh` defer 挙動を hooks/README.md に文書化

## 検証

- `bash -n` / shellcheck clean、textlint clean
- 一時ディレクトリで end-to-end 実行: 7 skill すべてを references/ 込みで vendoring
- idempotent: 再実行で AGENTS.md の river-review ブロックは 1 つのまま

Refs #966

🤖 Generated with [Claude Code](https://claude.com/claude-code)