### PR TITLE
docs: selection config design and use-case samples (skill pack Phase A follow-up)

### DIFF
--- a/docs/development/skill-pack-design.md
+++ b/docs/development/skill-pack-design.md
@@ -122,27 +122,56 @@ packs:
 
 テンプレートは `specs/templates/pack/pack.yaml` に配置します。
 
-## 6. 実行計画
+## 6. 導入プロジェクト側の selection 宣言
 
-| Phase | 内容                                                                                                                                                      | 変更範囲                                         |
-| ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
-| A     | 本方針・軸・テンプレートの合意（本 PR）                                                                                                                   | docs / specs のみ                                |
-| B     | 第 1 号 `typescript` pack + `schemas/pack.schema.json` + resolver 拡張（packs 優先・衝突エラー・複数指定の set-union）+ ゲートのゲート canary + S1 明文化 | registry.yaml / schemas / runners/core / scripts |
-| C     | 第 2 号 `ddd` pack（upstream 軸の実証、degraded mode 込み）+ tier 自動判定スクリプト                                                                      | skills / registry.yaml / scripts                 |
-| D     | カタログ生成（`skills:catalog` 拡張）、pages/ への公開ドキュメント、README 訴求更新、recommendations の deprecation 判断、tag 実行フィルタ検討            | scripts / pages / README                         |
+導入プロジェクトが「どの pack / tag / skill を使うか」を宣言する場所として、既存の `.river-review.yaml`（ConfigLoader + Zod 検証）に `selection` セクションを追加します。
+新しい設定ファイル形式（.env 風など）は導入しません。選択は配列と除外を含む構造化データであり、既存 config への統合が保守性で優位なためです。
+
+```yaml
+selection:
+  packs: # pack 単位の導入（複数指定は skill id で set-union）
+    - typescript
+  tags: # tag による横断追加
+    - a11y
+  skills:
+    include: # pack 外の個別 skill を追加
+      - rr-midstream-loading-state-001
+    exclude: # pack に含まれるが使わない skill を除外
+      - rr-midstream-typescript-strict-001
+  minTier: community # この tier 未満の pack を既定で除外
+```
+
+設計上のルールは次の通りです。
+
+- 優先順位は `exclude > include > packs / tags の union` とする
+- selection は「実行するか」の宣言であり、suppression（finding 単位の抑制）とは役割を分ける
+- CLI の `--skill-set` は selection の一時上書き手段として位置づけ直す
+- 環境変数（`RIVER_PACKS` 等）は CI での一時上書き用の補助とし、SSoT は `.river-review.yaml` とする
+- ユースケース別のサンプルは `examples/selection/` に配置する（React + TypeScript / TDD / SDD など）
+
+selection の resolver は Phase B の pack resolver と同時に設計します。tag 実行フィルタ（旧 Phase D 候補）は selection の一部として実装する方が一貫するため、§7 の通りスコープを再配置します。
+
+## 7. 実行計画
+
+| Phase | 内容                                                                                                                                                                        | 変更範囲                                         |
+| ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| A     | 本方針・軸・テンプレートの合意 + selection 設計とユースケース別サンプル                                                                                                     | docs / specs / examples のみ                     |
+| B     | 第 1 号 `typescript` pack + `schemas/pack.schema.json` + resolver 拡張（packs 優先・衝突警告・複数指定の set-union・selection 読み込み）+ ゲートのゲート canary + S1 明文化 | registry.yaml / schemas / runners/core / scripts |
+| C     | 第 2 号 `ddd` pack（upstream 軸の実証、degraded mode 込み）+ tier 自動判定スクリプト                                                                                        | skills / registry.yaml / scripts                 |
+| D     | カタログ生成（`skills:catalog` 拡張）、pages/ への公開ドキュメント、README 訴求更新、recommendations の deprecation 判断、tags 実行フィルタの selection への実装            | scripts / pages / README                         |
 
 Phase B は loader（`runners/core/skill-loader.mjs`）と検証スクリプトに踏み込むため軽微ではありません。
 AGENTS.md の「Ask before editing」に従い、`src/` / `runners/` に触れる変更は個別 PR で承認を取ります。
 Phase C の DDD pack は「plan / 設計レビューに効く」という River Review 固有の価値を示すショーケースとして位置付けます。
 
