### PR TITLE
docs(dev): heuristic-detector checklist + session retrospective

### DIFF
--- a/docs/development/heuristic-detector-checklist.md
+++ b/docs/development/heuristic-detector-checklist.md
@@ -12,7 +12,7 @@
 
 ## 1. コメント行・文字列の扱い（最頻出の FP/FN 源）
 
-- [ ] **matcher 内で両方を行う**（既存 `matchesDangerousEval` を参照）: ① 先頭がコメントの行を `trimmed.startsWith('//') || startsWith('*') || startsWith('/*')` で早期 return、② その後 `stripTrailingLineComment(trimmed).trim()` で行末コメントを除去してから判定。①だけだと行末コメント FP が再発する（gemini が毎 PR 指摘した class）。
+- [ ] **matcher 内で 2 段構えにする**（既存 `matchesDangerousEval` を参照）。① 先頭がコメントの行は早期 return（`startsWith('//')` 等）。② 残りは `stripTrailingLineComment(trimmed).trim()` で行末コメントを除去してから判定する。①のみだと行末コメント FP が再発する（gemini が毎 PR 指摘した class）。
 - [ ] **行末コメント除去は quote-aware な共有ヘルパー `stripTrailingLineComment(code)` を使う**。素朴な `code.replace(/\/\/.*$/, '')` は **禁止**—文字列リテラル内の `//`（例 `"http://x"; eval(y)`）でコメント開始を誤判定し、後続の本物（`eval`）を取りこぼす（false negative）。
 - [ ] パターンのキーワードが「コメント内に登場しただけ」で発火しないことを negative テストで確認する。
 

