### PR TITLE
feat(skills): "Skills changed" release-notes section from manifest diff

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -62,3 +62,32 @@ jobs:
 
           git tag -f "${MAJOR_TAG}" "${COMMIT}"
           git push --force origin "refs/tags/${MAJOR_TAG}"
+
+      - name: Append "Skills changed" to release notes
+        # Surfaces which skills changed since the previous release so selective
+        # adopters can detect drift (#1016). Best-effort: never fails the release.
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          TAG="${{ steps.release.outputs.tag_name }}"
+
+          git fetch --tags --force --quiet || true
+          PREV_TAG="$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -vx "${TAG}" | head -1 || true)"
+          if [ -z "${PREV_TAG}" ]; then
+            echo "No previous release tag; skipping skill changelog."
+            exit 0
+          fi
+
+          SECTION="$(node scripts/skill-changelog.mjs --base "${PREV_TAG}" --head "${TAG}" || true)"
+          if [ -z "${SECTION}" ]; then
+            echo "No skill changes between ${PREV_TAG} and ${TAG}."
+            exit 0
+          fi
+
+          BODY="$(gh release view "${TAG}" --json body --jq '.body' || true)"
+          {
+            printf '%s\n\n' "${BODY}"
+            printf '%s\n' "${SECTION}"
+          } | gh release edit "${TAG}" --notes-file - || echo "Failed to update release notes; continuing."

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "usage:summary": "node scripts/usage-summary.mjs",
     "skills:manifest": "node scripts/generate-skill-manifest.mjs",
     "skills:manifest:check": "node scripts/generate-skill-manifest.mjs --check",
+    "skills:changelog": "node scripts/skill-changelog.mjs",
     "feedback:apply": "node scripts/apply-feedback.mjs",
     "packs:tier": "node scripts/pack-tier-check.mjs",
     "suppression:analytics": "node scripts/suppression-analytics.mjs",

--- a/pages/guides/adopter-playbook.en.md
+++ b/pages/guides/adopter-playbook.en.md
@@ -55,6 +55,15 @@ In ongoing operation, turning review results into assets at the following granul
 
 This promotion loop codifies AI-review judgment into reproducible checks. For the judgment units, see [choosing skills](./choose-skills.en.md) and the [skill-writing guide](./write-a-skill.en.md).
 
+## 4. Drift detection for Skill-adoption-only
+
+With "Skill adoption only," when upstream (River Review) improves a skill, the porting side cannot tell, so the copy goes stale over time. Two machine-readable footholds detect this:
+
+- **Skill manifest**: `docs/data/skill-manifest.json` records each skill's `id` / `path` / `checksum` (a content hash). Compare the checksum of the skill you ported against your copy to detect upstream changes automatically in CI.
+- **"Skills changed" in release notes**: Each release's notes list the skills that changed since the previous release (Changed / Added / Removed), so you can track which viewpoints to revisit per release.
+
+Locally, `npm run skills:changelog -- --base <prev-tag> --head <tag>` produces the same diff.
+
 ## Common failures and fixes
 
 | Failure                                   | Cause                                              | Fix                                                                                  |

--- a/pages/guides/adopter-playbook.md
+++ b/pages/guides/adopter-playbook.md
@@ -55,6 +55,15 @@ severity と失敗条件の対応（CLI / runner 既定）:
 
 この昇格ループにより、AI レビューの判断を「再現可能な検査」へコード化していきます。判断単位の詳細は [スキルの選択と組み合わせ](./choose-skills.md) と [スキル作成ガイド](./write-a-skill.md) を参照してください。
 
+## 4. Skill adoption only の drift 検知
+
+観点を自前 skill へ移植する「Skill adoption only」では、上流（River Review）が skill を改善しても移植先が気づけず、時間とともに陳腐化します。これを機械的に検知する足場が2つあります。
+
+- **skill manifest**: `docs/data/skill-manifest.json` に各 skill の `id` / `path` / `checksum`（内容ハッシュ）が記録される。移植元 skill の checksum を自分のコピーと突き合わせれば、上流が変わったかを CI で自動検知できる。
+- **release notes の "Skills changed"**: 各リリースのノートに、前リリースから変わった skill（Changed / Added / Removed）が列挙される。どの観点を見直すべきかをリリース単位で追える。
+
+ローカルでも `npm run skills:changelog -- --base <前タグ> --head <タグ>` で同じ差分を確認できます。
+
 ## よくある失敗と対処
 
 | 失敗                               | 原因                                            | 対処                                                                         |

