### PR TITLE
fix(plugin): address Codex review of the distribution work

### DIFF
--- a/scripts/setup-codex.sh
+++ b/scripts/setup-codex.sh
@@ -13,8 +13,8 @@
 # Usage (from your project root):
 #   curl -fsSL https://raw.githubusercontent.com/s977043/river-review/main/scripts/setup-codex.sh | bash
 #
-# Or after cloning river-review:
-#   bash scripts/setup-codex.sh [target-project-dir]
+# Pin a branch, tag, or commit with RIVER_REVIEW_REF (default: main):
+#   RIVER_REVIEW_REF=v1.2.0 bash scripts/setup-codex.sh [target-project-dir]
 #
 # Idempotent: re-running refreshes the vendored skills and the AGENTS.md
 # River Review section without duplicating it.
@@ -23,7 +23,6 @@ set -euo pipefail
 REPO="s977043/river-review"
 REF="${RIVER_REVIEW_REF:-main}"
 RAW_BASE="https://raw.githubusercontent.com/${REPO}/${REF}"
-TARBALL_URL="https://codeload.github.com/${REPO}/tar.gz/refs/heads/${REF}"
 TARGET_DIR="${1:-$(pwd)}"
 MARKER_BEGIN="<!-- river-review:begin -->"
 MARKER_END="<!-- river-review:end -->"
@@ -32,11 +31,57 @@ log() { printf '[river-review:setup] %s\n' "$1"; }
 
 cd "$TARGET_DIR" || { echo "error: cannot cd into $TARGET_DIR" >&2; exit 1; }
 
-# --- 1. Fetch the AGENTS.md River Review section --------------------------
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Download the repo tarball. REF may be a branch, tag, or commit SHA, so try
+# the heads/ form first and fall back to tags/ then the bare ref (SHA).
+download_tarball() {
+  for path in "refs/heads/${REF}" "refs/tags/${REF}" "${REF}"; do
+    if curl -fsSL "https://codeload.github.com/${REPO}/tar.gz/${path}" \
+        -o "$TMP/river-review.tar.gz" 2>/dev/null; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# --- 1. Fetch the AGENTS.md guidance and the skills tarball ----------------
+# Do all network work and staging BEFORE mutating the target project, so a
+# failed download never leaves a half-initialized project (AGENTS.md written
+# but no skills, or vice versa).
 log "fetching River Review AGENTS.md guidance..."
 AGENTS_SECTION="$(curl -fsSL "${RAW_BASE}/templates/agent-workflow/codex/AGENTS.md")"
 
-# --- 2. Install / merge AGENTS.md -----------------------------------------
+log "downloading river-review agent-skills (ref: ${REF})..."
+if ! download_tarball; then
+  log "error: could not download repo tarball for ref '${REF}'" >&2
+  exit 1
+fi
+tar -xzf "$TMP/river-review.tar.gz" -C "$TMP"
+# The tarball top-level dir is river-review-<ref>; locate the agent-skills subtree.
+SRC_DIR="$(find "$TMP" -maxdepth 4 -type d -path '*/skills/agent-skills' | head -1)"
+if [ -z "$SRC_DIR" ] || [ -z "$(find "$SRC_DIR" -name SKILL.md -print -quit)" ]; then
+  log "error: skills/agent-skills (with SKILL.md) not found in tarball" >&2
+  exit 1
+fi
+
+# --- 2. Vendor the full agent-skills directory (including references/) ------
+# Replace each vendored skill directory atomically so a rename/removal upstream
+# does not leave stale skill dirs behind. Only the skills present in the tarball
+# are touched; unrelated skills the consumer added are left intact.
+log "vendoring river-review agent-skills (full directories)..."
+mkdir -p skills/agent-skills
+VENDORED=0
+while IFS= read -r skill_dir; do
+  name="$(basename "$skill_dir")"
+  rm -rf "skills/agent-skills/${name}"
+  cp -R "$skill_dir" "skills/agent-skills/${name}"
+  VENDORED=$((VENDORED + 1))
+done < <(find "$SRC_DIR" -maxdepth 1 -mindepth 1 -type d)
+log "vendored ${VENDORED} skill(s) with references/ into skills/agent-skills/"
+
+# --- 3. Install / merge AGENTS.md (last, after skills are in place) ---------
 WRAPPED="${MARKER_BEGIN}
 ${AGENTS_SECTION}
 ${MARKER_END}"
@@ -61,34 +106,6 @@ PY
 else
   printf '\n\n%s\n' "$WRAPPED" >> AGENTS.md
   log "appended River Review section to existing AGENTS.md"
-fi
-
-# --- 3. Vendor the full agent-skills directory (including references/) -----
-# Download a repo tarball and extract only skills/agent-skills/**, so every
-# skill ships its SKILL.md AND its references/ rubric files. The skill list is
-# derived from the tarball, never hardcoded.
-log "vendoring river-review agent-skills (full directories)..."
-TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
-
-if curl -fsSL "$TARBALL_URL" -o "$TMP/river-review.tar.gz"; then
-  # The tarball top-level dir is river-review-<ref>; strip it and keep only
-  # the agent-skills subtree.
-  mkdir -p skills/agent-skills
-  tar -xzf "$TMP/river-review.tar.gz" -C "$TMP"
-  SRC_DIR="$(find "$TMP" -maxdepth 4 -type d -path '*/skills/agent-skills' | head -1)"
-  if [ -n "$SRC_DIR" ]; then
-    # Copy the full agent-skills tree (SKILL.md + references/ + any assets).
-    cp -R "$SRC_DIR/." skills/agent-skills/
-    COUNT="$(find skills/agent-skills -maxdepth 1 -mindepth 1 -type d | wc -l | tr -d ' ')"
-    log "vendored ${COUNT} skill(s) with references/ into skills/agent-skills/"
-  else
-    log "error: skills/agent-skills not found in tarball" >&2
-    exit 1
-  fi
-else
-  log "error: could not download repo tarball from ${TARBALL_URL}" >&2
-  exit 1
 fi
 
 log "done."

--- a/scripts/validate-plugin-manifest.mjs
+++ b/scripts/validate-plugin-manifest.mjs
@@ -73,8 +73,10 @@ export async function validatePluginManifest() {
     );
   }
 
