### PR TITLE
ci: cut redundant work from the main CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,8 @@ jobs:
       - name: Run unit tests with coverage
         run: NODE_V8_COVERAGE=coverage npm test
       - name: Upload coverage to Codecov
+        # Coverage from one Node version is enough; skip the duplicate upload.
+        if: matrix.node-version == '22.x'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           directory: coverage
@@ -88,18 +90,18 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
-          cache: npm
-      - run: npm ci
-      - name: Check dist is up to date
+      # Timestamp judgement needs only git, so it runs BEFORE Node setup /
+      # npm ci. In the common case (dist newer than bundled sources) the job
+      # finishes here and skips the ~1-minute install entirely.
+      - name: Judge dist freshness by commit timestamps
+        id: judge
         run: |
           src_ts=$(git log -1 --format=%ct -- 'runners/github-action/src/' 'src/' 'package-lock.json')
           dist_ts=$(git log -1 --format=%ct -- 'runners/github-action/dist/')
 
           if [ -z "$src_ts" ]; then
             echo "No bundled-source commits in history; skipping dist staleness check."
+            echo "needs_rebuild=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -112,9 +114,22 @@ jobs:
             src_date=$(git log -1 --format=%ci -- 'runners/github-action/src/' 'src/' 'package-lock.json')
             dist_date=$(git log -1 --format=%ci -- 'runners/github-action/dist/')
             echo "dist/ is current (dist: ${dist_date}, src: ${src_date})"
+            echo "needs_rebuild=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
+          echo "Timestamp suggests dist is stale; will rebuild to verify."
+          echo "needs_rebuild=true" >> "$GITHUB_OUTPUT"
+      - uses: actions/setup-node@v6
+        if: steps.judge.outputs.needs_rebuild == 'true'
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+      - run: npm ci
+        if: steps.judge.outputs.needs_rebuild == 'true'
+      - name: Rebuild and verify dist bytes
+        if: steps.judge.outputs.needs_rebuild == 'true'
+        run: |
           # Timestamp says dist is stale, but the src or dependency change
           # might not affect the vendored bundle (e.g., a sibling helper the
           # action runner does not load, or a dep that ncc does not bundle).
@@ -124,7 +139,6 @@ jobs:
           # only fail if the rebuild actually produces a diff. This avoids
           # false positives that block PRs whose change is not part of the
           # shipped bundle.
-          echo "Timestamp suggests dist is stale; rebuilding to verify..."
           npm run build:action
           if git diff --quiet -- runners/github-action/dist/; then
             src_date=$(git log -1 --format=%ci -- 'runners/github-action/src/' 'src/' 'package-lock.json')
@@ -145,7 +159,10 @@ jobs:
   integration-test:
     name: Integration (CLI)
     runs-on: ubuntu-latest
-    needs: test
+    # Runs in parallel with the unit-test matrix (which already includes the
+    # integration tests via `node --test` discovery); chaining it after `test`
+    # only re-ran the same files a third time at the end of the critical path.
+    needs: lint
     timeout-minutes: 15
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## What

Audit-driven CI optimization. Measured first: the full suite is **1218 tests in ~12 s**, so the waste is in CI orchestration, not the tests themselves.

| Waste found | Fix | Effect |
|---|---|---|
| **Integration (CLI) ran the same tests a 3rd time, serially at the end** — `node --test` discovery in the unit matrix (20.x + 22.x) already includes `tests/integration/*` | `needs: test` → `needs: lint` (parallel) | **about −2 min wall-clock per push** (critical path is now lint → parallel fan-out) |
| Codecov upload ran from **both** matrix legs with identical coverage | upload `if: matrix.node-version == '22.x'` | one duplicate upload removed per run |
| `Action dist freshness` ran `npm ci` (~1 min) **before** the git-timestamp judgement, even though the common case (fresh dist) needs only git | judge first; `setup-node` + `npm ci` + rebuild run **only when stale** | ~1 min saved on most runs |

## Safety

- **Required check names unchanged** (Lint / Unit tests (20.x)(22.x) / Skill schema validation / Meta consistency / Action dist freshness / Integration (CLI)) — branch protection unaffected.
- dist-check semantics preserved: same timestamp judgement, same rebuild-and-byte-compare fallback (#1057), same error messages; only the install moved behind the staleness gate.
- Also audited but left alone (not waste): doc-quality (bilingual/placement, no textlint overlap), weekly-gc (intentional rot detection), PR-triggered doc workflows (already paths-filtered), 20.x+22.x matrix (both required).

## Verification

- YAML parses; job graph verified (`integration-test.needs == lint`, codecov `if` present, dist-check = 5 steps with gated install). prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)