### PR TITLE
chore: wire packs:tier --strict into CI + 2026-06-10..11 retrospective

### DIFF
--- a/.github/workflows/skill-validation.yml
+++ b/.github/workflows/skill-validation.yml
@@ -45,6 +45,13 @@ jobs:
           npm run skills:validate | tee skills-validate.log
         continue-on-error: true
 
+      - name: Check pack tiers
+        id: packs-tier
+        run: |
+          set -o pipefail
+          npm run packs:tier -- --strict | tee packs-tier.log
+        continue-on-error: true
+
       - name: Run tests
         id: test
         run: |
@@ -78,6 +85,7 @@ jobs:
           steps.agents-validate.outcome == 'failure' ||
           steps.agent-skills-validate.outcome == 'failure' ||
           steps.skills-validate.outcome == 'failure' ||
+          steps.packs-tier.outcome == 'failure' ||
           steps.test.outcome == 'failure' ||
           steps.lint.outcome == 'failure' ||
           steps.build.outcome == 'failure'
@@ -86,6 +94,7 @@ jobs:
           OUTCOME_AGENTS_VALIDATE: ${{ steps.agents-validate.outcome }}
           OUTCOME_AGENT_SKILLS_VALIDATE: ${{ steps.agent-skills-validate.outcome }}
           OUTCOME_SKILLS_VALIDATE: ${{ steps.skills-validate.outcome }}
+          OUTCOME_PACKS_TIER: ${{ steps.packs-tier.outcome }}
           OUTCOME_TEST: ${{ steps.test.outcome }}
           OUTCOME_LINT: ${{ steps.lint.outcome }}
           OUTCOME_BUILD: ${{ steps.build.outcome }}
@@ -114,6 +123,12 @@ jobs:
                 title: '定期チェック: npm run skills:validate が失敗しました',
                 outcome: process.env.OUTCOME_SKILLS_VALIDATE,
                 logPath: 'skills-validate.log',
