### PR TITLE
feat(eval): convergence efficiency evaluator (#1171 item4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "planner:eval": "node scripts/evaluate-planner.mjs",
     "planner:eval:dataset": "node scripts/evaluate-planner-dataset.mjs",
     "eval:fixtures": "node scripts/evaluate-review-fixtures.mjs",
+    "eval:convergence": "node scripts/evaluate-convergence-efficiency.mjs",
     "eval:repo-context": "node scripts/evaluate-repo-wide-fixtures.mjs",
     "meta:validate": "node scripts/validate-meta-consistency.mjs",
     "plugin:validate": "node scripts/validate-plugin-manifest.mjs",

--- a/scripts/evaluate-convergence-efficiency.mjs
+++ b/scripts/evaluate-convergence-efficiency.mjs
@@ -35,6 +35,25 @@ function round4(n) {
 }
 
 /**
+ * Sort run records chronologically (oldest first), NaN-safe with a runId
+ * tie-break — mirrors diffRunHistory so the "final run" metrics stay consistent
+ * with the internally-sorted oscillation count regardless of input order.
+ */
+function sortRunsChronologically(runs) {
+  return [...runs].sort((a, b) => {
+    const ta = a?.timestamp != null ? new Date(a.timestamp).getTime() : NaN;
+    const tb = b?.timestamp != null ? new Date(b.timestamp).getTime() : NaN;
+    const aNaN = Number.isNaN(ta);
+    const bNaN = Number.isNaN(tb);
+    if (aNaN && bNaN) return (a?.runId ?? '').localeCompare(b?.runId ?? '');
+    if (aNaN) return 1;
+    if (bNaN) return -1;
+    if (ta !== tb) return ta - tb;
+    return (a?.runId ?? '').localeCompare(b?.runId ?? '');
+  });
+}
+
+/**
  * Compute convergence metrics for a single run sequence.
  *
  * A "run" is a record shaped like `{ runId, timestamp, findings: [{severity,
@@ -51,7 +70,9 @@ function round4(n) {
  * }}
  */
 export function evaluateConvergence(runs) {
-  const list = Array.isArray(runs) ? runs : [];
+  // Sort defensively so "final run" metrics match the internally-sorted
+  // oscillation count even when the caller passes runs out of order.
+  const list = sortRunsChronologically(Array.isArray(runs) ? runs : []);
   const turnCount = list.length;
 
   const finalFindings = Array.isArray(list[turnCount - 1]?.findings)
@@ -130,8 +151,15 @@ function formatReport(results) {
   return lines.join('\n');
 }
 
-const isDirectRun =
-  process.argv[1] && import.meta.url === pathToFileURL(realpathSync(process.argv[1])).href;
+const isDirectRun = (() => {
+  try {
+    // realpathSync throws if argv[1] is a non-existent / synthetic path (some
+    // test runners / bundlers): importing this module must never crash.
+    return process.argv[1] && import.meta.url === pathToFileURL(realpathSync(process.argv[1])).href;
+  } catch {
+    return false;
+  }
+})();
 if (isDirectRun) {
   const args = process.argv.slice(2);
   const idx = args.indexOf('--cases');

--- a/scripts/evaluate-convergence-efficiency.mjs
+++ b/scripts/evaluate-convergence-efficiency.mjs
@@ -1,0 +1,141 @@
+/**
+ * Convergence Efficiency Eval — minimal version (Epic #1171 item4).
+ *
+ * Measures how efficiently a generate → review → revise loop converges, to
+ * quantify the economic value of River Review to a platform team ("with RR vs
+ * without RR, how many turns and how much $ to converge?").
+ *
+ * Pure / deterministic: reads existing signals (issue severities, run diff,
+ * usage.estimated_cost_usd) from a fixed run sequence. No LLM, no new telemetry.
+ * The CI test exercises only this fixture-based calculation; real LLM
+ * benchmarking is a manual exercise.
+ */
+
+import path from 'path';
+import { readFileSync } from 'fs';
+import { realpathSync } from 'fs';
+import { pathToFileURL, fileURLToPath } from 'url';
+
+import { diffRunHistory } from '../src/lib/review-differ.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DEFAULT_CASES = path.join(
+  repoRoot,
+  'tests',
+  'fixtures',
+  'convergence-efficiency',
+  'cases.json'
+);
+
+/** Severities that block convergence. */
+const BLOCKING = new Set(['critical', 'major']);
+
+function round4(n) {
+  return Math.round((Number(n) || 0) * 1e4) / 1e4;
+}
+
+/**
+ * Compute convergence metrics for a single run sequence.
+ *
+ * A "run" is a record shaped like `{ runId, timestamp, findings: [{severity,
+ * ruleId, file, message, line}], usage: { estimated_cost_usd } }` — the same
+ * fields River Review already emits.
+ *
+ * @param {Array<object>} runs - Chronological run records (oldest first).
+ * @returns {{
+ *   turnCount: number,
+ *   blockingFindingsRemaining: number,
+ *   oscillationCount: number,
+ *   estimatedCostUsd: number,
+ *   converged: boolean,
+ * }}
+ */
+export function evaluateConvergence(runs) {
+  const list = Array.isArray(runs) ? runs : [];
+  const turnCount = list.length;
+
+  const finalFindings = Array.isArray(list[turnCount - 1]?.findings)
+    ? list[turnCount - 1].findings
+    : [];
+  const blockingFindingsRemaining = finalFindings.filter(
+    (f) => f != null && BLOCKING.has(f.severity)
+  ).length;
+
+  const estimatedCostUsd = round4(
+    list.reduce((sum, r) => sum + (Number(r?.usage?.estimated_cost_usd) || 0), 0)
+  );
+
+  // Oscillation needs >= 3 runs to detect a present→absent→present pattern.
+  const oscillationCount = turnCount >= 3 ? (diffRunHistory(list).oscillated?.length ?? 0) : 0;
+
+  const converged = turnCount > 0 && blockingFindingsRemaining === 0;
+
+  return { turnCount, blockingFindingsRemaining, oscillationCount, estimatedCostUsd, converged };
+}
+
+/**
+ * Compare a baseline run sequence against a River-Review-assisted one and report
+ * the deltas (turns saved, cost delta).
+ *
+ * @param {{name?: string, description?: string, baseline: object[], treatment: object[]}} testCase
+ * @returns {{name: string, baseline: object, treatment: object, delta: object}}
+ */
+export function compareCase(testCase) {
+  const baseline = evaluateConvergence(testCase.baseline);
+  const treatment = evaluateConvergence(testCase.treatment);
+  return {
+    name: testCase.name ?? '(unnamed)',
+    baseline,
+    treatment,
+    delta: {
+      turnsSaved: baseline.turnCount - treatment.turnCount,
+      blockingDelta: treatment.blockingFindingsRemaining - baseline.blockingFindingsRemaining,
+      costDeltaUsd: round4(treatment.estimatedCostUsd - baseline.estimatedCostUsd),
+    },
+  };
+}
+
+/**
+ * Evaluate all cases in a cases file.
+ * @param {string} [casesPath]
+ * @returns {Array<ReturnType<typeof compareCase>>}
+ */
+export function evaluateCasesFile(casesPath = DEFAULT_CASES) {
+  const cases = JSON.parse(readFileSync(casesPath, 'utf8'));
+  return cases.map(compareCase);
+}
+
+function formatReport(results) {
+  const lines = ['# Convergence Efficiency Report', ''];
+  for (const r of results) {
+    lines.push(`## ${r.name}`);
+    lines.push('');
+    lines.push('| metric | baseline | with River Review |');
+    lines.push('| ------ | -------- | ----------------- |');
+    lines.push(`| turns | ${r.baseline.turnCount} | ${r.treatment.turnCount} |`);
+    lines.push(
+      `| blocking remaining | ${r.baseline.blockingFindingsRemaining} | ${r.treatment.blockingFindingsRemaining} |`
+    );
+    lines.push(
+      `| oscillations | ${r.baseline.oscillationCount} | ${r.treatment.oscillationCount} |`
+    );
+    lines.push(
+      `| est. cost (USD) | ${r.baseline.estimatedCostUsd} | ${r.treatment.estimatedCostUsd} |`
+    );
+    lines.push(`| converged | ${r.baseline.converged} | ${r.treatment.converged} |`);
+    lines.push('');
+    lines.push(`→ turns saved: ${r.delta.turnsSaved}, cost delta: ${r.delta.costDeltaUsd} USD`);
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+const isDirectRun =
+  process.argv[1] && import.meta.url === pathToFileURL(realpathSync(process.argv[1])).href;
+if (isDirectRun) {
+  const args = process.argv.slice(2);
+  const idx = args.indexOf('--cases');
+  const casesPath = idx >= 0 && args[idx + 1] ? args[idx + 1] : DEFAULT_CASES;
+  const results = evaluateCasesFile(casesPath);
+  process.stdout.write(formatReport(results) + '\n');
+}

--- a/tests/convergence-efficiency.test.mjs
+++ b/tests/convergence-efficiency.test.mjs
@@ -85,6 +85,19 @@ describe('evaluateConvergence', () => {
     assert.equal(evaluateConvergence(runs).oscillationCount, 1);
   });
 
+  test('is order-independent: unsorted input yields the same final-run metrics', () => {
+    const early = {
+      runId: 'r1',
+      timestamp: '2026-06-17T00:00:01.000Z',
+      findings: [{ severity: 'critical' }],
+    };
+    const late = { runId: 'r2', timestamp: '2026-06-17T00:00:02.000Z', findings: [] };
+    const sorted = evaluateConvergence([early, late]);
+    const shuffled = evaluateConvergence([late, early]);
+    assert.deepEqual(shuffled, sorted);
+    assert.equal(shuffled.converged, true); // final run (late) has no blocking findings
+  });
+
   test('no oscillation with fewer than 3 runs', () => {
     const f = {
       ruleId: 'rr-mid-perf-n1',

--- a/tests/convergence-efficiency.test.mjs
+++ b/tests/convergence-efficiency.test.mjs
@@ -1,0 +1,135 @@
+/**
+ * Tests for scripts/evaluate-convergence-efficiency.mjs (Epic #1171 item4).
+ *
+ * Deterministic, fixture-based. Asserts the four metrics
+ * (turnCount / blockingFindingsRemaining / oscillationCount / estimatedCostUsd)
+ * and the baseline-vs-treatment comparison. No LLM, no network.
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  evaluateConvergence,
+  compareCase,
+  evaluateCasesFile,
+} from '../scripts/evaluate-convergence-efficiency.mjs';
+
+describe('evaluateConvergence', () => {
+  test('empty run sequence → zeroed, not converged', () => {
+    const m = evaluateConvergence([]);
+    assert.deepEqual(m, {
+      turnCount: 0,
+      blockingFindingsRemaining: 0,
+      oscillationCount: 0,
+      estimatedCostUsd: 0,
+      converged: false,
+    });
+  });
+
+  test('counts blocking findings (critical + major) in the final run only', () => {
+    const runs = [
+      { runId: 'r1', timestamp: '2026-06-17T00:00:01.000Z', findings: [{ severity: 'critical' }] },
+      {
+        runId: 'r2',
+        timestamp: '2026-06-17T00:00:02.000Z',
+        findings: [{ severity: 'major' }, { severity: 'minor' }, { severity: 'info' }],
+      },
+    ];
+    const m = evaluateConvergence(runs);
+    assert.equal(m.turnCount, 2);
+    assert.equal(m.blockingFindingsRemaining, 1); // only the final run's major
+    assert.equal(m.converged, false);
+  });
+
+  test('converged when final run has no blocking findings', () => {
+    const runs = [
+      { runId: 'r1', timestamp: '2026-06-17T00:00:01.000Z', findings: [{ severity: 'major' }] },
+      { runId: 'r2', timestamp: '2026-06-17T00:00:02.000Z', findings: [{ severity: 'minor' }] },
+    ];
+    const m = evaluateConvergence(runs);
+    assert.equal(m.blockingFindingsRemaining, 0);
+    assert.equal(m.converged, true);
+  });
+
+  test('sums estimated_cost_usd across runs (rounded)', () => {
+    const runs = [
+      {
+        runId: 'r1',
+        timestamp: '2026-06-17T00:00:01.000Z',
+        findings: [],
+        usage: { estimated_cost_usd: 0.1 },
+      },
+      {
+        runId: 'r2',
+        timestamp: '2026-06-17T00:00:02.000Z',
+        findings: [],
+        usage: { estimated_cost_usd: 0.05 },
+      },
+    ];
+    assert.equal(evaluateConvergence(runs).estimatedCostUsd, 0.15);
+  });
+
+  test('detects oscillation across 3+ runs (present → absent → present)', () => {
+    const f = {
+      ruleId: 'rr-mid-perf-n1',
+      file: 'src/list.mjs',
+      message: 'N+1 query',
+      severity: 'major',
+    };
+    const runs = [
+      { runId: 'r1', timestamp: '2026-06-17T00:00:01.000Z', findings: [f] },
+      { runId: 'r2', timestamp: '2026-06-17T00:00:02.000Z', findings: [] },
+      { runId: 'r3', timestamp: '2026-06-17T00:00:03.000Z', findings: [f] },
+    ];
+    assert.equal(evaluateConvergence(runs).oscillationCount, 1);
+  });
+
+  test('no oscillation with fewer than 3 runs', () => {
+    const f = {
+      ruleId: 'rr-mid-perf-n1',
+      file: 'src/list.mjs',
+      message: 'N+1 query',
+      severity: 'major',
+    };
+    const runs = [
+      { runId: 'r1', timestamp: '2026-06-17T00:00:01.000Z', findings: [f] },
+      { runId: 'r2', timestamp: '2026-06-17T00:00:02.000Z', findings: [f] },
+    ];
+    assert.equal(evaluateConvergence(runs).oscillationCount, 0);
+  });
+});
+
+describe('compareCase / evaluateCasesFile (fixtures)', () => {
+  test('auth-endpoint-refactor: RR converges in fewer turns, baseline does not converge', () => {
+    const results = evaluateCasesFile();
+    const auth = results.find((r) => r.name === 'auth-endpoint-refactor');
+    assert.ok(auth, 'case present');
+    assert.equal(auth.baseline.converged, false);
+    assert.equal(auth.treatment.converged, true);
+    assert.equal(auth.delta.turnsSaved, 1); // 3 baseline turns - 2 treatment turns
+    assert.ok(auth.delta.costDeltaUsd < 0, 'RR variant costs less in total');
+  });
+
+  test('oscillating-fix-loop: baseline oscillates, treatment converges without oscillation', () => {
+    const results = evaluateCasesFile();
+    const osc = results.find((r) => r.name === 'oscillating-fix-loop');
+    assert.ok(osc, 'case present');
+    assert.equal(osc.baseline.oscillationCount, 1);
+    assert.equal(osc.treatment.oscillationCount, 0);
+    assert.equal(osc.treatment.converged, true);
+  });
+
+  test('compareCase returns baseline/treatment/delta shape', () => {
+    const r = compareCase({
+      name: 'unit',
+      baseline: [
+        { runId: 'a', timestamp: '2026-06-17T00:00:01.000Z', findings: [{ severity: 'critical' }] },
+      ],
+      treatment: [{ runId: 'b', timestamp: '2026-06-17T00:00:01.000Z', findings: [] }],
+    });
+    assert.equal(r.delta.turnsSaved, 0);
+    assert.equal(r.baseline.converged, false);
+    assert.equal(r.treatment.converged, true);
+  });
+});

--- a/tests/fixtures/convergence-efficiency/cases.json
+++ b/tests/fixtures/convergence-efficiency/cases.json
@@ -1,0 +1,164 @@
+[
+  {
+    "name": "auth-endpoint-refactor",
+    "description": "Without RR the loop converges slowly and leaves a blocking finding; with RR it converges in fewer turns at lower cost.",
+    "baseline": [
+      {
+        "runId": "20260617T000001-base1",
+        "timestamp": "2026-06-17T00:00:01.000Z",
+        "findings": [
+          {
+            "ruleId": "rr-mid-security-authz",
+            "severity": "critical",
+            "file": "src/api/auth.mjs",
+            "message": "Missing authz check",
+            "line": 12
+          },
+          {
+            "ruleId": "rr-mid-perf-n1",
+            "severity": "major",
+            "file": "src/api/auth.mjs",
+            "message": "N+1 query",
+            "line": 30
+          }
+        ],
+        "usage": { "estimated_cost_usd": 0.12 }
+      },
+      {
+        "runId": "20260617T000002-base2",
+        "timestamp": "2026-06-17T00:00:02.000Z",
+        "findings": [
+          {
+            "ruleId": "rr-mid-security-authz",
+            "severity": "critical",
+            "file": "src/api/auth.mjs",
+            "message": "Missing authz check",
+            "line": 12
+          }
+        ],
+        "usage": { "estimated_cost_usd": 0.12 }
+      },
+      {
+        "runId": "20260617T000003-base3",
+        "timestamp": "2026-06-17T00:00:03.000Z",
+        "findings": [
+          {
+            "ruleId": "rr-mid-security-authz",
+            "severity": "critical",
+            "file": "src/api/auth.mjs",
+            "message": "Missing authz check",
+            "line": 12
+          }
+        ],
+        "usage": { "estimated_cost_usd": 0.12 }
+      }
+    ],
+    "treatment": [
+      {
+        "runId": "20260617T000001-rr1",
+        "timestamp": "2026-06-17T00:00:01.000Z",
+        "findings": [
+          {
+            "ruleId": "rr-mid-security-authz",
+            "severity": "critical",
+            "file": "src/api/auth.mjs",
+            "message": "Missing authz check",
+            "line": 12
+          },
+          {
+            "ruleId": "rr-mid-perf-n1",
+            "severity": "major",
+            "file": "src/api/auth.mjs",
+            "message": "N+1 query",
+            "line": 30
+          }
+        ],
+        "usage": { "estimated_cost_usd": 0.1 }
+      },
+      {
+        "runId": "20260617T000002-rr2",
+        "timestamp": "2026-06-17T00:00:02.000Z",
+        "findings": [
+          {
+            "ruleId": "rr-mid-readability-naming",
+            "severity": "minor",
+            "file": "src/api/auth.mjs",
+            "message": "Rename variable",
+            "line": 5
+          }
+        ],
+        "usage": { "estimated_cost_usd": 0.1 }
+      }
+    ]
+  },
+  {
+    "name": "oscillating-fix-loop",
+    "description": "A revise loop that re-introduces a previously resolved finding — oscillation should be detected across 3+ runs.",
+    "baseline": [
+      {
+        "runId": "20260617T010001-osc1",
+        "timestamp": "2026-06-17T01:00:01.000Z",
+        "findings": [
+          {
+            "ruleId": "rr-mid-perf-n1",
+            "severity": "major",
+            "file": "src/list.mjs",
+            "message": "N+1 query in loop",
+            "line": 20
+          }
+        ],
+        "usage": { "estimated_cost_usd": 0.08 }
+      },
+      {
+        "runId": "20260617T010002-osc2",
+        "timestamp": "2026-06-17T01:00:02.000Z",
+        "findings": [
+          {
+            "ruleId": "rr-mid-readability-naming",
+            "severity": "minor",
+            "file": "src/list.mjs",
+            "message": "Rename variable",
+            "line": 4
+          }
+        ],
+        "usage": { "estimated_cost_usd": 0.08 }
+      },
+      {
+        "runId": "20260617T010003-osc3",
+        "timestamp": "2026-06-17T01:00:03.000Z",
+        "findings": [
+          {
+            "ruleId": "rr-mid-perf-n1",
+            "severity": "major",
+            "file": "src/list.mjs",
+            "message": "N+1 query in loop",
+            "line": 20
+          }
+        ],
+        "usage": { "estimated_cost_usd": 0.08 }
+      }
+    ],
+    "treatment": [
+      {
+        "runId": "20260617T010001-fix1",
+        "timestamp": "2026-06-17T01:00:01.000Z",
+        "findings": [
+          {
+            "ruleId": "rr-mid-perf-n1",
+            "severity": "major",
+            "file": "src/list.mjs",
+            "message": "N+1 query in loop",
+            "line": 20
+          }
+        ],
+        "usage": { "estimated_cost_usd": 0.08 }
+      },
+      {
+        "runId": "20260617T010002-fix2",
+        "timestamp": "2026-06-17T01:00:02.000Z",
+        "findings": [],
+        "usage": { "estimated_cost_usd": 0.08 }
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## What

#1171 **item4** = Convergence Efficiency Eval 最小版。generate → review → revise ループが「RR あり/なしで何ターン・いくらで収束したか」を測る、決定論的・fixture ベースの評価器。buyer=プラットフォームチームへの経済価値を定量化する。

## Changes

- `scripts/evaluate-convergence-efficiency.mjs`
  - `evaluateConvergence(runs)`: turnCount / blockingFindingsRemaining（最終 run の critical+major）/ oscillationCount（`review-differ` の oscillated を流用、3 run 以上で検知）/ estimatedCostUsd（`usage.estimated_cost_usd` 合算）/ converged。
  - `compareCase` / `evaluateCasesFile`: baseline vs treatment の delta（turnsSaved / costDelta）。
  - 直接実行で Markdown レポート出力（`import.meta.url` guard は realpathSync+pathToFileURL）。
- `tests/fixtures/convergence-efficiency/cases.json`: auth-refactor（RR で収束ターン減・低コスト）/ oscillating-fix-loop（振動検知）。
- `tests/convergence-efficiency.test.mjs`: 9 ケース。
- `package.json`: `eval:convergence` スクリプト。

## 設計方針（重複回避）

既存の `usage.estimated_cost_usd` / `diffRunHistory` の oscillated / issue severities を**読むだけ**。新 telemetry 基盤や新 command は作らない。CI は deterministic fixture の計算テストのみ（実 LLM benchmark は手動）。

## Verification

- `node --test tests/convergence-efficiency.test.mjs`: 9 pass
- `npm test`: 全 pass / 0 fail
- `npm run eval:convergence`: レポート出力 OK
- `format:check` / `check:dashes`: pass

Relates to #1171 (item4)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)