### PR TITLE
feat(skills): framework-agnostic migration safety review (#1196 S4)

### DIFF
--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "description": "Deterministic skill manifest for drift detection by selective adopters. Compare the checksum of your copied skill against this list to notice upstream changes. Regenerate with: npm run skills:manifest",
-  "skillCount": 111,
+  "skillCount": 112,
   "skills": [
     {
       "id": "adversarial-review",
@@ -535,6 +535,12 @@
       "id": "rr-upstream-migration-rollout-rollback-001",
       "path": "skills/upstream/rr-upstream-migration-rollout-rollback-001",
       "checksum": "sha256:058872d7f0c4cffd9d5392d79ccee923b9af34e070d813e133043c80b116c27e",
+      "files": 1
+    },
+    {
+      "id": "rr-upstream-migration-safety-001",
+      "path": "skills/upstream/rr-upstream-migration-safety-001",
+      "checksum": "sha256:0c808b00481bf87dbd40319b3d50b84fabbe4b0a408dcd463216a3e5b4f2156d",
       "files": 1
     },
     {

--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -540,7 +540,7 @@
     {
       "id": "rr-upstream-migration-safety-001",
       "path": "skills/upstream/rr-upstream-migration-safety-001",
-      "checksum": "sha256:0c808b00481bf87dbd40319b3d50b84fabbe4b0a408dcd463216a3e5b4f2156d",
+      "checksum": "sha256:f463d7c6e6ee2ca0154eafda599116b213da5f3d5193db9168ad71bda611fa9d",
       "files": 1
     },
     {

--- a/skills/registry.yaml
+++ b/skills/registry.yaml
@@ -602,6 +602,17 @@ skills:
     recommended: true
     description: 'モジュール/スキルの構造変更で当該ファイルは更新したが、caller 側が古い構造（旧参照・旧シグネチャ・旧採番）を参照したまま残るパターンを検出する'
 
+  - id: rr-upstream-migration-safety-001
+    version: '0.1.0'
+    name: 'Migration Safety Review (framework-agnostic)'
+    path: skills/upstream/rr-upstream-migration-safety-001/SKILL.md
+    category: upstream
+    phase: upstream
+    tags: [migration, database, schema, safety, rollback, upstream]
+    severity: major
+    recommended: true
+    description: 'スキーマ/データ移行の安全性を framework 非依存で審査する（破壊的変更・ロック誘発・backfill・ロールバック可逆性・expand-contract）。prisma / typeorm / Rails / Django / Alembic / 生 SQL に横断適用。'
+
   - id: rr-upstream-laravel-migration-safety-001
     version: '0.1.0'
     name: 'Laravel Migration Safety Review'

--- a/skills/upstream/rr-upstream-migration-safety-001/SKILL.md
+++ b/skills/upstream/rr-upstream-migration-safety-001/SKILL.md
@@ -1,0 +1,94 @@
+---
+id: rr-upstream-migration-safety-001
+name: 'Migration Safety Review (framework-agnostic)'
+description: 'スキーマ/データ移行の安全性を framework 非依存で審査する。破壊的スキーマ変更・ロック誘発・backfill・ロールバック可逆性・expand-contract の段階適用を、prisma / typeorm / Rails / Django / Alembic / 生 SQL などに横断適用する。'
+version: 0.1.0
+category: upstream
+phase: upstream
+applyTo:
+  - '**/migrations/**/*'
+  - '**/migrate/**/*'
+  - 'prisma/schema.prisma'
+  - 'prisma/migrations/**/*.sql'
+  - 'db/**/*.sql'
+  - '**/*.{sql}'
+tags: [migration, database, schema, safety, rollback, upstream]
+severity: major
+inputContext: [diff]
+outputKind: [findings, questions]
+modelHint: balanced
+dependencies: [code_search]
+---
+
+## Pattern declaration
+
+Primary pattern: Reviewer
+Secondary patterns: Inversion
+Why: 移行の破壊的・ロック誘発・不可逆操作をチェックリスト型で検査するが、移行を含まない差分では実行を止めるゲートが必要。
+
+## Goal / 目的
+
+- ORM やフレームワークに依存せず、スキーマ/データ移行に共通する**運用事故**（データ損失・本番ロック・ロールバック不能・反復不能）を検出する。
+- 特定フレームワーク固有の深い規約（例: Laravel `change()` の修飾子消失）は専用 skill に委ね、本 skill は**横断的な安全性**に集中する。
+
+## Non-goals / 扱わないこと
+
+- データモデル設計の妥当性（正規化・関連設計）は `rr-upstream-data-model-db-design-001` のスコープ。
+- フレームワーク固有の細則（Laravel 固有は `rr-upstream-laravel-migration-safety-001`）。
+- アプリ側のクエリ効率（N+1 等）。
+
+## Pre-execution Gate / 実行前ゲート
+
+このスキルは以下の条件がすべて満たされない限り `NO_REVIEW` を返す。
+
+- [ ] 差分にスキーマ/データ移行（migrations ディレクトリ・`schema.prisma`・`*.sql`・`ALTER`/`CREATE`/`DROP` を含む変更）が含まれている
+- [ ] diff コンテキストが利用可能である
+
+ゲート不成立時の出力: `NO_REVIEW: rr-upstream-migration-safety-001 — 移行の変更なし`
+
+## False-positive guards / 抑制条件
+
+- 新規テーブル作成内の index/制約追加は既存行へのロックが無いため指摘しない。
+- 不可逆な down/rollback は、データ変換系移行で完全な逆操作が原理的に不可能なケースが正当（コメントで明示があれば許容）。
+- 破壊的操作が「別 PR で deprecate 済み／expand-contract の contract フェーズ」と明示されている場合は指摘しない。
+- 小規模テーブルが diff／文脈から確実な場合はロック懸念を断定しない（`questions` で確認）。
+
+## Rule / ルール
+
+横断的に以下を確認する（該当するもののみ）:
+
+1. **破壊的スキーマ変更**: カラム/テーブル/制約の DROP、型の縮小変換（例: `text`→`varchar(n)`）、リネームは、データ損失と後方互換を確認する。
+2. **ロック誘発**: 大規模テーブルへの index 追加・`ALTER TABLE`・`NOT NULL` 追加は本番でロック/長時間化し得る。PostgreSQL なら `CREATE INDEX CONCURRENTLY`、MySQL なら online DDL / pt-osc 等の非ロック手段を検討する。
+3. **NOT NULL + default 無し**: 既存行があるテーブルへ default 無しの NOT NULL カラム追加は失敗/全行書込みになる。default 付与または backfill 後に制約化（expand-contract）を推奨。
+4. **backfill 安全性**: 大量 UPDATE/INSERT はバッチ分割・タイムアウト・レプリケーション遅延を考慮する。1 トランザクションでの巨大更新を避ける。
+5. **ロールバック可逆性**: down/rollback が up の逆操作として整合し、データを失わず戻せるか。不可逆なら明示する。
+6. **段階適用（expand-contract）**: 破壊的変更はコードのデプロイと移行の順序（expand→migrate→contract）で無停止化できないか。
+
+## Evidence / 根拠の取り方
+
+- 指摘は `<file>:<line>` で差分に紐づけ、検出した操作（DROP / ALTER / NOT NULL / 大量 backfill 等）を引用する。
+- テーブル規模が diff から不明な場合は断定せず `questions` で確認する。
+- フレームワーク固有 API には触れず、移行操作の意味（ロック/損失/不可逆）で説明する。
+
+## Output / 出力（短文版の推奨）
+
+コメントは日本語で返す。
+
+```text
+(migration-safety):1: [要約] 最も危険な移行操作は〈1文〉
+
+<file>:<line>: [移行リスク] <タイトル>
+  操作: <DROP / ALTER / NOT NULL 追加 / 大量 backfill / 不可逆 down>
+  影響: <データ損失 / 本番ロック / ロールバック不能 / 反復不能>
+  Fix: <CONCURRENTLY / default 付与 + backfill / expand-contract / down 整合 の最小案>
+```
+
+## 評価指標（Evaluation）
+
+- 合格基準: 検出操作が差分に紐づき、影響（損失/ロック/不可逆）と最小の安全策が示されている。
+- 不合格基準: 移行と無関係な一般論、規模不明なのにロックを断定、フレームワーク固有細則への越境。
+
+## 人間に返す条件（Human Handoff）
+
+- 本番データ規模・停止可否・移行ウィンドウの判断が必要な場合。
+- 破壊的変更の影響が他サービス／外部利用者に及ぶ場合。

--- a/skills/upstream/rr-upstream-migration-safety-001/SKILL.md
+++ b/skills/upstream/rr-upstream-migration-safety-001/SKILL.md
@@ -9,9 +9,7 @@ applyTo:
   - '**/migrations/**/*'
   - '**/migrate/**/*'
   - 'prisma/schema.prisma'
-  - 'prisma/migrations/**/*.sql'
   - 'db/**/*.sql'
-  - '**/*.{sql}'
 tags: [migration, database, schema, safety, rollback, upstream]
 severity: major
 inputContext: [diff]


### PR DESCRIPTION
## What

Epic #1196 の最終スライス S4。migration review を laravel 限定から **framework 非依存**へ汎用化。

## Changes

- `skills/upstream/rr-upstream-migration-safety-001/SKILL.md`（新規）
  - 横断的な移行安全性: 破壊的スキーマ変更 / ロック誘発 DDL / NOT NULL + default 無し / backfill 安全性 / ロールバック可逆性 / expand-contract 段階適用
  - prisma / typeorm / Rails / Django / Alembic / 生 SQL に applyTo で適用
  - フレームワーク固有細則は専用 skill に委譲（laravel 版は併存）
- `skills/registry.yaml` 登録 + `skill-manifest` 再生成（111→112）

## 方針

- laravel 版（`rr-upstream-laravel-migration-safety-001`）は残し、本 skill は**横断安全性**に集中（責務分離・重複なし）
- Pre-execution Gate で移行が無ければ NO_REVIEW、Evidence は差分紐付け必須、規模不明は questions

## Verification

- `skills:validate` / `agent-skills:validate` / `skills:manifest:check` / `meta:validate`: pass
- `textlint --no-cache` / `markdownlint` / `prettier` / `fix:dashes`: pass
- `npm test`: 全 pass / dist freshness: clean（skills は runtime ロード）

Relates to #1196（S4）。これで Epic #1196 の S1〜S4 が全着地。

🤖 Generated with [Claude Code](https://claude.com/claude-code)