### PR TITLE
feat(skills): add react-router, laravel, and gha-security packs from official docs

### DIFF
--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "description": "Deterministic skill manifest for drift detection by selective adopters. Compare the checksum of your copied skill against this list to notice upstream changes. Regenerate with: npm run skills:manifest",
-  "skillCount": 96,
+  "skillCount": 102,
   "skills": [
     {
       "id": "adversarial-review",
@@ -85,6 +85,12 @@
       "id": "rr-downstream-flaky-test-001",
       "path": "skills/downstream/rr-downstream-flaky-test-001",
       "checksum": "sha256:4b2b66b6a9c022f6e1fa949eea9bb0ae7d4276173f66d6a86ba9636502001a19",
+      "files": 1
+    },
+    {
+      "id": "rr-downstream-gha-workflow-security-001",
+      "path": "skills/downstream/rr-downstream-gha-workflow-security-001",
+      "checksum": "sha256:d3917d4c3d52d694f632a9a83c9e6278d7f8f3c97141b1aa1abc6140e55f641c",
       "files": 1
     },
     {
@@ -184,6 +190,18 @@
       "files": 9
     },
     {
+      "id": "rr-midstream-laravel-eloquent-nplus1-001",
+      "path": "skills/midstream/rr-midstream-laravel-eloquent-nplus1-001",
+      "checksum": "sha256:b2c9a8437f3f65d4ab263282fc7fc13a1aaaf9bfb8b71cadd59c965fc513290e",
+      "files": 1
+    },
+    {
+      "id": "rr-midstream-laravel-mass-assignment-001",
+      "path": "skills/midstream/rr-midstream-laravel-mass-assignment-001",
+      "checksum": "sha256:b0da099883fcc12208f08f0d96bfc6bea53fd4dfba5639615c985b4309e11c8e",
+      "files": 1
+    },
+    {
       "id": "rr-midstream-loading-state-001",
       "path": "skills/midstream/rr-midstream-loading-state-001",
       "checksum": "sha256:eb57e32d0b7b97a0b745511e76124eec12332fa6e54720a7d99d1e94eea66a2e",
@@ -247,6 +265,18 @@
       "id": "rr-midstream-pr-description-001",
       "path": "skills/midstream/rr-midstream-pr-description-001",
       "checksum": "sha256:9990a448481b228d2ff4535e2637ddd9688d589bc8c2cebc44c884992ee278ff",
+      "files": 1
+    },
+    {
+      "id": "rr-midstream-react-router-action-contract-001",
+      "path": "skills/midstream/rr-midstream-react-router-action-contract-001",
+      "checksum": "sha256:692002e2f314594a34e1d44ee278f128d7812328b24f3601546aed5e8dc21f13",
+      "files": 1
+    },
+    {
+      "id": "rr-midstream-react-router-loader-boundary-001",
+      "path": "skills/midstream/rr-midstream-react-router-loader-boundary-001",
+      "checksum": "sha256:95379b4590efc8a950e62cae35c95d7249de3510358706c0c7ca470df60d3ea7",
       "files": 1
     },
     {
@@ -445,6 +475,12 @@
       "id": "rr-upstream-integration-contracts-001",
       "path": "skills/upstream/rr-upstream-integration-contracts-001",
       "checksum": "sha256:891fd577269053661f9e001f82901eec9f5bbeccd0f9f2135ef618ecac4f4176",
+      "files": 1
+    },
+    {
+      "id": "rr-upstream-laravel-migration-safety-001",
+      "path": "skills/upstream/rr-upstream-laravel-migration-safety-001",
+      "checksum": "sha256:126ab5e919451e73ddccb9cfa137872adc1c1110fdc085b042e4f446e43608da",
       "files": 1
     },
     {

--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -90,7 +90,7 @@
     {
       "id": "rr-downstream-gha-workflow-security-001",
       "path": "skills/downstream/rr-downstream-gha-workflow-security-001",
-      "checksum": "sha256:d3917d4c3d52d694f632a9a83c9e6278d7f8f3c97141b1aa1abc6140e55f641c",
+      "checksum": "sha256:d40f8c47a4aecf19f77f1fac5fbaecb5b706db9365d7553df63a74ea9fb6c5d3",
       "files": 1
     },
     {
@@ -192,13 +192,13 @@
     {
       "id": "rr-midstream-laravel-eloquent-nplus1-001",
       "path": "skills/midstream/rr-midstream-laravel-eloquent-nplus1-001",
-      "checksum": "sha256:b2c9a8437f3f65d4ab263282fc7fc13a1aaaf9bfb8b71cadd59c965fc513290e",
+      "checksum": "sha256:bf31e12a6819364679b76e47b46f602b3ce99532d14ea4d8242e25a3d50a080e",
       "files": 1
     },
     {
       "id": "rr-midstream-laravel-mass-assignment-001",
       "path": "skills/midstream/rr-midstream-laravel-mass-assignment-001",
-      "checksum": "sha256:b0da099883fcc12208f08f0d96bfc6bea53fd4dfba5639615c985b4309e11c8e",
+      "checksum": "sha256:1d019045e8caabc2b4ec045cf765170ce0e1bc64bd840e3f9adad47a411a18bd",
       "files": 1
     },
     {
@@ -270,13 +270,13 @@
     {
       "id": "rr-midstream-react-router-action-contract-001",
       "path": "skills/midstream/rr-midstream-react-router-action-contract-001",
-      "checksum": "sha256:692002e2f314594a34e1d44ee278f128d7812328b24f3601546aed5e8dc21f13",
+      "checksum": "sha256:0da5c7037b2655bd1d609e6a82185664f6fcb32915bff0562c84d026d08bf740",
       "files": 1
     },
     {
       "id": "rr-midstream-react-router-loader-boundary-001",
       "path": "skills/midstream/rr-midstream-react-router-loader-boundary-001",
-      "checksum": "sha256:95379b4590efc8a950e62cae35c95d7249de3510358706c0c7ca470df60d3ea7",
+      "checksum": "sha256:c8f7b3e8417465de4fc317df0d99dab358c73208bc0604e1a78804f85feda9b1",
       "files": 1
     },
     {
@@ -480,7 +480,7 @@
     {
       "id": "rr-upstream-laravel-migration-safety-001",
       "path": "skills/upstream/rr-upstream-laravel-migration-safety-001",
-      "checksum": "sha256:126ab5e919451e73ddccb9cfa137872adc1c1110fdc085b042e4f446e43608da",
+      "checksum": "sha256:fbb82f5c3e1f9bc24656ab55a638baede6207dc6c64be24aaa1d1a9fea0da7b8",
       "files": 1
     },
     {

--- a/pages/reference/skills-catalog.md
+++ b/pages/reference/skills-catalog.md
@@ -1483,7 +1483,6 @@ redirect on success; and 3-branch ErrorBoundary handling.`
 - 対象:
   - `app/**/*.{ts,tsx,js,jsx}`
   - `src/routes/**/*.{ts,tsx,js,jsx}`
-  - `app/routes/**/*.{ts,tsx,js,jsx}`
 - 重要度: major
 - タグ: react-router / remix / actions / validation / frontend / midstream
 - 依存関係: none
@@ -1501,7 +1500,6 @@ and missing HydrateFallback in React Router v7 framework mode.`
 - 対象:
   - `app/**/*.{ts,tsx,js,jsx}`
   - `src/routes/**/*.{ts,tsx,js,jsx}`
-  - `app/routes/**/*.{ts,tsx,js,jsx}`
 - 重要度: major
 - タグ: react-router / remix / data-loading / frontend / midstream
 - 依存関係: none

--- a/pages/reference/skills-catalog.md
+++ b/pages/reference/skills-catalog.md
@@ -6,10 +6,13 @@ River Review に同梱されているスキル一覧です。フェーズ別に�
 
 梱包済みレビューナレッジの配布単位です。`--skill-set <id>` で導入できます（詳細は [Skill Pack を使う](../guides/use-skill-packs.md) を参照）。
 
-| id           | name                             | axis        | tier      | skills                                                                                                                             |
-| ------------ | -------------------------------- | ----------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `typescript` | TypeScript Review Pack           | technology  | official  | `rr-midstream-typescript-strict-001` / `rr-midstream-typescript-nullcheck-001` / `rr-midstream-type-driven-design-001`             |
-| `ddd`        | Domain-Driven Design Review Pack | methodology | community | `rr-upstream-bounded-context-language-001` / `rr-midstream-type-driven-design-001` / `rr-midstream-ubiquitous-language-naming-001` |
+| id             | name                             | axis        | tier         | skills                                                                                                                               |
+| -------------- | -------------------------------- | ----------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `typescript`   | TypeScript Review Pack           | technology  | official     | `rr-midstream-typescript-strict-001` / `rr-midstream-typescript-nullcheck-001` / `rr-midstream-type-driven-design-001`               |
+| `ddd`          | Domain-Driven Design Review Pack | methodology | community    | `rr-upstream-bounded-context-language-001` / `rr-midstream-type-driven-design-001` / `rr-midstream-ubiquitous-language-naming-001`   |
+| `react-router` | React Router Review Pack         | technology  | experimental | `rr-midstream-react-router-loader-boundary-001` / `rr-midstream-react-router-action-contract-001`                                    |
+| `laravel`      | Laravel Review Pack              | technology  | experimental | `rr-midstream-laravel-eloquent-nplus1-001` / `rr-upstream-laravel-migration-safety-001` / `rr-midstream-laravel-mass-assignment-001` |
+| `gha-security` | GitHub Actions Security Pack     | concern     | experimental | `rr-downstream-gha-workflow-security-001`                                                                                            |
 
 ## upstream
 
@@ -533,6 +536,22 @@ rollout/rollback expectations.`
 チェック項目の例:
 
 - summary / findings / actions / questions
+
+### `rr-upstream-laravel-migration-safety-001`
+
+- 名前: `Laravel Migration Safety Review`
+- 概要: `Reviews Laravel migrations for destructive operations; change() dropping modifiers; locking index creation on
+large tables (PostgreSQL); and asymmetric down().`
+- 対象:
+  - `database/migrations/**/*.php`
+- 重要度: major
+- タグ: laravel / migration / database / postgresql / safety / upstream
+- 依存関係: none
+- 適用条件: phase=upstream, inputContext=diff
+
+チェック項目の例:
+
+- findings / questions
 
 ### `rr-upstream-migration-rollout-rollback-001`
 
@@ -1218,6 +1237,40 @@ without source usage.`
 
 - findings / summary / actions
 
+### `rr-midstream-laravel-eloquent-nplus1-001`
+
+- 名前: `Laravel Eloquent N+1 and Query Efficiency Review`
+- 概要: `Detects N+1 query patterns (relation access inside loops without eager loading); full-table get()/all() loads;
+and unsafe chunk()/cursor() usage in Laravel Eloquent code.`
+- 対象:
+  - `app/**/*.php`
+  - `src/**/*.php`
+- 重要度: major
+- タグ: laravel / eloquent / performance / n-plus-1 / php / midstream
+- 依存関係: none
+- 適用条件: phase=midstream, inputContext=diff
+
+チェック項目の例:
+
+- findings / questions
+
+### `rr-midstream-laravel-mass-assignment-001`
+
+- 名前: `Laravel Mass Assignment and Authorization Review`
+- 概要: `Detects mass assignment via create/update($request->all()); unguarded models; and missing authorization on
+mutating controller actions in Laravel.`
+- 対象:
+  - `app/**/*.php`
+  - `src/**/*.php`
+- 重要度: major
+- タグ: laravel / security / mass-assignment / authorization / php / midstream
+- 依存関係: none
+- 適用条件: phase=midstream, inputContext=diff
+
+チェック項目の例:
+
+- findings / questions
+
 ### `rr-midstream-loading-state-001`
 
 - 名前: `Loading State Transition Review`
@@ -1421,6 +1474,42 @@ linked issues).`
 チェック項目の例:
 
 - findings / actions
+
+### `rr-midstream-react-router-action-contract-001`
+
+- 名前: `React Router Action Contract Review`
+- 概要: `Checks React Router v7 action conventions: validation errors returned as data with 4xx status (not thrown);
+redirect on success; and 3-branch ErrorBoundary handling.`
+- 対象:
+  - `app/**/*.{ts,tsx,js,jsx}`
+  - `src/routes/**/*.{ts,tsx,js,jsx}`
+  - `app/routes/**/*.{ts,tsx,js,jsx}`
+- 重要度: major
+- タグ: react-router / remix / actions / validation / frontend / midstream
+- 依存関係: none
+- 適用条件: phase=midstream, inputContext=diff
+
+チェック項目の例:
+
+- findings / questions
+
+### `rr-midstream-react-router-loader-boundary-001`
+
+- 名前: `React Router Loader Boundary Review`
+- 概要: `Detects route data fetched in useEffect instead of loaders; server/client API leaks across loader boundaries;
+and missing HydrateFallback in React Router v7 framework mode.`
+- 対象:
+  - `app/**/*.{ts,tsx,js,jsx}`
+  - `src/routes/**/*.{ts,tsx,js,jsx}`
+  - `app/routes/**/*.{ts,tsx,js,jsx}`
+- 重要度: major
+- タグ: react-router / remix / data-loading / frontend / midstream
+- 依存関係: none
+- 適用条件: phase=midstream, inputContext=diff
+
+チェック項目の例:
+
+- findings / questions
 
 ### `rr-midstream-review-automation-boundary-001`
 
@@ -1656,6 +1745,22 @@ under different names; or different concepts sharing a name).`
 チェック項目の例:
 
 - findings / actions / summary
+
+### `rr-downstream-gha-workflow-security-001`
+
+- 名前: `GitHub Actions Workflow Security Review`
+- 概要: `Reviews GitHub Actions workflow diffs for script injection of untrusted input; pull_request_target with
+untrusted checkout; over-broad GITHUB_TOKEN permissions; and unpinned third-party actions.`
+- 対象:
+  - `.github/workflows/**/*.{yml,yaml}`
+- 重要度: major
+- タグ: github-actions / security / ci / supply-chain / downstream
+- 依存関係: none
+- 適用条件: phase=downstream, inputContext=diff
+
+チェック項目の例:
+
+- findings / questions
 
 ### `rr-downstream-review-policy-standard-001`
 

--- a/skills/downstream/rr-downstream-gha-workflow-security-001/SKILL.md
+++ b/skills/downstream/rr-downstream-gha-workflow-security-001/SKILL.md
@@ -1,0 +1,75 @@
+---
+id: rr-downstream-gha-workflow-security-001
+name: 'GitHub Actions Workflow Security Review'
+description: 'Reviews GitHub Actions workflow diffs for script injection of untrusted input, pull_request_target with untrusted checkout, over-broad GITHUB_TOKEN permissions, and unpinned third-party actions.'
+version: 0.1.0
+category: downstream
+phase: downstream
+applyTo:
+  - '.github/workflows/**/*.{yml,yaml}'
+tags: [github-actions, security, ci, supply-chain, downstream]
+severity: major
+inputContext: [diff]
+outputKind: [findings, questions]
+modelHint: high-accuracy
+---
+
+## Pattern declaration
+
+Primary pattern: Reviewer
+Secondary patterns: Inversion
+Why: workflow の意味的なセキュリティ判断（権限の必要性・トリガーの用途）に集中し、決定論ツールが見ない文脈を検査する
+
+## Goal / 目的
+
+- untrusted input の式展開によるスクリプトインジェクションと、特権トリガー + untrusted checkout（pwn request）を検出する。
+- GITHUB_TOKEN の過剰権限と third-party action の未ピン留めを検出する。
+
+## Non-goals / 扱わないこと
+
+- 構文的に決定論で判定できる領域（pinned-dependencies / token-permissions の機械検出）は OpenSSF Scorecard / zizmor / CodeQL に委ねる（重複指摘しない）。
+- workflow のロジック・効率（セキュリティ以外）。
+
+## Pre-execution Gate / 実行前ゲート
+
+このスキルは以下の条件が**すべて**満たされない限り`NO_REVIEW`を返す。
+
+- [ ] 差分に `.github/workflows/` 配下の追加変更が含まれている
+- [ ] diff コンテキストが利用可能である
+
+ゲート不成立時の出力: `NO_REVIEW: rr-downstream-gha-workflow-security-001 — workflow の変更なし`
+
+## False-positive guards / 抑制条件
+
+- 同一 repo / 自 org 内 action（`./.github/actions/...`、自 org reusable workflow）はピン留め不要とする運用が一般的。minor 以下に留める。
+- `actions/*` 公式 action の tag 運用は third-party より低リスク。minor 扱い。
+- `if:` 条件式内の式展開、`github.event.*.number` / `github.sha` / `github.actor` 等の数値・制約付きフィールドは原則安全。
+- checkout なし、または base ref checkout のみの `pull_request_target` は安全パターン。
+- repo 可視性が不明な self-hosted runner は major でなく warning + 確認依頼にする。
+
+## Rule / ルール
+
+- 攻撃者制御フィールド（`github.event.issue.title/.body`、`pull_request.title/.body/.head.ref`、`comment.body`、`commits.*.message`、`github.head_ref` 等）を `run:` に直接式展開しない。`env:` 経由で変数化する。
+- `pull_request_target` / `issue_comment` / `workflow_run` で `head.sha` / `head.ref` を checkout して PR 由来コードを実行しない（secrets + write 権限の文脈での RCE）。
+- `permissions` は top-level を `contents: read` にし、write は必要な job 単位で昇格する（`write-all` を避ける）。
+- third-party action は full-length commit SHA でピン留めする（バージョンコメント併記を推奨）。
+
+## Evidence / 根拠の取り方
+
+- 指摘は `<file>:<line>` で差分に紐づけ、出典（securitylab.github.com / docs.github.com の secure-use）を 1 行で添える。
+- 重要度: untrusted input の `run:` 直挿し / `pull_request_target` + head checkout = critical、permissions 過剰 / public self-hosted = major、tag ピン / persist-credentials = minor。
+
+## Output / 出力（短文版の推奨）
+
+コメントは日本語で返す。
+
+- Finding: インジェクション / pwn request / 過剰権限 / 未ピンのどれか（1文）
+- Impact: RCE / secrets 漏えい / 権限昇格
+- Fix: env 経由 / トリガー分離 / job 単位 permissions / SHA ピンの最小案
+
+## Sources / 出典
+
+- GitHub — Secure use of GitHub Actions: <https://docs.github.com/en/actions/reference/security/secure-use>
+- GitHub Security Lab — Preventing pwn requests: <https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/>
+- GitHub Security Lab — Untrusted input: <https://securitylab.github.com/resources/github-actions-untrusted-input/>
+- OpenSSF Scorecard checks: <https://github.com/ossf/scorecard/blob/main/docs/checks.md>

--- a/skills/midstream/rr-midstream-laravel-eloquent-nplus1-001/SKILL.md
+++ b/skills/midstream/rr-midstream-laravel-eloquent-nplus1-001/SKILL.md
@@ -1,0 +1,75 @@
+---
+id: rr-midstream-laravel-eloquent-nplus1-001
+name: 'Laravel Eloquent N+1 and Query Efficiency Review'
+description: 'Detects N+1 query patterns (relation access inside loops without eager loading), full-table get()/all() loads, and unsafe chunk()/cursor() usage in Laravel Eloquent code.'
+version: 0.1.0
+category: midstream
+phase: midstream
+applyTo:
+  - 'app/**/*.php'
+  - 'src/**/*.php'
+tags: [laravel, eloquent, performance, n-plus-1, php, midstream]
+severity: major
+inputContext: [diff]
+outputKind: [findings, questions]
+modelHint: balanced
+---
+
+## Pattern declaration
+
+Primary pattern: Reviewer
+Secondary patterns: Inversion
+Why: Eloquent のクエリ効率規約への適合をチェックリスト型で検査する
+
+## Goal / 目的
+
+- ループ内 relation アクセスによる N+1 クエリ（公式例: 25 件で 26 クエリ）を検出する。
+- 巨大テーブルの全件ロード（`all()` / `get()`）と、`chunk()` / `cursor()` の誤用を検出する。
+
+## Non-goals / 扱わないこと
+
+- mass assignment / 認可（`rr-midstream-laravel-mass-assignment-001` のスコープ）。
+- migration の安全性（`rr-upstream-laravel-migration-safety-001` のスコープ）。
+- SQL チューニング一般・index 設計。
+
+## Pre-execution Gate / 実行前ゲート
+
+このスキルは以下の条件が**すべて**満たされない限り`NO_REVIEW`を返す。
+
+- [ ] 差分に Eloquent モデルのクエリ・relation アクセスの追加変更が含まれている
+- [ ] diff コンテキストが利用可能である
+
+ゲート不成立時の出力: `NO_REVIEW: rr-midstream-laravel-eloquent-nplus1-001 — Eloquent クエリの変更なし`
+
+## False-positive guards / 抑制条件
+
+- ループ前に `with()` / `load()` 済みの relation へのアクセスは指摘しない（diff 外で eager load されている可能性があるため、確証がなければ質問に留める）。
+- ループ対象が少数固定（config 由来等）の場合の relation アクセスは指摘しない。
+- `chaperone()` を使った親逆参照は正当。
+- `preventLazyLoading` が有効なプロジェクトでは N+1 がテストで落ちるため、重複指摘を避ける。
+
+## Rule / ルール
+
+- ループ内で relation を参照する場合は `with('relation')`（取得後なら `load()` / `loadCount()`）で eager load する。
+- 巨大テーブルの反復は `chunkById` / `lazyById` / `cursor` を使う。
+- `chunk()` でフィルタ対象カラムを更新しない（公式: inconsistent results。`chunkById` を使う）。
+- `cursor()` と eager loading を併用しない（cursor は relation を eager load できない。`lazy` を使う）。
+- `chunkById` / `lazyById` で `orWhere` を含む条件は closure で論理グループ化する。
+
+## Evidence / 根拠の取り方
+
+- 指摘は `<file>:<line>` で差分に紐づけ、公式規約（laravel.com/docs/12.x/eloquent-relationships#eager-loading 等）を 1 行で添える。
+- eager load の有無が diff から確定できない場合は断定せず `questions` で返す。
+
+## Output / 出力（短文版の推奨）
+
+コメントは日本語で返す。
+
+- Finding: N+1 / 全件ロード / chunk 誤用のどれか（1文）
+- Impact: クエリ数 / メモリ / 一貫性への影響
+- Fix: `with()` / `chunkById` / `lazy` 等の最小修正案
+
+## Sources / 出典
+
+- Laravel 12.x — Eloquent Relationships (Eager Loading): <https://laravel.com/docs/12.x/eloquent-relationships#eager-loading>
+- Laravel 12.x — Eloquent (chunk / cursor / strictness): <https://laravel.com/docs/12.x/eloquent>

--- a/skills/midstream/rr-midstream-laravel-mass-assignment-001/SKILL.md
+++ b/skills/midstream/rr-midstream-laravel-mass-assignment-001/SKILL.md
@@ -1,0 +1,76 @@
+---
+id: rr-midstream-laravel-mass-assignment-001
+name: 'Laravel Mass Assignment and Authorization Review'
+description: 'Detects mass assignment via create/update($request->all()), unguarded models, and missing authorization on mutating controller actions in Laravel.'
+version: 0.1.0
+category: midstream
+phase: midstream
+applyTo:
+  - 'app/**/*.php'
+  - 'src/**/*.php'
+tags: [laravel, security, mass-assignment, authorization, php, midstream]
+severity: major
+inputContext: [diff]
+outputKind: [findings, questions]
+modelHint: balanced
+---
+
+## Pattern declaration
+
+Primary pattern: Reviewer
+Secondary patterns: Inversion
+Why: mass assignment 脆弱性と認可漏れをチェックリスト型で検査する
+
+## Goal / 目的
+
+- `create($request->all())` 等による mass assignment 脆弱性（公式が `is_admin` 注入による権限昇格を例示）を検出する。
+- 更新・削除系コントローラアクションの認可チェック漏れを検出する。
+
+## Non-goals / 扱わないこと
+
+- クエリ効率（`rr-midstream-laravel-eloquent-nplus1-001` のスコープ）。
+- バリデーションルールの網羅性（要件依存のため一律指摘しない）。
+- Gate と Policy の使い分けの強制（公式が混在を許容）。
+
+## Pre-execution Gate / 実行前ゲート
+
+このスキルは以下の条件が**すべて**満たされない限り`NO_REVIEW`を返す。
+
+- [ ] 差分にモデルの create / update / fill、またはコントローラの mutating アクションの追加変更が含まれている
+- [ ] diff コンテキストが利用可能である
+
+ゲート不成立時の出力: `NO_REVIEW: rr-midstream-laravel-mass-assignment-001 — 対象操作の変更なし`
+
+## False-positive guards / 抑制条件
+
+- `$request->all()` でも直後に手動フィルタ / 明示カラム指定があれば安全。
+- CLI / seeder / 内部処理での `forceFill` / `unguard` は、ユーザー入力でなければ脆弱性ではない。
+- `authorize(): true` は認可を controller / middleware 側で実施していれば正当。
+- `before()` filter（admin 一括許可）がある場合、個別 policy メソッドに admin 分岐がないことを指摘しない。
+- Gate を使っていること自体は指摘しない（公式が Gate / Policy 混在を許容）。
+
+## Rule / ルール
+
+- ユーザー入力からのモデル作成・更新は `$request->validated()` / `$request->safe()->only([...])` を使う（`$request->all()` 直渡しを避ける）。
+- `$guarded = []`（全 unguarded）でユーザー入力を直接渡していないか確認する。
+- 更新・削除系アクションに認可（`Gate::authorize` / `$user->can` / `can` middleware / FormRequest `authorize()` のいずれか）があるか確認する。
+- 複雑・再利用される validation は FormRequest 化を推奨する。
+
+## Evidence / 根拠の取り方
+
+- 指摘は `<file>:<line>` で差分に紐づけ、公式規約（laravel.com/docs/12.x/eloquent#mass-assignment / authorization）を 1 行で添える。
+- 認可が diff 外の middleware にある可能性がある場合は断定せず `questions` で返す。
+
+## Output / 出力（短文版の推奨）
+
+コメントは日本語で返す。
+
+- Finding: mass assignment / 認可漏れのどちらか（1文）
+- Impact: 権限昇格 / 不正データ更新
+- Fix: `validated()` / `safe()->only()` / 認可追加の最小案
+
+## Sources / 出典
+
+- Laravel 12.x — Eloquent (Mass Assignment): <https://laravel.com/docs/12.x/eloquent#mass-assignment>
+- Laravel 12.x — Validation (Form Request): <https://laravel.com/docs/12.x/validation#form-request-validation>
+- Laravel 12.x — Authorization: <https://laravel.com/docs/12.x/authorization>

--- a/skills/midstream/rr-midstream-react-router-action-contract-001/SKILL.md
+++ b/skills/midstream/rr-midstream-react-router-action-contract-001/SKILL.md
@@ -8,7 +8,6 @@ phase: midstream
 applyTo:
   - 'app/**/*.{ts,tsx,js,jsx}'
   - 'src/routes/**/*.{ts,tsx,js,jsx}'
-  - 'app/routes/**/*.{ts,tsx,js,jsx}'
 tags: [react-router, remix, actions, validation, frontend, midstream]
 severity: major
 inputContext: [diff]

--- a/skills/midstream/rr-midstream-react-router-action-contract-001/SKILL.md
+++ b/skills/midstream/rr-midstream-react-router-action-contract-001/SKILL.md
@@ -1,0 +1,74 @@
+---
+id: rr-midstream-react-router-action-contract-001
+name: 'React Router Action Contract Review'
+description: 'Checks React Router v7 action conventions: validation errors returned as data with 4xx status (not thrown), redirect on success, and 3-branch ErrorBoundary handling.'
+version: 0.1.0
+category: midstream
+phase: midstream
+applyTo:
+  - 'app/**/*.{ts,tsx,js,jsx}'
+  - 'src/routes/**/*.{ts,tsx,js,jsx}'
+  - 'app/routes/**/*.{ts,tsx,js,jsx}'
+tags: [react-router, remix, actions, validation, frontend, midstream]
+severity: major
+inputContext: [diff]
+outputKind: [findings, questions]
+modelHint: balanced
+---
+
+## Pattern declaration
+
+Primary pattern: Reviewer
+Secondary patterns: Inversion
+Why: action のエラー契約と ErrorBoundary 分岐をチェックリスト型で検査する
+
+## Goal / 目的
+
+- バリデーション失敗が ErrorBoundary へ throw され、フォームのインラインエラー表示と自動 revalidation の制御が壊れるのを防ぐ。
+- action 成功時の `redirect()` 欠落による再送信問題、エラー返却時のステータス不備（2xx のまま）を検出する。
+
+## Non-goals / 扱わないこと
+
+- loader / data loading の規約（`rr-midstream-react-router-loader-boundary-001` のスコープ）。
+- Form と fetcher のどちらを使うべきかの UX 判断（要件依存のため一律指摘しない。質問に留める）。
+- バリデーションライブラリの選定。
+
+## Pre-execution Gate / 実行前ゲート
+
+このスキルは以下の条件が**すべて**満たされない限り`NO_REVIEW`を返す。
+
+- [ ] 差分に action / clientAction の追加・変更、または ErrorBoundary の変更が含まれている
+- [ ] diff コンテキストが利用可能である
+
+ゲート不成立時の出力: `NO_REVIEW: rr-midstream-react-router-action-contract-001 — action / ErrorBoundary の変更なし`
+
+## False-positive guards / 抑制条件
+
+- `throw data("Not Found", { status: 404 })` 等、リソース不在・認可エラーの **意図的な throw は公式に許可された規約**であり指摘しない（バリデーション失敗の throw と区別する）。
+- React Router 管理外の外部 API へ直接 POST する設計が要件上正当な場合は指摘しない。
+- 成功時に同一ページへ結果を表示する設計（redirect しない）が意図的な場合は質問に留める。
+
+## Rule / ルール
+
+- 期待されるバリデーション失敗は `return data({ errors }, { status: 400 })` で返す（throw しない。2xx のままだと不要な revalidation が走る点も確認）。
+- 成功時は `redirect()` で再送信問題を防ぐ。
+- ErrorBoundary は `isRouteErrorResponse(error)` / `error instanceof Error` / その他 の 3 分岐で処理し、`error.message` への直接アクセスを避ける。
+- 独立して失敗してよい UI 単位にはルート単位の ErrorBoundary を検討する（root のみでも最低限は満たすため、強制はしない）。
+
+## Evidence / 根拠の取り方
+
+- 指摘は `<file>:<line>` で差分に紐づけ、公式規約（form-validation / error-boundary）を 1 行で添える。
+
+## Output / 出力（短文版の推奨）
+
+コメントは日本語で返す。
+
+- Finding: どの契約に反しているか（1文）
+- Impact: インラインエラー不能 / 再送信 / 不要 revalidation 等
+- Fix: `data({errors}, {status: 400})` / `redirect()` / 3 分岐の最小修正案
+
+## Sources / 出典
+
+- React Router — Form Validation: <https://reactrouter.com/how-to/form-validation>
+- React Router — Error Boundaries: <https://reactrouter.com/how-to/error-boundary>
+- React Router — Actions: <https://reactrouter.com/start/framework/actions>

--- a/skills/midstream/rr-midstream-react-router-loader-boundary-001/SKILL.md
+++ b/skills/midstream/rr-midstream-react-router-loader-boundary-001/SKILL.md
@@ -8,7 +8,6 @@ phase: midstream
 applyTo:
   - 'app/**/*.{ts,tsx,js,jsx}'
   - 'src/routes/**/*.{ts,tsx,js,jsx}'
-  - 'app/routes/**/*.{ts,tsx,js,jsx}'
 tags: [react-router, remix, data-loading, frontend, midstream]
 severity: major
 inputContext: [diff]

--- a/skills/midstream/rr-midstream-react-router-loader-boundary-001/SKILL.md
+++ b/skills/midstream/rr-midstream-react-router-loader-boundary-001/SKILL.md
@@ -1,0 +1,73 @@
+---
+id: rr-midstream-react-router-loader-boundary-001
+name: 'React Router Loader Boundary Review'
+description: 'Detects route data fetched in useEffect instead of loaders, server/client API leaks across loader boundaries, and missing HydrateFallback in React Router v7 framework mode.'
+version: 0.1.0
+category: midstream
+phase: midstream
+applyTo:
+  - 'app/**/*.{ts,tsx,js,jsx}'
+  - 'src/routes/**/*.{ts,tsx,js,jsx}'
+  - 'app/routes/**/*.{ts,tsx,js,jsx}'
+tags: [react-router, remix, data-loading, frontend, midstream]
+severity: major
+inputContext: [diff]
+outputKind: [findings, questions]
+modelHint: balanced
+---
+
+## Pattern declaration
+
+Primary pattern: Reviewer
+Secondary patterns: Inversion
+Why: React Router framework mode の data loading 規約への適合をチェックリスト型で検査する
+
+## Goal / 目的
+
+- ルート遷移で確定するデータが `useEffect` + fetch でコンポーネント取得されること（二重フェッチ・レース・hydration mismatch の温床）を防ぐ。
+- loader / clientLoader の境界違反（loader 内のクライアント専用 API、clientLoader 内のサーバー専用 API）を検出する。
+
+## Non-goals / 扱わないこと
+
+- action / mutation の規約（`rr-midstream-react-router-action-contract-001` のスコープ）。
+- data mode / declarative mode のコード（framework mode のルートモジュールのみ対象）。
+- 一般的な React パフォーマンス（modern-web 系 skill のスコープ）。
+
+## Pre-execution Gate / 実行前ゲート
+
+このスキルは以下の条件が**すべて**満たされない限り`NO_REVIEW`を返す。
+
+- [ ] 差分が React Router framework mode のルートモジュール（loader / clientLoader / action の export、または routes 配下）に関係する
+- [ ] diff コンテキストが利用可能である
+
+ゲート不成立時の出力: `NO_REVIEW: rr-midstream-react-router-loader-boundary-001 — framework mode ルートの変更なし`
+
+## False-positive guards / 抑制条件
+
+- `useEffect` + fetch が **ナビゲーションに紐づかない** データの場合は指摘しない（ポーリング、WebSocket、リアルタイム更新、サードパーティ SDK 初期化）。「URL / ルート遷移で確定するデータか」で判定する。
+- 親ルートの loader で取得済みデータを子が利用する設計は正当。
+- data mode / declarative mode のコードには適用しない（モード誤判定が最大の誤検出源）。
+
+## Rule / ルール
+
+- ルート遷移で確定する初期データは `loader`（SSR、サーバー専用 API はクライアントバンドルから自動除去される）に置く。
+- ブラウザ専用データは `clientLoader` に置き、hydrate する場合は `HydrateFallback` を定義する（`clientLoader.hydrate = true as const` の `as const` 欠落も指摘）。
+- `loader` 内でクライアント専用 API（window / localStorage 等）、`clientLoader` 内でサーバー専用 API（DB 直接アクセス等）を使っていないか確認する。
+- loader の返却値はシリアライズ可能型に限る（class instance の返却を指摘）。
+
+## Evidence / 根拠の取り方
+
+- 指摘は `<file>:<line>` で差分に紐づけ、該当する公式規約（reactrouter.com/start/framework/data-loading）を 1 行で添える。
+- ナビゲーション紐づきの判断が割れる場合は断定せず `questions` で返す。
+
+## Output / 出力（短文版の推奨）
+
+コメントは日本語で返す。
+
+- Finding: どの境界規約に反しているか（1文）
+- Impact: 二重フェッチ / hydration mismatch / バンドル漏えい等の影響
+- Fix: loader / clientLoader への移動案（最小）
+
+## Sources / 出典
+
+- React Router — Data Loading: <https://reactrouter.com/start/framework/data-loading>

--- a/skills/registry.yaml
+++ b/skills/registry.yaml
@@ -217,6 +217,50 @@ skills:
     recommended: false
     description: 'Detects domain terms drifting between code identifiers and the established ubiquitous language.'
 
+  - id: rr-midstream-react-router-loader-boundary-001
+    version: '0.1.0'
+    name: 'React Router Loader Boundary Review'
+    path: skills/midstream/rr-midstream-react-router-loader-boundary-001/SKILL.md
+    category: midstream
+    phase: midstream
+    tags: [react-router, remix, data-loading, frontend, midstream]
+    severity: major
+    recommended: false
+    description: 'Detects route data fetched in useEffect instead of loaders and server/client API leaks across loader boundaries.'
+
+  - id: rr-midstream-react-router-action-contract-001
+    version: '0.1.0'
+    name: 'React Router Action Contract Review'
+    path: skills/midstream/rr-midstream-react-router-action-contract-001/SKILL.md
+    category: midstream
+    phase: midstream
+    tags: [react-router, remix, actions, validation, frontend, midstream]
+    severity: major
+    recommended: false
+    description: 'Checks React Router action conventions: validation errors as data with 4xx, redirect on success, 3-branch ErrorBoundary.'
+
+  - id: rr-midstream-laravel-eloquent-nplus1-001
+    version: '0.1.0'
+    name: 'Laravel Eloquent N+1 and Query Efficiency Review'
+    path: skills/midstream/rr-midstream-laravel-eloquent-nplus1-001/SKILL.md
+    category: midstream
+    phase: midstream
+    tags: [laravel, eloquent, performance, n-plus-1, php, midstream]
+    severity: major
+    recommended: false
+    description: 'Detects N+1 query patterns, full-table loads, and unsafe chunk()/cursor() usage in Laravel Eloquent.'
+
+  - id: rr-midstream-laravel-mass-assignment-001
+    version: '0.1.0'
+    name: 'Laravel Mass Assignment and Authorization Review'
+    path: skills/midstream/rr-midstream-laravel-mass-assignment-001/SKILL.md
+    category: midstream
+    phase: midstream
+    tags: [laravel, security, mass-assignment, authorization, php, midstream]
+    severity: major
+    recommended: false
+    description: 'Detects mass assignment via request->all() and missing authorization on mutating controller actions.'
+
   - id: rr-midstream-loading-state-001
     version: '0.1.0'
     name: 'Loading State Transition Review'
@@ -349,6 +393,17 @@ skills:
     description: '既存デザインシステムコンポーネント（Button / Input / Modal / Card 等）を再実装していないかを検出する。'
 
   # Downstream Skills (Testing & Release)
+  - id: rr-downstream-gha-workflow-security-001
+    version: '0.1.0'
+    name: 'GitHub Actions Workflow Security Review'
+    path: skills/downstream/rr-downstream-gha-workflow-security-001/SKILL.md
+    category: downstream
+    phase: downstream
+    tags: [github-actions, security, ci, supply-chain, downstream]
+    severity: major
+    recommended: false
+    description: 'Reviews workflow diffs for script injection, pull_request_target with untrusted checkout, over-broad permissions, and unpinned actions.'
+
   - id: agent-qa-regression
     version: '0.1.0'
     name: 'QA Regression (Playwright)'
@@ -449,6 +504,17 @@ skills:
     severity: major
     recommended: true
     description: '変更に含まれる設計判断・実装選択の論理的整合性を徹底的に検証し、確証バイアスを排除して判断精度を高める'
+
+  - id: rr-upstream-laravel-migration-safety-001
+    version: '0.1.0'
+    name: 'Laravel Migration Safety Review'
+    path: skills/upstream/rr-upstream-laravel-migration-safety-001/SKILL.md
+    category: upstream
+    phase: upstream
+    tags: [laravel, migration, database, postgresql, safety, upstream]
+    severity: major
+    recommended: false
+    description: 'Reviews Laravel migrations for destructive ops, change() dropping modifiers, locking index creation, and asymmetric down().'
 
   # Legacy Upstream Skills (Design Phase)
   - id: rr-upstream-review-policy-standard-001
@@ -888,6 +954,55 @@ packs:
       - rr-upstream-bounded-context-language-001
       - rr-midstream-type-driven-design-001
       - rr-midstream-ubiquitous-language-naming-001
+
+  - id: react-router
+    version: '0.1.0'
+    name: 'React Router Review Pack'
+    description: 'React Router v7 (framework mode) の data loading / action 契約 / ErrorBoundary のレビュー基準'
+    axis: technology
+    tier: experimental
+    sources:
+      - name: 'React Router Docs (framework mode)'
+        version: 'v7'
+        url: 'https://reactrouter.com/start/framework/data-loading'
+        reviewed_at: '2026-06-11'
+    skills:
+      - rr-midstream-react-router-loader-boundary-001
+      - rr-midstream-react-router-action-contract-001
+
+  - id: laravel
+    version: '0.1.0'
+    name: 'Laravel Review Pack'
+    description: 'Laravel 12 の Eloquent クエリ効率 / migration 安全性 / mass assignment・認可のレビュー基準'
+    axis: technology
+    tier: experimental
+    sources:
+      - name: 'Laravel Documentation'
+        version: '12.x'
+        url: 'https://laravel.com/docs/12.x'
+        reviewed_at: '2026-06-11'
+    skills:
+      - rr-midstream-laravel-eloquent-nplus1-001
+      - rr-upstream-laravel-migration-safety-001
+      - rr-midstream-laravel-mass-assignment-001
+
+  - id: gha-security
+    version: '0.1.0'
+    name: 'GitHub Actions Security Pack'
+    description: 'GitHub Actions workflow のスクリプトインジェクション / pwn request / 権限・ピン留めのセキュリティレビュー基準'
+    axis: concern
+    tier: experimental
+    sources:
+      - name: 'GitHub — Secure use of GitHub Actions'
+        version: '2026-06'
+        url: 'https://docs.github.com/en/actions/reference/security/secure-use'
+        reviewed_at: '2026-06-11'
+      - name: 'GitHub Security Lab — pwn requests / untrusted input'
+        version: '2026-06'
+        url: 'https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/'
+        reviewed_at: '2026-06-11'
+    skills:
+      - rr-downstream-gha-workflow-security-001
 
 # Recommended skill sets
 # NOTE: new additions are frozen (skill-pack-design.md §2). New bundles go to

--- a/skills/upstream/rr-upstream-laravel-migration-safety-001/SKILL.md
+++ b/skills/upstream/rr-upstream-laravel-migration-safety-001/SKILL.md
@@ -1,0 +1,70 @@
+---
+id: rr-upstream-laravel-migration-safety-001
+name: 'Laravel Migration Safety Review'
+description: 'Reviews Laravel migrations for destructive operations, change() dropping modifiers, locking index creation on large tables (PostgreSQL), and asymmetric down().'
+version: 0.1.0
+category: upstream
+phase: upstream
+applyTo:
+  - 'database/migrations/**/*.php'
+tags: [laravel, migration, database, postgresql, safety, upstream]
+severity: major
+inputContext: [diff]
+outputKind: [findings, questions]
+modelHint: balanced
+---
+
+## Pattern declaration
+
+Primary pattern: Reviewer
+Secondary patterns: Inversion
+Why: migration の破壊的・ロック誘発操作をチェックリスト型で検査する
+
+## Goal / 目的
+
+- `change()` による修飾子の意図しない消失（公式: 保持したい修飾子をすべて再指定しないと消える）を検出する。
+- 破壊的操作（dropColumn 等）と、大規模テーブルでのロック誘発 index 追加を検出する。
+
+## Non-goals / 扱わないこと
+
+- データモデル設計の妥当性（`rr-upstream-data-model-db-design-001` のスコープ）。
+- アプリ側クエリ効率（`rr-midstream-laravel-eloquent-nplus1-001` のスコープ）。
+
+## Pre-execution Gate / 実行前ゲート
+
+このスキルは以下の条件が**すべて**満たされない限り`NO_REVIEW`を返す。
+
+- [ ] 差分に `database/migrations/` 配下の追加変更が含まれている
+- [ ] diff コンテキストが利用可能である
+
+ゲート不成立時の出力: `NO_REVIEW: rr-upstream-laravel-migration-safety-001 — migration の変更なし`
+
+## False-positive guards / 抑制条件
+
+- 新規テーブル作成（`Schema::create`）内の index 追加はロック問題がないため指摘しない。
+- `down()` の非対称は、データ変換系 migration で完全な逆操作が不可能なケースが正当（コメントで明示があれば許容）。
+- `dropColumn` が「別 PR で deprecate 済みカラムの計画的削除」と明示されている場合は指摘しない。
+
+## Rule / ルール
+
+- `change()` 時は保持したい修飾子（`unsigned` / `default` / `comment` / `nullable` 等）をすべて再指定する。
+- `dropColumn` / `Schema::drop` 等の破壊的操作は影響とロールバック不能性を確認する（本番 `--force` 実行に注意）。
+- PostgreSQL の大規模テーブルへの index 追加は `->online()`（`CREATE INDEX CONCURRENTLY`）を検討する。併せてトランザクション外実行が必要な副作用も指摘する。
+- `down()` は `up()` の逆操作として整合させる。
+
+## Evidence / 根拠の取り方
+
+- 指摘は `<file>:<line>` で差分に紐づけ、公式規約（laravel.com/docs/12.x/migrations#modifying-columns 等）を 1 行で添える。
+- テーブル規模が diff から不明な場合は `online()` 提案を断定せず `questions` で返す。
+
+## Output / 出力（短文版の推奨）
+
+コメントは日本語で返す。
+
+- Finding: 修飾子消失 / 破壊的操作 / ロック誘発のどれか（1文）
+- Impact: データ損失 / 本番ロック / ロールバック不能
+- Fix: 修飾子の再指定 / `online()` / `down()` 整合の最小案
+
+## Sources / 出典
+
+- Laravel 12.x — Migrations (modifying columns / dropping / online index): <https://laravel.com/docs/12.x/migrations#modifying-columns>


### PR DESCRIPTION
## 概要

開発で使っているスタックの公式ドキュメント・公開ナレッジを **出典として参照**し（転載はせず pack の `sources` に URL を明示）、River Review 形式のレビュー判断 skill に変換した 3 つの新 pack を追加します。インベントリ方針（評価・検査のみ、汎用ガイドは持たない）に準拠しています。

## 新 pack（すべて tier: experimental）

### react-router（technology, v7 framework mode）
- `rr-midstream-react-router-loader-boundary-001` — useEffect fetch / loader・clientLoader 境界違反 / HydrateFallback 欠落
- `rr-midstream-react-router-action-contract-001` — バリデーションエラーの throw（4xx data 返却すべき）/ redirect 欠落 / ErrorBoundary 3 分岐
- 出典: reactrouter.com（公式 agent skills は実装支援型でレビュー特化は未提供のため独自価値あり）

### laravel（technology, 12.x）
- `rr-midstream-laravel-eloquent-nplus1-001` — N+1 / 全件ロード / chunk・cursor 誤用
- `rr-upstream-laravel-migration-safety-001` — change() の修飾子消失 / 破壊的操作 / PostgreSQL ロック誘発 index（online() 推奨）
- `rr-midstream-laravel-mass-assignment-001` — request->all() の mass assignment / 認可漏れ
- 出典: laravel.com/docs/12.x（anthropics/skills に Laravel レビュー skill なしを確認）

### gha-security（concern）
- `rr-downstream-gha-workflow-security-001` — script injection / pull_request_target + untrusted checkout / 過剰 permissions / 未ピン action
- **責務分界**: 構文的・決定論で判定できる領域（pinned-deps / token-permissions）は OpenSSF Scorecard / zizmor / CodeQL に委ね、AI 側は diff 文脈の意味的判断（権限が当該 job に本当に必要か等）に集中（.claude/rules の canary 方針と整合）
- 出典: docs.github.com secure-use + GitHub Security Lab

## 設計品質

- 各 skill に Pre-execution Gate / False-positive guards / Sources を完備。FP ガードはリサーチで判明した誤検出源（React Router の 3 モード判別、Laravel の eager-load 済み relation、GHA の自 org action 等）を反映
- 全 pack を **experimental tier** に設定（fixture 未整備のため正直に）。`packs:tier` で宣言 = 機械評価の一致を確認。fixture 整備後に community/official 昇格

## 検証

- `npm test` **1273/1273 pass** / `skills:validate` green / `packs:tier` 全 5 pack 一致 / manifest 102 skills / planner top1Match 100%

## フォローアップ

各 pack の community 昇格には S1 fixture 整備が必要（typescript pack #1120 と同じ流れ）。本 PR は規範と pack 構造の確立まで。

🤖 Generated with [Claude Code](https://claude.com/claude-code)