### PR TITLE
docs(architecture): CLI-first surface + resolution order (#1045 item 1)

### DIFF
--- a/pages/explanation/river-architecture.en.md
+++ b/pages/explanation/river-architecture.en.md
@@ -60,3 +60,27 @@ sequenceDiagram
   River->>River: select skills (selected/skipped)
   River-->>Dev: plan + findings (+ debug)
 ```
+
+## CLI-first execution surface and resolution order
+
+The **canonical execution surface of River Review is the CLI**. GitHub Action / Claude Code command / Codex skill / MCP / shell are designed as thin wrappers that call this CLI (e.g. the GitHub Action is a thin adapter: `runners/github-action/src/index.mjs` merely imports `src/cli.mjs`). Review judgement, skill resolution, and gate decisions live in the CLI, not in each surface.
+
+- **Command name**: both `river` and `river-review` bins point to `src/cli.mjs`. In agent-facing docs and examples, prefer `river-review` to avoid ambiguity.
+- **Subcommands**: `river-review run <path>` (local diff review), `river-review review plan|exec|verify` (artifact-driven gate), `river-review skills <subcommand>`.
+- **JSON is the first-class output**: the Review Artifact conforming to `schemas/review-artifact.schema.json` (`version: "1"`) is the machine-readable contract. PR inline comments / Checks / Markdown summary / dashboard / agent handoff are adapters that transform this JSON (`--output markdown` is a human-facing derived view).
+
+### skill / gate / config resolution order
+
+Which skills / gates / rules are ultimately selected is resolved deterministically and can be inspected via `--debug` output (`plan.selectedSkills` / `skippedSkills` with reasons). Precedence (highest first):
+
+1. **CLI explicit options** — `--config` / `--skill-set` / `--context` / `--dependency`, etc.
+2. **Repository local** — `.river-review.{json,yaml,yml}` (`src/config/loader.mjs`), `.river/rules.md` + `.river/rules.d/*.md`, `skills/registry.yaml`
+3. **Built-in** — bundled skills and defaults
+
+> A user-global tier (`~/.river-review/`) is not implemented yet ([#1045](https://github.com/s977043/river-review/issues/1045) follow-up). When added, it slots between "Repository local" and "Built-in".
+
+### No auto-update
+
+The CLI / Action ship no auto-update mechanism. Consumers pin and update versions explicitly (GitHub Action version pinning, npm lockfiles). This is a deliberate choice favoring deterministic execution and auditability.
+
+See also: gate responsibilities in [Review Gates Design](../../docs/development/review-gates-design.md), and config options in [config-schema](../reference/config-schema.en.md).

--- a/pages/explanation/river-architecture.en.md
+++ b/pages/explanation/river-architecture.en.md
@@ -73,7 +73,7 @@ The **canonical execution surface of River Review is the CLI**. GitHub Action / 
 
 Which skills / gates / rules are ultimately selected is resolved deterministically and can be inspected via `--debug` output (`plan.selectedSkills` / `skippedSkills` with reasons). Precedence (highest first):
 
-1. **CLI explicit options** — `--config` / `--skill-set` / `--context` / `--dependency`, etc.
+1. **CLI explicit options** — `--skill-set` / `--context` / `--dependency`, etc. (the config file is auto-detected from the repo root, not via a `--config` flag; see below)
 2. **Repository local** — `.river-review.{json,yaml,yml}` (`src/config/loader.mjs`), `.river/rules.md` + `.river/rules.d/*.md`, `skills/registry.yaml`
 3. **Built-in** — bundled skills and defaults
 

--- a/pages/explanation/river-architecture.md
+++ b/pages/explanation/river-architecture.md
@@ -58,3 +58,27 @@ sequenceDiagram
   River->>River: select skills (selected/skipped)
   River-->>Dev: plan + findings (+ debug)
 ```
+
+## CLI-first 実行面と解決順序
+
+River Review の**正規実行面は CLI** です。GitHub Action / Claude Code command / Codex skill / MCP / shell は、原則としてこの CLI を呼ぶ薄い wrapper として設計します。たとえば GitHub Action は `runners/github-action/src/index.mjs` が `src/cli.mjs` を import するだけの thin adapter です。レビュー判断・skill 解決・gate 判定は CLI 側に集約し、各 surface には持たせません。
+
+- **コマンド名**: bin は `river` と `river-review` の両方が `src/cli.mjs` を指す。agent 向けの説明・examples では、曖昧さを避けるため `river-review` を第一候補とする。
+- **サブコマンド**: `river-review run <path>`（ローカル diff レビュー）、`river-review review plan|exec|verify`（artifact-driven gate）、`river-review skills <subcommand>`。
+- **JSON が一次成果物**: `schemas/review-artifact.schema.json`（`version: "1"`）に準拠した Review Artifact が machine-readable 契約である。PR inline comment / Check / Markdown summary / dashboard / agent handoff は、この JSON を変換する adapter として扱う（`--output markdown` は人間向け派生表示）。
+
+### skill / gate / config の解決順序
+
+最終的にどの skill / gate / rule が採用されたかは決定論的に解決され、`--debug` 出力の `plan.selectedSkills` / `skippedSkills`（理由付き）で確認できます。優先順位は次のとおり（上が優先）:
+
+1. **CLI 明示指定** — `--config` / `--skill-set` / `--context` / `--dependency` など
+2. **リポジトリローカル** — `.river-review.{json,yaml,yml}`（`src/config/loader.mjs`）、`.river/rules.md` + `.river/rules.d/*.md`、`skills/registry.yaml`
+3. **ビルトイン** — 同梱 skill と既定値
+
+> ユーザーグローバル tier（`~/.river-review/`）は現時点では未実装です（[#1045](https://github.com/s977043/river-review/issues/1045) のフォローアップ）。導入時は「リポジトリローカル」と「ビルトイン」の間に挿入します。
+
+### auto-update は導入しない
+
+CLI / Action は自動アップデート機構を持ちません。バージョンは利用側が明示的に固定・更新します（GitHub Action のバージョンピン、npm の lockfile など）。これは決定論的な実行と監査可能性を優先する設計判断です。
+
+関連: review gate の責務分担は [Review Gates Design](../../docs/development/review-gates-design.md)、設定項目は [config-schema](../reference/config-schema.md) を参照。

--- a/pages/explanation/river-architecture.md
+++ b/pages/explanation/river-architecture.md
@@ -71,7 +71,7 @@ River Review の**正規実行面は CLI** です。GitHub Action / Claude Code 
 
 最終的にどの skill / gate / rule が採用されたかは決定論的に解決され、`--debug` 出力の `plan.selectedSkills` / `skippedSkills`（理由付き）で確認できます。優先順位は次のとおり（上が優先）:
 
-1. **CLI 明示指定** — `--config` / `--skill-set` / `--context` / `--dependency` など
+1. **CLI 明示指定** — `--skill-set` / `--context` / `--dependency` など（設定ファイルは `--config` フラグではなくリポジトリ直下から自動検出する。下記参照）
 2. **リポジトリローカル** — `.river-review.{json,yaml,yml}`（`src/config/loader.mjs`）、`.river/rules.md` + `.river/rules.d/*.md`、`skills/registry.yaml`
 3. **ビルトイン** — 同梱 skill と既定値
 


### PR DESCRIPTION
## What

Item 1 of the [#1045 reframe](https://github.com/s977043/river-review/issues/1045#issuecomment-4644457444): **document the already-true CLI-first architecture** rather than rewrite it. Adds a "CLI-first execution surface and resolution order" section to `river-architecture` (JA + EN).

Covers:
- CLI is the canonical execution surface; GitHub Action / Claude Code / Codex / MCP / shell are thin wrappers over `src/cli.mjs` (the Action already just imports it).
- `river` / `river-review` bins; `river-review` preferred in agent-facing docs.
- JSON Review Artifact (`schemas/review-artifact.schema.json` v1) is the machine-readable contract; PR comments / Checks / Markdown are adapters.
- skill/gate/config resolution precedence (CLI explicit > repo-local > built-in), inspectable via `--debug`; the user-global `~/.river-review/` tier is flagged as a future follow-up.
- auto-update: explicitly not adopted.

## Scope

Satisfies #1045 acceptance items **1, 2, 5, 8** by documenting existing reality. Remaining items are tracked as follow-ups (not in this PR):
- artifact `decision`/`usage`/`trace` block, global config tier, `--explain` → small additive impl gaps.
- npm publish / `private:false` → **#800**.

## Verification

- `check:bilingual` (85 paired) / `lint:md` / `lint:text` (である調 + sentence-length) / `fix:dashes` all clean.
- Docs-only; no `src/` change → no dist rebuild, no test impact.

Refs #1045.

🤖 Generated with [Claude Code](https://claude.com/claude-code)