### PR TITLE
feat(skills): design-quality guidance for encapsulation & over-abstraction (#1026)

### DIFF
--- a/skills/midstream/agent-code-quality/SKILL.md
+++ b/skills/midstream/agent-code-quality/SKILL.md
@@ -44,6 +44,8 @@ Why: 可読性と保守性を中心に、コード品質の基本的な劣化を
 ## Guidance
 
 - Check names and boundaries keep responsibilities clear; flatten deep nesting with guard clauses.
+- Flag names too broad to convey intent (`data`, `info`, `manager`, `handler`, `util`, `current`), unshared abbreviations, and the same concept named differently (or different concepts sharing a name).
+- Flag encapsulation leaks: code that reaches deep into an object's internals (`a.b.c.type === 'x'`), pulls a primitive out of a value object to branch on it externally, or exposes internal state through getters. Prefer Tell-Don't-Ask (e.g. `user.subscription.isPremium()` over `user.subscription.plan.type === 'premium'`).
 - Spot duplicated logic or unclear error handling/logging that harms readability.
 - Recommend small refactors that improve clarity without changing behaviour.
 - Prefer consistency with surrounding patterns instead of new conventions.
@@ -51,6 +53,8 @@ Why: 可読性と保守性を中心に、コード品質の基本的な劣化を
 ## Non-goals
 
 - 個人の好みや微細なスタイル差のみで指摘しない。
+- 型/値オブジェクトの設計（primitive obsession・brand 型・discriminated union）は `rr-midstream-type-driven-design-001` に委譲する。
+- null/undefined 契約は `rr-midstream-typescript-nullcheck-001`、例外の握りつぶし検出は `rr-midstream-logging-observability-001` に委譲する。
 
 ## False-positive guards
 

--- a/skills/midstream/agent-code-refactoring/SKILL.md
+++ b/skills/midstream/agent-code-refactoring/SKILL.md
@@ -48,12 +48,15 @@ Why: 挙動を変えずに設計を整えるためのリファクタリング手
 
 - Plan safety nets (tests/smoke) before refactors; keep steps small and reversible.
 - Extract focused functions/constants to reduce nesting and magic values without changing behaviour.
+- Flag over-abstraction (the reverse of duplication): premature DRY that couples code with different reasons to change, unnecessary layers/indirection/delegation, and interfaces/generics introduced for a single current caller. Distinguish "same concept duplicated" from "coincidentally similar".
+- Flag over-classification: a class/type where a function or plain data would be clearer, and speculative extensibility ("future-proofing") not needed by the current diff.
 - Align error handling/logging with neighbours and rerun tests after each step.
 - Call out areas needing tests before deeper refactors.
 
 ## Non-goals
 
 - ビジネス仕様を変える提案や大規模再設計の押し付けは避ける。
+- 概念モデリング・型設計は `rr-midstream-type-driven-design-001`、テスト安定性（I/O・日時・乱数依存）は `rr-downstream-flaky-test-001` に委譲する。
 
 ## False-positive guards
 


### PR DESCRIPTION
## What

Fills the two genuinely-uncovered design-quality gaps from #1026 by extending existing skills (no new skill), per the issue's decision and the Gemini design review:

- **agent-code-quality** — adds Tell-Don't-Ask / encapsulation-leak detection (`a.b.c.type === 'x'` → `isPremium()`) and broad-name detection (`data`/`manager`/`util`/`current`, unshared abbreviations, concept↔name mismatches).
- **agent-code-refactoring** — adds over-abstraction (premature DRY) and over-classification detection — the *reverse* of duplication (unnecessary layers, single-caller interfaces/generics, speculative extensibility).

## Why

#1026 confirmed (via SKILL.md audit) that concept modeling / value objects / types / testability / swallowed-exceptions are already covered by `type-driven-design`, `typescript-nullcheck`, `flaky-test`, `logging-observability`. Only **encapsulation** and **over-abstraction/over-classification** were uncovered. This adds exactly those, and adds **Non-goals delegation** lines so the skills don't double-fire with the existing ones.

## Changes

- `skills/midstream/agent-code-quality/SKILL.md`: Guidance + Non-goals.
- `skills/midstream/agent-code-refactoring/SKILL.md`: Guidance + Non-goals.

Body-only edits (no frontmatter change, no new skill, no src change).

## Verification

- `npm run skills:validate` — all skills pass.
- `npm run check:dashes` — clean.
- No code references these skills' prose; no dist rebuild needed (skills load from disk at runtime).

Closes #1026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)