### PR TITLE
docs(.river): incident-viewpoint injection via rules.d/incidents.md (#1025)

### DIFF
--- a/.river/README.md
+++ b/.river/README.md
@@ -14,3 +14,26 @@ Tips:
 
 - リポジトリの秘密情報は書かない（例示する場合はダミー値で）
 - 運用で変更があれば `rules.md` を更新し、レビュー基準を共有する
+
+## 過去インシデントを観点として注入する（rules.d/incidents.md）
+
+過去の障害・再発させたくないバグを「レビュー観点」として能動的に注入したい場合は、`.river/rules.d/incidents.md` に記述します（自動連結注入されます）。これは Riverbed Memory の suppression（過去指摘の抑制）とは逆方向 ―― 過去インシデントを**思い出させる**ための仕組みです。
+
+記述例:
+
+```markdown
+# 過去インシデント由来の再発防止観点
+
+## INC-2025-08: 課金ステータスの逆遷移で二重請求
+
+- 事象: `approved` から `pending` への逆遷移を許容し、請求処理が重複した。
+- 影響パス: `app/Services/Billing/**`, `app/Models/Subscription*`
+- レビュー観点: 課金ステータスの遷移が一方向か。逆遷移・再入を型/ガードで防いでいるか。
+
+## INC-2025-11: 認可チェック漏れで他テナントのデータ参照
+
+- 影響パス: `app/Http/Controllers/**`, `app/api/**`
+- レビュー観点: 取得系 API に owner/admin の認可チェックがあるか。テナント境界を跨いでいないか。
+```
+
+対象パスに応じて観点を当てたい場合は、影響パスを `.river/risk-map.yaml` の `require_human_review` / `escalate` と組み合わせる（[examples/risk-map](../examples/risk-map/) 参照）。


### PR DESCRIPTION
## What

Documents how to inject **past incidents as active review viewpoints** using `.river/rules.d/incidents.md` (auto-concatenated by the rules.d loader from #1032) + `risk-map.yaml` path routing. Includes a concrete `incidents.md` example.

## Why

Closes #1025. The issue's three parts are now complete:
- ✅ multi-file rules (`.river/rules.d/*.md`) — #1032
- ✅ review depth (`--depth`) — #1033
- ✅ **incident-viewpoint injection** — achieved via the existing rules.d loader + risk-map (no new mechanism), per the design decision recorded on #1025. This PR adds the usage doc/example that completes it.

Note the direction: this is the **reverse of suppression** (Riverbed Memory silences past findings; incidents.md *reminds* the reviewer of past failures).

## Changes

- `.river/README.md`: incident-viewpoint section + example.

## Verification

- `npm run fix:dashes` — no changes; `npm run lint:md` — clean.

Closes #1025.

🤖 Generated with [Claude Code](https://claude.com/claude-code)