### PR TITLE
feat(hooks): target-file-aware PostToolUse format hook + input contract doc

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -17,9 +17,22 @@ chmod +x .claude/hooks/format.sh
 
 ### How it works
 
-1. Detects changed files via `git diff`
-2. Filters for supported extensions (js, jsx, ts, tsx, json, md, yml, yaml, mjs)
-3. Runs `prettier --write` on those files
+1. If the PostToolUse stdin JSON provides `.tool_input.file_path` (the single
+   file just edited) and `jq` is available, formats only that file.
+2. Otherwise falls back to detecting changed files via `git diff`.
+3. Filters for supported extensions (js, jsx, ts, tsx, json, md, yml, yaml, mjs)
+4. Runs `prettier --write` on the selected file(s)
+
+### Hook input contract
+
+> **PostToolUse passes its input as a stdin JSON payload, not as environment
+> variables.** The edited file path is `.tool_input.file_path` in that JSON.
+> If you fork or reimplement this hook, read it from stdin (e.g.
+> `jq -r '.tool_input.file_path'`) — assuming an env var such as
+> `CLAUDE_TOOL_INPUT_FILE_PATH` silently turns the hook into a no-op.
+
+The stdin path is read only when stdin is not a TTY, so running the script
+manually in a terminal still works (it skips straight to the `git diff` path).
 
 ### Customization
 

--- a/hooks/format.sh
+++ b/hooks/format.sh
@@ -11,6 +11,25 @@ if [ ! -d .git ]; then
   exit 0
 fi
 
+# PostToolUse passes a stdin JSON payload whose .tool_input.file_path is the
+# single file just edited (the input is stdin JSON, not an env var). When that
+# file is available and jq can parse it, format only that file; otherwise fall
+# back to formatting the whole changed-file set below. This keeps the hook
+# backward-compatible when stdin / jq / file_path are absent.
+TARGET_FILE=""
+if [ ! -t 0 ]; then
+  HOOK_INPUT="$(cat 2>/dev/null || true)"
+  if [ -n "${HOOK_INPUT:-}" ] && command -v jq >/dev/null 2>&1; then
+    TARGET_FILE="$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null || true)"
+  fi
+fi
+
+if [ -n "$TARGET_FILE" ] && [ -f "$TARGET_FILE" ] && printf '%s' "$TARGET_FILE" | grep -qE '\.(js|jsx|ts|tsx|json|md|yml|yaml|mjs)$'; then
+  npx --no-install prettier --write "$TARGET_FILE" || true
+  echo "[format] Done (target: $TARGET_FILE)"
+  exit 0
+fi
+
 # Get changed files (both staged and unstaged, excluding deleted)
 CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB HEAD 2>/dev/null || echo "")
 

--- a/scripts/plugin-format-hook.sh
+++ b/scripts/plugin-format-hook.sh
@@ -34,6 +34,29 @@ if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   exit 0
 fi
 
+# PostToolUse passes a stdin JSON payload whose .tool_input.file_path is the
+# single file just edited (the input is stdin JSON, not an env var). When that
+# file is available and jq can parse it, format only that file; otherwise fall
+# back to formatting the whole changed-file set below. This keeps the hook
+# backward-compatible when stdin / jq / file_path are absent.
+TARGET_FILE=""
+if [ ! -t 0 ]; then
+  HOOK_INPUT="$(cat 2>/dev/null || true)"
+  if [ -n "${HOOK_INPUT:-}" ] && command -v jq >/dev/null 2>&1; then
+    TARGET_FILE="$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null || true)"
+  fi
+fi
+
+if [ -n "$TARGET_FILE" ] && [ -f "$TARGET_FILE" ] && printf '%s' "$TARGET_FILE" | grep -qE '\.(js|jsx|ts|tsx|cjs|mjs|json|md|yml|yaml)$'; then
+  if npx --no-install prettier --version >/dev/null 2>&1; then
+    npx --no-install prettier --write "$TARGET_FILE" || true
+    echo "[river-review:format] formatted 1 file (target: $TARGET_FILE)"
+  else
+    echo "[river-review:format] prettier not installed in project, skipping"
+  fi
+  exit 0
+fi
+
 CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB HEAD 2>/dev/null || echo "")
 if [ -z "$CHANGED_FILES" ]; then
   exit 0


### PR DESCRIPTION
Closes #1018.

## 背景 / Context

`hooks/format.sh` と `scripts/plugin-format-hook.sh` は PostToolUse hook として `git diff --name-only HEAD` で**変更ファイル集合全体**に prettier をかけており、Claude Code が stdin に渡す JSON（`.tool_input.file_path` = いま編集した1ファイル）を使っていなかった。これにより (1) 編集していない既存 dirty file まで再フォーマットされ意図しない差分が混ざる、(2) Write/Edit ごとに全変更集合を走査する無駄、という副作用があった。

## 変更 / What changed（enhancement・破壊的変更なし）

stdin JSON から編集対象ファイルを取得し、**そのファイルだけ**を対象にする fast path を追加:

- `hooks/format.sh` / `scripts/plugin-format-hook.sh`: target-file 経路を追加。`[ ! -t 0 ]` で stdin を読み、`jq` で `.tool_input.file_path` を抽出。対象拡張子に一致すればそのファイルのみ format して exit。
- **後方互換のフォールバック**: stdin が TTY / `jq` 不在 / `file_path` 不在 / 対象外拡張子のいずれでも、従来の git-diff 全体フォーマットへ自動フォールバック。
- `.claude/hooks/README.md`: 「PostToolUse 入力は env var ではなく stdin JSON」の**入力契約**を明記。`CLAUDE_TOOL_INPUT_FILE_PATH` のような env var を前提にして hook が恒久 no-op 化する事故（Growth 側の実体験）を予防。

## 検証 / Verification

- `bash -n` 構文チェック / `shellcheck` → clean（両スクリプト）
- 実動作テスト（一時 git リポジトリ、4経路）:
  - stdin JSON で target 指定 → 該当ファイルのみ対象（`Done (target: a.json)`）
  - 空 stdin / 不正 JSON / 非対象拡張子 → git-diff フォールバック
- `markdownlint` / `prettier --check` README → clean

## レビュー観点 / Needs review

- stdin 読み取りは `[ ! -t 0 ]` ガードで、手動実行（TTY）時は読まずにフォールバックするためハングしない。
- 対象拡張子リストは既存のフィルタと一致（plugin 側は `cjs` を含む既存差を踏襲）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)