### PR TITLE
docs: audit minor fixes — phase enum example, redundant phase, checkout @v6

### DIFF
--- a/pages/guides/debug-skill-routing.md
+++ b/pages/guides/debug-skill-routing.md
@@ -17,7 +17,7 @@
    # 失敗時の出力例（未知の phase 値）
    $ npm run skills:validate
    ✖ skills/midstream/rr-midstream-foo-001/SKILL.md
-     ValidationError: "phase" must be one of [upstream, midstream, downstream, core]
+     ValidationError: "phase" must be one of [upstream, midstream, downstream]
        received: "release"
 
    # 失敗時の出力例（必須フィールド欠落）

--- a/pages/guides/github-actions.en.md
+++ b/pages/guides/github-actions.en.md
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Run River Review (midstream)

--- a/pages/guides/github-actions.md
+++ b/pages/guides/github-actions.md
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Run River Review (midstream)

--- a/pages/guides/quickstart.md
+++ b/pages/guides/quickstart.md
@@ -10,7 +10,6 @@ River Review を最小構成で動かすための流れです。
    name: My Check
    description: サンプルのコード品質チェック
    category: midstream
-   phase: midstream
    applyTo:
      - 'src/**/*.ts'
    severity: minor

--- a/pages/guides/repo-wide-review.md
+++ b/pages/guides/repo-wide-review.md
@@ -49,7 +49,7 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # repo-wide context collector が周辺コミット履歴を読むため必須
       - name: Run River Review (midstream)

--- a/pages/guides/w-check.en.md
+++ b/pages/guides/w-check.en.md
@@ -112,7 +112,7 @@ jobs:
   ai-reviews:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run AI reviews
         run: |
@@ -131,7 +131,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ai-reviews
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download review artifacts
         uses: actions/download-artifact@v4

--- a/pages/guides/w-check.md
+++ b/pages/guides/w-check.md
@@ -124,7 +124,7 @@ jobs:
   ai-reviews:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run Codex review
         run: codex review > codex-review.md
@@ -144,7 +144,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download review artifacts
         uses: actions/download-artifact@v4

--- a/pages/tutorials/getting-started.md
+++ b/pages/tutorials/getting-started.md
@@ -35,7 +35,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: s977043/river-review/runners/github-action@v1.22.0


### PR DESCRIPTION
## What

監査（#1194）の follow-up。影響軽微な minor/nit を優先順に修正。

1. **[minor] debug-skill-routing.md**: 例のエラーメッセージの phase enum を実スキーマに合わせて `[upstream, midstream, downstream]` に修正（`core` を除去。core は category の値で phase の値ではない）
2. **[minor] quickstart.md**: 例から冗長な `phase: midstream` を除去（`category` が必須のルーティングキー、`phase` は非推奨エイリアス。両方併記は混同のもと）
3. **[nit] checkout バージョン統一**: ドキュメントの `actions/checkout@v4` を全て `@v6` に統一（リポジトリの実ワークフローは全29箇所 `@v6`。ja/en ペア内でも混在していた）

## Verification

- `npx textlint --no-cache`（変更 ja）/ `prettier --check`: pass
- `@v4` 残存 0 / quickstart の phase 行 0 / debug の core 参照 0

docs のみのため release 不要。これで監査由来の major/minor/nit をすべて解消。

🤖 Generated with [Claude Code](https://claude.com/claude-code)