-  // --- Codex manifest (optional but, if present, must be consistent) ---
-  if (await pathExists('.codex-plugin/plugin.json')) {
+  // --- Codex manifest (required: official distribution ships Codex too) ---
+  if (!(await pathExists('.codex-plugin/plugin.json'))) {
+    errors.push('.codex-plugin/plugin.json: missing (required for Codex plugin distribution)');
+  } else {
     const codexManifest = await readJson('.codex-plugin/plugin.json');
     if (codexManifest.version !== pkg.version) {
       errors.push(
@@ -86,12 +88,35 @@ export async function validatePluginManifest() {
         `.codex-plugin/plugin.json: name "${codexManifest.name}" !== .claude-plugin name "${ccManifest.name}"`
       );
     }
-    if (typeof codexManifest.skills === 'string') {
+    if (typeof codexManifest.skills !== 'string') {
+      errors.push('.codex-plugin/plugin.json: "skills" path is missing or not a string');
+    } else {
       const rel = normalizeRef(codexManifest.skills);
       if (!(await pathExists(rel))) {
         errors.push(
           `.codex-plugin/plugin.json: skills path does not exist: ${codexManifest.skills}`
         );
+      }
+    }
+    // The Codex plugin UI requires an interface block with these fields.
+    const iface = codexManifest.interface;
+    if (!iface || typeof iface !== 'object') {
+      errors.push('.codex-plugin/plugin.json: "interface" block is missing');
+    } else {
+      const requiredInterfaceFields = [
+        'displayName',
+        'shortDescription',
+        'longDescription',
+        'category',
+        'capabilities',
+      ];
+      for (const field of requiredInterfaceFields) {
+        if (iface[field] === undefined || iface[field] === null || iface[field] === '') {
+          errors.push(`.codex-plugin/plugin.json: interface.${field} is missing or empty`);
+        }
+      }
+      if (iface.capabilities !== undefined && !Array.isArray(iface.capabilities)) {
+        errors.push('.codex-plugin/plugin.json: interface.capabilities must be an array');
       }
     }
   }


### PR DESCRIPTION
## 背景

v1.2.0 の plugin 正式配布対応に対する **Codex のコードレビュー指摘**（Blocker なし / Major 3 / Minor 2）への対応。Gemini はクォータ枯渇のため今回は未取得。

## 対応した指摘

### `scripts/setup-codex.sh`
- **Major**: `RIVER_REVIEW_REF` が tag/SHA でも動くように。tarball を `refs/heads/` → `refs/tags/` → bare ref の順で試行（従来 `refs/heads/` 固定で tag/SHA は 404）
- **Major**: ネットワーク取得と staging を**プロジェクト変更前に**完了させ、skills tarball の妥当性を assert。失敗時に AGENTS.md だけ書かれた半初期化状態を防ぐ。AGENTS.md 書き込みを最後に移動
- **Minor**: skill ごとに atomic な rm+cp で置換（従来の merging `cp -R` だと upstream で内部ファイル削除時に stale が残る）。無関係な consumer skill は保持

### `scripts/validate-plugin-manifest.mjs`
- **Major**: `.codex-plugin/plugin.json` を**必須化**（正式配布は Codex も対象）。誤削除が silently pass せず CI で fail
- **Minor**: Codex `interface` の必須フィールド（displayName / shortDescription / longDescription / category / capabilities）と capabilities が配列であることを検証

## 検証

- `bash -n` + shellcheck clean
- 一時ディレクトリで end-to-end: 7 skill + references/ vendoring、冪等、atomic replace で stale 除去、無関係 dir 保持
- validator が interface フィールド欠落を検出
- `npm run plugin:validate` + unit test green

Refs #966

🤖 Generated with [Claude Code](https://claude.com/claude-code)