### PR TITLE
chore(lychee): exclude note.com / docs.aws.amazon.com (bot-blocked 403)

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -27,6 +27,14 @@ exclude = [
   '^https?://t\.co', # Twitter short links
   '^https?://([^/]+\.)?slack\.com',
 
+  # note.com returns 403 to bot user-agents (anti-scraping); the articles are
+  # valid in browsers. Linked from README as reference posts, not functional.
+  '^https?://([^/]+\.)?note\.com',
+
+  # docs.aws.amazon.com 403s HEAD requests from non-browser user-agents; the
+  # pages are valid (e.g. well-architected SaaS lens linked from a skill README).
+  '^https?://docs\.aws\.amazon\.com',
+
   # GitHub URLs that may not exist yet (for PRs)
   # Uncomment if needed:
   # 'github\.com/.*/tree/main/.*',

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -29,11 +29,11 @@ exclude = [
 
   # note.com returns 403 to bot user-agents (anti-scraping); the articles are
   # valid in browsers. Linked from README as reference posts, not functional.
-  '^https?://([^/]+\.)?note\.com',
+  '^https?://([^/]+\.)?note\.com(/|$)',
 
   # docs.aws.amazon.com 403s HEAD requests from non-browser user-agents; the
   # pages are valid (e.g. well-architected SaaS lens linked from a skill README).
-  '^https?://docs\.aws\.amazon\.com',
+  '^https?://docs\.aws\.amazon\.com(/|$)',
 
   # GitHub URLs that may not exist yet (for PRs)
   # Uncomment if needed:


### PR DESCRIPTION
## What

Link Check（lychee）の false-positive を解消。`note.com`（ユーザーの参照記事）と `docs.aws.amazon.com`（well-architected SaaS lens、skill README から参照）が **bot user-agent に 403** を返し、全リポスキャンの度に Link Check が fail していた（v1.24.0 リリース PR #1204 で観測）。

## Changes

- `.lychee.toml` の「Sites that commonly block bots」exclude に 2 ドメインを追加（既存 `openai.com/pricing` と同じ規約・コメント付き）。`accept` への 403 追加（全 403 を隠す）は採らず、対象を限定。

## Verification

- ローカル `lychee --config .lychee.toml README.md README.en.md <skill README>` → **0 Errors / 2 Excluded / exit 0**
- 正規表現が両 URL にマッチすることを確認

## 背景

v1.24.0 リリース PR では required チェックは全 green、lychee（非必須）のみがこの 403 で fail していた。本 PR で recurring CI ノイズを除去。

🤖 Generated with [Claude Code](https://claude.com/claude-code)