--- a/scripts/skill-changelog.mjs
+++ b/scripts/skill-changelog.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+// Skill changelog generator (#1016).
+//
+// Diffs the deterministic skill manifest (docs/data/skill-manifest.json) between
+// two git refs and renders a Markdown "Skills changed" section. Selective
+// adopters (who port viewpoints into their own skills rather than installing the
+// plugin) use this to see which upstream skills changed between releases.
+//
+// Pure functions (diffManifests / renderSkillChangelog) are exported for tests.
+// The CLI reads each side's manifest via `git show <ref>:<path>`.
+//
+// Usage:
+//   node scripts/skill-changelog.mjs --base <ref> [--head <ref>]
+//     --base   required. Previous git ref (e.g. the previous release tag).
+//     --head   optional. Newer git ref. Defaults to the working-tree manifest.
+//
+// Robustness: if a side's manifest is missing or unparseable (e.g. an old tag
+// from before the manifest existed), the CLI prints a short note and exits 0 so
+// it never fails a release pipeline.
+
+import { promises as fs } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+
+const MANIFEST_PATH = 'docs/data/skill-manifest.json';
+
+/**
+ * Diff two manifest skill arrays by id + checksum.
+ * @param {Array<{id:string,checksum:string}>} prevSkills
+ * @param {Array<{id:string,checksum:string}>} currSkills
+ * @returns {{added:string[], removed:string[], changed:string[]}} sorted id lists
+ */
+export function diffManifests(prevSkills, currSkills) {
+  const prev = new Map((prevSkills ?? []).map((s) => [s.id, s.checksum]));
+  const curr = new Map((currSkills ?? []).map((s) => [s.id, s.checksum]));
+
+  const added = [];
+  const removed = [];
+  const changed = [];
+
+  for (const [id, checksum] of curr) {
+    if (!prev.has(id)) {
+      added.push(id);
+    } else if (prev.get(id) !== checksum) {
+      changed.push(id);
+    }
+  }
+  for (const id of prev.keys()) {
+    if (!curr.has(id)) {
+      removed.push(id);
+    }
+  }
+
+  const sort = (arr) => arr.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  return { added: sort(added), removed: sort(removed), changed: sort(changed) };
+}
+
+/**
+ * Render a Markdown "Skills changed" section from a diff. Returns an empty
+ * string when there are no changes.
+ * @param {{added:string[], removed:string[], changed:string[]}} diff
+ * @returns {string}
+ */
+export function renderSkillChangelog(diff) {
+  const { added = [], removed = [], changed = [] } = diff ?? {};
+  if (added.length === 0 && removed.length === 0 && changed.length === 0) {
+    return '';
+  }
+
+  const lines = ['### Skills changed', ''];
+  const section = (title, ids) => {
+    if (ids.length === 0) return;
+    lines.push(`**${title}** (${ids.length})`);
+    lines.push('');
+    for (const id of ids) lines.push(`- \`${id}\``);
+    lines.push('');
+  };
+  section('Changed', changed);
+  section('Added', added);
+  section('Removed', removed);
+
+  lines.push(
+    'Selective adopters: compare the `checksum` of your copied skill against ' +
+      `\`${MANIFEST_PATH}\` to detect upstream drift.`
+  );
+  return `${lines.join('\n')}\n`;
+}
+
+/**
+ * Load the manifest's skill array from a git ref, or the working tree when ref
+ * is null/undefined. Returns null when the manifest is absent or unparseable.
+ */
+export async function loadSkillsAtRef(ref) {
+  let raw;
+  try {
+    if (ref) {
+      raw = execFileSync('git', ['show', `${ref}:${MANIFEST_PATH}`], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      });
+    } else {
+      raw = await fs.readFile(MANIFEST_PATH, 'utf8');
+    }
+  } catch {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed.skills) ? parsed.skills : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseArgs(argv) {
+  const args = { base: null, head: null };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--base') args.base = argv[++i];
+    else if (argv[i] === '--head') args.head = argv[++i];
+  }
+  return args;
+}
+
+async function main() {
+  const { base, head } = parseArgs(process.argv.slice(2));
+  if (!base) {
+    console.error('Usage: node scripts/skill-changelog.mjs --base <ref> [--head <ref>]');
+    return 2;
+  }
+
+  const prevSkills = await loadSkillsAtRef(base);
+  const currSkills = await loadSkillsAtRef(head);
+
+  if (prevSkills === null) {
+    console.error(`skill-changelog: no parseable manifest at base ref "${base}", skipping.`);
+    return 0;
+  }
+  if (currSkills === null) {
+    console.error(
+      `skill-changelog: no parseable manifest at head ref "${head ?? 'working tree'}", skipping.`
+    );
+    return 0;
+  }
+
+  const section = renderSkillChangelog(diffManifests(prevSkills, currSkills));
+  if (section) process.stdout.write(section);
+  return 0;
+}
+
+const isDirectRun = process.argv[1] && process.argv[1].endsWith('skill-changelog.mjs');
+if (isDirectRun) {
+  main()
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+}