--- a/docs/development/heuristic-detector-checklist.md
+++ b/docs/development/heuristic-detector-checklist.md
@@ -1,0 +1,66 @@
+# Heuristic Detector Checklist
+
+`src/lib/heuristic-review.mjs` に regex ベースの no-key 検出器（LLM キー無しで動く機械的チェック）を追加・変更するときのチェックリスト。
+
+これらの検出器は **LLM の判断なしに決定論で動く**ため、false positive / false negative がそのままレビューの質に直結する。本チェックリストは、過去に reviewer（gemini）が **検出器 1 本につきほぼ毎回**指摘した同一 class の不具合を front-load するためのもの。
+
+## いつ使うか
+
+- `heuristic-review.mjs` に `findXxx` 検出器を追加する
+- 既存検出器の正規表現を変更する
+- `SKILL_HEURISTIC_MAP` にエントリを追加する
+
+## 1. コメント行・文字列の扱い（最頻出の FP/FN 源）
+
+- [ ] **matcher 内で両方を行う**（既存 `matchesDangerousEval` を参照）: ① 先頭がコメントの行を `trimmed.startsWith('//') || startsWith('*') || startsWith('/*')` で早期 return、② その後 `stripTrailingLineComment(trimmed).trim()` で行末コメントを除去してから判定。①だけだと行末コメント FP が再発する（gemini が毎 PR 指摘した class）。
+- [ ] **行末コメント除去は quote-aware な共有ヘルパー `stripTrailingLineComment(code)` を使う**。素朴な `code.replace(/\/\/.*$/, '')` は **禁止**—文字列リテラル内の `//`（例 `"http://x"; eval(y)`）でコメント開始を誤判定し、後続の本物（`eval`）を取りこぼす（false negative）。
+- [ ] パターンのキーワードが「コメント内に登場しただけ」で発火しないことを negative テストで確認する。
+
+## 2. メソッド呼び出しと関数呼び出しの衝突
+
+- [ ] 関数名が他オブジェクトのメソッドと衝突しないか確認する。例: `exec` は `child_process.exec` だけでなく `RegExp.prototype.exec` / DB の `.exec` にも一致する。
+- [ ] 衝突する場合は **負の後読み** `(?<![.\w])exec\s*\(` で素の関数呼び出しに限定し、曖昧性のない alias（`execSync` / `spawn` / `spawnSync`）は `\b` で許容する。
+
+## 3. alias / 異形の網羅
+
+- [ ] 検出対象に異形がないか洗い出す。漏れがちな例:
+  - disabled test: `.skip` だけでなく `xit` / `xdescribe` / `xtest` / `xcontext`
+  - focused test: `describe` / `context` / `it` / `test` / `suite` / `bench` の `.only`
+  - merge conflict: `<<<<<<<` / `>>>>>>>` に加え diff3/zdiff3 の base marker `|||||||`（`=======` は Markdown h1 下線と衝突するため**使わない**）
+  - DOM 注入: `document.write` だけでなく `document.writeln`
+- [ ] 「設定値で危険になる」ものは条件を限定する。例: 環境変数 `NODE_TLS_REJECT_UNAUTHORIZED` は **`=0` に代入された場合のみ**（read や `=1` は除外）。オブジェクトリテラルの `rejectUnauthorized: false` は別 sink として扱う。
+
+## 4. スコープと上限
+
+- [ ] **テストファイル / fixture を除外**すべきか判断する（`looksLikeTestFile(filePath)` と `/fixtures/` + `/__fixtures__/` チェック）。セキュリティ系・debug 系は通常テストファイルを除外する。
+- [ ] 1 検出器あたりの件数上限を設ける（既存の多くは `MAX_*_COMMENTS = 3`。例外: `findSilentCatch` はハードコードの `>= 3`）。
+- [ ] **全体出力は `buildHeuristicComments` 末尾で `.slice(0, 8)` に bounded** である点を意識する。高頻度に発火する検出器を足すと、既存検出器が 8 枠を食い合って starve する。発火頻度が高い検出器は上限を低めにするか、配線順序を検討する。
+
+## 5. severity / confidence の較正
+
+- [ ] `review-engine.mjs` の `switch (c.kind)` に対応 case を追加し、finding / evidence / impact / fix / severity / confidence を埋める。
+- [ ] severity は内部語彙（blocker / warning / nit）。確実な危険は `blocker`、レビュー喚起レベルは `warning`、任意保留があり得るものは `nit`（例: `.skip` は意図的な保留がありうるため nit）。confidence は regex の確度に合わせる。
+
+## 6. 配線
+
+- [ ] `SKILL_HEURISTIC_MAP` の該当スキルに detector 名を追加する（ドキュメントとしての意味。実際の呼び出しは `buildHeuristicComments` 内で明示的に行う）。
+- [ ] `buildHeuristicComments` の該当スキルブロックに `for (const c of findXxx({ diff })) comments.push({ ...c, skillId });` を追加する。
+- [ ] 新スキルを heuristic 化する場合は、そのスキルの `applyTo` が対象ファイルに一致することを確認する（`SKILL.md` の `applyTo` を読む）。
+
+## 7. テスト（positive と negative の両方）
+
+- [ ] `tests/heuristic-review.test.mjs` に **検出される** ケースを追加する。
+- [ ] **検出されない** ケースを追加する: コメント内の言及 / 行末コメント / 安全な異形（例: `execFile(cmd, [args])` / `setTimeout(() => ...)` / `@ts-expect-error`）/ 条件を満たさない設定（`=1`）。
+- [ ] `node --test tests/heuristic-review.test.mjs` で確認後、`npm test` で全体を確認する。
+
+## 8. dist 再ビルド（必須）
+
+- [ ] `heuristic-review.mjs` / `review-engine.mjs` は GitHub Action の dist にバンドルされる。変更したら **docker で CI 一致 dist を再ビルド**する（詳細は [`dist-check-rebuild-guide.md`](./dist-check-rebuild-guide.md)）。
+- [ ] `what-is-river-review.md`（JA/EN）の実行モデル tier-2 の観点リストを更新する。編集後は `npm run lint:text` で確認する（textlint: 本文=ですます / 箇条書き=である / 1 文 ≤150 字 / 同一助詞の重複回避。ローカルは cache で pass しうるため CI でも確認）。
+
+## 関連
+
+- `src/lib/heuristic-review.mjs`—検出器本体と `stripTrailingLineComment` ヘルパー
+- `src/lib/review-engine.mjs`—`kind` → finding メッセージの `switch`
+- `docs/development/skill-severity-rubric.md`—severity 較正
+- `docs/development/dist-check-rebuild-guide.md`—dist 再ビルド手順