-## 7. 非ゴール
+## 8. 非ゴール
 
 - 既存 94 skill の物理的なディレクトリ再編（参照で束ねるため不要）
 - pack の外部レジストリ / リモート配布（npm 配布は Epic 1 で別管理）
 - `recommendations:` の即時廃止（互換期間を置く。新規追加凍結は Phase B、廃止判断は Phase D）
 - pack 単位の suppression。suppression / feedback は従来通り **skill 単位**（pack 非依存）で管理する。pack 固有の調整が必要になった場合は skill の fork で対応する
 
-## 8. 検証記録（2026-06-10）
+## 9. 検証記録（2026-06-10）
 
 本ドラフトは technical / consistency / adversarial の 3 視点並列セルフレビューを実施し、次の主要指摘を反映済みです。
 

--- a/docs/development/skill-pack-design.md
+++ b/docs/development/skill-pack-design.md
@@ -144,6 +144,7 @@ selection:
 設計上のルールは次の通りです。
 
 - 優先順位は `exclude > include > packs / tags の union` とする
+- `minTier` は **tags による暗黙追加にのみ** 適用する。`packs:` に明示指定した pack は minTier 未満でも実行する（明示は意図的な選択とみなす）。その際は tier 不足の警告をログに出す
 - selection は「実行するか」の宣言であり、suppression（finding 単位の抑制）とは役割を分ける
 - CLI の `--skill-set` は selection の一時上書き手段として位置づけ直す
 - 環境変数（`RIVER_PACKS` 等）は CI での一時上書き用の補助とし、SSoT は `.river-review.yaml` とする

--- a/examples/selection/README.md
+++ b/examples/selection/README.md
@@ -1,0 +1,22 @@
+# examples/selection/
+
+`.river-review.yaml` の `selection` セクション（pack / tag / 個別 skill の宣言）のユースケース別サンプルです。
+
+> **注意**: `selection` は設計段階の機能です。設計は [docs/development/skill-pack-design.md](../../docs/development/skill-pack-design.md) §6、実装は Phase B で行います。現時点では `--skill-set` フラグと registry.yaml の `recommendations:` を利用してください。
+
+## サンプル一覧
+
+| ファイル                   | 想定ユースケース                                                     |
+| -------------------------- | -------------------------------------------------------------------- |
+| `react-typescript.yaml`    | React + TypeScript（Next.js 含む）の Web アプリ開発                  |
+| `tdd.yaml`                 | TDD チーム。テスト雛形生成からカバレッジ・flaky 検査まで             |
+| `sdd.yaml`                 | 仕様駆動開発（SDD）。plan / pbi-input / ADR と実装の整合を多段で検査 |
+| `architecture-review.yaml` | アーキテクチャ重視チーム。DDD 境界・契約・運用性のドリフト防止       |
+
+## 使い方（selection 実装後）
+
+1. サンプルを自分のリポジトリの `.river-review.yaml` にコピーする
+2. `selection.skills.include` をスタックに合わせて取捨選択する
+3. `river run .` / GitHub Actions の両方が同じ宣言を読む
+
+各サンプルの skill id は `skills/` 配下に実在するものだけを参照しています（一部は registry.yaml 未掲載のカタログドリフトあり）。優先順位は `exclude > include > packs / tags の union` です。

--- a/examples/selection/README.md
+++ b/examples/selection/README.md
@@ -15,7 +15,7 @@
 
 ## 使い方（selection 実装後）
 
