### PR TITLE
ci: add plugin manifest validation to the Meta consistency gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-node-deps
       - run: npm run meta:validate
+      - run: npm run plugin:validate
 
   dist-check:
     name: Action dist freshness

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "eval:fixtures": "node scripts/evaluate-review-fixtures.mjs",
     "eval:repo-context": "node scripts/evaluate-repo-wide-fixtures.mjs",
     "meta:validate": "node scripts/validate-meta-consistency.mjs",
+    "plugin:validate": "node scripts/validate-plugin-manifest.mjs",
     "eval:all": "node scripts/evaluate-all.mjs",
     "check:bilingual": "node scripts/check-bilingual-pairs.mjs",
     "check:doc-placement": "node scripts/check-doc-placement.mjs",

--- a/scripts/validate-plugin-manifest.mjs
+++ b/scripts/validate-plugin-manifest.mjs
@@ -1,0 +1,128 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+const ROOT = path.resolve(import.meta.dirname, '..');
+
+async function readJson(filePath) {
+  const raw = await fs.readFile(path.join(ROOT, filePath), 'utf8');
+  return JSON.parse(raw);
+}
+
+async function pathExists(relPath) {
+  try {
+    await fs.access(path.join(ROOT, relPath));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Normalize a plugin-manifest path reference (e.g. "./.claude/commands/pr.md")
+ * to a repo-relative path.
+ */
+function normalizeRef(ref) {
+  return ref.replace(/^\.\//, '');
+}
+
+/**
+ * Validate the Claude Code + Codex plugin manifests and the marketplace
+ * manifest against the repository:
+ *  - every component path referenced by .claude-plugin/plugin.json exists
+ *  - .claude-plugin and .codex-plugin manifest versions match package.json
+ *  - marketplace plugins[].name matches the plugin manifest name
+ *  - the Codex manifest's skills path exists
+ *
+ * Returns array of error strings (empty = pass).
+ */
+export async function validatePluginManifest() {
+  const errors = [];
+
+  const pkg = await readJson('package.json');
+  const ccManifest = await readJson('.claude-plugin/plugin.json');
+  const marketplace = await readJson('.claude-plugin/marketplace.json');
+
+  // --- Claude Code manifest: version sync ---
+  if (ccManifest.version !== pkg.version) {
+    errors.push(
+      `.claude-plugin/plugin.json: version "${ccManifest.version}" !== package.json "${pkg.version}"`
+    );
+  }
+
+  // --- Claude Code manifest: component paths exist ---
+  const refs = [];
+  for (const cmd of ccManifest.commands || []) refs.push(cmd);
+  if (typeof ccManifest.agents === 'string') refs.push(ccManifest.agents);
+  else for (const a of ccManifest.agents || []) refs.push(a);
+  if (typeof ccManifest.skills === 'string') refs.push(ccManifest.skills);
+  if (typeof ccManifest.hooks === 'string') refs.push(ccManifest.hooks);
+
+  for (const ref of refs) {
+    const rel = normalizeRef(ref);
+    if (!(await pathExists(rel))) {
+      errors.push(`.claude-plugin/plugin.json: referenced path does not exist: ${ref}`);
+    }
+  }
+
+  // --- Marketplace: plugins[].name matches manifest name ---
+  const entry = (marketplace.plugins || []).find((p) => p.name === ccManifest.name);
+  if (!entry) {
+    errors.push(
+      `.claude-plugin/marketplace.json: no plugins[] entry with name "${ccManifest.name}"`
+    );
+  }
+
+  // --- Codex manifest (optional but, if present, must be consistent) ---
+  if (await pathExists('.codex-plugin/plugin.json')) {
+    const codexManifest = await readJson('.codex-plugin/plugin.json');
+    if (codexManifest.version !== pkg.version) {
+      errors.push(
+        `.codex-plugin/plugin.json: version "${codexManifest.version}" !== package.json "${pkg.version}"`
+      );
+    }
+    if (codexManifest.name !== ccManifest.name) {
+      errors.push(
+        `.codex-plugin/plugin.json: name "${codexManifest.name}" !== .claude-plugin name "${ccManifest.name}"`
+      );
+    }
+    if (typeof codexManifest.skills === 'string') {
+      const rel = normalizeRef(codexManifest.skills);
+      if (!(await pathExists(rel))) {
+        errors.push(
+          `.codex-plugin/plugin.json: skills path does not exist: ${codexManifest.skills}`
+        );
+      }
+    }
+  }
+
+  return errors;
+}
+
+// CLI entry point
+const isDirectRun =
+  process.argv[1] &&
+  (process.argv[1].endsWith('validate-plugin-manifest.mjs') ||
+    process.argv[1].endsWith('validate-plugin-manifest'));
+
+if (isDirectRun) {
+  validatePluginManifest()
+    .then((errors) => {
+      if (errors.length === 0) {
+        console.log('Plugin manifest: OK');
+        return 0;
+      }
+      console.error(`Plugin manifest: ${errors.length} error(s) found`);
+      for (const err of errors) {
+        console.error(`  - ${err}`);
+      }
+      return 1;
+    })
+    .then((code) => {
+      if (code !== 0) process.exitCode = code;
+    })
+    .catch((err) => {
+      console.error(`Plugin manifest check failed: ${err.message}`);
+      process.exitCode = 1;
+    });
+}

--- a/tests/validate-plugin-manifest.test.mjs
+++ b/tests/validate-plugin-manifest.test.mjs
@@ -1,0 +1,8 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { validatePluginManifest } from '../scripts/validate-plugin-manifest.mjs';
+
+test('validatePluginManifest passes on current repo state', async () => {
+  const errors = await validatePluginManifest();
+  assert.deepEqual(errors, [], `Expected no errors but got: ${errors.join(', ')}`);
+});


### PR DESCRIPTION
## 背景（plugin 配布監査 gap #3 major, #9）

プラグイン manifest を検証する PR-time チェックが存在せず、command / agent / skill / hook の rename・削除や version drift が main にマージされ、**壊れたコンポーネントが plugin インストール先に配布される**リスクがあった。

## 変更内容

- **新規** `scripts/validate-plugin-manifest.mjs`（`npm run plugin:validate`）が以下を検証:
  - `.claude-plugin/plugin.json` が参照する全コンポーネントパス（commands / agents / skills / hooks）の実在
  - `.claude-plugin`（および存在すれば `.codex-plugin`）の version === package.json version（#9）
  - marketplace `plugins[].name` === plugin manifest name（#9）
  - Codex manifest の skills パス実在
- `test.yml` の `meta-check` ジョブ（required check "Meta consistency"）に `npm run plugin:validate` を追加 → 新規 required check を増やさず既存ゲート内で強制
- ユニットテスト追加

## 検証

- `npm run plugin:validate` → Plugin manifest: OK
- `node --test tests/validate-plugin-manifest.test.mjs` pass
- prettier format clean

> 注: 本ブランチは `.codex-plugin/plugin.json`（#991）より前の main から派生しているため Codex manifest チェックは optional skip。#991 マージ後は Codex manifest も検証対象になります。

Refs #966

🤖 Generated with [Claude Code](https://claude.com/claude-code)