### PR TITLE
docs: keep /check and /pr commands as review-adjacent, clarify positioning

### DIFF
--- a/commands/check.md
+++ b/commands/check.md
@@ -1,5 +1,5 @@
 ---
-description: 'Pre-review harness check: run lint/typecheck/tests and summarize failures and risks'
+description: 'Pre-review harness check: run lint/tests and summarize failures and risks'
 ---
 
 対象プロジェクトに存在するチェックのみをこの順で実行して、失敗したら原因と修正案を出して：

--- a/commands/check.md
+++ b/commands/check.md
@@ -1,5 +1,5 @@
 ---
-description: 'Run lint/typecheck/tests and summarize failures'
+description: 'Pre-review harness check: run lint/typecheck/tests and summarize failures and risks'
 ---
 
 対象プロジェクトに存在するチェックのみをこの順で実行して、失敗したら原因と修正案を出して：

--- a/commands/pr.md
+++ b/commands/pr.md
@@ -1,5 +1,5 @@
 ---
-description: 'Draft a PR description using our template'
+description: 'Draft a review-ready PR description using our template (pairs with rr-midstream-pr-description-001)'
 ---
 
 この差分を、以下のテンプレートで PR 本文にして：

--- a/docs/development/skill-pack-design.md
+++ b/docs/development/skill-pack-design.md
@@ -82,6 +82,7 @@ pack はいずれか 1 つの軸に分類します。軸をまたぐ関心は ta
 - 汎用コードレビュー系の重複 skill は plugin の `river-review-code` に統合する（agent-code-review の多観点実行・件数制約、agent-code-quality の命名・カプセル化観点を統合済み）
 - 計画「作成」（rr-upstream-create-plan-001）は PlanGate の責務とし、PlanGate 側へ移管する（受け入れ Issue 登録済み。移管完了後に本リポジトリから削除し、以降は plan を検査する側の skill のみ持つ）
 - レビューと無関係な汎用開発ガイド（ドキュメント執筆・リファクタ手順）は持たない
+- plugin commands の `/check` / `/pr` は review-adjacent として **維持** する（2026-06-10 決定）。`/check` はレビュー前のハーネス検証（決定論チェックを先に走らせ AI レビューを高次判断に集中させる）、`/pr` は検査 skill `rr-midstream-pr-description-001` とペアを成す「レビュー可能な PR 本文」の生成側という位置づけである
 
 ## 4. 成熟度 tier
 


### PR DESCRIPTION
## 概要

skill インベントリ監査（#1105）の残課題だった plugin commands `/check` / `/pr` の処遇を「**残す**」で確定し、位置づけを明文化します（breaking change なし）。

## 変更内容

- `docs/development/skill-pack-design.md` — インベントリ方針に commands の維持と位置づけを追記
  - `/check` = レビュー前のハーネス検証（決定論チェックを先行させ AI レビューを高次判断に集中させる。README FAQ / Harness-first 戦略と整合）
  - `/pr` = 検査 skill `rr-midstream-pr-description-001` とペアの「レビュー可能な PR 本文」生成側
- `commands/check.md` / `commands/pr.md` — description を目的が伝わる表現へ微修正

## 検証

- `npx textlint --no-cache` green
- plugin manifest（.claude-plugin/plugin.json）は変更なし、互換維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)