-1. サンプルを自分のリポジトリの `.river-review.yaml` にコピーする
+1. サンプルの `selection` セクションを、自分のリポジトリの既存 `.river-review.yaml` に **マージ** する（`model` / `review` / `exclude` など既存セクションを上書きしないこと。config が無い場合はファイルごとコピーしてよい）
 2. `selection.skills.include` をスタックに合わせて取捨選択する
 3. `river run .` / GitHub Actions の両方が同じ宣言を読む
 

--- a/examples/selection/architecture-review.yaml
+++ b/examples/selection/architecture-review.yaml
@@ -1,0 +1,19 @@
+# .river-review.yaml の selection サンプル: アーキテクチャ重視チーム向け（DDD / マイクロサービス境界）
+# 設計ドキュメント・ADR を継続的にレビューし、境界・契約・運用性のドリフトを防ぐ。
+# 注意: selection セクションは設計段階の機能です（docs/development/skill-pack-design.md §6、実装は Phase B）。
+selection:
+  packs: []
+  # Phase C で ddd pack が landed したら packs: [ddd] へ移行する
+  tags:
+    - architecture
+  skills:
+    include:
+      - rr-upstream-bounded-context-language-001 # 境界づけられたコンテキストとユビキタス言語
+      - rr-upstream-architecture-boundaries-001 # 境界・依存方向・所有権
+      - rr-upstream-data-flow-state-ownership-001 # データフローと状態の所有
+      - rr-upstream-integration-contracts-001 # サービス間契約
+      - rr-upstream-event-driven-semantics-001 # イベント駆動の配信保証・冪等性
+      - rr-upstream-api-versioning-compat-001 # API 互換性と versioning
+      - rr-upstream-trust-boundaries-authz-001 # 信頼境界と認可
+    exclude: []
+  minTier: community

--- a/examples/selection/react-typescript.yaml
+++ b/examples/selection/react-typescript.yaml
@@ -1,0 +1,18 @@
+# .river-review.yaml の selection サンプル: React + TypeScript の Web アプリ開発向け
+# GitHub 上で React / TypeScript / Next.js を使う一般的なプロダクト開発を想定。
+# 注意: selection セクションは設計段階の機能です（docs/development/skill-pack-design.md §6、実装は Phase B）。
+selection:
+  packs:
+    - typescript # Phase B で提供予定の第 1 号 pack（strict / nullcheck / type-driven-design）
+  tags:
+    - a11y # アクセシビリティ観点を横断追加
+    - modern-web # semantic HTML / Core Web Vitals / Baseline 互換
+  skills:
+    include:
+      # フロントエンド固有の観点を個別追加（いずれも registry.yaml 実在の skill）
+      - rr-midstream-nextjs-app-router-boundary-001 # Server/Client Component 境界（Next.js 利用時）
+      - rr-midstream-loading-state-001 # ローディング状態の網羅
+      - rr-midstream-nullability-contract-001 # null/undefined の契約
+      - rr-midstream-security-basic-001 # 基本セキュリティ
+    exclude: []
+  minTier: community

--- a/examples/selection/sdd.yaml
+++ b/examples/selection/sdd.yaml
@@ -1,0 +1,22 @@
+# .river-review.yaml の selection サンプル: SDD（仕様駆動開発 / plan 駆動開発）向け
+# pbi-input / plan / ADR などの上流アーティファクトを起点に、仕様と実装の整合を多段で検査する。
+# artifact の渡し方は pages/reference/artifact-input-contract.md を参照。
+# 注意: selection セクションは設計段階の機能です（docs/development/skill-pack-design.md §6、実装は Phase B）。
+selection:
+  packs: []
+  tags:
+    - plangate # PlanGate 連携の整合チェック群
+  skills:
+    include:
+      # 仕様・計画の品質（実装前ゲート）
+      - rr-upstream-requirements-acceptance-001 # 受け入れ基準・スコープの明確性
+      - rr-upstream-create-plan-001 # 実行計画の作成とレビュー
+      - rr-upstream-plangate-plan-integrity-001 # pbi-input / plan / todo / test-cases の整合
+      # 実装と計画の整合（実装中ゲート）
+      - rr-upstream-plangate-exec-conformance-001 # 差分が plan から逸脱していないか
+      - rr-upstream-adr-decision-quality-001 # ADR の意思決定品質
+      - rr-upstream-architecture-traceability-001 # ADR・図・仕様間のドリフト検知
+      # レビュー結果の再点検（検証ゲート、W チェック）
+      - rr-upstream-plangate-verification-audit-001
+    exclude: []
+  minTier: community

