### PR TITLE
feat(adversarial-review): add 3 claim-vs-actual detection skills (#1177)

### DIFF
--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -1,12 +1,12 @@
 {
   "schemaVersion": 1,
   "description": "Deterministic skill manifest for drift detection by selective adopters. Compare the checksum of your copied skill against this list to notice upstream changes. Regenerate with: npm run skills:manifest",
-  "skillCount": 108,
+  "skillCount": 111,
   "skills": [
     {
       "id": "adversarial-review",
       "path": "skills/agent-skills/adversarial-review",
-      "checksum": "sha256:81270f4c6fc3e0227a6bbc2e46b995c4d6b1f349b0a4a9a4373bf4d4db61742c",
+      "checksum": "sha256:65c926203ae04d9539d36ac2b22455bd0055743ee803ced2eb435010a385c61e",
       "files": 2
     },
     {
@@ -154,6 +154,12 @@
       "files": 1
     },
     {
+      "id": "rr-midstream-cross-file-leakage-001",
+      "path": "skills/midstream/rr-midstream-cross-file-leakage-001",
+      "checksum": "sha256:000b7f18ecd0c46781777b111a5e167bc5c066a1a260fa0bb590199173cab228",
+      "files": 1
+    },
+    {
       "id": "rr-midstream-design-system-component-reuse-001",
       "path": "skills/midstream/community/rr-midstream-design-system-component-reuse-001",
       "checksum": "sha256:a760f8bc0bd722c78c9fa2b8649901f26bfa17e054cbc676a0fd1a7165f0ef2a",
@@ -292,6 +298,12 @@
       "files": 4
     },
     {
+      "id": "rr-midstream-refactor-claim-audit-001",
+      "path": "skills/midstream/rr-midstream-refactor-claim-audit-001",
+      "checksum": "sha256:7006c4b8923ac87c77315a42867b3cf68efd6ded5d1dcff1bde621758e3b514b",
+      "files": 1
+    },
+    {
       "id": "rr-midstream-review-automation-boundary-001",
       "path": "skills/midstream/rr-midstream-review-automation-boundary-001",
       "checksum": "sha256:5b420d50a3dc1e12daa874b8380fb14eef851c303f9fc5aff91c7ee879ee733f",
@@ -314,6 +326,12 @@
       "path": "skills/midstream/rr-midstream-security-basic-001",
       "checksum": "sha256:3497159259948365b97e86426c625e7abdb03a309aadd7576f5e25b94f73b936",
       "files": 9
+    },
+    {
+      "id": "rr-midstream-self-contradiction-001",
+      "path": "skills/midstream/rr-midstream-self-contradiction-001",
+      "checksum": "sha256:01c8c01b65e7b2ea243202aa4a01cdc0a7a0cadb79600e4f8d02e96200ec1675",
+      "files": 1
     },
     {
       "id": "rr-midstream-supabase-rls-policy-001",

--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -6,7 +6,7 @@
     {
       "id": "adversarial-review",
       "path": "skills/agent-skills/adversarial-review",
-      "checksum": "sha256:65c926203ae04d9539d36ac2b22455bd0055743ee803ced2eb435010a385c61e",
+      "checksum": "sha256:da20ff144735c904a4db10c60bda814239e8ffcd544642bc07b2fb01bb6a8535",
       "files": 2
     },
     {
@@ -156,7 +156,7 @@
     {
       "id": "rr-midstream-cross-file-leakage-001",
       "path": "skills/midstream/rr-midstream-cross-file-leakage-001",
-      "checksum": "sha256:000b7f18ecd0c46781777b111a5e167bc5c066a1a260fa0bb590199173cab228",
+      "checksum": "sha256:70834301dc5d9f24247c2a24aca9f9cbdb687a61235d4dc259962bbb7235884b",
       "files": 1
     },
     {

--- a/skills/agent-skills/adversarial-review/SKILL.md
+++ b/skills/agent-skills/adversarial-review/SKILL.md
@@ -128,9 +128,9 @@ AIをレビューに使う最大の価値は、情報の整理ではなく **思
 - Pre-mortem: X件 (失敗シナリオ)
 - War Game: Y件 (攻撃シナリオ)
 - Logic Torturing: Z件 (論理的な穴)
-- Self-Contradiction: 件数 (宣言と実装の乖離)
-- Refactor-Claim Audit: 件数 (完了主張の反証)
-- Cross-File Leakage: 件数 (caller 側残骸)
+- Self-Contradiction: A件 (宣言と実装の乖離)
+- Refactor-Claim Audit: B件 (完了主張の反証)
+- Cross-File Leakage: C件 (caller 側残骸)
 
 ### 最も重大な発見
 

--- a/skills/agent-skills/adversarial-review/SKILL.md
+++ b/skills/agent-skills/adversarial-review/SKILL.md
@@ -2,10 +2,11 @@
 id: adversarial-review
 name: adversarial-review
 description: |
-  認知バイアスを排除するための3つの敵対的分析手法を統合したレビュースキル。
-  Pre-mortem（失敗シナリオ分析）、War Game（攻撃者シミュレーション）、
-  Logic Torturing（論理検証）を組み合わせ、通常のレビューでは見えない
-  設計の盲点・防御の穴・論理の弱点を可視化する。
+  敵対的分析手法を統合したレビューの entry skill。認知バイアス対策の3手法
+  （Pre-mortem / War Game / Logic Torturing）と、宣言・主張と実態の乖離を突く
+  claim-vs-actual 検出3パターン（Self-Contradiction / Refactor-Claim Audit /
+  Cross-File Leakage）へルーティングし、通常のレビューでは見えない設計の盲点・
+  防御の穴・論理の弱点・宣言と実装のズレを可視化する。
 category: midstream
 phase: [upstream, midstream]
 severity: major
@@ -16,7 +17,20 @@ applyTo:
   - 'pages/**/*design*.md'
 inputContext: [diff, fullFile]
 outputKind: [findings, questions, actions]
-tags: [adversarial, pre-mortem, war-game, logic-torturing, cognitive-bias, entry, routing]
+tags:
+  [
+    adversarial,
+    pre-mortem,
+    war-game,
+    logic-torturing,
+    self-contradiction,
+    refactor-claim,
+    cross-file-leakage,
+    claim-vs-actual,
+    cognitive-bias,
+    entry,
+    routing,
+  ]
 version: '0.1.0'
 license: MIT
 ---
@@ -29,13 +43,23 @@ license: MIT
 ## 背景 / Background
 
 AIをレビューに使う最大の価値は、情報の整理ではなく **思考の死角を映す鏡** としての活用にある。
-このスキルは、3つの認知バイアス対策手法を体系化し、レビューの質を根本的に引き上げる。
+このスキルは、2系統の敵対的手法を体系化し、レビューの質を根本的に引き上げる。
+
+### 認知バイアス対策（思考の死角）
 
 | 手法            | 対策するバイアス           | 核心の問い                           |
 | --------------- | -------------------------- | ------------------------------------ |
 | Pre-mortem      | 生存バイアス・楽観バイアス | 「失敗した**として**、なぜ？」       |
 | War Game        | 自己中心バイアス           | 「敵の立場**から**、どう攻撃する？」 |
 | Logic Torturing | 確証バイアス               | 「この論理の穴を**潰して**」         |
+
+### claim-vs-actual 検出（宣言・主張と実態の乖離）
+
+| 手法                 | 対象とするズレ           | 核心の問い                                    |
+| -------------------- | ------------------------ | --------------------------------------------- |
+| Self-Contradiction   | 宣言と同一ファイルの実装 | 「規則 X を宣言した本人が**破って**いない？」 |
+| Refactor-Claim Audit | 完了主張と残骸           | 「『全部やった』を grep で**反証**できる？」  |
+| Cross-File Leakage   | 構造変更と caller 側     | 「直したのは変更元だけ、**参照元**は？」      |
 
 ## When to Use / いつ使うか
 
@@ -48,12 +72,15 @@ AIをレビューに使う最大の価値は、情報の整理ではなく **思
 
 入力に応じて、適切な手法へルーティングする。複数手法の併用も可能。
 
-| キーワード                                   | 手法            | スキルID                           |
-| -------------------------------------------- | --------------- | ---------------------------------- |
-| 失敗, リスク, 負債, インシデント, pre-mortem | Pre-mortem      | `rr-upstream-pre-mortem-001`       |
-| 攻撃, セキュリティ, 悪用, 脆弱性, war-game   | War Game        | `rr-midstream-war-game-001`        |
-| 論理, 判断, 根拠, なぜ, 代替案, logic        | Logic Torturing | `rr-midstream-logic-torturing-001` |
-| 敵対的, adversarial, 全部, フル              | **全手法実行**  | 上記3つすべて                      |
+| キーワード                                          | 手法                 | スキルID                                |
+| --------------------------------------------------- | -------------------- | --------------------------------------- |
+| 失敗, リスク, 負債, インシデント, pre-mortem        | Pre-mortem           | `rr-upstream-pre-mortem-001`            |
+| 攻撃, セキュリティ, 悪用, 脆弱性, war-game          | War Game             | `rr-midstream-war-game-001`             |
+| 論理, 判断, 根拠, なぜ, 代替案, logic               | Logic Torturing      | `rr-midstream-logic-torturing-001`      |
+| 自己矛盾, contradiction, 宣言と実装, declared but   | Self-Contradiction   | `rr-midstream-self-contradiction-001`   |
+| 削減, 完了, 全て置換, all replaced, -N%, リファクタ | Refactor-Claim Audit | `rr-midstream-refactor-claim-audit-001` |
+| caller, 残骸, 参照漏れ, 再採番, leakage             | Cross-File Leakage   | `rr-midstream-cross-file-leakage-001`   |
+| 敵対的, adversarial, 全部, フル                     | **全手法実行**       | 上記6つすべて                           |
 
 ### デフォルト動作
 
@@ -61,6 +88,9 @@ AIをレビューに使う最大の価値は、情報の整理ではなく **思
   - 設計ドキュメント/ADR → Pre-mortem + Logic Torturing
   - セキュリティ関連コード → War Game + Logic Torturing
   - 一般的なコード変更 → Logic Torturing
+  - 宣言的フレーズ（「禁止」「必ず」「MUST」等）を含む変更 → Self-Contradiction
+  - 完了主張（「全置換」「-N%」等）を含む commit/PR → Refactor-Claim Audit
+  - 構造変更（再採番・シンボル改名・分割）を含む変更 → Cross-File Leakage
   - 大規模変更（ファイル数10以上or差分500行以上）→ 全手法実行
 
 ## Execution Flow / 実行フロー
@@ -69,12 +99,18 @@ AIをレビューに使う最大の価値は、情報の整理ではなく **思
 1. 変更内容の分類
    ├─ 設計/ADR → Pre-mortem を優先実行
    ├─ セキュリティ関連 → War Game を優先実行
-   └─ 判断を含む変更 → Logic Torturing を実行
+   ├─ 判断を含む変更 → Logic Torturing を実行
+   ├─ 宣言的フレーズ → Self-Contradiction を実行
+   ├─ 完了主張 → Refactor-Claim Audit を実行
+   └─ 構造変更 → Cross-File Leakage を実行
 
 2. 各手法の実行（並列可能）
    ├─ Pre-mortem: 失敗シナリオ × 最大5件
    ├─ War Game: 攻撃シナリオ × 最大5件
-   └─ Logic Torturing: 論理検証 × 最大5件
+   ├─ Logic Torturing: 論理検証 × 最大5件
+   ├─ Self-Contradiction: 宣言と実装の乖離 × 最大5件
+   ├─ Refactor-Claim Audit: 完了主張の反証 × 最大5件
+   └─ Cross-File Leakage: caller 側残骸 × 最大5件
 
 3. 統合サマリの生成
    ├─ 重複する指摘の統合
@@ -92,6 +128,9 @@ AIをレビューに使う最大の価値は、情報の整理ではなく **思
 - Pre-mortem: X件 (失敗シナリオ)
 - War Game: Y件 (攻撃シナリオ)
 - Logic Torturing: Z件 (論理的な穴)
+- Self-Contradiction: 件数 (宣言と実装の乖離)
+- Refactor-Claim Audit: 件数 (完了主張の反証)
+- Cross-File Leakage: 件数 (caller 側残骸)
 
 ### 最も重大な発見
 

--- a/skills/midstream/rr-midstream-cross-file-leakage-001/SKILL.md
+++ b/skills/midstream/rr-midstream-cross-file-leakage-001/SKILL.md
@@ -1,0 +1,119 @@
+---
+id: rr-midstream-cross-file-leakage-001
+name: 'Cross-File Leakage リファクタ後の caller 側残骸検出'
+description: 'モジュール/スキルの構造変更で当該ファイルは更新したが、caller 側が古い構造（旧参照・旧シグネチャ・旧採番）を参照したまま残るパターンを検出する'
+version: 0.1.0
+category: midstream
+phase: midstream
+applyTo:
+  - '**/*.{ts,tsx,js,jsx,mjs}'
+  - '**/*.md'
+  - '**/SKILL.md'
+  - '**/*.{yaml,yml,json}'
+tags: [adversarial, cross-file-leakage, refactor, caller-drift, midstream, cognitive-bias]
+severity: major
+inputContext: [diff, fullFile]
+outputKind: [findings, actions]
+modelHint: high-accuracy
+dependencies: [code_search]
+---
+
+## Pattern declaration
+
+Primary pattern: Reviewer
+Secondary patterns: Inversion
+Why: 構造変更に対する caller 走査は grep による決定論的突合が主だが、構造変更を含まない変更では実行を止めるゲートが必要
+
+## Goal / 目的
+
+- スキル/モジュールを構造変更したとき、**当該ファイルは更新したが caller 側 N 箇所が古い構造を参照したまま** 残るパターンを検出する。
+- 「変更元は直したが、参照元を直し忘れた」ドリフトを、変更の波及範囲を grep で追って可視化する。
+
+## Non-goals / 扱わないこと
+
+- 構造変更そのものの良し悪しの判断。
+- 静的型エラーの検出（型システムが捕捉できる drift はコンパイラ/tsc の役割）。
+- 当該ファイル内の整合性（それは `rr-midstream-self-contradiction-001` の領域）。
+
+## Pre-execution Gate / 実行前ゲート
+
+このスキルは以下の条件がすべて満たされない限り `NO_REVIEW` を返す。
+
+- [ ] 差分に構造変更（記号の再採番、シンボル名変更、シグネチャ変更、セクション番号の振り直し、ファイル分割・移動）が含まれている
+- [ ] inputContext に diff が含まれている
+
+ゲート不成立時の出力: `NO_REVIEW: rr-midstream-cross-file-leakage-001 — 構造変更が検出されない`
+
+## False-positive guards / 抑制条件
+
+- 旧構造への参照を grep しても caller 側に残骸が見つからない場合は指摘しない。
+- 残骸が意図的（旧 API の互換 shim、移行期間中の dual-reference）で差分内に明記がある場合は抑制。
+- 参照が文字列として同一でも別シンボル/別スコープを指す場合は抑制。
+
+## Rule / ルール
+
+### 検出ロジック
+
+1. **構造変更の特定**: 差分から「何がどう変わったか」を抽出する（旧シンボル→新シンボル、`§2.1`→新採番、`foo(a)`→`foo(a, b)`、ファイル A→分割後）。
+2. **caller の列挙**: 旧構造の識別子（旧シンボル名・旧参照形式・旧パス）を repo 全体に grep し、参照している全箇所を列挙する。
+3. **残骸の判定**: 列挙した参照のうち、今回の差分で更新されていないものを残骸として特定する。
+4. **波及の報告**: 残骸を `<file>:<line>` と検索語で示し、更新漏れの caller を網羅的に挙げる。
+
+### 制約
+
+- 検出は最大 5 件（同一原因の残骸はまとめて1件とし、影響ファイルを列挙）。
+- 各指摘には「構造変更」「旧構造の検索語」「未更新の caller 位置」を必ず含める。
+- caller の列挙は grep で再現可能にし、「N 箇所」と件数を明示する。
+
+## Evidence / 根拠の取り方
+
+- 残骸は必ず `<file>:<line>` と grep 検索語を示し、推測で件数を述べない。
+- 「構造がどう変わったか」を旧→新で具体的に示し、なぜ caller が壊れる/古いかを説明する。
+
+## Output / 出力フォーマット
+
+すべて日本語。
+
+```text
+(cross-file-leakage):1: [要約] 最も影響の大きい未更新 caller は〈1文〉
+
+<file>:<line>: [caller 残骸1] <タイトル>
+  構造変更: <旧構造> → <新構造>(変更元: <file>:<line>)
+  検索語: `<grep pattern>`
+  未更新の caller: <N>箇所 — <file:line>, <file:line>, ...
+  影響: <古い参照が引き起こす不整合/破壊>
+  Fix: <caller 側 N 箇所を新構造に更新する>
+
+<file>:<line>: [caller 残骸2] ...
+```
+
+## Good / Bad Examples
+
+### Good
+
+```text
+review-output/SKILL.md:1: [caller 残骸] §再採番後に caller 9ファイルが旧セクション番号を参照
+  構造変更: review-output SKILL.md を §1-§6 構成に再採番(review-output/SKILL.md:1)
+  検索語: `§(2\.1|4\.4|3-R)`
+  未更新の caller: 9箇所 — a/SKILL.md:12, b/SKILL.md:30, scripts/build.py:88, ...
+  影響: caller が存在しない旧セクション番号を指し、参照が解決不能
+  Fix: caller 9ファイルの §2.1/§4.4/§3-R を新採番に更新
+```
+
+### Bad
+
+```text
+他のファイルも直す必要がありそう
+```
+
+（構造変更の特定なし、検索語なし、caller 位置・件数なし）
+
+## 評価指標（Evaluation）
+
+- 合格基準: 構造変更が旧→新で示され、未更新 caller が grep 再現可能な検索語 + `<file>:<line>` + 件数で網羅されている。
+- 不合格基準: 構造変更の特定が曖昧、caller を grep で再現できない、件数が推測、残骸がないのに指摘している。
+
+## 人間に返す条件（Human Handoff）
+
+- 更新すべき caller が他リポジトリ・外部利用者に及び、後方互換の判断を要する場合。
+- 構造変更を撤回するか caller を全更新するかが設計判断を要する場合。

--- a/skills/midstream/rr-midstream-cross-file-leakage-001/SKILL.md
+++ b/skills/midstream/rr-midstream-cross-file-leakage-001/SKILL.md
@@ -10,7 +10,16 @@ applyTo:
   - '**/*.md'
   - '**/SKILL.md'
   - '**/*.{yaml,yml,json}'
-tags: [adversarial, cross-file-leakage, refactor, caller-drift, midstream, cognitive-bias]
+tags:
+  [
+    adversarial,
+    cross-file-leakage,
+    claim-vs-actual,
+    refactor,
+    caller-drift,
+    midstream,
+    cognitive-bias,
+  ]
 severity: major
 inputContext: [diff, fullFile]
 outputKind: [findings, actions]

--- a/skills/midstream/rr-midstream-refactor-claim-audit-001/SKILL.md
+++ b/skills/midstream/rr-midstream-refactor-claim-audit-001/SKILL.md
@@ -1,0 +1,119 @@
+---
+id: rr-midstream-refactor-claim-audit-001
+name: 'Refactor-Claim Audit リファクタ完了主張の検証'
+description: 'コミット/PR の「全部置換した」「-N%削減」等の完了主張を、grep で反証できる残骸や best/typical/worst 試算で検証する'
+version: 0.1.0
+category: midstream
+phase: midstream
+applyTo:
+  - '**/*.{ts,tsx,js,jsx,mjs}'
+  - '**/*.md'
+  - '**/*.{yaml,yml,json}'
+tags: [adversarial, refactor-claim, claim-vs-actual, verification, midstream, cognitive-bias]
+severity: major
+inputContext: [diff, fullFile]
+outputKind: [findings, actions]
+modelHint: high-accuracy
+dependencies: [code_search]
+---
+
+## Pattern declaration
+
+Primary pattern: Reviewer
+Secondary patterns: Inversion
+Why: 完了主張の反証は grep 検索による決定論的突合が主だが、主張がない変更では実行を止めるゲートが必要
+
+## Goal / 目的
+
+- 「全部置換した」「すべて移行済み」「-83% 削減」のような **完了主張**（commit message / PR description / コメント）に対し、grep で簡単に反証できる残骸や、過大な数値主張を検証する。
+- 「やったと書いてあること」と「実際にやれていること」のギャップを可視化する。
+
+## Non-goals / 扱わないこと
+
+- リファクタの設計妥当性の判断（それ自体が良い変更かは問わない）。
+- 残骸が1件もない正当な完了主張への難癖（反証できなければ指摘しない）。
+- パフォーマンス計測の代替（数値は主張の論理的整合性のみ検証し、実測はしない）。
+
+## Pre-execution Gate / 実行前ゲート
+
+このスキルは以下の条件がすべて満たされない限り `NO_REVIEW` を返す。
+
+- [ ] 差分・commit message・PR description に完了主張（「全」「すべて」「all」「完了」「移行済」「置換」「-N%」「削減」等）が含まれている
+- [ ] inputContext に diff が含まれている
+
+ゲート不成立時の出力: `NO_REVIEW: rr-midstream-refactor-claim-audit-001 — 完了主張が検出されない`
+
+## False-positive guards / 抑制条件
+
+- 主張の対象を grep しても残骸が見つからない場合は指摘しない（反証できない主張は正しいとみなす）。
+- 残骸が意図的に残されたもの（後方互換のための alias、deprecation 期間中の旧 API 等）で、差分内にその旨が明記されている場合は抑制。
+- 数値主張が範囲表記（「-47%〜-55%」）で既に幅を持っている場合は抑制。
+
+## Rule / ルール
+
+### 検出ロジック
+
+1. **主張の抽出**: 完了主張を抽出し、検証可能な命題に変換する。
+   - 置換主張: 「A を B に全置換」→ 「repo 全体に A が残っていないはず」
+   - 完了主張: 「移行完了」→ 「旧構造への参照が残っていないはず」
+   - 数値主張: 「-N%」→ 「best/typical/worst のどのケースの値か」
+2. **反証検索**: 主張の対象パターン（旧 API 名・旧参照形式・旧記法）を repo 全体に grep し、残骸を探す。
+3. **数値の独立試算**: `-N%` 等の定量主張は、best-case / typical-case / worst-case を独立に算出し、主張値がどのケースか・過大表示でないかを併記要求する。
+4. **ギャップの報告**: 主張と、それを反証する残骸 or 試算を `<file>:<line>` で示す。
+
+### 制約
+
+- 検出は最大 5 件。反証が明確で影響が大きいものを優先。
+- 各指摘には「主張」「主張の出典」「反証（残骸位置 or 試算）」を必ず含める。
+- 残骸を挙げるときは grep で再現可能な検索語を明示する。
+
+## Evidence / 根拠の取り方
+
+- 反証する残骸は必ず `<file>:<line>` と検索語を示し、推測しない。
+- 数値主張は算出根拠（分母・分子・ケース定義）を明示し、best/typical/worst を区別する。
+
+## Output / 出力フォーマット
+
+すべて日本語。
+
+```text
+(refactor-claim-audit):1: [要約] 最も過大な完了主張は〈1文〉
+
+<file>:<line>: [完了主張の反証1] <タイトル>
+  主張: 「<完了主張の引用>」(<出典: commit message | PR | file:line>)
+  反証: <残骸の説明 or 試算>(検索語: `<grep pattern>`, <file>:<line>)
+  実態: <主張と実態のギャップ>
+  Fix: <残骸を処理するか、主張を実態に合わせて訂正する>
+
+<file>:<line>: [完了主張の反証2] ...
+```
+
+## Good / Bad Examples
+
+### Good
+
+```text
+sub-supervisor.md:1: [完了主張の反証] 「章番号参照を全置換」主張に対し本文7箇所が未置換
+  主張: 「sub-supervisor の章番号参照 → ファイル参照に置換」(commit message)
+  反証: 冒頭の参照表のみ置換、本文は §refs のまま (検索語: `§[0-9]`, sub-supervisor.md:38,68,85,87,111,123)
+  実態: 7 箇所が未置換で「全置換」は不成立
+  Fix: 本文 7 箇所を置換するか、commit message を「参照表のみ置換」に訂正
+```
+
+### Bad
+
+```text
+リファクタが不完全そうです
+```
+
+（主張の引用なし、残骸位置・検索語なし、具体性なし）
+
+## 評価指標（Evaluation）
+
+- 合格基準: 完了主張が引用され、反証が grep 再現可能な検索語 + `<file>:<line>`、または明示された試算で示されている。
+- 不合格基準: 主張の引用がない、残骸を grep で再現できない、数値試算の根拠がない、反証できないのに指摘している。
+
+## 人間に返す条件（Human Handoff）
+
+- 残骸を処理するか主張を訂正するかが、後方互換や移行戦略の判断を要する場合。
+- 数値主張の正しいケース定義（何を分母にするか）がチーム合意を要する場合。

--- a/skills/midstream/rr-midstream-self-contradiction-001/SKILL.md
+++ b/skills/midstream/rr-midstream-self-contradiction-001/SKILL.md
@@ -1,0 +1,119 @@
+---
+id: rr-midstream-self-contradiction-001
+name: 'Self-Contradiction Detector 自己矛盾検出'
+description: '同一ファイル/隣接ファイル内で「規則Xを守れ」と宣言した直後にXを破っている、宣言と実装の乖離を検出する'
+version: 0.1.0
+category: midstream
+phase: midstream
+applyTo:
+  - '**/*.md'
+  - '**/*.{ts,tsx,js,jsx,mjs}'
+  - '**/SKILL.md'
+  - '**/AGENTS.md'
+tags: [adversarial, self-contradiction, claim-vs-actual, consistency, midstream, cognitive-bias]
+severity: major
+inputContext: [diff, fullFile]
+outputKind: [findings, actions]
+modelHint: high-accuracy
+dependencies: [code_search]
+---
+
+## Pattern declaration
+
+Primary pattern: Reviewer
+Secondary patterns: Inversion
+Why: 宣言（declarative phrase）と実装の突合はチェックリスト型だが、宣言が差分に存在しない変更では実行を止めるゲートが必要
+
+## Goal / 目的
+
+- ファイル/スキル/ドキュメントが「規則 X を守れ」と宣言した直後・同じファイル内で **規則 X を破っている** パターンを検出する。
+- Pre-mortem（失敗シナリオ）や Logic Torturing（論理の穴）では捉えにくい、**「宣言」と「実装」の乖離** に特化する。
+
+## Non-goals / 扱わないこと
+
+- 個別の論理的整合性の検証（`rr-midstream-logic-torturing-001` の役割）。
+- 攻撃経路の分析（`rr-midstream-war-game-001` の役割）。
+- 規則そのものの妥当性判断（規則が正しいか否かではなく、宣言と実装が一致するかを見る）。
+
+## Pre-execution Gate / 実行前ゲート
+
+このスキルは以下の条件がすべて満たされない限り `NO_REVIEW` を返す。
+
+- [ ] 差分に宣言的フレーズ（「〜しない」「禁止」「必ず〜する」「don't」「never」「MUST」「always」等）が含まれている、またはそれを含む既存ファイルへの変更である
+- [ ] inputContext に diff または fullFile が含まれている
+
+ゲート不成立時の出力: `NO_REVIEW: rr-midstream-self-contradiction-001 — 宣言的フレーズが検出されない`
+
+## False-positive guards / 抑制条件
+
+- 宣言が「例外を明示している」場合（「ただし X の場合を除く」）で、実装がその例外条件に該当するなら抑制。
+- 宣言がコメントアウトされた旧仕様や、引用ブロック（「悪い例」として提示されたコード）の場合は抑制。
+- 宣言と実装が別の対象を指している（同名だがスコープが異なる）場合は抑制。
+
+## Rule / ルール
+
+### 検出ロジック
+
+1. **宣言の抽出**: 差分・対象ファイルから declarative phrase を抽出する。
+   - 禁止形: 「〜しない」「〜してはいけない」「禁止」「避ける」「don't」「never」「avoid」「MUST NOT」
+   - 義務形: 「必ず〜する」「〜すること」「MUST」「always」「required」
+2. **対象の特定**: 各宣言が何を規律しているか（参照形式・命名・依存方向・出力形式等）を1文で言語化する。
+3. **実装との突合**: 同一ファイル、次いで隣接/関連ファイルの本文・コードを走査し、宣言に違反する箇所を探す。
+4. **乖離の報告**: 宣言の位置と違反の位置を両方 `<file>:<line>` で示す。
+
+### 制約
+
+- 検出は最大 5 件。乖離が明白で影響の大きいものを優先。
+- 各指摘には「宣言」「宣言位置」「違反位置」「乖離の説明」を必ず含める。
+- 宣言が差分外にあっても、違反が差分内にあれば指摘可能（逆も可）。ただし両方とも差分外の場合は対象外。
+
+## Evidence / 根拠の取り方
+
+- 宣言と違反は必ず両方の `<file>:<line>` を示し、推測ではなく実際の行に紐づける。
+- 「規則 X」を引用し、違反箇所がどう X に反するかを具体的に説明する。
+
+## Output / 出力フォーマット
+
+すべて日本語。
+
+```text
+(self-contradiction):1: [要約] 最も重大な宣言と実装の乖離は〈1文〉
+
+<file>:<line>: [自己矛盾1] <タイトル>
+  宣言: 「<規則 X の引用>」(<file>:<宣言の行>)
+  違反: <宣言に反する実装の説明>(<file>:<違反の行>)
+  乖離: <なぜ宣言と矛盾するか>
+  Fix: <宣言に合わせるか宣言を改めるか、最小限の修正>
+
+<file>:<line>: [自己矛盾2] ...
+```
+
+## Good / Bad Examples
+
+### Good
+
+```text
+sub-supervisor.md:38: [自己矛盾] 章番号参照禁止を宣言した直後に章番号参照を使用
+  宣言: 「章番号参照ではなくファイル単位で参照する」(sub-supervisor.md:17)
+  違反: 本文で `SKILL §2.1` / `§4` と章番号参照を使用 (sub-supervisor.md:38,68,85)
+  乖離: L17 の宣言と同一ファイル L38 以降の実装が真逆
+  Fix: `SKILL §2.1` を該当ファイルパス参照に置換、または L17 の宣言を実態に合わせて緩和
+```
+
+### Bad
+
+```text
+sub-supervisor.md: 矛盾がありそう
+```
+
+（宣言の引用なし、違反位置なし、具体性なし）
+
+## 評価指標（Evaluation）
+
+- 合格基準: 宣言と違反が両方 `<file>:<line>` で示され、引用された規則に対し違反が具体的に説明されている。
+- 不合格基準: 宣言の引用がない、違反位置が曖昧、規則の妥当性への意見、差分にない矛盾の推測。
+
+## 人間に返す条件（Human Handoff）
+
+- 宣言と実装のどちらが正しいか（規則を直すか実装を直すか）が設計判断を要する場合。
+- 矛盾が複数ファイル・複数チームの規約にまたがる場合。

--- a/skills/registry.yaml
+++ b/skills/registry.yaml
@@ -560,6 +560,39 @@ skills:
     recommended: true
     description: '変更に含まれる設計判断・実装選択の論理的整合性を徹底的に検証し、確証バイアスを排除して判断精度を高める'
 
+  - id: rr-midstream-self-contradiction-001
+    version: '0.1.0'
+    name: 'Self-Contradiction Detector 自己矛盾検出'
+    path: skills/midstream/rr-midstream-self-contradiction-001/SKILL.md
+    category: midstream
+    phase: midstream
+    tags: [adversarial, self-contradiction, claim-vs-actual, consistency, midstream, cognitive-bias]
+    severity: major
+    recommended: true
+    description: '同一ファイル/隣接ファイル内で「規則Xを守れ」と宣言した直後にXを破っている、宣言と実装の乖離を検出する'
+
+  - id: rr-midstream-refactor-claim-audit-001
+    version: '0.1.0'
+    name: 'Refactor-Claim Audit リファクタ完了主張の検証'
+    path: skills/midstream/rr-midstream-refactor-claim-audit-001/SKILL.md
+    category: midstream
+    phase: midstream
+    tags: [adversarial, refactor-claim, claim-vs-actual, verification, midstream, cognitive-bias]
+    severity: major
+    recommended: true
+    description: 'コミット/PR の「全部置換した」「-N%削減」等の完了主張を、grep で反証できる残骸や best/typical/worst 試算で検証する'
+
+  - id: rr-midstream-cross-file-leakage-001
+    version: '0.1.0'
+    name: 'Cross-File Leakage リファクタ後の caller 側残骸検出'
+    path: skills/midstream/rr-midstream-cross-file-leakage-001/SKILL.md
+    category: midstream
+    phase: midstream
+    tags: [adversarial, cross-file-leakage, refactor, caller-drift, midstream, cognitive-bias]
+    severity: major
+    recommended: true
+    description: 'モジュール/スキルの構造変更で当該ファイルは更新したが、caller 側が古い構造を参照したまま残るパターンを検出する'
+
   - id: rr-upstream-laravel-migration-safety-001
     version: '0.1.0'
     name: 'Laravel Migration Safety Review'
@@ -1192,6 +1225,9 @@ recommendations:
       - rr-upstream-pre-mortem-001
       - rr-midstream-war-game-001
       - rr-midstream-logic-torturing-001
+      - rr-midstream-self-contradiction-001
+      - rr-midstream-refactor-claim-audit-001
+      - rr-midstream-cross-file-leakage-001
 
   multitenancy:
     description: 'Recommended skills for multi-tenant SaaS applications'

--- a/skills/registry.yaml
+++ b/skills/registry.yaml
@@ -588,10 +588,19 @@ skills:
     path: skills/midstream/rr-midstream-cross-file-leakage-001/SKILL.md
     category: midstream
     phase: midstream
-    tags: [adversarial, cross-file-leakage, refactor, caller-drift, midstream, cognitive-bias]
+    tags:
+      [
+        adversarial,
+        cross-file-leakage,
+        claim-vs-actual,
+        refactor,
+        caller-drift,
+        midstream,
+        cognitive-bias,
+      ]
     severity: major
     recommended: true
-    description: 'モジュール/スキルの構造変更で当該ファイルは更新したが、caller 側が古い構造を参照したまま残るパターンを検出する'
+    description: 'モジュール/スキルの構造変更で当該ファイルは更新したが、caller 側が古い構造（旧参照・旧シグネチャ・旧採番）を参照したまま残るパターンを検出する'
 
   - id: rr-upstream-laravel-migration-safety-001
     version: '0.1.0'


### PR DESCRIPTION
## What

#1177 提案の **3 finding パターン**を adversarial-review entry skill 配下の midstream sub-skill として追加。既存の認知バイアス対策3手法（Pre-mortem / War Game / Logic Torturing）を補完する claim-vs-actual 系統。

- **P1 Self-Contradiction Detector** (`rr-midstream-self-contradiction-001`): 「規則Xを守れ」宣言の直後に同一/隣接ファイルでXを破る、宣言と実装の乖離を検出
- **P2 Refactor-Claim Audit** (`rr-midstream-refactor-claim-audit-001`): 「全置換」「-N%削減」等の完了主張を grep 反証・best/typical/worst 試算で検証
- **P3 Cross-File Leakage** (`rr-midstream-cross-file-leakage-001`): 構造変更で変更元は直したが caller 側 N 箇所が旧構造を参照したまま残るドリフトを検出

## Changes

- `skills/midstream/rr-midstream-{self-contradiction,refactor-claim-audit,cross-file-leakage}-001/SKILL.md`（war-game テンプレート準拠: Pre-execution Gate / False-positive guards / Evidence / Output / Evaluation / Human Handoff）
- `skills/registry.yaml`: skill list 3件 + `adversarial` routing group に3件追加
- `skills/agent-skills/adversarial-review/SKILL.md`: routing table・デフォルト動作・実行フロー・出力フォーマットを6手法に拡張、description/tags 更新
- `docs/data/skill-manifest.json`: 再生成（108→111 skills）

## 設計方針

- 各 skill は **Pre-execution Gate** で対象シグナル（宣言的フレーズ/完了主張/構造変更）がなければ `NO_REVIEW` を返し過検出を抑制。
- **Evidence** で宣言・主張・残骸を必ず `<file>:<line>` + grep 検索語に紐づけ、推測指摘を禁止（差分にないコードへの指摘禁止という repo ルール準拠）。
- 既存 adversarial 3手法とは routing キーワードで棲み分け。

## Verification

- `npm run skills:validate` / `agent-skills:validate` / `skills:manifest:check`: pass
- `npm run meta:validate`: OK
- `npm test`: 1459 pass / 0 fail
- `markdownlint` / `format:check` / `check:dashes`: pass

Closes #1177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)