### PR TITLE
docs: document result store, --baseline, chunking/dedup, and config artifacts (#1011)

### DIFF
--- a/pages/guides/use-riverbed-memory.en.md
+++ b/pages/guides/use-riverbed-memory.en.md
@@ -101,7 +101,7 @@ river runs summary
 
 ### `--baseline`: regression-compare against a previous review
 
-Pass a previous review JSON (a `findings` array) to `--baseline <path>` to print a regression summary (new / fixed findings) before the normal output.
+Pass a previous review JSON to `--baseline <path>` to print a regression summary (new / fixed findings) before the normal output. The JSON may be a raw `findings` array, or an object with a `findings` (or `issues`) key — e.g. the output of `river run . --output json`.
 
 ```bash
 # 1. Save a baseline review as JSON

--- a/pages/guides/use-riverbed-memory.en.md
+++ b/pages/guides/use-riverbed-memory.en.md
@@ -74,6 +74,43 @@ jobs:
 
 It automatically downloads the previous artifact and uploads the updated version (90-day retention). If no memory is found, the system operates normally (stateless fallback).
 
+## Save and compare review runs (result store)
+
+You can persist review runs and compare them against earlier runs for regression. The result store lives in `.river/runs/`, separate from memory (`.river/memory/`).
+
+### `--save`: persist a run
+
+Add `--save` to `river run` to persist the run to the result store (`.river/runs/`).
+
+```bash
+river run . --reviewers auto --save
+```
+
+### `river runs`: inspect stored runs
+
+```bash
+# List stored runs (runId / phase / findings count, etc.)
+river runs list
+
+# Diff two runs (new / fixed findings)
+river runs diff <run-id-1> <run-id-2>
+
+# Aggregate metrics (dashboard-equivalent)
+river runs summary
+```
+
+### `--baseline`: regression-compare against a previous review
+
+Pass a previous review JSON (a `findings` array) to `--baseline <path>` to print a regression summary (new / fixed findings) before the normal output.
+
+```bash
+# 1. Save a baseline review as JSON
+river run . --output json > baseline.json
+
+# 2. Compare the current diff against the baseline
+river run . --baseline baseline.json
+```
+
 ## Record Types
 
 | type          | Purpose                                                       |

--- a/pages/guides/use-riverbed-memory.md
+++ b/pages/guides/use-riverbed-memory.md
@@ -74,6 +74,43 @@ jobs:
 
 前回のアーティファクトを自動ダウンロードし、更新後にアップロードします（90 日 retention）。メモリが見つからない場合も正常動作します（stateless fallback）。
 
+## レビュー実行を保存して比較する（result store）
+
+レビュー実行を保存し、過去の実行と回帰比較できます。result store はメモリ（`.river/memory/`）とは別の `.river/runs/` に保存されます。
+
+### `--save`: 実行を保存する
+
+`river run` に `--save` を付けると、その実行を result store（`.river/runs/`）に保存します。
+
+```bash
+river run . --reviewers auto --save
+```
+
+### `river runs`: 保存済み実行を確認する
+
+```bash
+# 保存済み実行の一覧（runId / phase / findings 数など）
+river runs list
+
+# 2 つの実行の差分（new / fixed findings）
+river runs diff <run-id-1> <run-id-2>
+
+# 集計（ダッシュボード相当のメトリクス）
+river runs summary
+```
+
+### `--baseline`: 過去のレビューと回帰比較する
+
+`--baseline <path>` に過去のレビュー JSON（`findings` 配列）を渡すと、通常の出力の前に回帰サマリ（new / fixed findings）を表示します。
+
+```bash
+# 1. 基準となるレビューを JSON で保存する
+river run . --output json > baseline.json
+
+# 2. 現在の差分を基準と比較する
+river run . --baseline baseline.json
+```
+
 ## レコード型
 
 | type          | 用途                                          |

--- a/pages/guides/use-riverbed-memory.md
+++ b/pages/guides/use-riverbed-memory.md
@@ -101,7 +101,7 @@ river runs summary
 
 ### `--baseline`: 過去のレビューと回帰比較する
 
-`--baseline <path>` に過去のレビュー JSON（`findings` 配列）を渡すと、通常の出力の前に回帰サマリ（new / fixed findings）を表示します。
+`--baseline <path>` に過去のレビュー JSON を渡すと、通常の出力の前に回帰サマリ（new / fixed findings）を表示します。JSON は `findings` 配列そのもの、または `findings`（あるいは `issues`）キーを持つオブジェクト（例: `river run . --output json` の出力）のいずれでも受け付けます。
 
 ```bash
 # 1. 基準となるレビューを JSON で保存する

--- a/pages/reference/config-schema.en.md
+++ b/pages/reference/config-schema.en.md
@@ -41,7 +41,7 @@ Place `.river-review.json` in the repository root to customize review model sett
   - `tokenizer`: Only `heuristic` is accepted (reserved for future expansion).
 - `artifacts`
   - Declares paths to input artifacts. Accepts these 12 IDs: `pbi-input` / `plan` / `todo` / `test-cases` / `review-self` / `review-external` / `diff` / `junit` / `coverage` / `lint` / `typecheck` / `findings-pool`.
-  - Each value is a string path, or an object `{ "path": "...", "optional": true }`.
+  - Each value is a string path, or an object `{ "path": "...", "optional": <boolean> }` (`optional` is a boolean).
   - Unknown keys are accepted for forward compatibility (catchall). See the [Artifact Input Contract](./artifact-input-contract.md) for the resolution order and per-artifact contract.
 
 ### Configuration Example

--- a/pages/reference/config-schema.en.md
+++ b/pages/reference/config-schema.en.md
@@ -39,6 +39,10 @@ Place `.river-review.json` in the repository root to customize review model sett
   - `ranking.enabled`: `true` to enable proximity-based reordering of context candidates.
   - `ranking.weights`: Per-signal weights for `pathProximity` / `symbolUsage` / `siblingTest` / `commitRecency`, each in `0.0`–`1.0`. Equal weighting if omitted.
   - `tokenizer`: Only `heuristic` is accepted (reserved for future expansion).
+- `artifacts`
+  - Declares paths to input artifacts. Accepts these 12 IDs: `pbi-input` / `plan` / `todo` / `test-cases` / `review-self` / `review-external` / `diff` / `junit` / `coverage` / `lint` / `typecheck` / `findings-pool`.
+  - Each value is a string path, or an object `{ "path": "...", "optional": true }`.
+  - Unknown keys are accepted for forward compatibility (catchall). See the [Artifact Input Contract](./artifact-input-contract.md) for the resolution order and per-artifact contract.
 
 ### Configuration Example
 

--- a/pages/reference/config-schema.md
+++ b/pages/reference/config-schema.md
@@ -48,6 +48,10 @@
   - `ranking.enabled`: `true` で変更ファイルへの近接度に基づいた候補並び替えを有効化する。
   - `ranking.weights`: `pathProximity` / `symbolUsage` / `siblingTest` / `commitRecency` を `0.0`〜`1.0` で指定する。省略時は等重みを使用する。
   - `tokenizer`: `heuristic` のみ受理する（将来拡張用）。
+- `artifacts`
+  - 入力アーティファクトのパスを宣言するセクション。次の 12 ID を受け付ける: `pbi-input` / `plan` / `todo` / `test-cases` / `review-self` / `review-external` / `diff` / `junit` / `coverage` / `lint` / `typecheck` / `findings-pool`。
+  - 各値は文字列パス、または `{ "path": "...", "optional": true }` のオブジェクトで指定する。
+  - 未知のキーは将来互換のため受理される（catchall）。解決順序と各アーティファクトの契約は [Artifact Input Contract](./artifact-input-contract.md) を参照。
 
 ### 設定例
 

--- a/pages/reference/config-schema.md
+++ b/pages/reference/config-schema.md
@@ -50,7 +50,7 @@
   - `tokenizer`: `heuristic` のみ受理する（将来拡張用）。
 - `artifacts`
   - 入力アーティファクトのパスを宣言するセクション。次の 12 ID を受け付ける: `pbi-input` / `plan` / `todo` / `test-cases` / `review-self` / `review-external` / `diff` / `junit` / `coverage` / `lint` / `typecheck` / `findings-pool`。
-  - 各値は文字列パス、または `{ "path": "...", "optional": true }` のオブジェクトで指定する。
+  - 各値は文字列パス、または `{ "path": "...", "optional": <boolean> }` のオブジェクトで指定する（`optional` は真偽値）。
   - 未知のキーは将来互換のため受理される（catchall）。解決順序と各アーティファクトの契約は [Artifact Input Contract](./artifact-input-contract.md) を参照。
 
 ### 設定例

--- a/pages/reference/runner-cli-reference.en.md
+++ b/pages/reference/runner-cli-reference.en.md
@@ -27,6 +27,10 @@ The selected roles are reported in the `autoSelectedRoles` field of the JSON out
 }
 ```
 
+### Large-diff chunking and finding deduplication
+
+When reviewing with multiple roles (including `auto`), large diffs are automatically split into chunks and run in parallel as role × chunk. Findings from each run are deduplicated across chunks and roles before final IDs are assigned (implemented in `src/lib/reviewer-orchestrator.mjs` as `splitDiffIntoChunks` / `deduplicateFindings`), so duplicate findings on the same location are collapsed into one.
+
 ## Commands
 
 - Agents: `npm run agents:validate` (or `node scripts/validate-agents.mjs`)

--- a/pages/reference/runner-cli-reference.md
+++ b/pages/reference/runner-cli-reference.md
@@ -32,6 +32,10 @@ JSON 出力の `autoSelectedRoles` フィールドで選択されたロールを
 }
 ```
 
