### PR TITLE
chore(lychee): anchor pre-existing domain excludes with (/|$)

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -21,21 +21,22 @@ exclude = [
   'your-org/',
 
   # Sites that commonly block bots or require authentication.
-  # Domain-only patterns are anchored with (/|$) so a look-alike suffix
-  # (e.g. slack.com.attacker.com) cannot bypass the link check (#1205 review).
-  '^https?://([^/]+\.)?linkedin\.com(/|$)',
-  '^https?://discord\.gg(/|$)',
+  # Domain-only patterns are anchored with ([/?#]|$) so a look-alike suffix
+  # (e.g. slack.com.attacker.com) cannot bypass the link check, while still
+  # matching path / query / fragment URLs (slack.com?x, slack.com#y) (#1206).
+  '^https?://([^/]+\.)?linkedin\.com([/?#]|$)',
+  '^https?://discord\.gg([/?#]|$)',
   '^https?://discord\.com/invite', # already path-bounded by /invite
-  '^https?://t\.co(/|$)', # Twitter short links
-  '^https?://([^/]+\.)?slack\.com(/|$)',
+  '^https?://t\.co([/?#]|$)', # Twitter short links
+  '^https?://([^/]+\.)?slack\.com([/?#]|$)',
 
   # note.com returns 403 to bot user-agents (anti-scraping); the articles are
   # valid in browsers. Linked from README as reference posts, not functional.
-  '^https?://([^/]+\.)?note\.com(/|$)',
+  '^https?://([^/]+\.)?note\.com([/?#]|$)',
 
   # docs.aws.amazon.com 403s HEAD requests from non-browser user-agents; the
   # pages are valid (e.g. well-architected SaaS lens linked from a skill README).
-  '^https?://docs\.aws\.amazon\.com(/|$)',
+  '^https?://docs\.aws\.amazon\.com([/?#]|$)',
 
   # GitHub URLs that may not exist yet (for PRs)
   # Uncomment if needed:

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -20,12 +20,14 @@ exclude = [
   'example\.com',
   'your-org/',
 
-  # Sites that commonly block bots or require authentication
-  '^https?://([^/]+\.)?linkedin\.com',
-  '^https?://discord\.gg',
-  '^https?://discord\.com/invite',
-  '^https?://t\.co', # Twitter short links
-  '^https?://([^/]+\.)?slack\.com',
+  # Sites that commonly block bots or require authentication.
+  # Domain-only patterns are anchored with (/|$) so a look-alike suffix
+  # (e.g. slack.com.attacker.com) cannot bypass the link check (#1205 review).
+  '^https?://([^/]+\.)?linkedin\.com(/|$)',
+  '^https?://discord\.gg(/|$)',
+  '^https?://discord\.com/invite', # already path-bounded by /invite
+  '^https?://t\.co(/|$)', # Twitter short links
+  '^https?://([^/]+\.)?slack\.com(/|$)',
 
   # note.com returns 403 to bot user-agents (anti-scraping); the articles are
   # valid in browsers. Linked from README as reference posts, not functional.


### PR DESCRIPTION
## Summary
直前セッション（#1201/#1203/#1204/#1205）の振り返り（軽量モード）から、改善 1 件を実装。

### B/A. セキュリティ・ハードニング（1件）
- `.lychee.toml` の既存ドメイン exclude（`linkedin` / `discord.gg` / `t.co` / `slack`）に `(/|$)` を追加。#1205 で gemini が指摘した前方一致バイパス（`slack.com.attacker.com` 等が exclude にマッチしてリンクチェックを回避）と同類の弱点を一掃。`discord.com/invite` 等は path で既に境界済みのため対象外。

## Test plan
- [x] regex 検証: 正規 URL は exclude 維持 / `*.attacker.com` 系は非マッチ（node スクリプトで確認）
- [x] `lychee --config .lychee.toml README.md docs/review/viewpoints.md` → 0 Errors（回帰なし）

## 関連セッション
- 前回の振り返り PR: #1202
- 対象セッションのマージ済み PR: #1201, #1203, #1204, #1205
- 起点インシデント: #1204 lychee fail（bot-block 403）→ #1205 → 本ハードニング

🤖 Generated with [Claude Code](https://claude.com/claude-code)