### PR TITLE
fix(plugin): address gemini-code-assist review of #1004

### DIFF
--- a/.claude/agents/river-review.md
+++ b/.claude/agents/river-review.md
@@ -14,10 +14,11 @@ The review skills under `skills/agent-skills/` are self-contained and require no
 external tooling. Drive the review with them:
 
 1. Read the current diff (`git diff` via the Bash tool, or the diff provided in context).
-2. Load `skills/agent-skills/river-review/SKILL.md` (the orchestrator) and route to the
-   relevant specialist skills (`river-review-code`, `-security`, `-performance`,
-   `-architecture`, `-testing`, `adversarial-review`) based on the diff content. When
-   installed as a plugin, the skills live under `${CLAUDE_PLUGIN_ROOT}/skills/agent-skills/`.
+2. Load `${CLAUDE_PLUGIN_ROOT:-.}/skills/agent-skills/river-review/SKILL.md` (the
+   orchestrator) and route to the relevant specialist skills (`river-review-code`,
+   `-security`, `-performance`, `-architecture`, `-testing`, `adversarial-review`)
+   based on the diff content. `${CLAUDE_PLUGIN_ROOT}` is set when installed as a
+   plugin; it falls back to the repo root (`.`) when run inside river-review itself.
 3. Produce findings with `severity` (`critical` → `major` → `minor` → `info`), `file`,
    `line`, and `message`.
 

--- a/scripts/setup-codex.sh
+++ b/scripts/setup-codex.sh
@@ -81,6 +81,11 @@ NEW_NAMES="$(find "$SRC_DIR" -maxdepth 1 -mindepth 1 -type d -exec basename {} \
 if [ -f "$MARKER_FILE" ]; then
   while IFS= read -r old_name; do
     [ -z "$old_name" ] && continue
+    # Only a plain directory name (no path separators, no leading dot) is a valid
+    # skill name; reject anything else to avoid an rm -rf path-traversal.
+    case "$old_name" in
+      */* | .*) continue ;;
+    esac
     if ! printf '%s\n' "$NEW_NAMES" | grep -qxF "$old_name"; then
       rm -rf "skills/agent-skills/${old_name}"
       log "removed stale vendored skill: ${old_name}"
@@ -90,7 +95,7 @@ fi
 
 VENDORED=0
 while IFS= read -r skill_dir; do
-  name="$(basename "$skill_dir")"
+  name="${skill_dir##*/}"
   rm -rf "skills/agent-skills/${name}"
   cp -R "$skill_dir" "skills/agent-skills/${name}"
   VENDORED=$((VENDORED + 1))
@@ -108,9 +113,12 @@ ${MARKER_END}"
 if [ ! -f AGENTS.md ]; then
   printf '%s\n' "$WRAPPED" > AGENTS.md
   log "created AGENTS.md"
-elif grep -qF "$MARKER_BEGIN" AGENTS.md; then
-  # Replace the existing river-review block in place. Uses awk (always available
-  # where bash runs) so there is no python3 dependency that could leave AGENTS.md
+elif grep -qF "$MARKER_BEGIN" AGENTS.md && grep -qF "$MARKER_END" AGENTS.md; then
+  # Replace the existing river-review block in place. Requires BOTH markers: if
+  # only the begin marker survived (e.g. a manual edit removed the end marker),
+  # the awk skip-until-end would silently drop the rest of the file, so we fall
+  # through to the safe append branch instead. Uses awk (always available where
+  # bash runs) so there is no python3 dependency that could leave AGENTS.md
   # un-refreshed after the skills were already vendored.
   printf '%s\n' "$WRAPPED" > "$TMP/block.md"
   awk -v blockfile="$TMP/block.md" '

--- a/scripts/setup-codex.sh
+++ b/scripts/setup-codex.sh
@@ -81,10 +81,11 @@ NEW_NAMES="$(find "$SRC_DIR" -maxdepth 1 -mindepth 1 -type d -exec basename {} \
 if [ -f "$MARKER_FILE" ]; then
   while IFS= read -r old_name; do
     [ -z "$old_name" ] && continue
