### PR TITLE
fix(ci): exclude generated CHANGELOG.md from lychee link check (#1065)

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -47,8 +47,11 @@ exclude = [
 
 ]
 
-# Exclude specific files that contain Docusaurus-internal routing links
-exclude_path = ["pages/index\\.md$", "pages/index\\.en\\.md$"]
+# Exclude specific files that contain Docusaurus-internal routing links.
+# CHANGELOG.md is release-please-generated and references many issue/PR URLs;
+# older entries point at the pre-rename repo name (s977043/river-reviewer) and
+# to issues that 404 over time, which is not actionable. Skip it (#1065).
+exclude_path = ["pages/index\\.md$", "pages/index\\.en\\.md$", "CHANGELOG\\.md$"]
 
 # Accept status codes
 # Redirects are handled by max_redirects (not listed here to ensure permanent redirects are visible in logs)


### PR DESCRIPTION
## What

The weekly link check (#1065) fails with **194 errors, all 404s in `CHANGELOG.md`** pointing at `s977043/river-reviewer` (the pre-rename repo name; correct is `river-review`) and at issue URLs that 404 over time.

Root cause: `CHANGELOG.md` is **release-please-generated** and its older entries use the old repo name. `package.json`'s `repository` is already correct (`s977043/river-review`), so this is historical, not an ongoing config bug. Rewriting 443 historical links would churn the changelog and risk release-please conflicts.

**Fix**: add `CHANGELOG\\.md$` to lychee `exclude_path` in `.lychee.toml` (changelogs reference transient issue/PR URLs and aren't actionable to link-check).

## Verification

- `.lychee.toml` `exclude_path` now includes CHANGELOG.md alongside the existing Docusaurus-index exclusions. lychee is not a required check; this takes effect on the next weekly run.

Closes #1065.

🤖 Generated with [Claude Code](https://claude.com/claude-code)