### PR TITLE
docs(guides): add Run store & regression comparison how-to (#1011)

### DIFF
--- a/pages/guides/_meta.json
+++ b/pages/guides/_meta.json
@@ -29,6 +29,7 @@
   "planner-eval-dataset": "Planner評価セット（オフライン評価）",
   "planner-evaluation": "Skill Planner の評価と最適化のためのミニガイド",
   "use-riverbed-memory": "Riverbed Memory を使用する",
+  "track-runs-and-regressions": "Run store と回帰比較（runs / --baseline）",
   "tracing": "Tracing / Observability",
   "agent-skills-codex-cli": "Manifest-driven Skills ガイド",
   "pr-review-agent-skills": "PR/品質レビュー向け Agent Skills カタログ",

--- a/pages/guides/track-runs-and-regressions.en.md
+++ b/pages/guides/track-runs-and-regressions.en.md
@@ -1,0 +1,156 @@
+---
+title: Run store and regression comparison (runs / --baseline)
+---
+
+River Review can persist review runs to a project-local **Run store** (`.river/runs/`) and compare against past runs to see regressions (new vs. resolved findings). Wired into CI, this lets you mechanically track "did this PR add findings?".
+
+> For the full list of flags and subcommands, see [Stable Interfaces (CLI reference)](../reference/stable-interfaces.md). This page focuses on the how-to.
+
+## Overview
+
+| What you want                                | Command                                   |
+| -------------------------------------------- | ----------------------------------------- |
+| Save a review run                            | `river run <path> --save`                 |
+| List saved runs                              | `river runs list`                         |
+| Diff (regression of) two saved runs          | `river runs diff <run-id-1> <run-id-2>`   |
+| See an aggregate dashboard across saved runs | `river runs summary`                      |
+| Compare against an arbitrary baseline JSON   | `river run <path> --baseline <prev.json>` |
+
+## 1. Save a review run (`--save`)
+
+Passing `--save` to `river run` persists the result to the Run store.
+
+```bash
+river run . --save
+```
+
+On success, the destination is printed to stderr.
+
+```text
+Run saved: 2026-06-06T08-30-00-000Z-a1b2c3 → /path/to/repo/.river/runs/2026-06-06T08-30-00-000Z-a1b2c3.json
+```
+
+### Where the Run store lives
+
+- Default: **`.river/runs/`** directly under the reviewed repository (project-local)
+- Fallback when no repository can be resolved: **`~/.river/runs/`** (global)
+
+Each run is saved as a single `<runId>.json` file. The `runId` is an ISO timestamp plus a short hash (e.g. `2026-06-06T08-30-00-000Z-a1b2c3`), designed so that lexicographic filename order equals chronological order.
+
+> `.river/runs/` is a run log and does not need to be committed. It is common to add it to `.gitignore`.
+
+### What is saved
+
+Each run record (JSON) contains:
+
+- `runId` / `timestamp` / `phase` / `reviewMode`
+- `mergeBase` / `defaultBranch` / `changedFiles`
+- `findings` and `suppressedFindings`
+- `finalSummary`: `findingsCount` / `suppressedCount` / `overviewCount` / `changedFilesCount` / `tokenEstimate`
+
+## 2. List saved runs (`river runs list`)
+
+Lists the runs in the Run store, newest first.
+
+```bash
+river runs list
+```
+
+```text
+Stored runs (/path/to/repo/.river/runs):
+
+  2026-06-06T08-30-00-000Z-a1b2c3  phase=midstream  findings=4  suppressed=1  files=7  2026-06-06T08:30:00.000Z
+  2026-06-05T17-10-00-000Z-d4e5f6  phase=midstream  findings=6  suppressed=0  files=5  2026-06-05T17:10:00.000Z
+```
+
+If there are no saved runs, `No stored runs found in ...` is printed.
+
+## 3. Compare two runs (`river runs diff`)
+
+Specify two saved runs by `runId` to compare finding regressions.
+
+```bash
+river runs diff 2026-06-05T17-10-00-000Z-d4e5f6 2026-06-06T08-30-00-000Z-a1b2c3
+```
+
+It prints a `## Regression Review Summary` Markdown block.
+
+| Item              | Meaning                                                         |
+| ----------------- | --------------------------------------------------------------- |
+| New findings      | Present in the second run but not the first (a regression)      |
+| Resolved findings | Present in the first run but gone in the second (resolved)      |
+| Persisting        | Present in both, with a small score change                      |
+| Score changed     | Present in both, but the composite score moved by ±0.05 or more |
+| Regression score  | `New − Resolved`. Positive means a net increase (worse)         |
+
+The New / Resolved / Score changes sections list the affected file and the finding content.
+
+> Finding identity is determined by a fingerprint. Findings with the same file location and rule are treated as identical.
+
+## 4. Aggregate dashboard (`river runs summary`)
+
+Prints a Markdown dashboard aggregated across the whole Run store.
+
+```bash
+river runs summary
+```
+
+```text
+## River Review Dashboard
+
+| Metric | Value |
+|---|---|
+| Total runs | 12 |
+| Total findings | 48 |
+| Total suppressed | 6 |
+| Suppress rate | 11.1% |
+| Avg findings/run | 4.0 |
+```
+
+It also prints Severity / Confidence distribution tables. Use it to grasp quality trends across many runs.
+
+## 5. Compare against an arbitrary baseline (`--baseline`)
+
+Whereas `runs diff` compares two saved runs, `--baseline` compares a **freshly executed result against any past review JSON**. This suits keeping a baseline generated on `main` as a file and checking for regressions on a PR branch.
+
+```bash
+river run . --baseline ./baseline-findings.json
+```
+
+The JSON passed to `--baseline` accepts either form:
+
+- A bare array of findings (`[ { ... }, { ... } ]`)
+- An object with a `findings` (or `issues`) key (`{ "findings": [ ... ] }`)
+
+The output is the same `## Regression Review Summary` format as `runs diff`. If the comparison fails, `Warning: --baseline comparison failed: ...` is printed and the review itself continues.
+
+### Creating a baseline file
+
+If you save a result with `--output json`, you can reuse it directly as a baseline.
+
+```bash
+# Create the baseline on main
+git switch main
+river run . --output json > baseline-findings.json
+
+# Check for regressions on the PR branch
+git switch feature/my-change
+river run . --baseline ./baseline-findings.json
+```
+
+## Example CI integration
+
+A minimal example that flags a net increase in findings on a PR.
+
+```bash
+# Assumes the baseline (main's findings) is kept as an artifact
+river run . --baseline ./baseline-findings.json --save
+```
+
+Combining `--save` accumulates each PR's run in the Run store, so you can later review trends with `river runs summary`.
+
+## Related pages
+
+- [Stable Interfaces (CLI reference)](../reference/stable-interfaces.md) — flag and subcommand list
+- [Use Riverbed Memory](./use-riverbed-memory.md) — suppressing findings
+- [Tracing / Observability](./tracing.md)

--- a/pages/guides/track-runs-and-regressions.en.md
+++ b/pages/guides/track-runs-and-regressions.en.md
@@ -85,7 +85,7 @@ It prints a `## Regression Review Summary` Markdown block.
 
 The New / Resolved / Score changes sections list the affected file and the finding content.
 
-> Finding identity is determined by a fingerprint. Findings with the same file location and rule are treated as identical.
+> Finding identity is determined by a fingerprint. Findings with the same file path, rule, and message gist are treated as identical; line-number shifts are ignored.
 
 ## 4. Aggregate dashboard (`river runs summary`)
 

--- a/pages/guides/track-runs-and-regressions.md
+++ b/pages/guides/track-runs-and-regressions.md
@@ -48,7 +48,7 @@ Run saved: 2026-06-06T08-30-00-000Z-a1b2c3 → /path/to/repo/.river/runs/2026-06
 - `findings`（指摘）/ `suppressedFindings`（抑制された指摘）
 - `finalSummary`: `findingsCount` / `suppressedCount` / `overviewCount` / `changedFilesCount` / `tokenEstimate`
 
-## 2. 保存済み実行の一覧（`river runs list`)
+## 2. 保存済み実行の一覧（`river runs list`）
 
 Run store に保存された実行を新しい順で表示します。
 
@@ -65,7 +65,7 @@ Stored runs (/path/to/repo/.river/runs):
 
 保存済み実行がない場合は `No stored runs found in ...` と表示されます。
 
-## 3. 2 つの実行を比較する（`river runs diff`)
+## 3. 2 つの実行を比較する（`river runs diff`）
 
 保存済みの 2 実行を `runId` で指定し、指摘の回帰を比較します。
 
@@ -85,9 +85,9 @@ river runs diff 2026-06-05T17-10-00-000Z-d4e5f6 2026-06-06T08-30-00-000Z-a1b2c3
 
 New / Resolved / Score changes の各セクションには、対象ファイルと指摘内容が一覧表示されます。
 
-> 指摘の同一性は fingerprint で判定されます。ファイル位置やルールが同じ指摘は同一とみなされます。
+> 指摘の同一性は fingerprint で判定されます。ファイルパス・ルール・指摘内容（メッセージ要旨）が同じ指摘は同一とみなされ、行番号のズレは無視されます。
 
-## 4. 集計ダッシュボード（`river runs summary`)
+## 4. 集計ダッシュボード（`river runs summary`）
 
 Run store 全体を集計した Markdown ダッシュボードを表示します。
 
@@ -109,7 +109,7 @@ river runs summary
 
 加えて、Severity / Confidence の分布表が出力されます。複数実行を横断した品質トレンドの把握に使います。
 
-## 5. 任意の baseline と比較する（`--baseline`)
+## 5. 任意の baseline と比較する（`--baseline`）
 
 `runs diff` が「保存済み 2 実行の比較」なのに対し、`--baseline` は **新しく実行した結果を、任意の過去レビュー JSON と比較**します。`main` ブランチ等で生成した基準（baseline）をファイルとして持っておき、PR ブランチで回帰チェックする用途に向きます。
 
@@ -143,7 +143,7 @@ river run . --baseline ./baseline-findings.json
 PR で指摘が純増したら気付けるようにする最小例です。
 
 ```bash
-# 基準（main の findings）を成果物として持っている前提
+# 基準（main の指摘）を成果物として持っている前提
 river run . --baseline ./baseline-findings.json --save
 ```
 

--- a/pages/guides/track-runs-and-regressions.md
+++ b/pages/guides/track-runs-and-regressions.md
@@ -1,0 +1,156 @@
+---
+title: Run store と回帰比較（runs / --baseline）
+---
+
+River Review はレビュー実行（run）の結果をプロジェクトローカルの **Run store**（`.river/runs/`）に保存し、過去の実行と比較して回帰（新規・解消された指摘）を確認できます。CI に組み込めば「この PR で指摘が増えていないか」を機械的に追跡できます。
+
+> 各フラグ・サブコマンドの一覧は [Stable Interfaces（CLI リファレンス）](../reference/stable-interfaces.md) を参照してください。本ページは使い方（how-to）に絞っています。
+
+## 全体像
+
+| やりたいこと                               | コマンド                                  |
+| ------------------------------------------ | ----------------------------------------- |
+| レビュー実行を保存する                     | `river run <path> --save`                 |
+| 保存済み実行の一覧を見る                   | `river runs list`                         |
+| 保存済み実行 2 つの差分（回帰）を見る      | `river runs diff <run-id-1> <run-id-2>`   |
+| 保存済み実行全体の集計ダッシュボードを見る | `river runs summary`                      |
+| 任意の baseline JSON と比較する            | `river run <path> --baseline <prev.json>` |
+
+## 1. レビュー実行を保存する（`--save`）
+
+`river run` に `--save` を付けると、実行結果が Run store に保存されます。
+
+```bash
+river run . --save
+```
+
+保存に成功すると、標準エラー出力に保存先が表示されます。
+
+```text
+Run saved: 2026-06-06T08-30-00-000Z-a1b2c3 → /path/to/repo/.river/runs/2026-06-06T08-30-00-000Z-a1b2c3.json
+```
+
+### Run store の場所
+
+- 既定: レビュー対象リポジトリ直下の **`.river/runs/`**（プロジェクトローカル）
+- リポジトリが特定できない場合のフォールバック: **`~/.river/runs/`**（グローバル）
+
+各実行は `<runId>.json` という 1 ファイルとして保存されます。`runId` は ISO タイムスタンプ + 短いハッシュ（例: `2026-06-06T08-30-00-000Z-a1b2c3`）で構成され、ファイル名の辞書順が時系列順と一致するよう設計されています。
+
+> `.river/runs/` は実行ログであり、リポジトリにコミットする必要はありません。`.gitignore` に追加して運用するのが一般的です。
+
+### 保存される内容
+
+各 run record（JSON）には次の情報が含まれます。
+
+- `runId` / `timestamp` / `phase` / `reviewMode`
+- `mergeBase` / `defaultBranch` / `changedFiles`
+- `findings`（指摘）/ `suppressedFindings`（抑制された指摘）
+- `finalSummary`: `findingsCount` / `suppressedCount` / `overviewCount` / `changedFilesCount` / `tokenEstimate`
+
+## 2. 保存済み実行の一覧（`river runs list`)
+
+Run store に保存された実行を新しい順で表示します。
+
+```bash
+river runs list
+```
+
+```text
+Stored runs (/path/to/repo/.river/runs):
+
+  2026-06-06T08-30-00-000Z-a1b2c3  phase=midstream  findings=4  suppressed=1  files=7  2026-06-06T08:30:00.000Z
+  2026-06-05T17-10-00-000Z-d4e5f6  phase=midstream  findings=6  suppressed=0  files=5  2026-06-05T17:10:00.000Z
+```
+
+保存済み実行がない場合は `No stored runs found in ...` と表示されます。
+
+## 3. 2 つの実行を比較する（`river runs diff`)
+
+保存済みの 2 実行を `runId` で指定し、指摘の回帰を比較します。
+
+```bash
+river runs diff 2026-06-05T17-10-00-000Z-d4e5f6 2026-06-06T08-30-00-000Z-a1b2c3
+```
+
+`## Regression Review Summary` という Markdown が出力されます。
+
+| 項目              | 意味                                                     |
+| ----------------- | -------------------------------------------------------- |
+| New findings      | 1 つ目になく 2 つ目に現れた指摘（回帰）                  |
+| Resolved findings | 1 つ目にあり 2 つ目で消えた指摘（解消）                  |
+| Persisting        | 両方に存在し、スコア変化が小さい指摘                     |
+| Score changed     | 両方に存在するが composite スコアが ±0.05 以上動いた指摘 |
+| Regression score  | `New − Resolved`。正なら指摘が純増（悪化）               |
+
+New / Resolved / Score changes の各セクションには、対象ファイルと指摘内容が一覧表示されます。
+
+> 指摘の同一性は fingerprint で判定されます。ファイル位置やルールが同じ指摘は同一とみなされます。
+
+## 4. 集計ダッシュボード（`river runs summary`)
+
+Run store 全体を集計した Markdown ダッシュボードを表示します。
+
+```bash
+river runs summary
+```
+
+```text
+## River Review Dashboard
+
+| Metric | Value |
+|---|---|
+| Total runs | 12 |
+| Total findings | 48 |
+| Total suppressed | 6 |
+| Suppress rate | 11.1% |
+| Avg findings/run | 4.0 |
+```
+
+加えて、Severity / Confidence の分布表が出力されます。複数実行を横断した品質トレンドの把握に使います。
+
+## 5. 任意の baseline と比較する（`--baseline`)
+
+`runs diff` が「保存済み 2 実行の比較」なのに対し、`--baseline` は **新しく実行した結果を、任意の過去レビュー JSON と比較**します。`main` ブランチ等で生成した基準（baseline）をファイルとして持っておき、PR ブランチで回帰チェックする用途に向きます。
+
+```bash
+river run . --baseline ./baseline-findings.json
+```
+
+`--baseline` に渡す JSON は次のいずれかの形式を受け付けます。
+
+- findings の配列そのもの（`[ { ... }, { ... } ]`）
+- `findings`（または `issues`）キーを持つオブジェクト（`{ "findings": [ ... ] }`）
+
+出力は `runs diff` と同じ `## Regression Review Summary` 形式です。比較に失敗した場合は `Warning: --baseline comparison failed: ...` が出力され、レビュー自体は継続します。
+
+### baseline ファイルの作り方
+
+`--output json` で実行結果を保存しておけば、そのまま baseline として再利用できます。
+
+```bash
+# main で基準を作成
+git switch main
+river run . --output json > baseline-findings.json
+
+# PR ブランチで回帰チェック
+git switch feature/my-change
+river run . --baseline ./baseline-findings.json
+```
+
+## CI への組み込み例
+
+PR で指摘が純増したら気付けるようにする最小例です。
+
+```bash
+# 基準（main の findings）を成果物として持っている前提
+river run . --baseline ./baseline-findings.json --save
+```
+
+`--save` を併用すると、各 PR の実行も Run store に蓄積され、後から `river runs summary` でトレンドを確認できます。
+
+## 関連ページ
+
+- [Stable Interfaces（CLI リファレンス）](../reference/stable-interfaces.md) — フラグ・サブコマンド一覧
+- [Riverbed Memory を使用する](./use-riverbed-memory.md) — 指摘の抑制（suppression）
+- [Tracing / Observability](./tracing.md)


### PR DESCRIPTION
## 概要

`--save` / `.river/runs/` / `river runs list|diff|summary` / `--baseline` の使い方ページを新規追加（監査 gap #1/#5/#6、#1011 項目1, **major**）。これまで reference のフラグ表（`stable-interfaces.md`）にしか記載がなかった Run store と回帰比較の how-to を、JA/EN ペアの guides ページとして整備した。

## 変更内容

- `pages/guides/track-runs-and-regressions.md`（新規, JA）
- `pages/guides/track-runs-and-regressions.en.md`（新規, EN）
- `pages/guides/_meta.json`: Advanced セクション（use-riverbed-memory の隣）に登録

## 記載内容

- `river run <path> --save` — Run store への保存、出力メッセージ、`.river/runs/` レイアウト（既定 `<repo>/.river/runs/`、フォールバック `~/.river/runs/`）、runId 形式、run record フィールド
- `river runs list` — 保存済み実行の一覧（新しい順）
- `river runs diff <id1> <id2>` — 保存済み 2 実行の回帰比較（New/Resolved/Persisting/Score changed/Regression score）
- `river runs summary` — Run store 全体の集計ダッシュボード
- `river run <path> --baseline <prev.json>` — 任意の過去 JSON との回帰比較、受け付ける JSON 形式、baseline ファイルの作り方、CI 組み込み例

すべて `src/lib/result-store.mjs` / `src/lib/review-differ.mjs` / `src/cli.mjs` の実装（既定パス・出力形式・runId 生成・終了挙動）を読んで記載。

## 検証

- `npm run check:bilingual` — 84 paired / 0 missing / 0 orphaned
- `npm run check:dashes` — pass
- `npx prettier --check` — pass
- `npx markdownlint` — clean
- `npx textlint pages/guides/track-runs-and-regressions.md` — clean（exit 0）
- `node src/cli.mjs run . --dry-run --save` で実挙動を確認（生成された runs JSON は gitignore 済・コミット対象外）

## 関連

- #1011 項目1（Result store / runs / regression の文書化, major）
- 項目2/5/6 は #1019・#1020 で対応済み。残 minor（項目3/4）は追従 PR 予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)