### PR TITLE
fix(docs): repair 5 broken links failing lychee on every PR

### DIFF
--- a/docs/migration/migration-guide-agent-skills.md
+++ b/docs/migration/migration-guide-agent-skills.md
@@ -42,4 +42,4 @@ cp -r templates/references/ skills/agent-skills/my-new-skill/references/
 - **バリデーション**: `npm run agent-skills:validate`
 - **スキル監査**: `node scripts/skills-audit.mjs`
 
-詳細は [CONTRIBUTING.md](../CONTRIBUTING.md) を参照してください。
+詳細は [CONTRIBUTING.md](../../CONTRIBUTING.md) を参照してください。

--- a/pages/guides/github-actions.en.md
+++ b/pages/guides/github-actions.en.md
@@ -44,7 +44,7 @@ Most teams should use **`midstream`**. It runs a review when the PR is opened an
 
 ## Using Anthropic (Claude)
 
-Specify a `claude-*` model in `.river-review.json` (placed in the repository root) and pass `ANTHROPIC_API_KEY`. For all available fields, see the [Config Schema Reference](/reference/config-schema).
+Specify a `claude-*` model in `.river-review.json` (placed in the repository root) and pass `ANTHROPIC_API_KEY`. For all available fields, see the [Config Schema Reference](../reference/config-schema.md).
 
 ```yaml
 - name: Run River Review (midstream, Claude)

--- a/pages/guides/github-actions.md
+++ b/pages/guides/github-actions.md
@@ -44,7 +44,7 @@ PR へのコメント投稿には `issues: write` が必要です。権限不足
 
 ## Anthropic (Claude) を使う場合
 
-`.river-review.json`（リポジトリルートに配置）で `claude-*` モデルを指定し、`ANTHROPIC_API_KEY` を渡します。設定できる全フィールドは [設定スキーマリファレンス](/reference/config-schema) を参照してください。
+`.river-review.json`（リポジトリルートに配置）で `claude-*` モデルを指定し、`ANTHROPIC_API_KEY` を渡します。設定できる全フィールドは [設定スキーマリファレンス](../reference/config-schema.md) を参照してください。
 
 ```yaml
 - name: Run River Review (midstream, Claude)

--- a/runners/node-api/README.md
+++ b/runners/node-api/README.md
@@ -8,10 +8,10 @@ The Node API runner provides a TypeScript/JavaScript API for integrating River R
 
 ## Package
 
-|         | `@river-review/node-api`                                                                         | `@river-review/core-runner`                                                                            |
-| ------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------ |
-| npm     | [npmjs.com/package/@river-review/node-api](https://www.npmjs.com/package/@river-review/node-api) | [npmjs.com/package/@river-review/core-runner](https://www.npmjs.com/package/@river-review/core-runner) |
-| Version | see [package.json](./package.json)                                                               | see [core package.json](../core/package.json)                                                          |
+|         | `@river-review/node-api`                                                                           | `@river-review/core-runner`                                                                           |
+| ------- | -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| npm     | `@river-review/node-api`（npm 未公開、[#800](https://github.com/s977043/river-review/issues/800)） | `@river-review/core-runner`（npm 未公開、[#800](https://github.com/s977043/river-review/issues/800)） |
+| Version | see [package.json](./package.json)                                                                 | see [core package.json](../core/package.json)                                                         |
 
 ## Installation
 

--- a/runners/node-api/README.md
+++ b/runners/node-api/README.md
@@ -8,10 +8,10 @@ The Node API runner provides a TypeScript/JavaScript API for integrating River R
 
 ## Package
 
-|         | `@river-review/node-api`                                                                           | `@river-review/core-runner`                                                                           |
-| ------- | -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| npm     | `@river-review/node-api`（npm 未公開、[#800](https://github.com/s977043/river-review/issues/800)） | `@river-review/core-runner`（npm 未公開、[#800](https://github.com/s977043/river-review/issues/800)） |
-| Version | see [package.json](./package.json)                                                                 | see [core package.json](../core/package.json)                                                         |
+|         | `@river-review/node-api`                                                                                             | `@river-review/core-runner`                                                                                             |
+| ------- | -------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| npm     | `@river-review/node-api` (not yet published to npm — see [#800](https://github.com/s977043/river-review/issues/800)) | `@river-review/core-runner` (not yet published to npm — see [#800](https://github.com/s977043/river-review/issues/800)) |
+| Version | see [package.json](./package.json)                                                                                   | see [core package.json](../core/package.json)                                                                           |
 
 ## Installation
 


### PR DESCRIPTION
## 概要

全 PR の lychee チェックを恒常的に fail させていた既存リンク切れ 5 件を修正します（#1102〜#1106 の CI で毎回 fail していたもの）。

## 修正内容

| ファイル | 修正 |
| --- | --- |
| `docs/migration/migration-guide-agent-skills.md` | `../CONTRIBUTING.md`（存在しない docs/CONTRIBUTING.md を指していた）→ `../../CONTRIBUTING.md` |
| `pages/guides/github-actions.md` / `.en.md` | root-relative `/reference/config-schema`（lychee がローカル解決不可）→ 相対 `../reference/config-schema.md` |
| `runners/node-api/README.md` | npm 未公開パッケージへのリンク 2 件（403）→ コード表記 + [#800](https://github.com/s977043/river-review/issues/800) 参照に置換（公開後に復元） |

## 検証

- ローカル lychee: 対象 4 ファイルで 12 links / 0 errors
- リンク先（CONTRIBUTING.md / pages/reference/config-schema.md）の実在確認済み
- `npm run lint:text`（CI 同等、pages のみ対象）green

🤖 Generated with [Claude Code](https://claude.com/claude-code)