--- a/docs/development/heuristic-detector-checklist.md
+++ b/docs/development/heuristic-detector-checklist.md
@@ -12,7 +12,7 @@
 
 ## 1. コメント行・文字列の扱い（最頻出の FP/FN 源）
 
-- [ ] **matcher 内で 2 段構えにする**（既存 `matchesDangerousEval` を参照）。① 先頭がコメントの行は早期 return（`startsWith('//')` 等）。② 残りは `stripTrailingLineComment(trimmed).trim()` で行末コメントを除去してから判定する。①のみだと行末コメント FP が再発する（gemini が毎 PR 指摘した class）。
+- [ ] **matcher 内で 2 段構えにする**（既存 `matchesDangerousEval` を参照）。① 先頭がコメントの行は早期 return（`trimmed.startsWith('//')` 等）。② 残りは `stripTrailingLineComment(trimmed).trim()` で行末コメントを除去してから判定する。①のみだと行末コメント FP が再発する（gemini が毎 PR 指摘した class）。
 - [ ] **行末コメント除去は quote-aware な共有ヘルパー `stripTrailingLineComment(code)` を使う**。素朴な `code.replace(/\/\/.*$/, '')` は **禁止**—文字列リテラル内の `//`（例 `"http://x"; eval(y)`）でコメント開始を誤判定し、後続の本物（`eval`）を取りこぼす（false negative）。
 - [ ] パターンのキーワードが「コメント内に登場しただけ」で発火しないことを negative テストで確認する。
 
@@ -56,7 +56,7 @@
 ## 8. dist 再ビルド（必須）
 
 - [ ] `heuristic-review.mjs` / `review-engine.mjs` は GitHub Action の dist にバンドルされる。変更したら **docker で CI 一致 dist を再ビルド**する（詳細は [`dist-check-rebuild-guide.md`](./dist-check-rebuild-guide.md)）。
-- [ ] `what-is-river-review.md`（JA/EN）の実行モデル tier-2 の観点リストを更新する。編集後は `npm run lint:text` で確認する（textlint: 本文=ですます / 箇条書き=である / 1 文 ≤150 字 / 同一助詞の重複回避。ローカルは cache で pass しうるため CI でも確認）。
+- [ ] `what-is-river-review.md`（JA/EN）の実行モデル「2. 機械的チェック」の観点リストを更新する。編集後は `npm run lint:text` で確認する（textlint: 本文=ですます / 箇条書き=である / 1 文 ≤150 字 / 同一助詞の重複回避。ローカルは cache で pass しうるため CI でも確認）。
 
 ## 関連
 
@@ -64,3 +64,4 @@
 - `src/lib/review-engine.mjs`—`kind` → finding メッセージの `switch`
 - `docs/development/skill-severity-rubric.md`—severity 較正
 - `docs/development/dist-check-rebuild-guide.md`—dist 再ビルド手順
+- `pages/explanation/what-is-river-review.md`—実行モデル（no-key 観点リストの SSoT）

--- a/docs/development/retrospectives/2026-06-06-09.md
+++ b/docs/development/retrospectives/2026-06-06-09.md
@@ -4,16 +4,16 @@
 
 ## Numerical summary
 