--- a/scripts/skill-changelog.mjs
+++ b/scripts/skill-changelog.mjs
@@ -30,8 +30,10 @@ const MANIFEST_PATH = 'docs/data/skill-manifest.json';
  * @returns {{added:string[], removed:string[], changed:string[]}} sorted id lists
  */
 export function diffManifests(prevSkills, currSkills) {
-  const prev = new Map((prevSkills ?? []).map((s) => [s.id, s.checksum]));
-  const curr = new Map((currSkills ?? []).map((s) => [s.id, s.checksum]));
+  // Filter out malformed entries (null / undefined / missing id) defensively so
+  // a corrupt manifest can never crash the release pipeline.
+  const prev = new Map((prevSkills ?? []).filter((s) => s?.id).map((s) => [s.id, s.checksum]));
+  const curr = new Map((currSkills ?? []).filter((s) => s?.id).map((s) => [s.id, s.checksum]));
 
   const added = [];
   const removed = [];

--- a/tests/skill-changelog.test.mjs
+++ b/tests/skill-changelog.test.mjs
@@ -38,6 +38,18 @@ test('diffManifests tolerates null / undefined inputs', () => {
   assert.deepEqual(diffManifests(null, undefined), { added: [], changed: [], removed: [] });
 });
 
+test('diffManifests skips malformed elements (null / missing id)', () => {
+  // null entries and entries without an id must not crash; valid ids still diff.
+  assert.deepEqual(
+    diffManifests([null, { checksum: '1' }], [{ id: 'a', checksum: 'x' }, undefined]),
+    {
+      added: ['a'],
+      changed: [],
+      removed: [],
+    }
+  );
+});
+
 test('renderSkillChangelog returns empty string when there are no changes', () => {
   assert.equal(renderSkillChangelog({ added: [], changed: [], removed: [] }), '');
 });

--- a/tests/skill-changelog.test.mjs
+++ b/tests/skill-changelog.test.mjs
@@ -1,0 +1,63 @@
+// tests/skill-changelog.test.mjs
+//
+// Skill changelog generator (#1016): manifest diff classification (added /
+// changed / removed) and Markdown rendering.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { diffManifests, renderSkillChangelog } from '../scripts/skill-changelog.mjs';
+
+const skill = (id, checksum) => ({ id, checksum, path: `skills/${id}`, files: 1 });
+
+test('diffManifests classifies added / changed / removed by id + checksum', () => {
+  const prev = [skill('a', 'sha256:1'), skill('b', 'sha256:2'), skill('c', 'sha256:3')];
+  const curr = [
+    skill('a', 'sha256:1'), // unchanged
+    skill('b', 'sha256:CHANGED'), // changed
+    skill('d', 'sha256:4'), // added
+    // 'c' removed
+  ];
+
+  const diff = diffManifests(prev, curr);
+  assert.deepEqual(diff, { added: ['d'], changed: ['b'], removed: ['c'] });
+});
+
+test('diffManifests returns empty lists when nothing changed', () => {
+  const m = [skill('a', 'sha256:1'), skill('b', 'sha256:2')];
+  assert.deepEqual(diffManifests(m, m), { added: [], changed: [], removed: [] });
+});
+
+test('diffManifests sorts each list by id', () => {
+  const prev = [];
+  const curr = [skill('z', 'x'), skill('a', 'x'), skill('m', 'x')];
+  assert.deepEqual(diffManifests(prev, curr).added, ['a', 'm', 'z']);
+});
+
+test('diffManifests tolerates null / undefined inputs', () => {
+  assert.deepEqual(diffManifests(null, undefined), { added: [], changed: [], removed: [] });
+});
+
+test('renderSkillChangelog returns empty string when there are no changes', () => {
+  assert.equal(renderSkillChangelog({ added: [], changed: [], removed: [] }), '');
+});
+
+test('renderSkillChangelog renders headings and ids for changes', () => {
+  const out = renderSkillChangelog({ added: ['d'], changed: ['b'], removed: ['c'] });
+  assert.match(out, /### Skills changed/);
+  assert.match(out, /\*\*Changed\*\* \(1\)/);
+  assert.match(out, /\*\*Added\*\* \(1\)/);
+  assert.match(out, /\*\*Removed\*\* \(1\)/);
+  assert.match(out, /- `b`/);
+  assert.match(out, /- `d`/);
+  assert.match(out, /- `c`/);
+  // adopter drift-detection hint references the manifest path
+  assert.match(out, /docs\/data\/skill-manifest\.json/);
+});
+
+test('renderSkillChangelog omits empty sections', () => {
+  const out = renderSkillChangelog({ added: ['x'], changed: [], removed: [] });
+  assert.match(out, /\*\*Added\*\*/);
+  assert.doesNotMatch(out, /\*\*Changed\*\*/);
+  assert.doesNotMatch(out, /\*\*Removed\*\*/);
+});


### PR DESCRIPTION
Addresses #1016 (item 2: skill changelog).

## 背景 / Context

#1016 は selective adopter（本体を導入せず観点を自前 skill へ移植する採用者）が**上流 skill の更新に気づけず陳腐化する**問題への drift 検知の仕組みを求めている。3 提案のうち item1（version stamp）と item3（manifest + checksum）は実装済みで、残る **item2「release notes に "Skills changed" 節」**を本 PR で埋める。

## 変更 / What changed

| ファイル | 役割 |
| --- | --- |
| `scripts/skill-changelog.mjs` | `docs/data/skill-manifest.json` を2つの git ref 間で diff し、Changed / Added / Removed を Markdown `### Skills changed` として描画。純粋関数 `diffManifests` / `renderSkillChangelog` を export。manifest 不在・不正・ref 欠落時は graceful skip（exit 0） |
| `tests/skill-changelog.test.mjs` | diff 分類（id+checksum）・描画・空セクション省略・null 入力の網羅テスト |
| `.github/workflows/release-please.yml` | release 作成後に前タグ↔新タグの差分を GitHub Release notes へ追記。**best-effort**（`|| true` でリリースを失敗させない） |
| `package.json` | `npm run skills:changelog` |
| `pages/guides/adopter-playbook.md` (+ `.en`) | §4「drift 検知」に manifest + Skills changed の使い方を追記 |

## 設計判断 / Design notes

- **決定論**: checksum ベースの差分のみ。LLM 非依存。
- **非破壊**: release pipeline を壊さないよう全ステップ best-effort。manifest が無い古いタグ（v0.1.0 等）は自動 skip。
- **既存資産の再利用**: `generate-skill-manifest.mjs` が生成する manifest をそのまま入力に使う（新たな生成物なし）。

## 検証 / Verification

- `npm test` → **1280 pass / 0 fail**（新規 7 ケース含む）
- 実タグ実機確認:
  - `v1.11.0 → v1.12.0` → Changed 6 skills
  - `v1.12.0 → v1.13.0` → Added 5 skills（#1132 の新パック）
  - 古いタグ / 不在 ref → graceful skip（exit 0）
- `textlint --no-cache`（JA、である/ですます 整合）/ markdownlint / `check:docs`（bilingual）/ `format:check` / yaml 構文 → clean

## レビュー観点 / Needs review

- release notes への追記は `gh release edit --notes-file -` で本文末尾に追加する方式。重複追記防止は「リリースは1タグ1回」前提（release-please の挙動）に依存。
- workflow step は手動 `gh release edit` 権限（`contents: write`）に依存（既存 permission で充足）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)