+              },
+              {
+                key: 'packs:tier',
+                title: '定期チェック: npm run packs:tier -- --strict が失敗しました',
+                outcome: process.env.OUTCOME_PACKS_TIER,
+                logPath: 'packs-tier.log',
               },
               {
                 key: 'test',

--- a/docs/development/retrospectives/2026-06-10-11.md
+++ b/docs/development/retrospectives/2026-06-10-11.md
@@ -43,5 +43,5 @@
 
 - **release-please CI 不発火の恒久対策は PAT 設定**（fine-grained token を release-please workflow に渡す）。ユーザー操作のため未着手。設定されれば empty-commit 儀式が消える。
 - **gh アカウント自動切替**は本セッションで最頻の摩擦。CLAUDE.md への昇格案を承認待ちとして残す。
-- **community pack の official 昇格**には per-skill promptfoo eval 整備が必要（typescript pack #1120 と同じ最終段階）。react-router / laravel / gha-security の 4 community pack が対象。
+- **community pack の official 昇格**には per-skill promptfoo eval 整備が必要（typescript pack #1120 と同じ最終段階）。ddd / react-router / laravel / gha-security の 4 community pack が対象。
 - **#1045 残スコープ**（global user config / result envelope v1 / river-review 正規名 docs 寄せ）は契約変更のため要ユーザー判断。

--- a/docs/development/retrospectives/2026-06-10-11.md
+++ b/docs/development/retrospectives/2026-06-10-11.md
@@ -1,0 +1,47 @@
+# Retrospective: 2026-06-10 → 2026-06-11 Session
+
+「AI エージェントにチーム所有のレビュー判断を供給する OSS」というコンセプト転換を、設計 → 棚卸し → 実装 → 公式ナレッジ pack 化まで一気通貫で出荷したマルチセッション。Skill Pack（配布単位）/ selection（導入宣言）/ 改善ループ（L1〜L6）の 3 本柱を設計から実装まで通し、開発スタック（Laravel 12 / React Router v7 / GitHub Actions）の公式ドキュメントを出典参照したレビュー pack を追加して **v1.7.0 → v1.12.0** をリリースした。
+
+## Numerical summary
+
+| Metric                   | Value                                                                                                                       |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| Merged PRs               | 28 (#1102–#1129)                                                                                                            |
+| Releases                 | 5 (v1.8.0 / v1.9.0 / v1.10.0 / v1.11.0 / v1.12.0)                                                                           |
+| New packs                | 5 (typescript / ddd / react-router / laravel / gha-security)                                                                |
+| Skill count              | 96 → 102                                                                                                                    |
+| Official-tier packs      | 1 (typescript)                                                                                                              |
+| Community-tier packs     | 4 (ddd / react-router / laravel / gha-security)                                                                             |
+| Improvement-loop links   | L1–L6 all wired (feedback CLI / apply / suppression analytics / eval-regression auto-issue / per-skill FP / rule promotion) |
+| Cross-repo migration     | 1 (create-plan → PlanGate#523)                                                                                              |
+| Auto-guards added        | 3 (.mjs format, manifest auto-regen, lychee transient)                                                                      |
+| Parallel research agents | 3 (Laravel / React Router / GHA official docs)                                                                              |
+
+## What worked
+
+- **3 並列 Explore agent での公式 docs リサーチ**: Laravel / React Router / GHA を同時調査し、FP ガード（React Router の 3 モード判別 / Laravel の eager-load 済み relation / GHA の制約付きフィールド）まで含めた素材を一度に収集。pack 化の律速を解消した。
+- **tier の誠実な機械判定**: `packs:tier` で「宣言 ≤ 機械評価」を保ち、fixture 未整備の pack を official に水増しせず experimental → community → official を段階運用した。typescript のみ promptfoo eval まで揃えて official とし、他は community に留めた。
+- **改善ループのドッグフーディング**: 自作した L1〜L6 の思想を、リポジトリ運用の摩擦（mjs 整形すり抜け / manifest stale / lychee transient）の自動ガード化（#1124 / #1125）にも適用した。「使うほど良くなる」をプロダクトと repo 運用の両方に効かせた。
+- **観測した摩擦 → 即 B 化**: セッション中に再発した `.mjs` 整形すり抜け（3 回）と manifest stale（2 回）を #1124 で lint-staged ガードに落とし、再発を機械的に停止した。
+- **多視点セルフレビュー**: 設計ドキュメントを technical / consistency / adversarial の 3 視点並列で検証し、critical/high 指摘を合意前に反映した。
+
+## What needs improvement
+
+| #   | 問題                                          | 発生箇所                 | 影響                                                                                                                                            |
+| --- | --------------------------------------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | `packs:tier` の over-declaration が CI 未配線 | skill-validation.yml     | pack を 5 個追加したが、tier 過大宣言（fixtures なしで community 等）を止めるのは手動実行のみ。`skills:validate` は official ゲートしか持たない |
+| 2   | release PR の CI 不発火                       | 各リリース（v1.8〜1.12） | 毎回 empty commit + update-branch の手動儀式（計 6 回）。bot push が CI を起動しない GitHub 仕様が根本で、PAT 設定まで解消不可                  |
+| 3   | gh アカウントのセッション中自動切替           | 全 write 操作            | 5+ 回 `kominem-unilabo` へ切替し 404/permission エラー。memory の per-write-op ガードで都度回復するが CLAUDE.md 未昇格                          |
+
+## Codified actions
+
+- **#1 → B（自動ガード）**: 本振り返りで `npm run packs:tier -- --strict` を `skill-validation.yml` に追加。tier 過大宣言を CI で機械検知し、失敗時 issue 起票にも組み込んだ。
+- **#2 → A + carry-over**: release runbook への empty-commit 手順明文化は別途。PAT 設定はユーザー操作のため carry-over。
+- **#3 → 提案（Always-ask）**: CLAUDE.md AI Misoperation Guards への昇格は CLAUDE.md 変更のため、承認を取ってから別 PR とする。
+
+## Carry-over observations
+
+- **release-please CI 不発火の恒久対策は PAT 設定**（fine-grained token を release-please workflow に渡す）。ユーザー操作のため未着手。設定されれば empty-commit 儀式が消える。
+- **gh アカウント自動切替**は本セッションで最頻の摩擦。CLAUDE.md への昇格案を承認待ちとして残す。
+- **community pack の official 昇格**には per-skill promptfoo eval 整備が必要（typescript pack #1120 と同じ最終段階）。react-router / laravel / gha-security の 4 community pack が対象。
+- **#1045 残スコープ**（global user config / result envelope v1 / river-review 正規名 docs 寄せ）は契約変更のため要ユーザー判断。


### PR DESCRIPTION
## Summary

直前の 2026-06-10〜11 コンセプト転換セッション（#1102–#1129、v1.8.0→v1.12.0、28 PR）の振り返りから、最頻の再発摩擦を自動ガード化します。

### B. 自動ガード（1件）
- `skill-validation.yml` に `npm run packs:tier -- --strict` を追加。pack の tier 過大宣言（fixtures なしで community 宣言など）を CI で機械検知する。`skills:validate` は official tier のゲートしか持たず、community/experimental の over-declaration はすり抜けていた。本セッションで 5 pack を追加したが tier の妥当性は手動チェックのみだった
- 失敗時の定期 issue 起票にも `packs:tier` を組み込み

### A. ドキュメント（1件）
- `docs/development/retrospectives/2026-06-10-11.md` — repo の retrospectives 形式に沿った振り返り（numerical summary / what worked / improvement / codified actions / carry-over）

## Test plan
- [x] `npm run packs:tier -- --strict` をローカル dry-run（exit 0、全 5 pack で 宣言 ≤ 機械評価を確認）
- [x] workflow YAML 構文検証（python yaml.safe_load）

## 関連セッション
- 前回の振り返り PR: #1086（retrospectives/2026-06-06-09）
- 対象セッションの主要 PR: #1102（Phase A 設計）〜 #1128（stack pack community 昇格）、release #1109/#1119/#1123/#1127/#1129
- インシデント: force-push / orphan commit なし。再発摩擦は #1124（mjs format / manifest）#1125（lychee）で既に B 化済み

## Carry-over（本 PR では未対処）
- release-please CI 不発火 → PAT 設定（ユーザー操作）
- gh アカウント自動切替ガードの CLAUDE.md 昇格 → Always-ask のため承認後に別 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)