-    # Only a plain directory name (no path separators, no leading dot) is a valid
-    # skill name; reject anything else to avoid an rm -rf path-traversal.
+    # Only a plain directory name (no path separators, no leading dot, no leading
+    # dash) is a valid skill name; reject anything else to avoid an rm -rf
+    # path-traversal or a leading-dash being treated as a grep/rm option.
     case "$old_name" in
-      */* | .*) continue ;;
+      */* | .* | -*) continue ;;
     esac
     if ! printf '%s\n' "$NEW_NAMES" | grep -qxF "$old_name"; then
       rm -rf "skills/agent-skills/${old_name}"

--- a/scripts/validate-plugin-manifest.mjs
+++ b/scripts/validate-plugin-manifest.mjs
@@ -75,12 +75,14 @@ export async function validatePluginManifest() {
       } catch {
         errors.push(`${ccManifest.hooks}: not valid JSON`);
       }
-      if (hooksDef && hooksDef.hooks) {
+      if (hooksDef && hooksDef.hooks && typeof hooksDef.hooks === 'object') {
         const commands = [];
         for (const matchers of Object.values(hooksDef.hooks)) {
-          for (const matcher of matchers || []) {
-            for (const hook of matcher.hooks || []) {
-              if (hook.type === 'command' && typeof hook.command === 'string') {
+          if (!Array.isArray(matchers)) continue;
+          for (const matcher of matchers) {
+            if (!matcher || !Array.isArray(matcher.hooks)) continue;
+            for (const hook of matcher.hooks) {
+              if (hook && hook.type === 'command' && typeof hook.command === 'string') {
                 commands.push(hook.command);
               }
             }

--- a/scripts/validate-plugin-manifest.mjs
+++ b/scripts/validate-plugin-manifest.mjs
@@ -75,6 +75,9 @@ export async function validatePluginManifest() {
       } catch {
         errors.push(`${ccManifest.hooks}: not valid JSON`);
       }
+      if (hooksDef && (!hooksDef.hooks || typeof hooksDef.hooks !== 'object')) {
+        errors.push(`${ccManifest.hooks}: "hooks" field is missing or not an object`);
+      }
       if (hooksDef && hooksDef.hooks && typeof hooksDef.hooks === 'object') {
         const commands = [];
         for (const matchers of Object.values(hooksDef.hooks)) {


### PR DESCRIPTION
## 背景

`gemini-code-assist[bot]` が PR #1004 に対して 5 件のレビュー指摘（HIGH 1 / security-medium 1 / medium 3）を投稿。いずれも妥当なため対応する。

## 対応

- **HIGH** (`setup-codex.sh`): awk の marker 置換が begin マーカーのみで実行されていたため、end マーカーが手動編集等で欠落した場合に begin 以降を skip して**ファイル末尾をサイレント切り捨て**するリスク。**両マーカー必須**に変更し、欠けていれば安全な append ブランチへフォールスルー。検証: end マーカー欠落時に末尾行が保持されることを確認
- **SECURITY** (`setup-codex.sh`): stale-skill cleanup で marker file から読む `old_name` を `rm -rf` 前にパス区切り・先頭ドットでガード（path traversal 防止）
- **MEDIUM** (`setup-codex.sh`): `basename` サブシェルを `${skill_dir##*/}` に置換
- **MEDIUM** (`validate-plugin-manifest.mjs`): hooks.json 走査に配列/null ガードを追加し、不正な hooks 定義でも TypeError でクラッシュせずエラー報告。検証: 非配列 matchers で throw しないことを確認
- **MEDIUM** (`.claude/agents/river-review.md`): skills パスを `${CLAUDE_PLUGIN_ROOT:-.}` で明示（skill.md と統一、plugin/in-repo 両対応）

## 検証

- shellcheck clean、`npm run plugin:validate` + unit test + prettier/dashes green

Refs #966, #996

🤖 Generated with [Claude Code](https://claude.com/claude-code)