### PR TITLE
fix(plugin): make the distributed plugin CLI-independent and self-contained

### DIFF
--- a/.claude/agents/river-review.md
+++ b/.claude/agents/river-review.md
@@ -6,29 +6,36 @@ model: inherit
 permissionMode: default
 ---
 
-You are a strict but helpful reviewer for this repository.
+You are a strict but helpful reviewer.
 
-## Step 1 — Run river CLI (required first action)
+## Step 1 — Review the diff using the bundled skills
 
-Before performing any manual analysis, invoke river via the Bash tool:
+The review skills under `skills/agent-skills/` are self-contained and require no
+external tooling. Drive the review with them:
+
+1. Read the current diff (`git diff` via the Bash tool, or the diff provided in context).
+2. Load `skills/agent-skills/river-review/SKILL.md` (the orchestrator) and route to the
+   relevant specialist skills (`river-review-code`, `-security`, `-performance`,
+   `-architecture`, `-testing`, `adversarial-review`) based on the diff content. When
+   installed as a plugin, the skills live under `${CLAUDE_PLUGIN_ROOT}/skills/agent-skills/`.
+3. Produce findings with `severity` (`critical` → `major` → `minor` → `info`), `file`,
+   `line`, and `message`.
+
+### Optional accelerator — the `river` CLI
+
+If the `river` CLI happens to be on PATH, you may use it to bootstrap structured findings:
 
 ```bash
 river run . --reviewers auto --output json
 ```
 
-Capture the JSON output. The result contains:
-
-- `findings` — array of review findings with `severity`, `file`, `line`, `message`
-- `autoSelectedRoles` — the reviewer roles river selected for this diff
-- `score` — aggregate quality score
-
-If the command fails (e.g. river not installed, no diff), report the error and fall back to manual review.
+The JSON contains `findings`, `autoSelectedRoles`, and `score`. This is an optimization
+only — the `river` CLI is **not required** and may not be installed. If it is absent or
+fails, proceed with the skill-driven review from Step 1; do not treat its absence as an error.
 
 ## Step 2 — Interpret and report
 
-Present the structured findings from the JSON output. Group by severity (`critical` → `major` → `minor` → `info`). For each finding, include file path, line number, and message.
-
-Do not re-derive findings that river already reported from scratch. Add context or explanation where the message is ambiguous.
+Present the findings grouped by severity (`critical` → `major` → `minor` → `info`). For each finding, include file path, line number, and message.
 
 ## Additional rules
 

--- a/.claude/commands/check.md
+++ b/.claude/commands/check.md
@@ -2,10 +2,12 @@
 description: 'Run lint/typecheck/tests and summarize failures'
 ---
 
-次をこの順で実行して、失敗したら原因と修正案を出して：
+対象プロジェクトに存在するチェックのみをこの順で実行して、失敗したら原因と修正案を出して：
 
-1. `npm run lint`
-2. `npm test`
+1. lint（`package.json` に `lint` スクリプトがあれば `npm run lint`。なければプロジェクトの lint コマンドに読み替えるか省略する）
+2. test（`package.json` に `test` スクリプトがあれば `npm test`。なければプロジェクトのテストコマンドに読み替えるか省略する）
+
+> 注: このコマンドは Node プロジェクトの `npm run lint` / `npm test` を想定しています。スクリプトが無い場合は `Missing script` エラーにせず、該当コマンドへ読み替えてください。
 
 成功したら、変更の要点とリスクを 3 点でまとめて：
 

--- a/.claude/commands/skill.md
+++ b/.claude/commands/skill.md
@@ -4,11 +4,16 @@ argument-hint: '[keyword]'
 allowed-tools: Bash(rg:*)
 ---
 
-Find the best matching skill under `skills/` for: $ARGUMENTS
+Find the best matching review skill for: $ARGUMENTS
+
+The bundled skills live in `${CLAUDE_PLUGIN_ROOT}/skills/agent-skills/` when this is
+installed as a plugin, or in `./skills/agent-skills/` when working inside the
+river-review repo itself.
 
 Steps:
 
-1. Search `skills/` for the keyword using ripgrep.
-2. Identify the most relevant `skills/**/skill.md`.
+1. Set `SKILL_ROOT="${CLAUDE_PLUGIN_ROOT:-.}/skills/agent-skills"` and search it for the
+   keyword (case-insensitive), e.g. `rg -i "$ARGUMENTS" "$SKILL_ROOT"`.
+2. Identify the most relevant `SKILL.md` (note: filenames are uppercase `SKILL.md`).
 3. Summarize the workflow rules from that skill.
 4. Apply those rules to the current task and proceed.

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -6,7 +6,7 @@
     "name": "river-review maintainers",
     "url": "https://github.com/s977043/river-review"
   },
