### PR TITLE
docs: record deriveVerdict boolean extension and S2a→S2b dependency (self-review fixes)

### DIFF
--- a/docs/ai/generate-review-revise-loop.md
+++ b/docs/ai/generate-review-revise-loop.md
@@ -108,7 +108,7 @@ S4（plan-review-gate）は #976 の pre-exec skill set で即時利用できる
 補足:
 
 - S2a の「unresolved」判定は run history / fingerprint（S2b の基盤）を前提とするため、S2b を先行させる。
-- S4 は #1148 で確定した human_approval policy を実装するため、`deriveVerdict` に `humanApprovalRequired` boolean を 1 個追加する。true なら axis スコアを汚染せず `human-review-required` へ短絡する（critical finding の emit で代替するとスコアを 30〜50 点不当に減点するため不可）。call site 伝播は `docs/development/pipeline-params-checklist.md` に従う。詳細は #1148 のコメントを参照。
+- S4 は #1148 で確定した human_approval policy を実装するため、`deriveVerdict` に `humanApprovalRequired` boolean を 1 個追加する。true なら axis スコアを汚染せず `human-review-required` へ短絡する（critical finding の emit で代替するとスコアを 30〜50 点不当に減点するため不可）。`deriveVerdict` は `scoreReview` 内部から呼ばれるため、伝播経路は `finalizeArtifact`（`review-plan.mjs`）→ `scoreReview(findings, { humanApprovalRequired })` → `deriveVerdict` の 3 段になる。call site 伝播は `docs/development/pipeline-params-checklist.md` に従う。詳細は #1148 のコメントを参照。
 
 ## 未確定事項
 

--- a/docs/ai/generate-review-revise-loop.md
+++ b/docs/ai/generate-review-revise-loop.md
@@ -97,16 +97,22 @@ orchestrator┼─ security-scanner  (既存)
 
 S4（plan-review-gate）は #976 の pre-exec skill set で即時利用できるため S3 に依存させない。S2 は停止条件と振動検知に分割可能。S3 は diff review team の品質改善として独立させる。
 
-| スライス | 内容                                                                                         | 依存         |
-| -------- | -------------------------------------------------------------------------------------------- | ------------ |
-| S1       | critic API: `river run` の verdict と handoff をループ消費可能な契約として固める             | 既存ほぼ完成 |
-| S2a      | 停止条件: blocking ゼロ かつ unresolved major / critical ゼロの複合条件（caller が消費）     | S1           |
-| S2b      | 振動検知: 既存 `finding-fingerprint` と run history による再発検知                           | S1           |
-| S3       | review team の契約化: 既存 `reviewer-orchestrator.mjs` に `mergeFindings` + adversarial 追加 | S1           |
-| S4       | plan-review-gate（#1148）: 既存 skill set + verdict 契約で実装、S1 後に前倒し可              | S1           |
+| スライス | 内容                                                                                                                  | 依存         |
+| -------- | --------------------------------------------------------------------------------------------------------------------- | ------------ |
+| S1       | critic API: `river run` の verdict と handoff をループ消費可能な契約として固める                                      | 既存ほぼ完成 |
+| S2a      | 停止条件: blocking ゼロ かつ unresolved major / critical ゼロの複合条件（caller が消費）                              | S1, S2b      |
+| S2b      | 振動検知: 既存 `finding-fingerprint` と run history による再発検知                                                    | S1           |
+| S3       | review team の契約化: 既存 `reviewer-orchestrator.mjs` に `mergeFindings` + adversarial 追加                          | S1           |
+| S4       | plan-review-gate（#1148）: 既存 skill set + verdict 契約で実装、S1 後に前倒し可。`deriveVerdict` の拡張を含む（下記） | S1           |
+
+補足:
+
+- S2a の「unresolved」判定は run history / fingerprint（S2b の基盤）を前提とするため、S2b を先行させる。
+- S4 は #1148 で確定した human_approval policy を実装するため、`deriveVerdict` に `humanApprovalRequired` boolean を 1 個追加する。true なら axis スコアを汚染せず `human-review-required` へ短絡する（critical finding の emit で代替するとスコアを 30〜50 点不当に減点するため不可）。call site 伝播は `docs/development/pipeline-params-checklist.md` に従う。詳細は #1148 のコメントを参照。
 
 ## 未確定事項
 
 - Epic 起票時の #976 / #1148 / #921 との親子関係。
 - review team をマルチエージェントで実装するか、軽量な逐次 fallback も残すか。
