### PR TITLE
chore(registry): sync exec-conformance test-cases tag (follow-up to #1043)

### DIFF
--- a/skills/registry.yaml
+++ b/skills/registry.yaml
@@ -820,7 +820,7 @@ skills:
     path: skills/upstream/rr-upstream-plangate-exec-conformance-001/SKILL.md
     category: upstream
     phase: upstream
-    tags: [plangate, conformance, exec, plan, todo, upstream]
+    tags: [plangate, conformance, exec, plan, todo, test-cases, upstream]
     severity: major
     recommended: false
     description: '実装差分が plan / todo / test-cases アーティファクトの方針と一致しているかを検査し、逸脱・漏れ・意図外変更を検知する'


### PR DESCRIPTION
Follow-up to gemini-code-assist on #1043: the catalog entry for `rr-upstream-plangate-exec-conformance-001` omitted the `test-cases` tag present in its SKILL.md frontmatter. Sync them. Additive metadata only; `meta:validate` OK. Refs #976.

🤖 Generated with [Claude Code](https://claude.com/claude-code)