-  "homepage": "https://github.com/s977043/river-review",
+  "homepage": "https://river-review.the3396.com/",
   "repository": "https://github.com/s977043/river-review",
   "license": "MIT",
   "keywords": [

--- a/README.en.md
+++ b/README.en.md
@@ -274,7 +274,7 @@ river-review ships as a Claude Code plugin from a same-repo marketplace.
    /plugin marketplace add s977043/river-review
    ```
 
-   Pin to a tag if you want reproducible installs: `/plugin marketplace add s977043/river-review@v1.0.0`.
+   Pin to a tag if you want reproducible installs: `/plugin marketplace add s977043/river-review@v1.2.1`.
 
 2. Install the plugin:
 

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ river-review は同一リポジトリ内のマーケットプレイスから Cla
    /plugin marketplace add s977043/river-review
    ```
 
-   再現可能なインストールが必要ならタグを固定: `/plugin marketplace add s977043/river-review@v1.0.0`。
+   再現可能なインストールが必要ならタグを固定: `/plugin marketplace add s977043/river-review@v1.2.1`。
 
 2. プラグインをインストール:
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -5,11 +5,11 @@
 
 ## スクリプト一覧
 
-| スクリプト              | 用途                                   | 呼び出し元                              |
-| ----------------------- | -------------------------------------- | --------------------------------------- |
-| `format.sh`             | 変更ファイルにPrettierを実行           | `.claude/hooks/format.sh`               |
-| `hooks.json`            | プラグイン配布用 PostToolUse hook 定義 | プラグインインストール先（Claude Code） |
-| `plugin-format-hook.sh` | プラグイン同梱の自己完結フォーマッター | `hooks.json`（`${CLAUDE_PLUGIN_ROOT}`） |
+| スクリプト                      | 用途                                                                                       | 呼び出し元                                                            |
+| ------------------------------- | ------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
+| `format.sh`                     | 変更ファイルにPrettierを実行                                                               | `.claude/hooks/format.sh`                                             |
+| `hooks.json`                    | プラグイン配布用 PostToolUse hook 定義                                                     | プラグインインストール先（Claude Code）                               |
+| `scripts/plugin-format-hook.sh` | プラグイン同梱の自己完結フォーマッター（リポジトリ上は `hooks/` ではなく `scripts/` 配下） | `hooks.json`（`${CLAUDE_PLUGIN_ROOT}/scripts/plugin-format-hook.sh`） |
 
 ### `plugin-format-hook.sh` の defer 挙動
 

--- a/scripts/plugin-format-hook.sh
+++ b/scripts/plugin-format-hook.sh
@@ -20,6 +20,7 @@ cd "$PROJECT_DIR" || exit 0
 # repo-internal format hook (e.g. developing the river-review repo itself,
 # where .claude/settings.json wires .claude/hooks/format.sh), defer to it.
 if [ -f .claude/hooks/format.sh ]; then
+  echo "[river-review:format] project has its own .claude/hooks/format.sh, deferring to it"
   exit 0
 fi
 

--- a/scripts/setup-codex.sh
+++ b/scripts/setup-codex.sh
@@ -14,7 +14,7 @@
 #   curl -fsSL https://raw.githubusercontent.com/s977043/river-review/main/scripts/setup-codex.sh | bash
 #
 # Pin a branch, tag, or commit with RIVER_REVIEW_REF (default: main):
-#   RIVER_REVIEW_REF=v1.2.0 bash scripts/setup-codex.sh [target-project-dir]
+#   RIVER_REVIEW_REF=v1.2.1 bash scripts/setup-codex.sh [target-project-dir]
 #
 # Idempotent: re-running refreshes the vendored skills and the AGENTS.md
 # River Review section without duplicating it.
@@ -67,11 +67,27 @@ if [ -z "$SRC_DIR" ] || [ -z "$(find "$SRC_DIR" -name SKILL.md -print -quit)" ];
 fi
 
 # --- 2. Vendor the full agent-skills directory (including references/) ------
-# Replace each vendored skill directory atomically so a rename/removal upstream
-# does not leave stale skill dirs behind. Only the skills present in the tarball
-# are touched; unrelated skills the consumer added are left intact.
+# Replace each vendored skill directory atomically. A marker file records which
+# skills we vendored last time, so skills that were renamed or removed upstream
+# are cleaned up on re-run. Unrelated skills the consumer added are left intact.
 log "vendoring river-review agent-skills (full directories)..."
 mkdir -p skills/agent-skills
+MARKER_FILE="skills/agent-skills/.river-review-vendored"
+
+# Skills present in the freshly downloaded tarball.
+NEW_NAMES="$(find "$SRC_DIR" -maxdepth 1 -mindepth 1 -type d -exec basename {} \; | sort)"
+
+# Remove previously-vendored skills that no longer exist upstream.
+if [ -f "$MARKER_FILE" ]; then
+  while IFS= read -r old_name; do
+    [ -z "$old_name" ] && continue
+    if ! printf '%s\n' "$NEW_NAMES" | grep -qxF "$old_name"; then
+      rm -rf "skills/agent-skills/${old_name}"
+      log "removed stale vendored skill: ${old_name}"
+    fi
+  done < "$MARKER_FILE"
+fi
+
 VENDORED=0
 while IFS= read -r skill_dir; do
   name="$(basename "$skill_dir")"
@@ -79,6 +95,9 @@ while IFS= read -r skill_dir; do
   cp -R "$skill_dir" "skills/agent-skills/${name}"
   VENDORED=$((VENDORED + 1))
 done < <(find "$SRC_DIR" -maxdepth 1 -mindepth 1 -type d)
+
+# Record the vendored set for the next upgrade's stale-skill cleanup.
+printf '%s\n' "$NEW_NAMES" > "$MARKER_FILE"
 log "vendored ${VENDORED} skill(s) with references/ into skills/agent-skills/"
 
 # --- 3. Install / merge AGENTS.md (last, after skills are in place) ---------
@@ -90,18 +109,17 @@ if [ ! -f AGENTS.md ]; then
   printf '%s\n' "$WRAPPED" > AGENTS.md
   log "created AGENTS.md"
 elif grep -qF "$MARKER_BEGIN" AGENTS.md; then
-  # Replace the existing river-review block in place.
-  python3 - "$AGENTS_SECTION" <<'PY'
-import re, sys
-section = sys.argv[1]
-begin, end = "<!-- river-review:begin -->", "<!-- river-review:end -->"
-block = f"{begin}\n{section}\n{end}"
-with open("AGENTS.md") as f:
-    text = f.read()
-text = re.sub(re.escape(begin) + r".*?" + re.escape(end), block, text, flags=re.DOTALL)
-with open("AGENTS.md", "w") as f:
-    f.write(text)
-PY
+  # Replace the existing river-review block in place. Uses awk (always available
+  # where bash runs) so there is no python3 dependency that could leave AGENTS.md
+  # un-refreshed after the skills were already vendored.
+  printf '%s\n' "$WRAPPED" > "$TMP/block.md"
+  awk -v blockfile="$TMP/block.md" '
+    BEGIN { block = ""; while ((getline line < blockfile) > 0) block = block line "\n" }
+    index($0, "<!-- river-review:begin -->") { printf "%s", block; skip = 1; next }
+    index($0, "<!-- river-review:end -->")   { skip = 0; next }
+    !skip { print }
+  ' AGENTS.md > "$TMP/AGENTS.md.new"
+  mv "$TMP/AGENTS.md.new" AGENTS.md
   log "refreshed River Review section in existing AGENTS.md"
 else
   printf '\n\n%s\n' "$WRAPPED" >> AGENTS.md

--- a/scripts/validate-plugin-manifest.mjs
+++ b/scripts/validate-plugin-manifest.mjs
@@ -65,6 +65,41 @@ export async function validatePluginManifest() {
     }
   }
 