+- `mergeFindings()` の置き場所: `reviewer-orchestrator.mjs` 内の純関数とするか、schema（`agreement` / `validatedStatus`）への書き込み主体をどこに置くか（S3 着手前に要決定）。
 - いずれもアーキ変更であり、実装着手前に人間承認が必要である。

--- a/docs/ai/generate-review-revise-loop.md
+++ b/docs/ai/generate-review-revise-loop.md
@@ -108,7 +108,7 @@ S4（plan-review-gate）は #976 の pre-exec skill set で即時利用できる
 補足:
 
 - S2a の「unresolved」判定は run history / fingerprint（S2b の基盤）を前提とするため、S2b を先行させる。
-- S4 は #1148 で確定した human_approval policy を実装するため、`deriveVerdict` に `humanApprovalRequired` boolean を 1 個追加する。true なら axis スコアを汚染せず `human-review-required` へ短絡する（critical finding の emit で代替するとスコアを 30〜50 点不当に減点するため不可）。`deriveVerdict` は `scoreReview` 内部から呼ばれるため、伝播経路は `finalizeArtifact`（`review-plan.mjs`）→ `scoreReview(findings, { humanApprovalRequired })` → `deriveVerdict` の 3 段になる。call site 伝播は `docs/development/pipeline-params-checklist.md` に従う。詳細は #1148 のコメントを参照。
+- S4 は #1148 で確定した human_approval policy を実装するため、`deriveVerdict` に `humanApprovalRequired` boolean を 1 個追加する。true なら axis スコアを汚染せず `human-review-required` へ短絡する。critical finding の emit で代替する案はスコアを 30〜50 点不当に減点するため不可。`deriveVerdict` は `scoreReview` 内部から呼ばれる。伝播経路は `finalizeArtifact` → `scoreReview(findings, { humanApprovalRequired })` → `deriveVerdict` の 3 段になる。call site 伝播は `docs/development/pipeline-params-checklist.md` に従う。詳細は #1148 のコメントを参照。
 
 ## 未確定事項
 


### PR DESCRIPTION
## What

#1149 マージ後のセルフレビューで検出した設計 SSoT の分裂と依存漏れを修正する（docs のみ、3 箇所）。

## Findings → Fixes

| Finding | Fix |
| --- | --- |
| **F1 (major)**: #1148 で確定した `deriveVerdict` への `humanApprovalRequired` boolean 追加が issue コメントにのみ存在し doc に未反映（S4 実装に scoring エンジン変更が必要という事実が doc から読めない） | S4 行に「`deriveVerdict` の拡張を含む」を明記し、補足に boolean の趣旨（score 非汚染で short-circuit、critical emit 代替は 30〜50 点の不当減点で不可）と pipeline-params-checklist 参照を追加 |
| **F2 (minor)**: S2a の「unresolved」判定は run history / fingerprint（S2b 基盤）前提なのに依存が S1 のみだった | S2a の依存を S1, S2b に修正し補足を追加 |
| **F3 (minor)**: `mergeFindings()` の置き場所（schema 書き込み主体）が未定義 | 未確定事項に「S3 着手前に要決定」として追記 |

## Verification

- `npx textlint --no-cache docs/ai/generate-review-revise-loop.md` → pass
- `npm run fix:dashes` 適用済み

Relates to #1150, #1148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)