### PR TITLE
feat(examples): loop reference agent + contract test (#1171 item2)

### DIFF
--- a/examples/loop-reference-agent/README.md
+++ b/examples/loop-reference-agent/README.md
@@ -1,0 +1,64 @@
+# Loop Reference Agent
+
+A deterministic, API-free reference for how a **caller** consumes River Review's
+loop contract to drive a generate → review → revise loop.
+
+River Review is the **review stage** only. It returns judgment material
+(`decision`, finding severities, `oscillated`, `suggestedLoopSignal`, exit code).
+Iteration, stopping, and escalation are the **caller's** responsibility
+(the [#976 boundary](../../docs/ai/generate-review-revise-loop.md)). This example
+encodes that caller-side logic exactly as the
+[loop convergence contract](../../pages/reference/loop-convergence-contract.md)
+specifies, so it works as both an executable demo and a contract test.
+
+## Files
+
+- `reference-loop.mjs` — pure decision logic (`decideLoopAction`) and a loop
+  driver (`runReferenceLoop`). No LLM, filesystem, or network access.
+- `../../tests/loop-reference-agent.test.mjs` — contract test asserting every
+  terminal outcome.
+- `../../tests/fixtures/loop-reference-agent/` — fixed Review Artifacts and a
+  `runs diff` fixture.
+
+## Decision precedence
+
+`decideLoopAction` resolves one review result to one action, highest priority first:
+
+| Priority | Condition                                        | Signal                 | Action                |
+| -------- | ------------------------------------------------ | ---------------------- | --------------------- |
+| 1        | Caller policy fires (cost cap, HITL label)       | `STOP_POLICY_REQUIRED` | `stop-policy`         |
+| 2        | Oscillation (`runs diff` `oscillated` non-empty) | `STOP_OSCILLATED`      | `stop-escalate`       |
+| 2        | `decision === 'human-review-required'`           | `ESCALATE_HUMAN`       | `stop-escalate`       |
+| 3        | No blocking findings + auto-approve equivalent   | `CONVERGED`            | `stop-converged`      |
+| 4        | Would revise but `iteration >= maxIterations`    | `STOP_MAX_ITERATIONS`  | `stop-max-iterations` |
+| 5        | Blocking findings remain                         | `REVISE_REQUIRED`      | `revise`              |
+
+`CONVERGED` / escalation take priority over the max-iterations guard: reaching
+the cap on a converged or escalated result is not a "max iterations" stop.
+
+Layers 1–2 (`CONVERGED` / `REVISE_REQUIRED` / `ESCALATE_HUMAN` / `STOP_OSCILLATED`)
+are derived by River Review via `src/lib/loop-signal.mjs`. Layer 3
+(`STOP_MAX_ITERATIONS` / `STOP_POLICY_REQUIRED`) is synthesized by the caller —
+River Review deliberately never emits those.
+
+## Usage sketch
+
+```js
+import { runReferenceLoop } from './reference-loop.mjs';
+
+const result = runReferenceLoop({
+  // In production, `review` shells out to `river run ... --output json --save`
+  // and returns the parsed artifact (+ `runs diff` once 3+ runs exist).
+  review: ({ iteration, history }) => ({ artifact: runRiverReview(iteration, history) }),
+  maxIterations: 5,
+  policyFor: ({ history }) => (costExceeded(history) ? 'STOP_POLICY_REQUIRED' : null),
+});
+
+// result.action ∈ stop-converged | stop-escalate | stop-max-iterations | stop-policy
+```
+
+## Run the contract test
+
+```bash
+node --test tests/loop-reference-agent.test.mjs
+```

--- a/examples/loop-reference-agent/README.md
+++ b/examples/loop-reference-agent/README.md
@@ -43,13 +43,18 @@ River Review deliberately never emits those.
 
 ## Usage sketch
 
+`review` and `policyFor` may be sync or async — the driver awaits both, so real
+callers can run `river run` subprocesses / LLM calls inside them.
+
 ```js
 import { runReferenceLoop } from './reference-loop.mjs';
 
-const result = runReferenceLoop({
+const result = await runReferenceLoop({
   // In production, `review` shells out to `river run ... --output json --save`
   // and returns the parsed artifact (+ `runs diff` once 3+ runs exist).
-  review: ({ iteration, history }) => ({ artifact: runRiverReview(iteration, history) }),
+  review: async ({ iteration, history }) => ({
+    artifact: await runRiverReview(iteration, history),
+  }),
   maxIterations: 5,
   policyFor: ({ history }) => (costExceeded(history) ? 'STOP_POLICY_REQUIRED' : null),
 });

--- a/examples/loop-reference-agent/reference-loop.mjs
+++ b/examples/loop-reference-agent/reference-loop.mjs
@@ -99,11 +99,14 @@ export function decideLoopAction({
   }
 
   // 4. We would revise (REVISE_REQUIRED or NO_SIGNAL) — apply the divergence guard.
-  if (iteration >= maxIterations) {
+  // Guard against null / NaN / non-numeric maxIterations: a bad value must not
+  // silently disable the cap (infinite loop) or trip it on iteration 1.
+  const limit = typeof maxIterations === 'number' && maxIterations > 0 ? maxIterations : 5;
+  if (iteration >= limit) {
     return {
       signal: 'STOP_MAX_ITERATIONS',
       action: LOOP_ACTIONS.STOP_MAX_ITERATIONS,
-      reason: `reached max iterations (${maxIterations}) without converging`,
+      reason: `reached max iterations (${limit}) without converging`,
     };
   }
 
@@ -122,19 +125,22 @@ export function decideLoopAction({
  * it returns a fixed artifact (and optional runsDiff) so the loop is fully
  * deterministic with no LLM / IO.
  *
+ * `review` and `policyFor` may be sync or async (returning a Promise): real
+ * callers await `river run` subprocesses / LLM calls, so the driver awaits both.
+ *
  * @param {object} params
- * @param {(ctx: {iteration: number, history: object[]}) => ({artifact: object, runsDiff?: object|null})} params.review
- *   Returns the review result for the given iteration.
+ * @param {(ctx: {iteration: number, history: object[]}) => (({artifact: object, runsDiff?: object|null}) | Promise<{artifact: object, runsDiff?: object|null}>)} params.review
+ *   Returns (or resolves to) the review result for the given iteration.
  * @param {number} [params.maxIterations=5] - Divergence guard.
- * @param {(ctx: {iteration: number, history: object[]}) => (string|null)} [params.policyFor]
- *   Returns 'STOP_POLICY_REQUIRED' to force a policy stop, else null.
- * @returns {{signal: string, action: string, reason: string, iteration: number, history: object[]}}
+ * @param {(ctx: {iteration: number, history: object[]}) => ((string|null) | Promise<string|null>)} [params.policyFor]
+ *   Returns (or resolves to) 'STOP_POLICY_REQUIRED' to force a policy stop, else null.
+ * @returns {Promise<{signal: string, action: string, reason: string, iteration: number, history: object[]}>}
  */
-export function runReferenceLoop({ review, maxIterations = 5, policyFor = () => null }) {
+export async function runReferenceLoop({ review, maxIterations = 5, policyFor = () => null }) {
   const history = [];
 
   for (let iteration = 1; ; iteration++) {
-    const { artifact, runsDiff = null } = review({ iteration, history });
+    const { artifact, runsDiff = null } = await review({ iteration, history });
     history.push(artifact);
 
     const decision = decideLoopAction({
@@ -142,7 +148,7 @@ export function runReferenceLoop({ review, maxIterations = 5, policyFor = () => 
       runsDiff,
       iteration,
       maxIterations,
-      policySignal: policyFor({ iteration, history }),
+      policySignal: await policyFor({ iteration, history }),
     });
 
     if (decision.action !== LOOP_ACTIONS.REVISE) {

--- a/examples/loop-reference-agent/reference-loop.mjs
+++ b/examples/loop-reference-agent/reference-loop.mjs
@@ -1,0 +1,153 @@
+/**
+ * Reference Loop Agent (Epic #1171 item2).
+ *
+ * A deterministic, API-free reference implementation of how a *caller* consumes
+ * River Review's loop contract to drive a generate → review → revise loop.
+ *
+ * River Review only returns judgment material (`decision`, finding severities,
+ * `oscillated`, `suggestedLoopSignal`). Iteration / stop / escalation is the
+ * caller's responsibility (#976 boundary). This module encodes that caller-side
+ * decision logic exactly as specified in
+ * `pages/reference/loop-convergence-contract.md`, so it doubles as a contract
+ * test fixture and an executable demo.
+ *
+ * All functions are pure / side-effect-free. The loop driver delegates the
+ * actual "run River Review" step to an injected `review` callback, so tests feed
+ * fixed artifacts and never touch a real LLM or the filesystem.
+ */
+
+import {
+  deriveLoopSignalFromArtifact,
+  deriveLoopSignalFromRunsDiff,
+} from '../../src/lib/loop-signal.mjs';
+
+/** Caller-side loop actions. */
+export const LOOP_ACTIONS = Object.freeze({
+  REVISE: 'revise',
+  STOP_CONVERGED: 'stop-converged',
+  STOP_ESCALATE: 'stop-escalate',
+  STOP_MAX_ITERATIONS: 'stop-max-iterations',
+  STOP_POLICY: 'stop-policy',
+});
+
+/**
+ * Decide the next loop action for one review result. Pure.
+ *
+ * Precedence (highest first):
+ * 1. caller policy (cost cap, HITL label, …) → STOP_POLICY  (Layer 3)
+ * 2. STOP_OSCILLATED / ESCALATE_HUMAN        → STOP_ESCALATE (Layer 2/1)
+ * 3. CONVERGED                                → STOP_CONVERGED
+ * 4. would revise but hit the iteration cap   → STOP_MAX_ITERATIONS (Layer 3)
+ * 5. otherwise (REVISE_REQUIRED / NO_SIGNAL)  → REVISE
+ *
+ * Note CONVERGED/ESCALATE take priority over the max-iterations guard: reaching
+ * the cap on a converged/escalated result is not a "max iterations" stop.
+ *
+ * @param {object} params
+ * @param {object} params.artifact - Latest Review Artifact (findings + decision).
+ * @param {object|null} [params.runsDiff] - `runs diff` output when 3+ runs exist
+ *   (enables STOP_OSCILLATED). Omit/null for single-run derivation.
+ * @param {number} params.iteration - 1-based iteration counter.
+ * @param {number} params.maxIterations - Divergence guard (recommended 3–5).
+ * @param {string|null} [params.policySignal] - Caller-synthesized Layer 3 signal,
+ *   e.g. 'STOP_POLICY_REQUIRED' when a cost cap or HITL label fires.
+ * @returns {{signal: string, action: string, reason: string}}
+ */
+export function decideLoopAction({
+  artifact,
+  runsDiff = null,
+  iteration,
+  maxIterations,
+  policySignal = null,
+}) {
+  // 1. Caller policy (Layer 3) — highest priority external override.
+  if (policySignal === 'STOP_POLICY_REQUIRED') {
+    return {
+      signal: 'STOP_POLICY_REQUIRED',
+      action: LOOP_ACTIONS.STOP_POLICY,
+      reason: 'caller policy (cost cap / HITL label) requires stopping',
+    };
+  }
+
+  // 2/3/5. River Review-derived signal (Layer 2 when a diff is supplied, else Layer 1).
+  const signal = runsDiff
+    ? deriveLoopSignalFromRunsDiff(runsDiff, artifact)
+    : deriveLoopSignalFromArtifact(artifact);
+
+  if (signal === 'STOP_OSCILLATED') {
+    return {
+      signal,
+      action: LOOP_ACTIONS.STOP_ESCALATE,
+      reason: 'oscillation detected — revise is re-introducing resolved findings',
+    };
+  }
+
+  if (signal === 'ESCALATE_HUMAN') {
+    return {
+      signal,
+      action: LOOP_ACTIONS.STOP_ESCALATE,
+      reason: 'decision is human-review-required',
+    };
+  }
+
+  if (signal === 'CONVERGED') {
+    return {
+      signal,
+      action: LOOP_ACTIONS.STOP_CONVERGED,
+      reason: 'no blocking findings and decision is auto-approve equivalent',
+    };
+  }
+
+  // 4. We would revise (REVISE_REQUIRED or NO_SIGNAL) — apply the divergence guard.
+  if (iteration >= maxIterations) {
+    return {
+      signal: 'STOP_MAX_ITERATIONS',
+      action: LOOP_ACTIONS.STOP_MAX_ITERATIONS,
+      reason: `reached max iterations (${maxIterations}) without converging`,
+    };
+  }
+
+  return {
+    signal,
+    action: LOOP_ACTIONS.REVISE,
+    reason: 'blocking findings remain — revise and re-run',
+  };
+}
+
+/**
+ * Drive the generate → review → revise loop until a stop action is reached.
+ *
+ * The `review` callback abstracts "run River Review for this iteration". In
+ * production it would shell out to `river run` and parse the artifact; in tests
+ * it returns a fixed artifact (and optional runsDiff) so the loop is fully
+ * deterministic with no LLM / IO.
+ *
+ * @param {object} params
+ * @param {(ctx: {iteration: number, history: object[]}) => ({artifact: object, runsDiff?: object|null})} params.review
+ *   Returns the review result for the given iteration.
+ * @param {number} [params.maxIterations=5] - Divergence guard.
+ * @param {(ctx: {iteration: number, history: object[]}) => (string|null)} [params.policyFor]
+ *   Returns 'STOP_POLICY_REQUIRED' to force a policy stop, else null.
+ * @returns {{signal: string, action: string, reason: string, iteration: number, history: object[]}}
+ */
+export function runReferenceLoop({ review, maxIterations = 5, policyFor = () => null }) {
+  const history = [];
+
+  for (let iteration = 1; ; iteration++) {
+    const { artifact, runsDiff = null } = review({ iteration, history });
+    history.push(artifact);
+
+    const decision = decideLoopAction({
+      artifact,
+      runsDiff,
+      iteration,
+      maxIterations,
+      policySignal: policyFor({ iteration, history }),
+    });
+
+    if (decision.action !== LOOP_ACTIONS.REVISE) {
+      return { ...decision, iteration, history };
+    }
+    // else: revise and continue to the next iteration.
+  }
+}

--- a/tests/fixtures/loop-reference-agent/artifact-converged.json
+++ b/tests/fixtures/loop-reference-agent/artifact-converged.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1",
+  "phase": "midstream",
+  "decision": "auto-approve",
+  "findings": [
+    {
+      "id": "f-2",
+      "ruleId": "rr-mid-readability-naming",
+      "severity": "minor",
+      "title": "Unclear variable name",
+      "message": "Rename `x` to something descriptive.",
+      "file": "src/api/users.mjs",
+      "line": 10
+    }
+  ],
+  "suggestedLoopSignal": "CONVERGED"
+}

--- a/tests/fixtures/loop-reference-agent/artifact-escalate.json
+++ b/tests/fixtures/loop-reference-agent/artifact-escalate.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1",
+  "phase": "midstream",
+  "decision": "human-review-required",
+  "findings": [
+    {
+      "id": "f-3",
+      "ruleId": "rr-mid-security-authz",
+      "severity": "critical",
+      "title": "Authorization bypass risk",
+      "message": "Endpoint changes touch auth — human sign-off required.",
+      "file": "src/api/auth.mjs",
+      "line": 7
+    }
+  ],
+  "suggestedLoopSignal": "ESCALATE_HUMAN"
+}

--- a/tests/fixtures/loop-reference-agent/artifact-revise.json
+++ b/tests/fixtures/loop-reference-agent/artifact-revise.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1",
+  "phase": "midstream",
+  "decision": "auto-approve",
+  "findings": [
+    {
+      "id": "f-1",
+      "ruleId": "rr-mid-security-sql-injection",
+      "severity": "critical",
+      "title": "SQL injection in user lookup",
+      "message": "Unsanitized input concatenated into query.",
+      "file": "src/api/users.mjs",
+      "line": 42
+    }
+  ],
+  "suggestedLoopSignal": "REVISE_REQUIRED"
+}

--- a/tests/fixtures/loop-reference-agent/runs-diff-oscillated.json
+++ b/tests/fixtures/loop-reference-agent/runs-diff-oscillated.json
@@ -1,0 +1,11 @@
+{
+  "oscillated": [
+    {
+      "fingerprint": "rr-mid-security-sql-injection|src/api/users.mjs|Unsanitized input",
+      "appearedIn": ["run-1", "run-3"],
+      "resolvedIn": ["run-2"]
+    }
+  ],
+  "new": [],
+  "resolved": []
+}

--- a/tests/loop-reference-agent.test.mjs
+++ b/tests/loop-reference-agent.test.mjs
@@ -1,0 +1,146 @@
+/**
+ * Contract test for the Reference Loop Agent (Epic #1171 item2).
+ *
+ * Proves a caller consuming River Review's loop contract reaches every terminal
+ * outcome deterministically from fixed artifacts / run-diff fixtures — no LLM,
+ * no filesystem, no network. This is the executable counterpart to
+ * pages/reference/loop-convergence-contract.md.
+ *
+ * Asserts: CONVERGED, REVISE (→ eventual stop), ESCALATE_HUMAN,
+ * STOP_OSCILLATED, STOP_MAX_ITERATIONS, plus the caller-only STOP_POLICY.
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import {
+  decideLoopAction,
+  runReferenceLoop,
+  LOOP_ACTIONS,
+} from '../examples/loop-reference-agent/reference-loop.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixDir = join(here, 'fixtures', 'loop-reference-agent');
+const load = (name) => JSON.parse(readFileSync(join(fixDir, name), 'utf8'));
+
+const REVISE = load('artifact-revise.json');
+const CONVERGED = load('artifact-converged.json');
+const ESCALATE = load('artifact-escalate.json');
+const OSCILLATED_DIFF = load('runs-diff-oscillated.json');
+
+// ---------------------------------------------------------------------------
+// decideLoopAction — single-step decisions
+// ---------------------------------------------------------------------------
+
+describe('decideLoopAction', () => {
+  test('CONVERGED → stop-converged', () => {
+    const d = decideLoopAction({ artifact: CONVERGED, iteration: 1, maxIterations: 5 });
+    assert.equal(d.signal, 'CONVERGED');
+    assert.equal(d.action, LOOP_ACTIONS.STOP_CONVERGED);
+  });
+
+  test('blocking findings → revise', () => {
+    const d = decideLoopAction({ artifact: REVISE, iteration: 1, maxIterations: 5 });
+    assert.equal(d.signal, 'REVISE_REQUIRED');
+    assert.equal(d.action, LOOP_ACTIONS.REVISE);
+  });
+
+  test('human-review-required → stop-escalate', () => {
+    const d = decideLoopAction({ artifact: ESCALATE, iteration: 1, maxIterations: 5 });
+    assert.equal(d.signal, 'ESCALATE_HUMAN');
+    assert.equal(d.action, LOOP_ACTIONS.STOP_ESCALATE);
+  });
+
+  test('oscillation diff → stop-escalate (STOP_OSCILLATED)', () => {
+    const d = decideLoopAction({
+      artifact: REVISE,
+      runsDiff: OSCILLATED_DIFF,
+      iteration: 3,
+      maxIterations: 5,
+    });
+    assert.equal(d.signal, 'STOP_OSCILLATED');
+    assert.equal(d.action, LOOP_ACTIONS.STOP_ESCALATE);
+  });
+
+  test('blocking findings at the iteration cap → stop-max-iterations', () => {
+    const d = decideLoopAction({ artifact: REVISE, iteration: 5, maxIterations: 5 });
+    assert.equal(d.signal, 'STOP_MAX_ITERATIONS');
+    assert.equal(d.action, LOOP_ACTIONS.STOP_MAX_ITERATIONS);
+  });
+
+  test('caller policy overrides everything → stop-policy', () => {
+    const d = decideLoopAction({
+      artifact: REVISE,
+      iteration: 1,
+      maxIterations: 5,
+      policySignal: 'STOP_POLICY_REQUIRED',
+    });
+    assert.equal(d.action, LOOP_ACTIONS.STOP_POLICY);
+  });
+
+  test('CONVERGED at the cap is converged, not max-iterations', () => {
+    const d = decideLoopAction({ artifact: CONVERGED, iteration: 5, maxIterations: 5 });
+    assert.equal(d.action, LOOP_ACTIONS.STOP_CONVERGED);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runReferenceLoop — full loop drive
+// ---------------------------------------------------------------------------
+
+describe('runReferenceLoop', () => {
+  test('revises until convergence', () => {
+    // Two revise rounds, then converge.
+    const sequence = [REVISE, REVISE, CONVERGED];
+    const result = runReferenceLoop({
+      review: ({ iteration }) => ({ artifact: sequence[iteration - 1] }),
+      maxIterations: 5,
+    });
+    assert.equal(result.action, LOOP_ACTIONS.STOP_CONVERGED);
+    assert.equal(result.iteration, 3);
+    assert.equal(result.history.length, 3);
+  });
+
+  test('stops at max iterations when never converging', () => {
+    const result = runReferenceLoop({
+      review: () => ({ artifact: REVISE }),
+      maxIterations: 3,
+    });
+    assert.equal(result.action, LOOP_ACTIONS.STOP_MAX_ITERATIONS);
+    assert.equal(result.iteration, 3);
+  });
+
+  test('escalates immediately on human-review-required', () => {
+    const result = runReferenceLoop({
+      review: () => ({ artifact: ESCALATE }),
+      maxIterations: 5,
+    });
+    assert.equal(result.action, LOOP_ACTIONS.STOP_ESCALATE);
+    assert.equal(result.iteration, 1);
+  });
+
+  test('escalates on oscillation surfaced from runs diff', () => {
+    // First two rounds revise; third round surfaces oscillation via runsDiff.
+    const result = runReferenceLoop({
+      review: ({ iteration }) =>
+        iteration >= 3 ? { artifact: REVISE, runsDiff: OSCILLATED_DIFF } : { artifact: REVISE },
+      maxIterations: 10,
+    });
+    assert.equal(result.signal, 'STOP_OSCILLATED');
+    assert.equal(result.action, LOOP_ACTIONS.STOP_ESCALATE);
+    assert.equal(result.iteration, 3);
+  });
+
+  test('caller policy stops the loop mid-flight', () => {
+    const result = runReferenceLoop({
+      review: () => ({ artifact: REVISE }),
+      maxIterations: 5,
+      policyFor: ({ iteration }) => (iteration === 2 ? 'STOP_POLICY_REQUIRED' : null),
+    });
+    assert.equal(result.action, LOOP_ACTIONS.STOP_POLICY);
+    assert.equal(result.iteration, 2);
+  });
+});

--- a/tests/loop-reference-agent.test.mjs
+++ b/tests/loop-reference-agent.test.mjs
@@ -85,6 +85,15 @@ describe('decideLoopAction', () => {
     const d = decideLoopAction({ artifact: CONVERGED, iteration: 5, maxIterations: 5 });
     assert.equal(d.action, LOOP_ACTIONS.STOP_CONVERGED);
   });
+
+  test('invalid maxIterations falls back to default (no premature/absent cap)', () => {
+    // null would coerce to 0 (iteration >= 0 → premature stop); guard must prevent it.
+    const early = decideLoopAction({ artifact: REVISE, iteration: 1, maxIterations: null });
+    assert.equal(early.action, LOOP_ACTIONS.REVISE);
+    // and the default cap (5) still trips when reached.
+    const capped = decideLoopAction({ artifact: REVISE, iteration: 5, maxIterations: null });
+    assert.equal(capped.action, LOOP_ACTIONS.STOP_MAX_ITERATIONS);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -92,10 +101,10 @@ describe('decideLoopAction', () => {
 // ---------------------------------------------------------------------------
 
 describe('runReferenceLoop', () => {
-  test('revises until convergence', () => {
+  test('revises until convergence', async () => {
     // Two revise rounds, then converge.
     const sequence = [REVISE, REVISE, CONVERGED];
-    const result = runReferenceLoop({
+    const result = await runReferenceLoop({
       review: ({ iteration }) => ({ artifact: sequence[iteration - 1] }),
       maxIterations: 5,
     });
@@ -104,8 +113,8 @@ describe('runReferenceLoop', () => {
     assert.equal(result.history.length, 3);
   });
 
-  test('stops at max iterations when never converging', () => {
-    const result = runReferenceLoop({
+  test('stops at max iterations when never converging', async () => {
+    const result = await runReferenceLoop({
       review: () => ({ artifact: REVISE }),
       maxIterations: 3,
     });
@@ -113,8 +122,8 @@ describe('runReferenceLoop', () => {
     assert.equal(result.iteration, 3);
   });
 
-  test('escalates immediately on human-review-required', () => {
-    const result = runReferenceLoop({
+  test('escalates immediately on human-review-required', async () => {
+    const result = await runReferenceLoop({
       review: () => ({ artifact: ESCALATE }),
       maxIterations: 5,
     });
@@ -122,9 +131,9 @@ describe('runReferenceLoop', () => {
     assert.equal(result.iteration, 1);
   });
 
-  test('escalates on oscillation surfaced from runs diff', () => {
+  test('escalates on oscillation surfaced from runs diff', async () => {
     // First two rounds revise; third round surfaces oscillation via runsDiff.
-    const result = runReferenceLoop({
+    const result = await runReferenceLoop({
       review: ({ iteration }) =>
         iteration >= 3 ? { artifact: REVISE, runsDiff: OSCILLATED_DIFF } : { artifact: REVISE },
       maxIterations: 10,
@@ -134,13 +143,23 @@ describe('runReferenceLoop', () => {
     assert.equal(result.iteration, 3);
   });
 
-  test('caller policy stops the loop mid-flight', () => {
-    const result = runReferenceLoop({
+  test('caller policy stops the loop mid-flight', async () => {
+    const result = await runReferenceLoop({
       review: () => ({ artifact: REVISE }),
       maxIterations: 5,
       policyFor: ({ iteration }) => (iteration === 2 ? 'STOP_POLICY_REQUIRED' : null),
     });
     assert.equal(result.action, LOOP_ACTIONS.STOP_POLICY);
+    assert.equal(result.iteration, 2);
+  });
+
+  test('awaits async review and policyFor callbacks', async () => {
+    const result = await runReferenceLoop({
+      review: async ({ iteration }) => ({ artifact: iteration >= 2 ? CONVERGED : REVISE }),
+      maxIterations: 5,
+      policyFor: async () => null,
+    });
+    assert.equal(result.action, LOOP_ACTIONS.STOP_CONVERGED);
     assert.equal(result.iteration, 2);
   });
 });


### PR DESCRIPTION
## What

#1171 **item2** = Reference Loop Implementation + Contract Test。caller が River Review の loop 契約（generate → review → revise）をどう消費するかを **deterministic に証明**する、実 API 不使用の参照実装。demo と contract test を同一資産に統合。

## Changes

- `examples/loop-reference-agent/reference-loop.mjs`
  - `decideLoopAction(...)`: 1 レビュー結果 → 1 アクションの純関数。優先順位は loop-convergence-contract.md 準拠（policy → oscillation/escalate → converged → max-iterations → revise）。
  - `runReferenceLoop(...)`: injected `review` callback でループ駆動（本番は `river run`、テストは fixture）。
  - Layer1/2 は `src/lib/loop-signal.mjs` を流用、Layer3（STOP_MAX_ITERATIONS / STOP_POLICY_REQUIRED）は caller 合成。新 command なし。
- `examples/loop-reference-agent/README.md`: 優先順位表 + usage sketch。contract doc / #976 boundary へ相互リンク。
- `tests/loop-reference-agent.test.mjs` + `tests/fixtures/loop-reference-agent/`: 固定 artifact / runs diff。

## DoD（達成）

固定入力（実 API 不使用）で全終端を assert:
- ✅ CONVERGED / REVISE→収束 / ESCALATE_HUMAN / STOP_OSCILLATED / STOP_MAX_ITERATIONS / （caller-only）STOP_POLICY
- ✅ CONVERGED at cap は max-iterations より優先（境界ケース）

## Verification

- `node --test tests/loop-reference-agent.test.mjs`: 12 pass
- `npm test`: 1471 pass / 0 fail
- `format:check` / `check:dashes` / `markdownlint`: pass

Relates to #1171 (item2)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)