+### 大きな diff の分割と findings の重複排除
+
+複数のロール（`auto` を含む）でレビューする場合、大きな diff は自動的にチャンクに分割され、ロール × チャンクで並列実行されます。各実行から得られた findings は、最終 ID を割り当てる前にチャンク・ロール間で重複排除されます（実装: `src/lib/reviewer-orchestrator.mjs` の `splitDiffIntoChunks` / `deduplicateFindings`）。このため、同一箇所の重複指摘は 1 件に統合されます。
+
 ## コマンド
 
 - Agents: `npm run agents:validate` (または `node scripts/validate-agents.mjs`)


### PR DESCRIPTION
## 背景（#1011 / ドリフト監査フォローアップ）

shipped 済みだが未文書化だった機能群をドキュメント化する。

## 変更内容

- **use-riverbed-memory.md/.en.md**: 「result store」節を追加 — `--save`、`.river/runs/` ストア、`river runs list|diff|summary`、`--baseline <path>` 回帰比較
- **runner-cli-reference.md/.en.md**: `--reviewers` 配下に、大きな diff の chunk 分割と findings の重複排除（`splitDiffIntoChunks` / `deduplicateFindings`）の注記を追加
- **config-schema.md/.en.md**: `artifacts` 設定節を追加（12 ID、string or {path,optional}、catchall）。Artifact Input Contract へ相互リンク

## 検証

- textlint（pages スコープ）/ markdownlint / prettier / check:dashes clean
- docusaurus build（ja+en）成功・リンク切れなし

#1011 の残項目（EN skills カタログ、i18n ペア欠落、skills import/export ガイド、registry）は引き続き同 Issue で追跡。

Refs #1011, #966

🤖 Generated with [Claude Code](https://claude.com/claude-code)