### PR TITLE
docs(guides): add adopter playbook for integration modes and rollout policy (How-to)

### DIFF
--- a/pages/guides/_meta.json
+++ b/pages/guides/_meta.json
@@ -5,6 +5,7 @@
   },
   "quickstart": "クイックスタート (River Review)",
   "github-actions": "GitHub Actions で River Review をセットアップする",
+  "adopter-playbook": "導入プレイブック（Integration modes と段階導入）",
   "troubleshooting": "トラブルシューティング",
   "faq": "FAQ（よくある失敗）",
   "-- Skills": {

--- a/pages/guides/adopter-playbook.en.md
+++ b/pages/guides/adopter-playbook.en.md
@@ -1,0 +1,72 @@
+# Adopter Playbook (Integration modes and staged rollout)
+
+When you bring River Review into a new repository or team, the hardest part is often not the features themselves but the early operational decisions: which integration path to use, where to start gating, and how to promote review viewpoints into your own skills. This how-to collects those early decisions.
+
+This guide focuses on early-adoption judgment. For the concrete setup steps of each path, see the dedicated guides ([GitHub Actions](./github-actions.en.md) / [Using Skill Packs](./use-skill-packs.en.md) / [Two-stage review gate](./two-stage-review-gate.en.md)).
+
+## 1. Choose an integration mode
+
+River Review is not a single integration path; there are several depending on your goal. Note that **which path reads `.river-review.json` differs per path**.
+
+| Mode                           | What it means                                                                          |                      Reads `.river-review.json`?                      | Recommended for                                                |
+| ------------------------------ | -------------------------------------------------------------------------------------- | :-------------------------------------------------------------------: | -------------------------------------------------------------- |
+| GitHub Actions                 | Run the River Review runner in CI                                                      |                 Yes (runner reads it from repo root)                  | Automated review at PR time                                    |
+| CLI / `river run`              | Run the CLI directly from local or any CI                                              |                 Yes (runner reads it from repo root)                  | Pre-PR self-review, headless runs                              |
+| Plugin (Claude Code / Codex …) | Strengthen the agent's review ability via skills                                       | No (the agent applies skills; repo rules come from `.river/rules.md`) | Interactive review, agent-driven development                   |
+| Skill adoption only (mode C)   | Port only the review viewpoints into your own agent skills without installing the core |               No (follows the destination's operation)                | Importing viewpoints into an existing in-house review workflow |
+
+Rules of thumb:
+
+- You want automated PR review first → **GitHub Actions**
+- You want the agent to review interactively → **Plugin**
+- You already have in-house skills/workflow and only want the viewpoints → **Skill adoption only**
+
+> **How `.river-review.json` is read**: The config file is read on the `river run` / CLI / Action-runner path from the repo root (searched in the order `.river-review.json` / `.river-review.yaml` / `.river-review.yml`). On the Plugin path the agent applies skills, so instead of the config file your repository rules in `.river/rules.md` / `.river/rules.d/*.md` take effect (see [repo-wide review](./repo-wide-review.en.md)). To avoid "I dropped a config file but nothing changed," confirm which path you are on first.
+
+## 2. Rollout policy (staged adoption)
+
+Starting with a blocking gate tends to slow development down via false positives. Tightening in this order is safer:
+
+1. **comment-only**: Only post review results as PR comments; do not fail CI. Observe noise volume and usefulness first.
+2. **fail-if-required (warn)**: Fail on `critical` only; keep `major` as a warning. Gate only on serious findings.
+3. **blocking gate**: Promote to a required check and block merge above a chosen severity.
+
+Severity-to-failure mapping (CLI / runner defaults):
+
+- `critical` = fail
+- `major` = fail-if-required (default: warn)
+- `minor` = comment-only
+- `info` = skipped
+
+Examples of low-noise initial settings:
+
+- Start from a small official [Skill Pack](./use-skill-packs.en.md) (scope with `--skill-set`).
+- Apply only to the artifacts/files relevant to the change ([repo-wide review](./repo-wide-review.en.md) tuning).
+- Narrow target PRs via label control (`prLabelsToIgnore`).
+- Start from the "pre-PR local + post-PR labeled automation" of the [two-stage review gate](./two-stage-review-gate.en.md).
+
+## 3. Promote viewpoints into skills / fixtures / suppression
+
+In ongoing operation, turning review results into assets at the following granularity prevents staleness:
+
+- **accepted (useful findings)**: If you want a viewpoint repeatedly, codify it as a skill ([add a new skill](./add-new-skill.en.md)).
+- **false positive**: Pin deterministically-decidable false positives as a skill fixture (false-positive guard case) to prevent regressions. Handle project-specific suppression via suppression (the `rr-midstream-suppression-feedback-001` workflow).
+- **missed issue**: Turn missed viewpoints into a new fixture (happy path) and a skill viewpoint.
+
+This promotion loop codifies AI-review judgment into reproducible checks. For the judgment units, see [choosing skills](./choose-skills.en.md) and the [skill-writing guide](./write-a-skill.en.md).
+
+## Common failures and fixes
+
+| Failure                                   | Cause                                              | Fix                                                                                  |
+| ----------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Dropped a config file but nothing changed | The Plugin path does not read `.river-review.json` | Confirm the path; on the Plugin path use `.river/rules.md` (§1)                      |
+| Gating too early stalls development       | Blocking from the start                            | Adopt in stages from comment-only (§2)                                               |
+| Viewpoints overlap with in-house skills   | Responsibility boundary undefined                  | Decide Skill-adoption-only vs Plugin and consolidate overlapping viewpoints (§1, §3) |
+
+## See also
+
+- [Set up River Review with GitHub Actions](./github-actions.en.md)
+- [Using Skill Packs](./use-skill-packs.en.md)
+- [Two-stage review gate (pre-PR + post-PR)](./two-stage-review-gate.en.md)
+- [Repo-wide review setup and tuning](./repo-wide-review.en.md)
+- [Choosing and combining skills](./choose-skills.en.md)

--- a/pages/guides/adopter-playbook.md
+++ b/pages/guides/adopter-playbook.md
@@ -1,0 +1,72 @@
+# 導入プレイブック（Integration modes と段階導入）
+
+River Review を新しいリポジトリやチームへ導入するとき、機能そのものより先に「どの経路で導入するか」「どこから gate 化するか」「観点をどう自前 skill に昇格するか」で迷いやすいです。このガイドは How-to として、その初期判断をまとめます。
+
+このガイドは導入初期の運用判断にフォーカスします。各経路の具体的なセットアップ手順は、それぞれのガイド（[GitHub Actions](./github-actions.md) / [Skill Pack を使う](./use-skill-packs.md) / [2 段構えレビューゲート](./two-stage-review-gate.md)）を参照してください。
+
+## 1. Integration modes（導入経路）を選ぶ
+
+River Review は単一の導入経路ではなく、目的に応じて複数の経路があります。`.river-review.json` がどの経路で読まれるかは経路ごとに異なるため、注意が必要です。
+
+| Mode                             | 意味                                                            |                       `.river-review.json` を読むか                       | 向いている用途                                |
+| -------------------------------- | --------------------------------------------------------------- | :-----------------------------------------------------------------------: | --------------------------------------------- |
+| GitHub Actions                   | CI 上で River Review runner を実行する                          |                    Yes（runner が repo root から読む）                    | PR 時点の自動レビュー                         |
+| CLI / `river run`                | ローカルや任意の CI から CLI を直接実行する                     |                    Yes（runner が repo root から読む）                    | PR 前セルフレビュー、headless 実行            |
+| Plugin（Claude Code / Codex 等） | エージェントのレビュー能力を skill で強化する                   | No（エージェントが skill を適用。repo ルールは `.river/rules.md` を参照） | 対話的なレビュー、エージェント駆動開発        |
+| Skill adoption only（方式C）     | 本体を導入せず、レビュー観点だけを自前の agent skill へ移植する |                         No（移植先の運用に従う）                          | 既存の社内 review workflow に観点だけ取り込む |
+
+判断の目安:
+
+- まず PR 自動レビューが欲しい → **GitHub Actions**
+- 対話的にエージェントへレビューさせたい → **Plugin**
+- 既存の社内 skill / workflow があり、観点だけ取り込みたい → **Skill adoption only**
+
+> **`.river-review.json` の読まれ方**: 設定ファイルは `river run` / CLI / Action runner の経路で repo root から読まれます（`.river-review.json` / `.river-review.yaml` / `.river-review.yml` の順で探索）。Plugin 経路ではエージェントが skill を適用するため、設定ファイルではなく `.river/rules.md` / `.river/rules.d/*.md` のリポジトリ固有ルールが効きます（[リポジトリ全体レビュー](./repo-wide-review.md) 参照）。「設定ファイルを置いたが反映されない」を避けるため、自分の経路がどちらかを先に確認してください。
+
+## 2. Rollout policy（段階導入）
+
+最初から blocking gate にすると、false positive で開発速度が落ちやすいです。次の順で段階的に締めるのが安全です。
+
+1. **comment-only**: レビュー結果を PR コメントとして出すだけで、CI は失敗させない。まずノイズ量と有用性を観察する。
+2. **fail-if-required（warn）**: `critical` のみ失敗、`major` は警告に留める。重大な指摘だけを gate にする。
+3. **blocking gate**: 必須チェックに昇格し、一定 severity 以上でマージをブロックする。
+
+severity と失敗条件の対応（CLI / runner 既定）:
+
+- `critical` = fail
+- `major` = fail-if-required（既定は warn）
+- `minor` = comment-only
+- `info` = skipped
+
+ノイズを抑える初期設定の例:
+
+- 対象スキルを小さな公式 [Skill Pack](./use-skill-packs.md) から始める（`--skill-set` で限定）。
+- 変更に関係するアーティファクト・ファイルにだけ当てる（[リポジトリ全体レビュー](./repo-wide-review.md) のチューニング）。
+- ラベルによる実行制御（`prLabelsToIgnore`）で対象 PR を絞る。
+- まず [2 段構えレビューゲート](./two-stage-review-gate.md) の「PR 前ローカル + PR 後ラベル付き自動実行」から始める。
+
+## 3. 観点を skill / fixture / suppression へ昇格する
+
+導入後の運用では、レビュー結果を次の単位で資産化すると陳腐化を防げます。
+
+- **accepted（有用だった指摘）**: 繰り返し出したい観点なら skill として明文化する（[スキルを追加する](./add-new-skill.md)）。
+- **false positive（誤検出）**: 決定論で判定できる誤検出は skill の fixture（false-positive guard ケース）として固定し、回帰を防ぐ。プロジェクト固有の抑制は suppression（`rr-midstream-suppression-feedback-001` の運用）で扱う。
+- **missed issue（見逃し）**: 拾えなかった観点は新しい fixture（happy path）と skill 観点に落とす。
+
+この昇格ループにより、AI レビューの判断を「再現可能な検査」へコード化していきます。判断単位の詳細は [スキルの選択と組み合わせ](./choose-skills.md) と [スキル作成ガイド](./write-a-skill.md) を参照してください。
+
+## よくある失敗と対処
+
+| 失敗                               | 原因                                            | 対処                                                                         |
+| ---------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------- |
+| 設定ファイルを置いたが反映されない | Plugin 経路では `.river-review.json` を読まない | 経路を確認し、Plugin 経路では `.river/rules.md` を使う（§1）                 |
+| gate 化が早すぎて開発が止まる      | 最初から blocking                               | comment-only から段階導入する（§2）                                          |
+| 社内 skill と観点が重複する        | 責務分界が未定義                                | Skill adoption only か Plugin かを決め、重複観点はどちらかに寄せる（§1, §3） |
+
+## 関連
+
+- [GitHub Actions で River Review をセットアップする](./github-actions.md)
+- [Skill Pack を使う](./use-skill-packs.md)
+- [2 段構えレビューゲート（PR 前 + PR 後）](./two-stage-review-gate.md)
+- [リポジトリ全体を踏まえたレビューの導入とチューニング](./repo-wide-review.md)
+- [スキルの選択と組み合わせ](./choose-skills.md)


### PR DESCRIPTION
Closes #1013.

## 背景 / Context

Growth チームの導入検討で、River Review 本体の価値は高い一方、**導入初期の運用判断**（どの経路で導入するか / どこから gate 化するか / 観点をどう自前 skill に昇格するか）で迷いやすいことが分かった。機能不足ではなく運用導線の問題のため、How-to ガイドで明文化する。

## 変更 / What changed

導入プレイブックを追加（JA + EN parity）:

- `pages/guides/adopter-playbook.md`
- `pages/guides/adopter-playbook.en.md`
- `pages/guides/_meta.json`（Setup セクションに登録）

### 内容（#1013 の論点に対応）

1. **Integration modes** — GitHub Actions / CLI / Plugin / Skill adoption only の4経路と、各経路で `.river-review.json` が読まれるか否かの表。「設定ファイルを置いたが読まれない」失敗を防ぐ。
2. **Rollout policy** — comment-only → fail-if-required(warn) → blocking の段階導入。severity↔失敗条件の対応（critical=fail / major=warn / minor=comment / info=skip）を明記し「gate 化が早すぎる」失敗を防ぐ。
3. **観点の昇格ループ** — accepted→skill / false-positive→fixture(guard)・suppression / missed→fixture(happy) の単位で資産化し「社内 skill と観点が重複する」失敗を防ぐ。
4. **よくある失敗と対処**の早見表。

既存ガイド（github-actions / use-skill-packs / two-stage-review-gate / repo-wide-review / choose-skills）へクロスリンクし、セットアップ手順の重複記載は避けた。

## 事実確認の根拠 / Grounding

- `.river-review.json` の読み込み経路は `src/config/loader.mjs`（`fileNames = ['.river-review.json', '.river-review.yaml', '.river-review.yml']`、repo root 探索）を確認して記述。
- severity↔失敗条件は CLI/runner 既定（`pages/reference/cli-review-plan-spec.md` のポリシー）に整合。

## 検証 / Verification

- `npm run check:docs`（bilingual pair + doc placement）→ pass
- `npx textlint --no-cache`（JA）/ markdownlint → clean
- `npm run meta:validate` / `npm run format:check` → pass
- 内部リンク先 7 ガイドの JA/EN 実在を確認

## レビュー観点 / Needs review

- Rollout policy の段階名（comment-only / fail-if-required / blocking）は CLI のポリシー語彙に合わせたが、運用推奨の閾値はプロジェクト判断の余地あり。
- EN 版は JA と構造 parity。用語の自然さは要確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)