### PR TITLE
chore(plugin): enrich manifest metadata and harden distribution hygiene

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,15 +2,21 @@
   "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
   "name": "river-review-marketplace",
   "owner": {
-    "name": "s977043",
-    "email": "masatake.komine@proni.co.jp"
+    "name": "river-review maintainers",
+    "url": "https://github.com/s977043/river-review"
   },
-  "description": "Marketplace distributing the river-review code-review plugin for Claude Code.",
+  "description": "Marketplace distributing the river-review code-review plugin for Claude Code and Codex.",
   "plugins": [
     {
       "name": "river-review",
       "source": "./",
       "description": "Skill-routed code review: orchestrator agent + specialist review skills + adversarial pass.",
+      "author": {
+        "name": "river-review maintainers",
+        "url": "https://github.com/s977043/river-review"
+      },
+      "homepage": "https://river-review.the3396.com/",
+      "license": "MIT",
       "category": "code-review",
       "tags": ["code-review", "security", "performance", "architecture", "testing"]
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -8,7 +8,7 @@
     "name": "river-review maintainers",
     "url": "https://github.com/s977043/river-review"
   },
-  "homepage": "https://github.com/s977043/river-review",
+  "homepage": "https://river-review.the3396.com/",
   "repository": "https://github.com/s977043/river-review",
   "license": "MIT",
   "keywords": [

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,8 @@
 runners/github-action/dist/*.mjs text eol=lf
 runners/github-action/dist/*.map text eol=lf
 runners/github-action/dist/*.cjs text eol=lf
+
+# The plugin ships scripts/plugin-format-hook.sh and hooks/format.sh, which are
+# executed by bash on the consumer's machine. Pin LF so a Windows checkout with
+# autocrlf=true cannot corrupt the shebang / line endings and break execution.
+*.sh text eol=lf


### PR DESCRIPTION
## 背景（plugin 配布監査 gap #7 #10 #11 #18 #19）

marketplace / plugin manifest のメタデータ不足と配布衛生上の小欠陥をまとめて修正。

## 変更内容

- **#7 / #10**: `marketplace.json` の plugin entry に schema 必須の `author` と `homepage` / `license` を追加。owner.email の個人法人アドレス（`masatake.komine@proni.co.jp`）を maintainers URL に置換（公開 manifest への個人アドレス掲載を回避）
- **#19**: marketplace description を「Claude Code and Codex」に更新（dual-tool 対応を反映）
- **#18**: `plugin.json` の homepage を package.json と揃える（the3396.com docs site）→ marketplace UI と package metadata で同一の canonical URL を提示
- **#11**: `.gitattributes` に `*.sh text eol=lf` を追加。プラグイン同梱の bash hook（`scripts/plugin-format-hook.sh` / `hooks/format.sh`）が Windows checkout（autocrlf=true）で CRLF 化して shebang が壊れるのを防止

## 検証

- JSON 構文 valid、`claude plugin validate .` → ✔ Validation passed
- `.claude-plugin/` / `.codex-plugin/` に個人メール残存なし

Refs #966

🤖 Generated with [Claude Code](https://claude.com/claude-code)