### PR TITLE
chore(registry): catalog the two missing plangate skills (drift fix, refs #976)

### DIFF
--- a/skills/registry.yaml
+++ b/skills/registry.yaml
@@ -814,6 +814,28 @@ skills:
     recommended: false
     description: 'pbi-input, plan, todo, test-cases 間の整合性をチェックし、実装着手前の仕様漏れを検知する'
 
+  - id: rr-upstream-plangate-exec-conformance-001
+    version: '0.1.0'
+    name: 'PlanGate Exec Conformance Guard'
+    path: skills/upstream/rr-upstream-plangate-exec-conformance-001/SKILL.md
+    category: upstream
+    phase: upstream
+    tags: [plangate, conformance, exec, plan, todo, upstream]
+    severity: major
+    recommended: false
+    description: '実装差分が plan / todo / test-cases アーティファクトの方針と一致しているかを検査し、逸脱・漏れ・意図外変更を検知する'
+
+  - id: rr-upstream-plangate-verification-audit-001
+    version: '0.1.0'
+    name: 'PlanGate 検証監査 (W チェック)'
+    path: skills/upstream/rr-upstream-plangate-verification-audit-001/SKILL.md
+    category: upstream
+    phase: upstream
+    tags: [plangate, verification, w-check, audit, upstream]
+    severity: major
+    recommended: false
+    description: '既存のレビュー結果 (review-self / review-external) を再点検し、漏れ・誤検知・ハルシネーション・根拠欠落を検出する W チェック skill'
+
 # Recommended skill sets
 recommendations:
   basic:


### PR DESCRIPTION
## What

Adds the two missing PlanGate skills to the `skills:` catalog in `skills/registry.yaml`:
- `rr-upstream-plangate-exec-conformance-001`
- `rr-upstream-plangate-verification-audit-001`

## Why

Both skills exist on disk and are loaded at runtime, but were absent from the registry catalog while their sibling `rr-upstream-plangate-plan-integrity-001` was listed — a registry drift flagged as a follow-up in `docs/development/review-gates-design.md` (#976). Cataloging them makes the PlanGate family consistent and discoverable (e.g. for future skill-set bundles).

## Safety

- Metadata copied verbatim from each `SKILL.md` frontmatter (id / name / path / category / phase / tags / severity / description).
- **Additive only.** No validator enforces catalog completeness, so this changes no behavior — `loadSkills` already loads them from disk; this just records them in the catalog.
- No src change → no dist rebuild.

## Verification

- `npm run meta:validate` — OK. `npm run skills:validate` — clean.
- registry.yaml parses; both ids present; catalog size 74.
- `npm test` — 1171 pass / 0 fail.

Refs #976.

🤖 Generated with [Claude Code](https://claude.com/claude-code)