### PR TITLE
feat(loop): suppression analytics and nightly eval regression auto-issue (L-3)

### DIFF
--- a/.github/workflows/nightly-eval.yml
+++ b/.github/workflows/nightly-eval.yml
@@ -59,11 +59,19 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if node scripts/compare-eval-ledger.mjs > compare-output.txt 2>&1; then
+          set +e
+          node scripts/compare-eval-ledger.mjs > compare-output.txt 2>&1
+          rc=$?
+          set -e
+          cat compare-output.txt
+          if [ "$rc" -eq 0 ]; then
             echo "No KPI regression detected."
             exit 0
           fi
-          cat compare-output.txt
+          if [ "$rc" -ne 1 ]; then
+            echo "compare-eval-ledger failed with exit code $rc (fatal error, not a regression); skipping issue creation."
+            exit 0
+          fi
           existing=$(gh issue list --label eval-regression --state open --json number --jq 'length')
           if [ "$existing" -gt 0 ]; then
             echo "An eval-regression issue is already open; skipping creation."

--- a/.github/workflows/nightly-eval.yml
+++ b/.github/workflows/nightly-eval.yml
@@ -17,6 +17,7 @@ concurrency:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   eval:
@@ -52,6 +53,35 @@ jobs:
             lines.push('', 'Status: **' + r.status.toUpperCase() + '**');
             fs.writeFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join('\n'));
           "
+
+      - name: Open issue on KPI regression (improvement loop L-3)
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if node scripts/compare-eval-ledger.mjs > compare-output.txt 2>&1; then
+            echo "No KPI regression detected."
+            exit 0
+          fi
+          cat compare-output.txt
+          existing=$(gh issue list --label eval-regression --state open --json number --jq 'length')
+          if [ "$existing" -gt 0 ]; then
+            echo "An eval-regression issue is already open; skipping creation."
+            exit 0
+          fi
+          {
+            echo "Nightly eval detected a KPI regression (improvement loop L-3 auto-trigger)."
+            echo ""
+            echo '```'
+            cat compare-output.txt
+            echo '```'
+            echo ""
+            echo "Next action: identify the skill behind the regressed metric and run the feedback loop (docs/development/skill-improvement-loop-design.md §3 L3)."
+          } > issue-body.md
+          gh issue create \
+            --title "eval: nightly KPI regression detected ($(date -u +%Y-%m-%d))" \
+            --label eval-regression \
+            --body-file issue-body.md
 
       - name: Upload eval artifacts
         if: always()

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "skills:manifest": "node scripts/generate-skill-manifest.mjs",
     "skills:manifest:check": "node scripts/generate-skill-manifest.mjs --check",
     "feedback:apply": "node scripts/apply-feedback.mjs",
-    "packs:tier": "node scripts/pack-tier-check.mjs"
+    "packs:tier": "node scripts/pack-tier-check.mjs",
+    "suppression:analytics": "node scripts/suppression-analytics.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.102.0",

--- a/scripts/suppression-analytics.mjs
+++ b/scripts/suppression-analytics.mjs
@@ -70,7 +70,9 @@ export function analyzeSuppressions(entries, { now = new Date(), thresholds = TH
       fingerprint: e.context?.fingerprint ?? null,
       severity: e.context.severity,
       createdAt: e.createdAt,
-      ageDays: Math.floor((now.getTime() - new Date(e.createdAt).getTime()) / (24 * 60 * 60 * 1000)),
+      ageDays: Math.floor(
+        (now.getTime() - new Date(e.createdAt).getTime()) / (24 * 60 * 60 * 1000)
+      ),
       rationale: e.context?.rationale ?? e.summary ?? null,
     }));
 
