### PR TITLE
chore: prettier-ignore release-please-managed plugin manifests

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -17,3 +17,9 @@ dist/
 .vale/
 .lychee.toml
 CHANGELOG.md
+
+# Version-managed by release-please (its JSON serializer expands short arrays,
+# which conflicts with prettier's inline formatting and breaks Lint on every
+# release that bumps the version).
+.claude-plugin/plugin.json
+.codex-plugin/plugin.json


### PR DESCRIPTION
## 背景

release-please の JSON updater（extra-files の `$.version` bump）が manifest を再シリアライズし、`"capabilities": ["Read"]` のような短い inline 配列を多行展開する。これを prettier が flag するため、**version を bump する release PR の Lint が毎回 fail** する（v1.2.0 release PR #997 で発生）。

## 変更内容

- `.prettierignore` に `.claude-plugin/plugin.json` と `.codex-plugin/plugin.json` を追加（release-please 管理の `CHANGELOG.md` と同じ扱い）
- これで `format:check` が release-please のシリアライズと衝突しなくなる
- 内容の検証は `plugin:validate` CI ゲート（#993）が引き続き担保

## 検証

- `npm run format:check` pass

Refs #966