--- a/examples/selection/tdd.yaml
+++ b/examples/selection/tdd.yaml
@@ -1,0 +1,20 @@
+# .river-review.yaml の selection サンプル: TDD（テスト駆動開発）チーム向け
+# テストファースト運用を前提に、テスト雛形生成（upstream）からカバレッジ検査（downstream）までを束ねる。
+# 注意: selection セクションは設計段階の機能です（docs/development/skill-pack-design.md §6、実装は Phase B）。
+selection:
+  packs: []
+  tags:
+    - unit-test # test scaffold 系 skill を横断追加
+    - tdd
+  skills:
+    include:
+      # 仕様からテスト雛形を生成する upstream skill（スタックに合わせて取捨選択する）
+      - rr-upstream-test-code-unit-ts-jest-001 # TypeScript (Jest/Vitest)
+      - rr-upstream-test-code-react-001 # React コンポーネント (RTL)
+      # 実装中〜実装後のテスト品質ゲート
+      - rr-downstream-test-existence-001 # 変更に対応するテストの存在
+      - rr-downstream-coverage-gap-001 # カバレッジの穴
+      - rr-downstream-test-naming-001 # テスト名の意図明確性
+      - rr-downstream-flaky-test-001 # flaky パターンの検出
+    exclude: []
+  minTier: community


### PR DESCRIPTION
## 概要

#1102 のフォローアップ。導入プロジェクト側が pack / tag / 個別 skill を宣言する `selection` セクションの設計を skill pack design doc に追記し、実際の開発環境を想定したユースケース別サンプルを追加します。

## 変更内容

- `docs/development/skill-pack-design.md` — §6「導入プロジェクト側の selection 宣言」を新設（.env 風の新形式は採用せず既存 `.river-review.yaml` に統合、優先順位 `exclude > include > packs/tags union`、suppression との役割分離、`--skill-set` / 環境変数の位置づけ）。実行計画を §7 に再配置し、selection resolver を Phase B、tags 実行フィルタを Phase D に組み込み
- `examples/selection/` — ユースケース別サンプル 4 件 + README
  - `react-typescript.yaml` — React + TypeScript (Next.js) Web アプリ
  - `tdd.yaml` — TDD（テスト雛形生成〜カバレッジ・flaky 検査）
  - `sdd.yaml` — 仕様駆動開発（plan / pbi-input / ADR 整合の多段検査）
  - `architecture-review.yaml` — DDD 境界・契約・運用性のドリフト防止

## 検証

- サンプルが参照する全 skill id が `skills/` 配下に実在することを grep で確認済み
- `npx textlint --no-cache` green / `npm run fix:dashes` 適用済み

## 発見事項（フォローアップ候補）

サンプル作成時に、`skills/` に実在するが registry.yaml に未掲載の skill を 6 件発見（`rr-midstream-loading-state-001`, `rr-midstream-nullability-contract-001`, `rr-downstream-test-existence-001`, `rr-downstream-coverage-gap-001`, `rr-downstream-test-naming-001`, `rr-downstream-flaky-test-001`）。カタログドリフトとして別 Issue で追跡予定。

## スコープ

docs / examples のみ（src / runners / schemas には触れません）。selection は設計段階であり、サンプルにもその旨を明記しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)