### PR TITLE
test(merge): adversarial set for mergeFindings (#1171 item5)

### DIFF
--- a/tests/fixtures/review-team-adversarial/cases.json
+++ b/tests/fixtures/review-team-adversarial/cases.json
@@ -1,0 +1,148 @@
+{
+  "transitiveChain": {
+    "description": "#1170 F2: A–B–C overlap chain where A and C are NOT directly overlapping (4 lines apart) must still collapse into ONE cluster via connected-components, regardless of input order.",
+    "findings": [
+      {
+        "reviewerRole": "bug-hunter",
+        "file": "src/api/users.mjs",
+        "lineStart": 10,
+        "message": "Unsanitized input flows into SQL query construction here",
+        "severity": "major",
+        "evidence": ["e-a"]
+      },
+      {
+        "reviewerRole": "security-scanner",
+        "file": "src/api/users.mjs",
+        "lineStart": 12,
+        "message": "Unsanitized input flows into SQL query construction here",
+        "severity": "critical",
+        "evidence": ["e-b"]
+      },
+      {
+        "reviewerRole": "perf-auditor",
+        "file": "src/api/users.mjs",
+        "lineStart": 14,
+        "message": "Unsanitized input flows into SQL query construction here",
+        "severity": "minor",
+        "evidence": ["e-c"]
+      }
+    ]
+  },
+  "lineShiftTolerance": {
+    "description": "Findings within ±2 lines merge (revise shifts line numbers); a 3-line gap does NOT merge.",
+    "withinTolerance": [
+      {
+        "reviewerRole": "bug-hunter",
+        "file": "src/list.mjs",
+        "lineStart": 20,
+        "message": "N+1 query inside the loop body",
+        "severity": "major"
+      },
+      {
+        "reviewerRole": "perf-auditor",
+        "file": "src/list.mjs",
+        "lineStart": 22,
+        "message": "N+1 query inside the loop body",
+        "severity": "major"
+      }
+    ],
+    "beyondTolerance": [
+      {
+        "reviewerRole": "bug-hunter",
+        "file": "src/list.mjs",
+        "lineStart": 20,
+        "message": "N+1 query inside the loop body",
+        "severity": "major"
+      },
+      {
+        "reviewerRole": "perf-auditor",
+        "file": "src/list.mjs",
+        "lineStart": 23,
+        "message": "N+1 query inside the loop body",
+        "severity": "major"
+      }
+    ]
+  },
+  "messageDrift": {
+    "description": "Same location: message edit-distance ≤ 10 (first 80 chars, lower-cased) merges; a larger drift does NOT.",
+    "smallDrift": [
+      {
+        "reviewerRole": "bug-hunter",
+        "file": "src/auth.mjs",
+        "lineStart": 7,
+        "message": "Missing authorization check on the endpoint",
+        "severity": "critical"
+      },
+      {
+        "reviewerRole": "security-scanner",
+        "file": "src/auth.mjs",
+        "lineStart": 7,
+        "message": "Missing authorization checks on the endpoint",
+        "severity": "critical"
+      }
+    ],
+    "largeDrift": [
+      {
+        "reviewerRole": "bug-hunter",
+        "file": "src/auth.mjs",
+        "lineStart": 7,
+        "message": "Missing authorization check on the endpoint",
+        "severity": "critical"
+      },
+      {
+        "reviewerRole": "security-scanner",
+        "file": "src/auth.mjs",
+        "lineStart": 7,
+        "message": "Hardcoded credentials committed to the repository root",
+        "severity": "critical"
+      }
+    ]
+  },
+  "severityMaxAndEvidenceUnion": {
+    "description": "A merged cluster takes the MAX severity and the deduplicated UNION of evidence.",
+    "findings": [
+      {
+        "reviewerRole": "bug-hunter",
+        "file": "src/pay.mjs",
+        "lineStart": 40,
+        "message": "Race condition on the payment ledger update",
+        "severity": "minor",
+        "evidence": ["log-1", "shared"]
+      },
+      {
+        "reviewerRole": "security-scanner",
+        "file": "src/pay.mjs",
+        "lineStart": 41,
+        "message": "Race condition on the payment ledger update",
+        "severity": "critical",
+        "evidence": ["log-2", "shared"]
+      }
+    ]
+  },
+  "agreementNonMajority": {
+    "description": "agreement is the collected SET of all reviewer roles in the cluster — not a majority vote. A finding raised by 1 of 3 reviewers still records that single role.",
+    "findings": [
+      {
+        "reviewerRole": "bug-hunter",
+        "file": "src/cache.mjs",
+        "lineStart": 5,
+        "message": "Stale cache entry never invalidated on write",
+        "severity": "major"
+      },
+      {
+        "reviewerRole": "security-scanner",
+        "file": "src/cache.mjs",
+        "lineStart": 6,
+        "message": "Stale cache entry never invalidated on write",
+        "severity": "major"
+      },
+      {
+        "reviewerRole": "perf-auditor",
+        "file": "src/other.mjs",
+        "lineStart": 100,
+        "message": "Solo finding raised by exactly one reviewer",
+        "severity": "minor"
+      }
+    ]
+  }
+}

--- a/tests/merge-findings.test.mjs
+++ b/tests/merge-findings.test.mjs
@@ -1,0 +1,97 @@
+/**
+ * Adversarial regression set for mergeFindings (Epic #1171 item5).
+ *
+ * Locks in the cross-reviewer merge contract so #1170 F2 (non-transitive merge)
+ * and fingerprint-tolerance regressions cannot silently return:
+ *   - connected-components: A–B–C chains collapse into one cluster (order-free)
+ *   - severity = max of cluster
+ *   - evidence = deduplicated union
+ *   - agreement = collected set of reviewer roles (NOT a majority vote)
+ *   - line-shift tolerance (±2) and message-drift tolerance (edit-distance ≤ 10)
+ *
+ * Fixtures: tests/fixtures/review-team-adversarial/cases.json
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { mergeFindings } from '../src/lib/reviewer-orchestrator.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const CASES = JSON.parse(
+  readFileSync(join(here, 'fixtures', 'review-team-adversarial', 'cases.json'), 'utf8')
+);
+
+const sorted = (a) => [...a].sort();
+
+describe('mergeFindings — adversarial set (#1171 item5)', () => {
+  test('transitive A–B–C chain collapses into ONE cluster (#1170 F2)', () => {
+    const input = CASES.transitiveChain.findings;
+    const merged = mergeFindings(input);
+    assert.equal(merged.length, 1, 'chain must form a single cluster');
+    // severity = max across the chain (minor + major + critical → critical)
+    assert.equal(merged[0].severity, 'critical');
+    // evidence = union of all three
+    assert.deepEqual(sorted(merged[0].evidence), ['e-a', 'e-b', 'e-c']);
+    // agreement = all three reviewer roles
+    assert.deepEqual(sorted(merged[0].agreement), [
+      'bug-hunter',
+      'perf-auditor',
+      'security-scanner',
+    ]);
+  });
+
+  test('transitive merge is order-independent', () => {
+    const input = CASES.transitiveChain.findings;
+    const reversed = [...input].reverse();
+    const merged = mergeFindings(reversed);
+    assert.equal(merged.length, 1);
+    assert.equal(merged[0].severity, 'critical');
+  });
+
+  test('line-shift within ±2 merges; a 3-line gap does not', () => {
+    const within = mergeFindings(CASES.lineShiftTolerance.withinTolerance);
+    assert.equal(within.length, 1, '2-line shift should merge');
+
+    const beyond = mergeFindings(CASES.lineShiftTolerance.beyondTolerance);
+    assert.equal(beyond.length, 2, '3-line gap should NOT merge');
+  });
+
+  test('message drift within edit-distance ≤ 10 merges; large drift does not', () => {
+    const small = mergeFindings(CASES.messageDrift.smallDrift);
+    assert.equal(small.length, 1, 'singular/plural drift should merge');
+
+    const large = mergeFindings(CASES.messageDrift.largeDrift);
+    assert.equal(large.length, 2, 'unrelated messages must not merge');
+  });
+
+  test('cluster takes max severity and deduplicated evidence union', () => {
+    const merged = mergeFindings(CASES.severityMaxAndEvidenceUnion.findings);
+    assert.equal(merged.length, 1);
+    assert.equal(merged[0].severity, 'critical', 'minor + critical → critical');
+    assert.deepEqual(sorted(merged[0].evidence), ['log-1', 'log-2', 'shared'], 'union, deduped');
+  });
+
+  test('agreement is the collected role set, not a majority vote', () => {
+    const merged = mergeFindings(CASES.agreementNonMajority.findings);
+    // Two cache.mjs findings merge; the solo other.mjs finding stays separate.
+    assert.equal(merged.length, 2);
+
+    const cluster = merged.find((f) => f.file === 'src/cache.mjs');
+    assert.deepEqual(sorted(cluster.agreement), ['bug-hunter', 'security-scanner']);
+
+    const solo = merged.find((f) => f.file === 'src/other.mjs');
+    assert.deepEqual(
+      solo.agreement,
+      ['perf-auditor'],
+      'a 1-of-3 finding still records its single role'
+    );
+  });
+
+  test('empty input → empty output', () => {
+    assert.deepEqual(mergeFindings([]), []);
+  });
+});

--- a/tests/merge-findings.test.mjs
+++ b/tests/merge-findings.test.mjs
@@ -50,6 +50,13 @@ describe('mergeFindings — adversarial set (#1171 item5)', () => {
     const merged = mergeFindings(reversed);
     assert.equal(merged.length, 1);
     assert.equal(merged[0].severity, 'critical');
+    // severity/evidence/agreement must be invariant under input order.
+    assert.deepEqual(sorted(merged[0].evidence), ['e-a', 'e-b', 'e-c']);
+    assert.deepEqual(sorted(merged[0].agreement), [
+      'bug-hunter',
+      'perf-auditor',
+      'security-scanner',
+    ]);
   });
 
   test('line-shift within ±2 merges; a 3-line gap does not', () => {
@@ -81,9 +88,11 @@ describe('mergeFindings — adversarial set (#1171 item5)', () => {
     assert.equal(merged.length, 2);
 
     const cluster = merged.find((f) => f.file === 'src/cache.mjs');
+    assert.ok(cluster, 'should find merged cluster for src/cache.mjs');
     assert.deepEqual(sorted(cluster.agreement), ['bug-hunter', 'security-scanner']);
 
     const solo = merged.find((f) => f.file === 'src/other.mjs');
+    assert.ok(solo, 'should find solo finding for src/other.mjs');
     assert.deepEqual(
       solo.agreement,
       ['perf-auditor'],


### PR DESCRIPTION
## What

#1171 **item5**（最終）= Merge/Fingerprint Adversarial Set。`mergeFindings` のクロスレビューア統合契約を回帰固定し、#1170 F2（非推移 merge）や fingerprint 揺れの再発を防ぐ。

## Changes

- `tests/fixtures/review-team-adversarial/cases.json` + `tests/merge-findings.test.mjs`（7 ケース）

固定する契約:
- **connected-components**: A–B–C overlap chain（A と C は直接重ならない）が 1 cluster に collapse、入力順非依存（#1170 F2）
- **severity = max**: minor + major + critical → critical
- **evidence = union**: 重複排除した和集合
- **agreement = 非多数決**: cluster 内全 reviewerRole の集合（1/3 の指摘でもその role を記録）
- **line-shift tolerance**: ±2 行は merge、3 行差は非 merge
- **message-drift tolerance**: edit-distance ≤ 10（先頭80字 lower-case）は merge、大きな drift は非 merge

## Verification

- `node --test tests/merge-findings.test.mjs`: 7 pass
- `npm test`: 全 pass / 0 fail
- `format:check` / `check:dashes`: pass

Relates to #1171 (item5)。これで #1171 の item1〜5 が全着地（#1171 クローズ可）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)