### PR TITLE
docs(guides): add skills import/export/list CLI how-to (#1011)

### DIFF
--- a/pages/guides/_meta.json
+++ b/pages/guides/_meta.json
@@ -16,6 +16,7 @@
   "validate-skill-schema": "スキルスキーマを検証する",
   "choose-skills": "スキルの選択と組み合わせ",
   "debug-skill-routing": "スキルルーティングのデバッグ",
+  "manage-skills-cli": "スキルを import / export / list する（CLI）",
   "agent-workflow": "AI エージェントから River Review を使う",
   "w-check": "W チェック（二重レビュー）",
   "repo-wide-review": "リポジトリ全体を踏まえたレビューの導入とチューニング",

--- a/pages/guides/manage-skills-cli.en.md
+++ b/pages/guides/manage-skills-cli.en.md
@@ -4,7 +4,7 @@ title: Import / export / list skills (CLI)
 
 River Review can convert between Agent Skills (`SKILL.md` packages) and River Review-format skills, and list them. The `river skills import|export|list` subcommands let you bring in external Agent Skills, write your own skills out in Agent Skills format, and inspect which skills are currently recognized.
 
-> For the skill definition format itself, see the [Manifest-driven Skills guide](./agent-skills-codex-cli.en.md); for validation, see [Validate the skill schema](./validate-skill-schema.en.md). This page focuses only on the import / export / list CLI.
+> For the skill definition format itself, see the [Manifest-driven Skills guide](./agent-skills-codex-cli.md); for validation, see [Validate the skill schema](./validate-skill-schema.md). This page focuses only on the import / export / list CLI.
 
 ## 1. Inspect the skill list (`skills list`)
 
@@ -108,6 +108,6 @@ On completion, the counts of "exported / failed" are printed. If `failed` is one
 
 ## Related pages
 
-- [Manifest-driven Skills guide](./agent-skills-codex-cli.en.md) — skill definition format (Markdown / YAML)
-- [Add a new skill (quickest path)](./add-new-skill.en.md)
-- [Validate the skill schema](./validate-skill-schema.en.md)
+- [Manifest-driven Skills guide](./agent-skills-codex-cli.md) — skill definition format (Markdown / YAML)
+- [Add a new skill (quickest path)](./add-new-skill.md)
+- [Validate the skill schema](./validate-skill-schema.md)

--- a/pages/guides/manage-skills-cli.en.md
+++ b/pages/guides/manage-skills-cli.en.md
@@ -1,0 +1,113 @@
+---
+title: Import / export / list skills (CLI)
+---
+
+River Review can convert between Agent Skills (`SKILL.md` packages) and River Review-format skills, and list them. The `river skills import|export|list` subcommands let you bring in external Agent Skills, write your own skills out in Agent Skills format, and inspect which skills are currently recognized.
+
+> For the skill definition format itself, see the [Manifest-driven Skills guide](./agent-skills-codex-cli.en.md); for validation, see [Validate the skill schema](./validate-skill-schema.en.md). This page focuses only on the import / export / list CLI.
+
+## 1. Inspect the skill list (`skills list`)
+
+Lists the skills River Review currently recognizes.
+
+```bash
+river skills list
+```
+
+It prints a table of `ID` / `NAME` / `SOURCE` / `PATH`. `SOURCE` is one of:
+
+- `rr` — River Review-format skill (under `skills/`)
+- `agent` — Agent Skills-format package (a `SKILL.md` under `.agents/skills` / `.github/skills` / `.claude/skills`)
+
+An Agent Skill that has already been loaded as a River Review-format skill (i.e. imported) is de-duplicated and shown only as `rr`.
+
+### Filter by source (`--source`)
+
+```bash
+river skills list --source rr      # River Review format only
+river skills list --source agent   # Agent Skills format only
+river skills list --source all     # both (default)
+```
+
+## 2. Import Agent Skills (`skills import`)
+
+Converts external `SKILL.md` packages into River Review format and imports them.
+
+```bash
+river skills import
+```
+
+When `--from` is not given, the following directories are scanned by default:
+
+- `.agents/skills`
+- `.github/skills`
+- `.claude/skills`
+
+Converted skills are written to `skills/agent-skills/` by default.
+
+### Specify source and destination (`--from` / `--to`)
+
+```bash
+river skills import --from ./vendor/skills --to ./skills/imported
+```
+
+- `--from <path>` — source directory to scan for `SKILL.md`
+- `--to <path>` — output directory for the converted skills
+
+### Validation mode (`--strict` / `--loose`)
+
+- `--strict` (default) — requires full River Review schema compliance. Missing required fields are reported as failures.
+- `--loose` — requires only minimal fields such as `name` / `description` and auto-fills the rest. Use this to quickly bring in an external skill you want to try locally.
+
+### Validate without writing (`--dry-run`)
+
+```bash
+river skills import --from ./vendor/skills --dry-run
+```
+
+Performs conversion and validation only, without writing files. Use it as a pre-import check.
+
+On completion, the counts of "imported / failed / warnings" are printed. If `failed` is one or more, the exit code is `1`.
+
+## 3. Export skills to Agent Skills format (`skills export`)
+
+Converts River Review-format skills (under `skills/`) into the Agent Skills `SKILL.md` format.
+
+```bash
+river skills export
+```
+
+The default destination is `.agents/skills`. Change it with `--to`.
+
+```bash
+river skills export --to ./dist/agent-skills
+```
+
+### Include accompanying assets (`--include-assets`)
+
+```bash
+river skills export --include-assets
+```
+
+Copies the `references/` / `scripts/` / `prompt/` directories alongside `SKILL.md`. Use it when you want to distribute reference files and scripts together with the skill body.
+
+On completion, the counts of "exported / failed" are printed. If `failed` is one or more, the exit code is `1`.
+
+## Options at a glance
+
+| Subcommand | Option             | Description                                                             |
+| ---------- | ------------------ | ----------------------------------------------------------------------- |
+| `import`   | `--from <path>`    | Source directory to scan for `SKILL.md` (default: standard search dirs) |
+| `import`   | `--to <path>`      | Output directory for converted skills (default: `skills/agent-skills/`) |
+| `import`   | `--strict`         | Require full River Review schema compliance (default)                   |
+| `import`   | `--loose`          | Require only minimal fields and auto-fill the rest                      |
+| `import`   | `--dry-run`        | Validate only, without writing files                                    |
+| `export`   | `--to <path>`      | Output directory for `SKILL.md` (default: `.agents/skills`)             |
+| `export`   | `--include-assets` | Also copy `references/` `scripts/` `prompt/`                            |
+| `list`     | `--source <type>`  | Filter: `rr` / `agent` / `all` (default: `all`)                         |
+
+## Related pages
+
+- [Manifest-driven Skills guide](./agent-skills-codex-cli.en.md) — skill definition format (Markdown / YAML)
+- [Add a new skill (quickest path)](./add-new-skill.en.md)
+- [Validate the skill schema](./validate-skill-schema.en.md)

--- a/pages/guides/manage-skills-cli.md
+++ b/pages/guides/manage-skills-cli.md
@@ -1,0 +1,113 @@
+---
+title: スキルを import / export / list する（CLI）
+---
+
+River Review は Agent Skills（`SKILL.md` パッケージ）と River Review 形式のスキルを相互変換し、一覧表示する CLI サブコマンドを備えています。`river skills import|export|list` を使うと、外部の Agent Skills を取り込んだり、自分のスキルを Agent Skills 形式で書き出したり、現在認識されているスキルを確認したりできます。
+
+> スキル定義のフォーマットそのものについては [Manifest-driven Skills ガイド](./agent-skills-codex-cli.md)、検証手順は [スキルスキーマを検証する](./validate-skill-schema.md) を参照してください。本ページは CLI での import / export / list の使い方に絞っています。
+
+## 1. スキル一覧を確認する（`skills list`）
+
+現在 River Review が認識しているスキルを一覧表示します。
+
+```bash
+river skills list
+```
+
+`ID` / `NAME` / `SOURCE` / `PATH` の表が出力されます。`SOURCE` は次の 2 種類です。
+
+- `rr` — River Review 形式のスキル（`skills/` 配下）
+- `agent` — Agent Skills 形式のパッケージ（`.agents/skills` / `.github/skills` / `.claude/skills` 配下の `SKILL.md`）
+
+すでに River Review 形式として読み込まれている（import 済みの）Agent Skill は重複排除され、`rr` としてのみ表示されます。
+
+### ソースで絞り込む（`--source`）
+
+```bash
+river skills list --source rr      # River Review 形式のみ
+river skills list --source agent   # Agent Skills 形式のみ
+river skills list --source all     # 両方（既定）
+```
+
+## 2. Agent Skills を取り込む（`skills import`）
+
+外部の `SKILL.md` パッケージを River Review 形式に変換して取り込みます。
+
+```bash
+river skills import
+```
+
+`--from` を指定しない場合、次のディレクトリを既定で走査します。
+
+- `.agents/skills`
+- `.github/skills`
+- `.claude/skills`
+
+変換結果は既定で `skills/agent-skills/` に書き出されます。
+
+### 取り込み元・出力先を指定する（`--from` / `--to`）
+
+```bash
+river skills import --from ./vendor/skills --to ./skills/imported
+```
+
+- `--from <path>` — `SKILL.md` を探索するソースディレクトリ
+- `--to <path>` — 変換後スキルの出力ディレクトリ
+
+### 検証モード（`--strict` / `--loose`）
+
+- `--strict`（既定）— River Review スキーマへの完全準拠を要求する。必須フィールドが欠けていれば失敗として報告される。
+- `--loose` — `name` / `description` など最小限のフィールドのみを要求し、欠落フィールドは自動補完する。手元で試したい外部スキルを素早く取り込みたいときに使う。
+
+### 書き込まずに検証する（`--dry-run`）
+
+```bash
+river skills import --from ./vendor/skills --dry-run
+```
+
+ファイルを書き出さずに変換・検証だけを行います。取り込み前の事前チェックに使います。
+
+import 完了時には「imported / failed / warnings」の件数が出力されます。`failed` が 1 件以上ある場合、終了コードは `1` になります。
+
+## 3. スキルを Agent Skills 形式で書き出す（`skills export`）
+
+River Review 形式のスキル（`skills/` 配下）を Agent Skills の `SKILL.md` 形式に変換して書き出します。
+
+```bash
+river skills export
+```
+
+既定の出力先は `.agents/skills` です。`--to` で変更できます。
+
+```bash
+river skills export --to ./dist/agent-skills
+```
+
+### 付随アセットも含める（`--include-assets`）
+
+```bash
+river skills export --include-assets
+```
+
+`references/` / `scripts/` / `prompt/` ディレクトリを `SKILL.md` と並べてコピーします。スキル本体だけでなく、参照ファイルやスクリプトもまとめて配布したいときに指定します。
+
+export 完了時には「exported / failed」の件数が出力されます。`failed` が 1 件以上ある場合、終了コードは `1` になります。
+
+## オプション早見表
+
+| サブコマンド | オプション         | 説明                                                                  |
+| ------------ | ------------------ | --------------------------------------------------------------------- |
+| `import`     | `--from <path>`    | `SKILL.md` を探索するソースディレクトリ（既定: 標準探索ディレクトリ） |
+| `import`     | `--to <path>`      | 変換後スキルの出力ディレクトリ（既定: `skills/agent-skills/`）        |
+| `import`     | `--strict`         | River Review スキーマへの完全準拠を要求（既定）                       |
+| `import`     | `--loose`          | 最小限のフィールドのみ要求し欠落を自動補完                            |
+| `import`     | `--dry-run`        | ファイルを書き出さずに検証のみ実行                                    |
+| `export`     | `--to <path>`      | `SKILL.md` の出力ディレクトリ（既定: `.agents/skills`）               |
+| `export`     | `--include-assets` | `references/` `scripts/` `prompt/` も併せてコピー                     |
+| `list`       | `--source <type>`  | フィルタ: `rr` / `agent` / `all`（既定: `all`）                       |
+
+## 関連ページ
+
+- [Manifest-driven Skills ガイド](./agent-skills-codex-cli.md) — スキル定義フォーマット（Markdown / YAML）
+- [スキルを追加する（最短手順）](./add-new-skill.md)
+- [スキルスキーマを検証する](./validate-skill-schema.md)


### PR DESCRIPTION
## 概要

`river skills import|export|list` の how-to ガイドを新規追加（監査 gap #8 / #1011 項目2）。これまで `docs/CLI-architecture.md` の表のみだった使い方を、JA/EN ペアの guides ページとして整備した。

## 変更内容

- `pages/guides/manage-skills-cli.md`（新規, JA）
- `pages/guides/manage-skills-cli.en.md`（新規, EN）
- `pages/guides/_meta.json`: Skills セクションに登録

## 記載内容

- `skills list`（`--source rr|agent|all`）— 認識中スキルの一覧、rr/agent の重複排除挙動
- `skills import`（`--from` / `--to` / `--strict` / `--loose` / `--dry-run`）— 既定探索ディレクトリ、既定出力先 `skills/agent-skills/`、検証モード、exit code
- `skills export`（`--to` / `--include-assets`）— 既定出力先 `.agents/skills`、アセット同梱
- オプション早見表

すべて `src/lib/agent-skill-bridge.mjs` の実装（既定値・探索ディレクトリ・終了コード）を読んで記載。

## 検証

- `npm run check:bilingual` — 83 paired / 0 missing / 0 orphaned
- `npm run check:dashes` — pass
- `npx prettier --check` — pass
- `npx markdownlint` — clean
- `npx textlint pages/guides/manage-skills-cli.md` — clean

## 関連

- #1011 項目2（skills import/export/list ガイド）
- #1011 項目5/6 は #1019 で対応済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)