@@ -146,8 +148,12 @@ if (isDirectRun) {
     console.log(formatIssueBody(result));
   } else {
     console.log(`active suppressions: ${result.active}`);
-    console.log(`repeated fingerprints (>=${THRESHOLDS.repeatPrCount} PRs): ${result.repeatedFingerprints.length}`);
-    console.log(`stale major/critical (>=${THRESHOLDS.staleHighSeverityDays}d): ${result.staleHighSeverity.length}`);
+    console.log(
+      `repeated fingerprints (>=${THRESHOLDS.repeatPrCount} PRs): ${result.repeatedFingerprints.length}`
+    );
+    console.log(
+      `stale major/critical (>=${THRESHOLDS.staleHighSeverityDays}d): ${result.staleHighSeverity.length}`
+    );
     if (result.repeatedFingerprints.length || result.staleHighSeverity.length) {
       console.log('\nRun with --issue-body to generate a diagnosis-request issue body.');
       process.exitCode = 2;

--- a/scripts/suppression-analytics.mjs
+++ b/scripts/suppression-analytics.mjs
@@ -122,7 +122,13 @@ export async function runSuppressionAnalytics({
     log(`No memory index found at ${indexPath}; nothing to analyze.`);
     return { active: 0, repeatedFingerprints: [], staleHighSeverity: [] };
   }
-  const index = JSON.parse(raw);
+  let index;
+  try {
+    index = JSON.parse(raw);
+  } catch (err) {
+    log(`Memory index at ${indexPath} is not valid JSON (${err.message}); nothing to analyze.`);
+    return { active: 0, repeatedFingerprints: [], staleHighSeverity: [] };
+  }
   const entries = Array.isArray(index?.entries) ? index.entries : [];
   return analyzeSuppressions(entries, { now });
 }

--- a/scripts/suppression-analytics.mjs
+++ b/scripts/suppression-analytics.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+// Suppression pattern analytics (L4 in
+// docs/development/skill-improvement-loop-design.md §3).
+//
+// Scans Riverbed Memory suppression entries and flags patterns that signal
+// "this needs a skill fix, not another suppression":
+// - the same fingerprint suppressed across N+ distinct PRs (default 3)
+// - active major/critical suppressions older than N days (default 14)
+// The output feeds the skill-optimizer diagnosis as-is; this script only
+// detects and reports — it never edits memory or skills.
+//
+// Usage: node scripts/suppression-analytics.mjs [--index <path>] [--issue-body] [--json]
+import path from 'path';
+import { promises as fs } from 'fs';
+import { realpathSync } from 'fs';
+import { pathToFileURL, fileURLToPath } from 'url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DEFAULT_INDEX = path.join(repoRoot, '.river', 'memory', 'index.json');
+
+export const THRESHOLDS = {
+  repeatPrCount: 3,
+  staleHighSeverityDays: 14,
+};
+
+function isActiveSuppression(entry, now) {
+  if (entry?.type !== 'suppression') return false;
+  if (entry?.context?.active === false) return false;
+  const expiresAt = entry?.context?.expiresAt;
+  if (expiresAt && new Date(expiresAt).getTime() <= now.getTime()) return false;
+  return true;
+}
+
+/**
+ * Pure analysis over memory entries.
+ *
+ * @param {Array<object>} entries Riverbed Memory entries
+ * @param {{ now?: Date, thresholds?: typeof THRESHOLDS }} [options]
+ * @returns {{ active: number, repeatedFingerprints: Array, staleHighSeverity: Array }}
+ */
+export function analyzeSuppressions(entries, { now = new Date(), thresholds = THRESHOLDS } = {}) {
+  const active = entries.filter((e) => isActiveSuppression(e, now));
+
+  const byFingerprint = new Map();
+  for (const entry of active) {
+    const fp = entry.context?.fingerprint;
+    if (!fp) continue;
+    if (!byFingerprint.has(fp)) byFingerprint.set(fp, []);
+    byFingerprint.get(fp).push(entry);
+  }
+  const repeatedFingerprints = [];
+  for (const [fingerprint, group] of byFingerprint) {
+    const prs = new Set(group.map((e) => e.context?.sourcePR).filter(Boolean));
+    if (prs.size >= thresholds.repeatPrCount) {
+      repeatedFingerprints.push({
+        fingerprint,
+        prCount: prs.size,
+        prs: [...prs].sort((a, b) => a - b),
+        severities: [...new Set(group.map((e) => e.context?.severity).filter(Boolean))],
+      });
+    }
+  }
+
+  const staleMs = thresholds.staleHighSeverityDays * 24 * 60 * 60 * 1000;
+  const staleHighSeverity = active
+    .filter((e) => ['major', 'critical'].includes(e.context?.severity))
+    .filter((e) => e.createdAt && now.getTime() - new Date(e.createdAt).getTime() >= staleMs)
+    .map((e) => ({
+      id: e.id,
+      fingerprint: e.context?.fingerprint ?? null,
+      severity: e.context.severity,
+      createdAt: e.createdAt,
+      ageDays: Math.floor((now.getTime() - new Date(e.createdAt).getTime()) / (24 * 60 * 60 * 1000)),
+      rationale: e.context?.rationale ?? e.summary ?? null,
+    }));
+
+  return { active: active.length, repeatedFingerprints, staleHighSeverity };
+}
+
+export function formatIssueBody(result) {
+  const lines = [
+    '## Suppression pattern analytics（skill 改善の診断推奨）',
+    '',
+    `アクティブな suppression: ${result.active} 件`,
+    '',
+  ];
+  if (result.repeatedFingerprints.length) {
+    lines.push(`### 反復 suppress（${THRESHOLDS.repeatPrCount} PR 以上で同一 fingerprint）`, '');
+    for (const r of result.repeatedFingerprints) {
+      lines.push(
+        `- \`${r.fingerprint}\` — ${r.prCount} PRs (${r.prs.map((p) => `#${p}`).join(', ')})` +
+          (r.severities.length ? ` / severity: ${r.severities.join(', ')}` : '')
+      );
+    }
+    lines.push('');
+  }
+  if (result.staleHighSeverity.length) {
+    lines.push(
+      `### 長期滞留している major / critical suppression（${THRESHOLDS.staleHighSeverityDays} 日以上）`,
+      ''
+    );
+    for (const s of result.staleHighSeverity) {
+      lines.push(`- \`${s.fingerprint ?? s.id}\` — ${s.severity}, ${s.ageDays} 日経過`);
+    }
+    lines.push('');
+  }
+  lines.push(
+    '次のアクション: 該当 skill に対して skill-optimizer の診断を実行し、suppression の恒久化ではなく skill 本体の改善（fixture 追加・gate 修正）を検討してください。'
+  );
+  return lines.join('\n');
+}
+
+export async function runSuppressionAnalytics({
+  indexPath = DEFAULT_INDEX,
+  now = new Date(),
+  log = console.log,
+} = {}) {
+  let raw;
+  try {
+    raw = await fs.readFile(indexPath, 'utf8');
+  } catch {
+    log(`No memory index found at ${indexPath}; nothing to analyze.`);
+    return { active: 0, repeatedFingerprints: [], staleHighSeverity: [] };
+  }
+  const index = JSON.parse(raw);
+  const entries = Array.isArray(index?.entries) ? index.entries : [];
+  return analyzeSuppressions(entries, { now });
+}
+
+const isDirectRun =
+  process.argv[1] && import.meta.url === pathToFileURL(realpathSync(process.argv[1])).href;
+if (isDirectRun) {
+  const args = process.argv.slice(2);
+  const idx = args.indexOf('--index');
+  const indexPath = idx >= 0 ? path.resolve(args[idx + 1]) : DEFAULT_INDEX;
+  const result = await runSuppressionAnalytics({ indexPath });
+  if (args.includes('--json')) {
+    console.log(JSON.stringify(result, null, 2));
+  } else if (args.includes('--issue-body')) {
+    console.log(formatIssueBody(result));
+  } else {
+    console.log(`active suppressions: ${result.active}`);
+    console.log(`repeated fingerprints (>=${THRESHOLDS.repeatPrCount} PRs): ${result.repeatedFingerprints.length}`);
+    console.log(`stale major/critical (>=${THRESHOLDS.staleHighSeverityDays}d): ${result.staleHighSeverity.length}`);
+    if (result.repeatedFingerprints.length || result.staleHighSeverity.length) {
+      console.log('\nRun with --issue-body to generate a diagnosis-request issue body.');
+      process.exitCode = 2;
+    }
+  }
+}

--- a/scripts/suppression-analytics.mjs
+++ b/scripts/suppression-analytics.mjs
@@ -140,6 +140,10 @@ const isDirectRun =
 if (isDirectRun) {
   const args = process.argv.slice(2);
   const idx = args.indexOf('--index');
+  if (idx >= 0 && !args[idx + 1]) {
+    console.error('Error: --index requires a path argument.');
+    process.exit(2);
+  }
   const indexPath = idx >= 0 ? path.resolve(args[idx + 1]) : DEFAULT_INDEX;
   const result = await runSuppressionAnalytics({ indexPath });
   if (args.includes('--json')) {

--- a/tests/suppression-analytics.test.mjs
+++ b/tests/suppression-analytics.test.mjs
@@ -1,0 +1,87 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  analyzeSuppressions,
+  formatIssueBody,
+  THRESHOLDS,
+} from '../scripts/suppression-analytics.mjs';
+
+const NOW = new Date('2026-06-10T00:00:00Z');
+
+function suppression({
+  fingerprint = 'a1b2c3d4e5f60718',
+  sourcePR = 1,
+  severity = 'minor',
+  createdAt = '2026-06-01T00:00:00Z',
+  active = true,
+  expiresAt = null,
+} = {}) {
+  return {
+    id: `sup-${fingerprint}-${sourcePR}`,
+    type: 'suppression',
+    createdAt,
+    context: { fingerprint, sourcePR, severity, active, ...(expiresAt ? { expiresAt } : {}) },
+  };
+}
+
+test('flags a fingerprint suppressed across 3+ distinct PRs', () => {
+  const entries = [
+    suppression({ sourcePR: 10 }),
+    suppression({ sourcePR: 11 }),
+    suppression({ sourcePR: 12 }),
+    suppression({ fingerprint: 'ffffffffffffffff', sourcePR: 10 }),
+  ];
+  const result = analyzeSuppressions(entries, { now: NOW });
+  assert.equal(result.repeatedFingerprints.length, 1);
+  assert.equal(result.repeatedFingerprints[0].fingerprint, 'a1b2c3d4e5f60718');
+  assert.deepEqual(result.repeatedFingerprints[0].prs, [10, 11, 12]);
+});
+
+test('same PR repeated does not count toward the repeat threshold', () => {
+  const entries = [
+    suppression({ sourcePR: 10 }),
+    suppression({ sourcePR: 10 }),
+    suppression({ sourcePR: 10 }),
+  ];
+  const result = analyzeSuppressions(entries, { now: NOW });
+  assert.equal(result.repeatedFingerprints.length, 0);
+});
+
+test('flags stale major/critical suppressions but not recent or minor ones', () => {
+  const entries = [
+    suppression({ severity: 'major', createdAt: '2026-05-01T00:00:00Z' }), // 40d old
+    suppression({ severity: 'critical', createdAt: '2026-06-09T00:00:00Z', sourcePR: 2 }), // 1d old
+    suppression({ severity: 'minor', createdAt: '2026-01-01T00:00:00Z', sourcePR: 3 }), // old but minor
+  ];
+  const result = analyzeSuppressions(entries, { now: NOW });
+  assert.equal(result.staleHighSeverity.length, 1);
+  assert.equal(result.staleHighSeverity[0].severity, 'major');
+  assert.ok(result.staleHighSeverity[0].ageDays >= THRESHOLDS.staleHighSeverityDays);
+});
+
+test('inactive, expired, and non-suppression entries are excluded', () => {
+  const entries = [
+    suppression({ active: false }),
+    suppression({ expiresAt: '2026-06-01T00:00:00Z', sourcePR: 2 }),
+    { type: 'adr', context: {} },
+    suppression({ sourcePR: 3 }),
+  ];
+  const result = analyzeSuppressions(entries, { now: NOW });
+  assert.equal(result.active, 1);
+});
+
+test('formatIssueBody renders both signal sections with next action', () => {
+  const result = analyzeSuppressions(
+    [
+      suppression({ sourcePR: 10 }),
+      suppression({ sourcePR: 11 }),
+      suppression({ sourcePR: 12, severity: 'major', createdAt: '2026-05-01T00:00:00Z' }),
+    ],
+    { now: NOW }
+  );
+  const body = formatIssueBody(result);
+  assert.match(body, /反復 suppress/);
+  assert.match(body, /長期滞留/);
+  assert.match(body, /skill-optimizer/);
+});


### PR DESCRIPTION
## 概要

skill-improvement-loop-design.md の L-3（missing link L3 + L4）の実装です。「使用 → 改善」ループの検知側を自動化します。

## 変更内容

### L4: suppression パターン分析（`npm run suppression:analytics`)
- 同一 fingerprint が **3 PR 以上**で suppress されているパターンを検出（同一 PR 内の反復はカウントしない）
- **14 日以上**滞留しているアクティブな major / critical suppression を検出
- `--issue-body` で skill-optimizer 診断依頼用の Issue 本文を生成。検知と報告のみで、memory / skill は一切編集しない（design §6）
- 本リポジトリの CI には suppression データが無い（.river/memory は gitignore）ため、**定期 workflow は追加せず**導入リポジトリ / ローカル実行向けのコマンドとして提供

### L3: eval 回帰の自動起票（nightly-eval workflow 拡張）
- 統合 eval 後に `eval:compare` を実行し、KPI 回帰検知時に `eval-regression` ラベル付き Issue を自動作成
- 既存の open Issue がある場合はスキップ（毎晩の重複起票を防止）
- permissions に issues: write を追加、ラベルは作成済み

## 検証

- 新規テスト 5 件（反復検知 / 同一 PR 除外 / stale 判定 / inactive・expired 除外 / Issue 本文）を含む `npm test` **1255/1255 pass**
- workflow YAML の構文検証済み
- スクリプト単体実行で memory 不在時の clean exit を確認

Refs: docs/development/skill-improvement-loop-design.md §3 L3/L4

🤖 Generated with [Claude Code](https://claude.com/claude-code)