### PR TITLE
fix(docs): repair docusaurus build — broken links + MDX import/export (#1061)

### DIFF
--- a/pages/explanation/river-architecture.en.md
+++ b/pages/explanation/river-architecture.en.md
@@ -83,4 +83,4 @@ Which skills / gates / rules are ultimately selected is resolved deterministical
 
 The CLI / Action ship no auto-update mechanism. Consumers pin and update versions explicitly (GitHub Action version pinning, npm lockfiles). This is a deliberate choice favoring deterministic execution and auditability.
 
-See also: gate responsibilities in [Review Gates Design](../../docs/development/review-gates-design.md), and config options in [config-schema](../reference/config-schema.en.md).
+See also: gate responsibilities in [Review Gates Design](https://github.com/s977043/river-review/blob/main/docs/development/review-gates-design.md) (in-repo dev doc), and config options in [config-schema](../reference/config-schema.en.md).

--- a/pages/explanation/river-architecture.md
+++ b/pages/explanation/river-architecture.md
@@ -81,4 +81,4 @@ River Review の**正規実行面は CLI** です。GitHub Action / Claude Code 
 
 CLI / Action は自動アップデート機構を持ちません。バージョンは利用側が明示的に固定・更新します（GitHub Action のバージョンピン、npm の lockfile など）。これは決定論的な実行と監査可能性を優先する設計判断です。
 
-関連: review gate の責務分担は [Review Gates Design](../../docs/development/review-gates-design.md)、設定項目は [config-schema](../reference/config-schema.md) を参照。
+関連: review gate の責務分担は [Review Gates Design](https://github.com/s977043/river-review/blob/main/docs/development/review-gates-design.md)（リポジトリ内 dev ドキュメント）、設定項目は [config-schema](../reference/config-schema.md) を参照。

--- a/pages/guides/manage-skills-cli.md
+++ b/pages/guides/manage-skills-cli.md
@@ -67,7 +67,7 @@ river skills import --from ./vendor/skills --dry-run
 
 ファイルを書き出さずに変換・検証だけを行います。取り込み前の事前チェックに使います。
 
-import 完了時には「imported / failed / warnings」の件数が出力されます。`failed` が 1 件以上ある場合、終了コードは `1` になります。
+`import` 完了時には「imported / failed / warnings」の件数が出力されます。`failed` が 1 件以上ある場合、終了コードは `1` になります。
 
 ## 3. スキルを Agent Skills 形式で書き出す（`skills export`）
 
@@ -91,7 +91,7 @@ river skills export --include-assets
 
 `references/` / `scripts/` / `prompt/` ディレクトリを `SKILL.md` と並べてコピーします。スキル本体だけでなく、参照ファイルやスクリプトもまとめて配布したいときに指定します。
 
-export 完了時には「exported / failed」の件数が出力されます。`failed` が 1 件以上ある場合、終了コードは `1` になります。
+`export` 完了時には「exported / failed」の件数が出力されます。`failed` が 1 件以上ある場合、終了コードは `1` になります。
 
 ## オプション早見表
 

--- a/pages/reference/skills-catalog.en.md
+++ b/pages/reference/skills-catalog.en.md
@@ -14,6 +14,6 @@ Japanese, organized by phase:
 > (currently Japanese). An English-generated catalog will follow once skills carry
 > English `description` fields.
 
-To browse skills directly, see [`skills/`](../../skills)
+To browse skills directly, see [`skills/`](https://github.com/s977043/river-review/tree/main/skills)
 in the repository. For how skills are selected and routed, see the
 [agent workflow guide](../guides/agent-workflow.en.md).


### PR DESCRIPTION
## What

Weekly GC (#1061) failed at `npm run build` (docusaurus). Build is not a required PR check, so these accumulated unnoticed. Triaged the failing run and reproduced locally; three causes:

1. **`pages/explanation/river-architecture.md`(.en)** — the #1045 CLI-first section linked to `../../docs/development/review-gates-design.md`, which is **outside the docusaurus `pages/` root** → broken link. Repointed to the GitHub blob URL (the dev doc is not part of the published site). *(introduced this session)*
2. **`pages/guides/manage-skills-cli.md`** — two prose lines started with the bare words `import` / `export`; MDX v3 parsed them as ESM statements ("Could not parse import/exports with acorn"). Wrapped the leading word in backticks. *(pre-existing)*
3. **`pages/reference/skills-catalog.en.md`** — pre-existing broken link `../../skills` (outside the root) → GitHub tree URL. *(pre-existing)*

## Verification

- `npm run build` → **exit 0**, "Generated static files" (was exit 1).
- `npm run lint` / `npm test`-class checks clean; `check:bilingual` 85 paired; `fix:dashes` clean.

## Note

The weekly GC surfaced build breakage that the required PR checks miss (build/doc-quality are not required gates). Consider making `build` a required check in a follow-up so broken links fail at PR time rather than weekly.

Closes #1061.

🤖 Generated with [Claude Code](https://claude.com/claude-code)