-| Metric                    | Value                                                            |
-| ------------------------- | ---------------------------------------------------------------- |
-| Merged PRs                | 11 (#1074 release / #1076–#1085)                                 |
-| Releases                  | 1 (v1.4.0)                                                       |
-| Issues closed             | 2 (#1065 / #1067)                                                |
-| New heuristic viewpoints  | 8 (4 → 12; SSoT の列挙基準)                                      |
-| New heuristic skills wired | 1 (typescript-strict を新規 heuristic 化)                       |
-| Gemini round-trips        | 6 (heuristic PR #1080–#1085 の各 1 本につき 1 回 FP/FN 指摘)     |
-| docs reframed (JA/EN)     | 4 (what-is-river-review / playbook / quickstart / README)        |
-| dist rebuilds (docker)    | ~9                                                               |
+| Metric                     | Value                                                        |
+| -------------------------- | ------------------------------------------------------------ |
+| Merged PRs                 | 11 (#1074 release / #1076–#1085)                             |
+| Releases                   | 1 (v1.4.0)                                                   |
+| Issues closed              | 2 (#1065 / #1067)                                            |
+| New heuristic viewpoints   | 8 (4 → 12; SSoT の列挙基準)                                  |
+| New heuristic skills wired | 1 (typescript-strict を新規 heuristic 化)                    |
+| Gemini round-trips         | 6 (heuristic PR #1080–#1085 の各 1 本につき 1 回 FP/FN 指摘) |
+| docs reframed (JA/EN)      | 4 (what-is-river-review / playbook / quickstart / README)    |
+| dist rebuilds (docker)     | ~9                                                           |
 
 ## What worked
 
@@ -24,7 +24,7 @@
 
 ## What didn't work
 
-- **heuristic detector の regex FP/FN を後追いで潰した**: 6 本すべてで gemini が同じ *class* の不具合（コメント行・文字列内 `//`・メソッド呼び出し衝突・alias 集合の漏れ）を指摘し、その都度 fix commit + dist 再ビルド + CI 再 poll を回した。front-load できれば 6 往復を削減できた。
+- **heuristic detector の regex FP/FN を後追いで潰した**: 同じ _class_ の不具合（コメント行・文字列内 `//`・メソッド呼び出し衝突・alias 集合の漏れ）を gemini が 6 本すべてで指摘した。その都度 fix commit + dist 再ビルド + CI 再 poll を回しており、front-load できれば 6 往復を削減できた。
 - **textlint の context ルールが doc 編集を繰り返し止めた**: 本文=ですます / 箇条書き=である、1 文 150 字、助詞重複（「も」二度）で CI が複数回 fail。さらに **ローカル `npm run lint:text` は cache で pass し、CI で初めて落ちた**。
 - **gh active account が処理の途中で kominem-unilabo に切り替わる**: session 開始時チェックでは防げず、`update-branch`/`merge` が権限エラーで失敗（3 回以上）。
 
@@ -35,34 +35,34 @@
 
 ## Pivot points (in hindsight)
 
-| #   | Moment                               | Better action                                                                                       |
-| --- | ------------------------------------ | --------------------------------------------------------------------------------------------------- |
-| 1   | 最初の heuristic PR (#1080) 着手前   | regex 検出器の FP/FN チェックリストを先に作り、コメント/文字列/メソッド衝突を front-load する        |
-| 2   | 実行モデル節の初回 doc 編集前        | 「本文=ですます・箇条書き=である・1 文 150 字・助詞重複」を doc 編集チェックリストとして先に参照する |
-| 3   | 2 回目の gh 権限エラー後             | gh write op ごとに `gh api user \| grep -q s977043 \|\| gh auth switch` を前置する習慣に切り替える   |
+| #   | Moment                             | Better action                                                                                        |
+| --- | ---------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| 1   | 最初の heuristic PR (#1080) 着手前 | regex 検出器の FP/FN チェックリストを先に作り、コメント/文字列/メソッド衝突を front-load する        |
+| 2   | 実行モデル節の初回 doc 編集前      | 「本文=ですます・箇条書き=である・1 文 150 字・助詞重複」を doc 編集チェックリストとして先に参照する |
+| 3   | 2 回目の gh 権限エラー後           | gh write op ごとに `gh api user \| grep -q s977043 \|\| gh auth switch` を前置する習慣に切り替える   |
 
 ## Improvement priorities (Skills / Agents / Workflow)
 
 ### Skills
 
-| Priority | ID  | Content                                                                                                                                                                              |
-| -------- | --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Priority | ID  | Content                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| -------- | --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | P1       | S1  | `docs/development/heuristic-detector-checklist.md` を新設。regex 検出器の FP/FN ガード（leading + trailing コメント除去は quote-aware、テストファイル/fixture 除外、メソッド呼び出し衝突 `.exec` の負の後読み、alias 集合の網羅 = xit/xdescribe/xcontext・diff3 `\|\|\|\|\|\|\|`、severity/confidence 較正、件数上限、positive **と** negative の両テスト）を encode する。今 session で gemini が 6 回指摘した class を front-load する。 |
-| P2       | S2  | heuristic 対応スキルの SKILL.md に「no-key で動く観点」を注記し、`what-is-river-review.md` の実行モデルへリンクする（5 スキルが該当）。                                              |
+| P2       | S2  | heuristic 対応スキルの SKILL.md に「no-key で動く観点」を注記し、`what-is-river-review.md` の実行モデルへリンクする（5 スキルが該当）。                                                                                                                                                                                                                                                                                                    |
 
 ### Agents
 
-| Priority | ID  | Content                                                                                                                              |
-| -------- | --- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Priority | ID  | Content                                                                                                                                |
+| -------- | --- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | P2       | A1  | `agents/river-review.md` に実行モデルの 1 行（「あなた自身がスキルを適用する。LLM キーはヘッドレス CLI/Action のみ必要」）を追記検討。 |
 
 ### Workflow
 
-| Priority | ID  | Content                                                                                                                                                          |
-| -------- | --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Priority | ID  | Content                                                                                                                                                                                                |
+| -------- | --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | P1       | W1  | doc 編集チェックリスト（`docs/development/*.md` または CLAUDE.md guard）: 本文=ですます / 箇条書き=である / 1 文 ≤150 字 / 助詞重複回避、かつ commit 前に textlint を **cache を無効化して**実行する。 |
-| P2       | W2  | memory `feedback_gh_active_account_check` を強化: session 開始時のみでなく、**gh write op（merge / update-branch / pr create）ごとに** active account を確認する習慣に更新する。 |
-| P3       | W3  | heuristic 拡張時は push 前に self-review で「コメント / 文字列 / メソッド衝突 / alias 網羅」を点検し、gemini 往復を削減する（S1 の checklist を self-review に組み込む）。 |
+| P2       | W2  | memory `feedback_gh_active_account_check` を強化: session 開始時のみでなく、**gh write op（merge / update-branch / pr create）ごとに** active account を確認する習慣に更新する。                       |
+| P3       | W3  | heuristic 拡張時は push 前に self-review で「コメント / 文字列 / メソッド衝突 / alias 網羅」を点検し、gemini 往復を削減する（S1 の checklist を self-review に組み込む）。                             |
 
 ## 関連
 

--- a/docs/development/retrospectives/2026-06-06-09.md
+++ b/docs/development/retrospectives/2026-06-06-09.md
@@ -1,0 +1,71 @@
+# Retrospective: 2026-06-06 → 2026-06-09 Session
+
+「River Review のスキルは、River Review 自身が LLM を呼ぶ設定ではなく、**AI エージェントのレビュー能力を強化する capability pack** である」という位置づけアップデートを doc・実装・リリースまで通した session。実行モデルを 3 層（エージェント駆動 / 機械的チェック / ヘッドレス LLM）に整理し、no-key で動く機械的チェックを **4 → 12 観点**（SSoT `what-is-river-review.md` の列挙基準）に拡張して **v1.4.0** をリリースした。
+
+## Numerical summary
+
+| Metric                    | Value                                                            |
+| ------------------------- | ---------------------------------------------------------------- |
+| Merged PRs                | 11 (#1074 release / #1076–#1085)                                 |
+| Releases                  | 1 (v1.4.0)                                                       |
+| Issues closed             | 2 (#1065 / #1067)                                                |
+| New heuristic viewpoints  | 8 (4 → 12; SSoT の列挙基準)                                      |
+| New heuristic skills wired | 1 (typescript-strict を新規 heuristic 化)                       |
+| Gemini round-trips        | 6 (heuristic PR #1080–#1085 の各 1 本につき 1 回 FP/FN 指摘)     |
+| docs reframed (JA/EN)     | 4 (what-is-river-review / playbook / quickstart / README)        |
+| dist rebuilds (docker)    | ~9                                                               |
+
+## What worked
+
+- **位置づけの SSoT 化**: 実行モデルを `what-is-river-review.md` に 1 箇所定義し、playbook / quickstart / README をそこへ寄せた。framing の分散を防げた。
+- **heuristic は既存スキルへ detector を足す方針**: 新スキルを増やさず `SKILL_HEURISTIC_MAP` に detector を追加。selection 経路を変えず低リスクで拡張できた。
+- **gemini の非同期レビューが毎回実バグを捕捉**: looksLikeTestFile のバグ、コメント行 FP、diff3 marker、xcontext、RegExp.exec 衝突など、すべてマージ前に修正できた。
+- **docker による CI 一致 dist 再ビルド**が安定。daemon 停止時も `open -a Docker` で復帰。
+
+## What didn't work
+
+- **heuristic detector の regex FP/FN を後追いで潰した**: 6 本すべてで gemini が同じ *class* の不具合（コメント行・文字列内 `//`・メソッド呼び出し衝突・alias 集合の漏れ）を指摘し、その都度 fix commit + dist 再ビルド + CI 再 poll を回した。front-load できれば 6 往復を削減できた。
+- **textlint の context ルールが doc 編集を繰り返し止めた**: 本文=ですます / 箇条書き=である、1 文 150 字、助詞重複（「も」二度）で CI が複数回 fail。さらに **ローカル `npm run lint:text` は cache で pass し、CI で初めて落ちた**。
+- **gh active account が処理の途中で kominem-unilabo に切り替わる**: session 開始時チェックでは防げず、`update-branch`/`merge` が権限エラーで失敗（3 回以上）。
+
+## Surprises
+
+- 既存 doc（`agent-workflow.md`）は既に「plugin/agent が主、CLI は任意」という実行モデルを述べており、アーキテクチャは新 framing を支持していた。ギャップは messaging の不統一だけだった。
+- `=======`（git conflict の中間 marker）は Markdown h1 下線と衝突するため、conflict 検出では `<<<<<<<` / `>>>>>>>` / `|||||||` のみを使うべきだった。
+
+## Pivot points (in hindsight)
+
+| #   | Moment                               | Better action                                                                                       |
+| --- | ------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| 1   | 最初の heuristic PR (#1080) 着手前   | regex 検出器の FP/FN チェックリストを先に作り、コメント/文字列/メソッド衝突を front-load する        |
+| 2   | 実行モデル節の初回 doc 編集前        | 「本文=ですます・箇条書き=である・1 文 150 字・助詞重複」を doc 編集チェックリストとして先に参照する |
+| 3   | 2 回目の gh 権限エラー後             | gh write op ごとに `gh api user \| grep -q s977043 \|\| gh auth switch` を前置する習慣に切り替える   |
+
+## Improvement priorities (Skills / Agents / Workflow)
+
+### Skills
+
+| Priority | ID  | Content                                                                                                                                                                              |
+| -------- | --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P1       | S1  | `docs/development/heuristic-detector-checklist.md` を新設。regex 検出器の FP/FN ガード（leading + trailing コメント除去は quote-aware、テストファイル/fixture 除外、メソッド呼び出し衝突 `.exec` の負の後読み、alias 集合の網羅 = xit/xdescribe/xcontext・diff3 `\|\|\|\|\|\|\|`、severity/confidence 較正、件数上限、positive **と** negative の両テスト）を encode する。今 session で gemini が 6 回指摘した class を front-load する。 |
+| P2       | S2  | heuristic 対応スキルの SKILL.md に「no-key で動く観点」を注記し、`what-is-river-review.md` の実行モデルへリンクする（5 スキルが該当）。                                              |
+
+### Agents
+
+| Priority | ID  | Content                                                                                                                              |
+| -------- | --- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| P2       | A1  | `agents/river-review.md` に実行モデルの 1 行（「あなた自身がスキルを適用する。LLM キーはヘッドレス CLI/Action のみ必要」）を追記検討。 |
+
+### Workflow
+
+| Priority | ID  | Content                                                                                                                                                          |
+| -------- | --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P1       | W1  | doc 編集チェックリスト（`docs/development/*.md` または CLAUDE.md guard）: 本文=ですます / 箇条書き=である / 1 文 ≤150 字 / 助詞重複回避、かつ commit 前に textlint を **cache を無効化して**実行する。 |
+| P2       | W2  | memory `feedback_gh_active_account_check` を強化: session 開始時のみでなく、**gh write op（merge / update-branch / pr create）ごとに** active account を確認する習慣に更新する。 |
+| P3       | W3  | heuristic 拡張時は push 前に self-review で「コメント / 文字列 / メソッド衝突 / alias 網羅」を点検し、gemini 往復を削減する（S1 の checklist を self-review に組み込む）。 |
+
+## 関連
+
+- `docs/development/improvement-flow.md`—この振り返りの codification プロセス
+- `pages/explanation/what-is-river-review.md`—実行モデル（本 session で SSoT 化）
+- `src/lib/heuristic-review.mjs`—no-key 機械的チェック（12 観点 / 13 検出器）


### PR DESCRIPTION
## What

Improvement Flow (`docs/development/improvement-flow.md`) codification of the 2026-06-06→09 session.

- **`docs/development/heuristic-detector-checklist.md`** — the headline artifact. Every regex-based no-key heuristic detector added this session (#1080–#1085) hit the same class of FP/FN that gemini caught only post-hoc, costing 6 review round-trips. This checklist front-loads those guards: quote-aware `stripTrailingLineComment`, test-file/`__fixtures__` exclusion, negative-lookbehind for method-call collisions (`RegExp.exec`), alias completeness (`xcontext`, diff3 `|||||||`), severity calibration, the 8-item global cap, positive **and** negative tests, dist rebuild.
- **`docs/development/retrospectives/2026-06-06-09.md`** — session retrospective with Numerical summary, What worked/didn't, Surprises, Pivot points, and Skills/Agents/Workflow improvement priorities.

## Review

Multi-agent 3-perspective review (Quality / Code-reuse / Accuracy) applied:
- **[Major]** reconciled the no-key viewpoint count to the SSoT `what-is-river-review.md` (**4 → 12**, was mis-stated as 14).
- **[Major]** made the 8-item global cap (`.slice(0, 8)`) an actionable checklist item (starvation/ordering).
- **[Minor]** added `/__fixtures__/` guard, the `findSilentCatch` `MAX_*` exception, clarified the two-step comment handling, removed a dangling "textlint rules" reference.

## Follow-ups (not in this PR — require approval / separate scope)

- **W1**: a doc-edit textlint guard (CLAUDE.md = always-ask).
- **W2**: strengthen the `feedback_gh_active_account_check` memory (per-write-op check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)