+  // --- Hooks: parse hooks.json and verify each command's script target exists ---
+  if (typeof ccManifest.hooks === 'string') {
+    const hooksRel = normalizeRef(ccManifest.hooks);
+    if (await pathExists(hooksRel)) {
+      let hooksDef;
+      try {
+        hooksDef = await readJson(hooksRel);
+      } catch {
+        errors.push(`${ccManifest.hooks}: not valid JSON`);
+      }
+      if (hooksDef && hooksDef.hooks) {
+        const commands = [];
+        for (const matchers of Object.values(hooksDef.hooks)) {
+          for (const matcher of matchers || []) {
+            for (const hook of matcher.hooks || []) {
+              if (hook.type === 'command' && typeof hook.command === 'string') {
+                commands.push(hook.command);
+              }
+            }
+          }
+        }
+        // Extract ${CLAUDE_PLUGIN_ROOT}/<path> targets and verify they exist.
+        for (const command of commands) {
+          const matches = command.match(/\$\{CLAUDE_PLUGIN_ROOT\}\/([^\s"']+)/g) || [];
+          for (const m of matches) {
+            const scriptRel = m.replace(/\$\{CLAUDE_PLUGIN_ROOT\}\//, '');
+            if (!(await pathExists(scriptRel))) {
+              errors.push(`${ccManifest.hooks}: hook command target does not exist: ${scriptRel}`);
+            }
+          }
+        }
+      }
+    }
+  }
+
   // --- Marketplace: plugins[].name matches manifest name ---
   const entry = (marketplace.plugins || []).find((p) => p.name === ccManifest.name);
   if (!entry) {

--- a/templates/agent-workflow/codex/AGENTS.md
+++ b/templates/agent-workflow/codex/AGENTS.md
@@ -1,25 +1,30 @@
 # AGENTS.md — River Review integration
 
-## Prerequisite: the `river` CLI
+## Code review (primary: skill-driven, no CLI required)
 
-The commands below invoke the `river` CLI. Make sure it is available on `PATH`
-first — install it (`npm install -g river-review`) or run it via `npx river ...`.
-If the CLI is not installed, use the agent-skills under `skills/agent-skills/`
-directly instead of the CLI commands.
+Before finalizing any code change, review the diff using the bundled review skills
+under `skills/agent-skills/` — they are self-contained and need no external tooling.
+Load `skills/agent-skills/river-review/SKILL.md` (the orchestrator) and route to the
+relevant specialist skills (`river-review-code`, `-security`, `-performance`,
+`-architecture`, `-testing`, `adversarial-review`) based on the diff content.
 
-## Code review
+### Optional accelerator — the `river` CLI
 
-Before finalizing any code change, run River Review to catch issues:
+If the `river` CLI is available on `PATH`, you may use it to bootstrap structured
+findings. It is **optional**, not required:
 
 ```bash
 river run . --reviewers auto
 ```
 
-If neither the `ANTHROPIC_API_KEY` nor the `OPENAI_API_KEY` environment variable is set, use dry-run mode:
+If neither `ANTHROPIC_API_KEY` nor `OPENAI_API_KEY` is set, use dry-run mode:
 
 ```bash
 river run . --dry-run
 ```
+
+The CLI is distributed separately from this skill set; if it is not installed, rely on
+the skills above.
 
 ## When to invoke
 


### PR DESCRIPTION
## 背景

「ClaudeCode / Codex 用 Plugin の用意はできているか」を確認するための **3視点セルフレビュー（technical / consistency / adversarial）+ Codex レビュー** を実施。結果、**パッケージング（manifest / marketplace / CI ゲート）は production-ready だが、配布される command/agent の中身が river-review リポジトリ内部の環境を前提**にしており、marketplace-only ユーザーの初回レビューが失敗し得ることが判明（`river` CLI は未公開: package.json が private、`npm view river-review` → 404）。

ユーザー判断: **プラグインを CLI 非依存に作り直す** + 自己完結な修正をまとめて 1 PR。

## 変更内容

### プラグインを CLI 非依存に
- `.claude/agents/river-review.md`: bundled skill ルーティング主導に。`river` CLI は**任意の高速化**に降格（必須の Step 1 ではない）。skill は `${CLAUDE_PLUGIN_ROOT}/skills/agent-skills/` で解決
- `templates/agent-workflow/codex/AGENTS.md`: 同様に skill 主導へ。`npm install -g river-review` 前提を削除
- `.claude/commands/skill.md`: `${CLAUDE_PLUGIN_ROOT:-.}/skills/agent-skills/` の大文字 `SKILL.md` を検索（従来は消費者 cwd の存在しない小文字 `skills/**/skill.md` を grep）
- `.claude/commands/check.md`: npm lint/test スクリプトの存在を前提にしない

### レビュー指摘のその他対応
- README.md/.en.md: Claude Code ピン `@v1.0.0` → `v1.2.1`
- `.codex-plugin/plugin.json`: homepage を docs サイトに統一（`.claude-plugin` と一致）
- `scripts/setup-codex.sh`: **python3 依存を排除**（awk ベースの marker 置換、欠落時の partial state を防止）/ **marker file で rename・削除 skill を upgrade 時にクリーンアップ** / header の ref 例を v1.2.1
- `scripts/plugin-format-hook.sh`: project 独自 hook へ defer する際に理由をログ出力
- `scripts/validate-plugin-manifest.mjs`: **hooks.json を parse し各 hook command の `${CLAUDE_PLUGIN_ROOT}` script ターゲット実在を検証**（従来はパス存在のみ）
- `hooks/README.md`: plugin-format-hook.sh のパスを `scripts/` に修正

## 検証

- shellcheck clean
- setup-codex end-to-end: awk marker 置換が冪等、stale-skill cleanup が rename/削除 skill を除去しつつ consumer skill を保持、python3 不要
- validator が壊れた hook ターゲットを検出（negative test）
- `npm run plugin:validate` + unit test + `claude plugin validate .` + prettier/markdownlint/dashes すべて green

## レビュー出典

3視点セルフレビュー（Explore×2 + Plan adversarial）+ Codex。Gemini はクォータ枯渇で取得不可。

Refs #966, #996

🤖 Generated with [Claude Code](https://claude.com/claude-code)