### PR TITLE
feat(skills): ddd pack with degraded mode and pack tier assessment (Phase C)

### DIFF
--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "description": "Deterministic skill manifest for drift detection by selective adopters. Compare the checksum of your copied skill against this list to notice upstream changes. Regenerate with: npm run skills:manifest",
-  "skillCount": 96,
+  "skillCount": 97,
   "skills": [
     {
       "id": "adversarial-review",
@@ -296,6 +296,12 @@
       "path": "skills/midstream/rr-midstream-typescript-strict-001",
       "checksum": "sha256:0ea9d7a3d66add162ee44f5f0f488639212c6a301fccd9c279c91bfe7059e0b9",
       "files": 7
+    },
+    {
+      "id": "rr-midstream-ubiquitous-language-naming-001",
+      "path": "skills/midstream/rr-midstream-ubiquitous-language-naming-001",
+      "checksum": "sha256:4958582f8998b91f228d4ef76a34f0a9fc9ab9f2878717d6e3f81ae67075aa92",
+      "files": 1
     },
     {
       "id": "rr-midstream-war-game-001",

--- a/examples/selection/architecture-review.yaml
+++ b/examples/selection/architecture-review.yaml
@@ -2,13 +2,12 @@
 # 設計ドキュメント・ADR を継続的にレビューし、境界・契約・運用性のドリフトを防ぐ。
 # 注意: selection セクションは設計段階の機能です（docs/development/skill-pack-design.md §6、実装は Phase B）。
 selection:
-  packs: []
-  # Phase C で ddd pack が landed したら packs: [ddd] へ移行する
+  packs:
+    - ddd # bounded-context / type-driven-design / ubiquitous-language-naming（experimental tier のため minTier 注意）
   tags:
     - architecture
   skills:
     include:
-      - rr-upstream-bounded-context-language-001 # 境界づけられたコンテキストとユビキタス言語
       - rr-upstream-architecture-boundaries-001 # 境界・依存方向・所有権
       - rr-upstream-data-flow-state-ownership-001 # データフローと状態の所有
       - rr-upstream-integration-contracts-001 # サービス間契約
@@ -16,4 +15,4 @@ selection:
       - rr-upstream-api-versioning-compat-001 # API 互換性と versioning
       - rr-upstream-trust-boundaries-authz-001 # 信頼境界と認可
     exclude: []
-  minTier: community
+  minTier: community # packs への明示指定（ddd）は minTier より優先される（警告のみ）

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "usage:summary": "node scripts/usage-summary.mjs",
     "skills:manifest": "node scripts/generate-skill-manifest.mjs",
     "skills:manifest:check": "node scripts/generate-skill-manifest.mjs --check",
-    "feedback:apply": "node scripts/apply-feedback.mjs"
+    "feedback:apply": "node scripts/apply-feedback.mjs",
+    "packs:tier": "node scripts/pack-tier-check.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.102.0",

--- a/scripts/pack-tier-check.mjs
+++ b/scripts/pack-tier-check.mjs
@@ -14,7 +14,7 @@
 import path from 'path';
 import { promises as fs } from 'fs';
 import { realpathSync } from 'fs';
-import { pathToFileURL, fileURLToPath } from 'url';
+import { pathToFileURL } from 'url';
 import {
   defaultPaths,
   createSkillValidator,
@@ -27,7 +27,7 @@ import {
 const TIER_RANK = { experimental: 0, community: 1, official: 2 };
 
 async function buildSkillAssetIndex({ skillsDir, repoRoot }) {
-  const schema = await loadSchema(defaultPaths.schemaPath);
+  const schema = await loadSchema(path.join(repoRoot, 'schemas', 'skill.schema.json'));
   const validator = createSkillValidator(schema);
   const index = new Map();
   for (const filePath of await listSkillFiles(skillsDir)) {

--- a/scripts/pack-tier-check.mjs
+++ b/scripts/pack-tier-check.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+// Mechanical tier assessment for skill packs (Phase C of
+// docs/development/skill-pack-design.md §4).
+//
+// For each pack in skills/registry.yaml, checks the machine-verifiable tier
+// conditions (per-skill fixtures/eval assets) and reports:
+// - promotion candidates (declared tier lower than the assets justify)
+// - demotion mismatches (declared tier higher than the assets justify)
+// Tier changes themselves stay a maintainer decision — official additionally
+// requires maintainer review, so this script never edits the registry.
+//
+// Usage: node scripts/pack-tier-check.mjs [--strict]
+//   --strict  exit 1 when a declared tier exceeds its mechanical assessment
+import path from 'path';
+import { promises as fs } from 'fs';
+import { realpathSync } from 'fs';
+import { pathToFileURL, fileURLToPath } from 'url';
+import {
+  defaultPaths,
+  createSkillValidator,
+  loadSchema,
+  loadSkillFile,
+  listSkillFiles,
+  loadPacks,
+} from '../runners/core/skill-loader.mjs';
+
+const TIER_RANK = { experimental: 0, community: 1, official: 2 };
+
+async function buildSkillAssetIndex({ skillsDir, repoRoot }) {
+  const schema = await loadSchema(defaultPaths.schemaPath);
+  const validator = createSkillValidator(schema);
+  const index = new Map();
+  for (const filePath of await listSkillFiles(skillsDir)) {
+    const basename = path.basename(filePath);
+    if (basename === 'skill.yaml' || basename === 'skill.yml') continue;
+    if (path.relative(repoRoot, filePath).includes('agent-skills')) continue;
+    try {
+      const skill = await loadSkillFile(filePath, { validator });
+      if (!skill?.metadata?.id) continue;
+      const entries = await fs.readdir(path.dirname(filePath)).catch(() => []);
+      index.set(skill.metadata.id, {
+        hasAssets: entries.includes('fixtures') || entries.includes('eval'),
+      });
+    } catch {
+      // invalid skill files are reported by skills:validate
+    }
+  }
+  return index;
+}
+
+/**
+ * Mechanical assessment: official requires all member skills to carry
+ * fixtures/eval assets; community requires at least one; otherwise
+ * experimental. (Content sufficiency is judged by maintainers.)
+ */
+export function assessTier(pack, assetIndex) {
+  const skills = pack.skills ?? [];
+  const withAssets = skills.filter((id) => assetIndex.get(id)?.hasAssets).length;
+  if (skills.length > 0 && withAssets === skills.length) return 'official';
+  if (withAssets > 0) return 'community';
+  return 'experimental';
+}
+
+export async function checkPackTiers({
+  skillsDir = defaultPaths.skillsDir,
+  repoRoot = defaultPaths.repoRoot,
+  log = console.log,
+} = {}) {
+  const packs = await loadPacks({ skillsDir });
+  if (!packs.length) {
+    log('No packs declared in skills/registry.yaml.');
+    return { packs: 0, overDeclared: [], promotable: [] };
+  }
+  const assetIndex = await buildSkillAssetIndex({ skillsDir, repoRoot });
+  const overDeclared = [];
+  const promotable = [];
+  for (const pack of packs) {
+    const assessed = assessTier(pack, assetIndex);
+    const declared = pack.tier ?? 'experimental';
+    if (TIER_RANK[declared] > TIER_RANK[assessed]) {
+      overDeclared.push({ id: pack.id, declared, assessed });
+      log(`❌ pack "${pack.id}": declared tier "${declared}" exceeds mechanical assessment "${assessed}"`);
+    } else if (TIER_RANK[declared] < TIER_RANK[assessed]) {
+      promotable.push({ id: pack.id, declared, assessed });
+      log(
+        `⬆️  pack "${pack.id}": assets would support "${assessed}" (declared "${declared}") — ` +
+          'promotion still requires maintainer review'
+      );
+    } else {
+      log(`✅ pack "${pack.id}": tier "${declared}" matches mechanical assessment`);
+    }
+  }
+  return { packs: packs.length, overDeclared, promotable };
+}
+
+const isDirectRun =
+  process.argv[1] && import.meta.url === pathToFileURL(realpathSync(process.argv[1])).href;
+if (isDirectRun) {
+  const strict = process.argv.includes('--strict');
+  const result = await checkPackTiers({});
+  if (strict && result.overDeclared.length > 0) {
+    process.exitCode = 1;
+  }
+}

--- a/skills/midstream/rr-midstream-ubiquitous-language-naming-001/SKILL.md
+++ b/skills/midstream/rr-midstream-ubiquitous-language-naming-001/SKILL.md
@@ -1,0 +1,74 @@
+---
+id: rr-midstream-ubiquitous-language-naming-001
+name: 'Ubiquitous Language Naming Consistency'
+description: 'Detects domain terms drifting between code identifiers and the established ubiquitous language (same concept under different names, or different concepts sharing a name).'
+version: 0.1.0
+category: midstream
+phase: midstream
+applyTo:
+  - 'src/**/*.{ts,tsx,js,jsx,mjs}'
+  - 'app/**/*.{ts,tsx,js,jsx,mjs}'
+  - 'lib/**/*.{ts,tsx,js,jsx,mjs}'
+tags: [ddd, domain, naming, ubiquitous-language, midstream]
+severity: minor
+inputContext: [diff]
+outputKind: [findings, questions]
+modelHint: balanced
+---
+
+## Pattern declaration
+
+Primary pattern: Reviewer
+Secondary patterns: なし
+Why: 差分内の識別子をドメイン用語の一貫性という単一観点で評価するレビュースキル
+
+## Goal / 目的
+
+- ドメイン概念の命名ドリフト（同一概念の別名、別概念の同名）が差分から混入するのを防ぐ。
+- diff 単体で安全に動作し、plan / ADR が無いリポジトリでも ddd pack の空振りを防ぐ。
+
+## Non-goals / 扱わないこと
+
+- 集約境界・コンテキスト境界の設計判断（`rr-upstream-bounded-context-language-001` が artifact ベースで扱う）。
+- primitive obsession / brand 型の検出（`rr-midstream-type-driven-design-001` に委譲する）。
+- 一般的な命名の良し悪し（広すぎる名前等）。ドメイン用語の **一貫性** のみを見る。
+
+## Pre-execution Gate / 実行前ゲート
+
+このスキルは以下の条件が**すべて**満たされない限り`NO_REVIEW`を返す。
+
+- [ ] 差分にドメイン語彙を含む識別子（型名・関数名・プロパティ名）の追加または改名が含まれている
+- [ ] diff コンテキストが利用可能である
+
+ゲート不成立時の出力: `NO_REVIEW: rr-midstream-ubiquitous-language-naming-001 — ドメイン識別子の変更なし`
+
+補足: plan / ADR / 用語集が利用可能な場合はそれを正とし、無い場合は **差分周辺の既存コードの語彙** を正とする（degraded mode）。
+
+## False-positive guards / 抑制条件
+
+- 外部 API / ライブラリ由来の名前（SDK の型名等）はプロジェクトの用語と一致しなくても指摘しない。
+- テストダブル・fixture 内の意図的な別名は指摘しない。
+- 単数形/複数形・大文字小文字のみの揺れで、文脈上意味が同一と判断できる場合は質問に留める。
+
+## Rule / ルール
+
+- 同一概念が差分内・周辺コードで別名になっていないか（例: `Customer` と `Client` の混在）。
+- 既存の別概念と同じ名前を新規に割り当てていないか（例: 課金の `Account` と認証の `Account`）。
+- ドメイン用語の翻訳揺れ（和英混在で同一概念を指す等）が新規導入されていないか。
+
+## Evidence / 根拠の取り方
+
+- 指摘は `<file>:<line>` で差分に紐づけ、衝突相手（既存の識別子と位置）を併記する。
+- 用語の正が判断できない場合は断定せず、`questions` として「どちらの用語に揃えるか」を返す。
+
+## Output / 出力（短文版の推奨）
+
+コメントは日本語で返す。
+
+- Finding: どの用語がどこでドリフトしたか（1文）
+- Impact: ドメイン理解・検索性への影響（短く）
+- Fix: 揃える先の用語と最小の改名案
+
+例:
+
+- `src/billing/invoice.ts:24: 既存の Customer と同概念の Client を新規導入。用語が分裂し検索性が低下。Fix: Customer に統一`

--- a/skills/registry.yaml
+++ b/skills/registry.yaml
@@ -206,6 +206,17 @@ skills:
     recommended: true
     description: 'Meta-review skill: detects review findings that belong in CI/lint/formatter rather than human review'
 
+  - id: rr-midstream-ubiquitous-language-naming-001
+    version: '0.1.0'
+    name: 'Ubiquitous Language Naming Consistency'
+    path: skills/midstream/rr-midstream-ubiquitous-language-naming-001/SKILL.md
+    category: midstream
+    phase: midstream
+    tags: [ddd, domain, naming, ubiquitous-language, midstream]
+    severity: minor
+    recommended: false
+    description: 'Detects domain terms drifting between code identifiers and the established ubiquitous language.'
+
   - id: rr-midstream-loading-state-001
     version: '0.1.0'
     name: 'Loading State Transition Review'
@@ -868,6 +879,26 @@ packs:
       - rr-midstream-typescript-strict-001
       - rr-midstream-typescript-nullcheck-001
       - rr-midstream-type-driven-design-001
+
+  # 設計手法軸の実証 pack（skill-pack-design.md §3）。
+  # degraded mode: bounded-context は artifact / 設計ドキュメント差分にのみ反応し、
+  # diff 単体のリポジトリでは ubiquitous-language-naming / type-driven-design が
+  # 空振りを防ぐ。
+  - id: ddd
+    version: '0.1.0'
+    name: 'Domain-Driven Design Review Pack'
+    description: '境界づけられたコンテキスト・ユビキタス言語・型駆動のドメインモデリングのレビュー基準'
+    axis: methodology
+    tier: experimental
+    sources:
+      - name: 'Domain-Driven Design (Eric Evans)'
+        version: '2003 / Evans classification'
+        url: 'https://www.domainlanguage.com/ddd/'
+        reviewed_at: '2026-06-10'
+    skills:
+      - rr-upstream-bounded-context-language-001
+      - rr-midstream-type-driven-design-001
+      - rr-midstream-ubiquitous-language-naming-001
 
 # Recommended skill sets
 # NOTE: new additions are frozen (skill-pack-design.md §2). New bundles go to

--- a/tests/fixtures/execution-plan-midstream.json
+++ b/tests/fixtures/execution-plan-midstream.json
@@ -78,6 +78,13 @@
       "dependencies": []
     },
     {
+      "id": "rr-midstream-ubiquitous-language-naming-001",
+      "phase": "midstream",
+      "modelHint": "balanced",
+      "outputKind": ["findings", "questions"],
+      "dependencies": []
+    },
+    {
       "id": "rr-midstream-gh-address-comments-001",
       "phase": "midstream",
       "modelHint": "high-accuracy",

--- a/tests/pack-tier-check.test.mjs
+++ b/tests/pack-tier-check.test.mjs
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { assessTier, checkPackTiers } from '../scripts/pack-tier-check.mjs';
+
+const index = new Map([
+  ['with-assets-a', { hasAssets: true }],
+  ['with-assets-b', { hasAssets: true }],
+  ['bare', { hasAssets: false }],
+]);
+
+test('assessTier: all skills with assets → official', () => {
+  assert.equal(assessTier({ skills: ['with-assets-a', 'with-assets-b'] }, index), 'official');
+});
+
+test('assessTier: some skills with assets → community', () => {
+  assert.equal(assessTier({ skills: ['with-assets-a', 'bare'] }, index), 'community');
+});
+
+test('assessTier: no assets (or unknown ids) → experimental', () => {
+  assert.equal(assessTier({ skills: ['bare'] }, index), 'experimental');
+  assert.equal(assessTier({ skills: ['ghost'] }, index), 'experimental');
+  assert.equal(assessTier({ skills: [] }, index), 'experimental');
+});
+
+test('real registry: no pack declares a tier above its mechanical assessment', async () => {
+  const logs = [];
+  const result = await checkPackTiers({ log: (m) => logs.push(m) });
+  assert.ok(result.packs >= 2, 'typescript and ddd packs are declared');
+  assert.deepEqual(
+    result.overDeclared,
+    [],
+    `over-declared tiers found: ${JSON.stringify(result.overDeclared)}`
+  );
+});


### PR DESCRIPTION
## 概要

skill-pack-design.md の Phase C 実装。設計手法軸（methodology）の実証として ddd pack を追加し、tier の機械判定スクリプトを導入します。

## 変更内容

### ddd pack（axis: methodology / tier: experimental）
- `rr-upstream-bounded-context-language-001`（既存、artifact / 設計ドキュメント差分にのみ path-gate で反応）
- `rr-midstream-type-driven-design-001`（既存、diff-safe な戦術的 DDD）
- **新規** `rr-midstream-ubiquitous-language-naming-001` — ドメイン用語の命名ドリフト検出（同一概念の別名 / 別概念の同名）。plan / ADR が無い場合は差分周辺の既存語彙を正とする **degraded mode** を明記し、境界設計は bounded-context へ、型設計は type-driven-design へ委譲する Non-goals 付き

設計の要点: artifact 必須 skill は path-gate で空振りせず、diff-safe な 2 skill がライトユーザーでも価値を出します（design §3 の degraded mode 必須要件）。

### tier 機械判定（`npm run packs:tier`）
- `scripts/pack-tier-check.mjs`: pack ごとに全 skill の fixtures/eval 資産を集計し、宣言 tier と機械評価を突合。過大宣言は ❌（`--strict` で exit 1）、昇格余地は ⬆️ 表示（official 昇格は maintainer review 必須のまま）
- 現状: typescript = community 一致 / ddd = experimental 一致を確認済み

### 付随
- execution-plan スナップショット再生成（新 midstream skill が選択されるため。スナップショットがドリフトを正しく検知）
- skill manifest 再生成（97 skills）
- `examples/selection/architecture-review.yaml` を landed した ddd pack 参照へ更新

## 検証

- `npm test` **1250/1250 pass**（新規 4 テスト含む）
- `npm run planner:eval:dataset` top1Match 100%（31 cases）
- `npm run skills:validate` green（packs 2 件 valid）/ `npm run packs:tier` 全 pack 一致

Refs: docs/development/skill-pack-design.md §3/§4/§7 Phase C

🤖 Generated with [Claude Code](https://claude.com/claude-code)