### PR TITLE
docs(contributing): River → River Review (complete naming sweep)

### DIFF
--- a/CONTRIBUTING.en.md
+++ b/CONTRIBUTING.en.md
@@ -127,7 +127,7 @@ To keep reviews smooth:
   - Docs: Tutorial—Getting started with River Review
   - Docs: How-to—Add a custom skill
   - Docs: Reference—GitHub Action inputs
-  - Docs: Explanation—River flow model
+  - Docs: Explanation—River Review flow model
 
 ## ✍️ Document style (dashes)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,7 +145,7 @@ River Review のドキュメントは [Diátaxis documentation framework](https:
   - Docs: Tutorial—Getting started with River Review
   - Docs: How-to—Add a custom skill
   - Docs: Reference—GitHub Action inputs
-  - Docs: Explanation—River flow model）
+  - Docs: Explanation—River Review flow model）
 
 ## ✍️ ドキュメントスタイル（ダッシュ）
 


### PR DESCRIPTION
Completes the standalone-"River" sweep (follow-up to #1075): CONTRIBUTING(.en) docs-category example `River flow model` → `River Review flow model`. Repo-wide grep now finds **no standalone prose "River"** (CLI names / `Riverbed Memory` / UA strings excluded as intended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)