### PR TITLE
docs: foreground the three axes — agent review enhancement, review skills, review team

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -46,6 +46,28 @@ River Review is not another prompt wrapper around a PR diff. It is a way to make
 
 In AI-assisted workflows, River Review acts as the **team-owned audit layer**: implementation agents can write code, but River Review checks whether that work still follows the team's rules.
 
+## Three core axes
+
+River Review's value falls into three axes. All three derive from the same foundation: turning your team's review judgment into a versioned, repo-owned asset.
+
+### 1. A capability pack that strengthens an AI agent's review ability
+
+River Review's skill and agent definitions are a **capability pack** that brings your team's review judgment to AI agents such as Claude Code, Cursor, and Codex. In normal use the agent's own model applies the skills, so **no River Review LLM key is required**. A key is needed only for headless execution (GitHub Action / standalone `river run`); mechanically-decidable viewpoints run even without one (see the [FAQ](#faq) for the execution model).
+
+### 2. Review skills (the Skill Registry)
+
+The foundation is the Skill Registry. Team-specific tacit knowledge — security, accessibility, migration safety, dependency policy, plan conformance, and more — is made explicit as a versioned, repo-owned review asset, then improved continuously with fixtures and golden outputs. See [Core Model](#core-model) for details.
+
+### 3. A review agent plus a viewpoint-based review team
+
+River Review offers three review-focused execution shapes.
+
+- **Review agent definition**: `agents/river-review.md`, distributed as a plugin / sub-agent. It works as a skill-routed orchestrator and lets you invoke each specialist skill via `/river-review:<skill>`.
+- **A review team that runs viewpoint-based reviewers in parallel**: roles such as bug-hunter, security-scanner, test-gap, dependency-reviewer, frontend-reviewer, and ci-cd-reviewer run in parallel inside a single orchestrator (`src/lib/reviewer-orchestrator.mjs`), and their findings are merged via connected-components. Pass `--reviewers auto` to select viewpoints automatically from the diff type.
+- **A verdict-bearing critic (the Agent layer)**: in a generate → review → revise loop, it emits findings plus a verdict (decision material). The Reference Loop lives in `examples/loop-reference-agent/`, and the convergence contract in [`pages/reference/loop-convergence-contract.md`](pages/reference/loop-convergence-contract.md) (Agent-layer Epic [#1150](https://github.com/s977043/river-review/issues/1150)).
+
+> **Role split and HITL boundary**: the review team emits findings plus a verdict, but the GO / NO-GO decision, iteration, and stopping remain the caller's or human's responsibility. It does not auto-approve or auto-merge. The review team here means "viewpoint-based reviewer roles run in parallel inside one orchestrator with their findings merged," not a set of fully autonomous independent agents. River Review keeps the "River Review reviews / PlanGate stops or passes" role split.
+
 ## Getting Started
 
 The shortest no-install path is the bundled plugin: add the marketplace and ask the `river-review` agent to review the current diff — see [Installing the river-review plugin](#installing-the-river-review-plugin). For CI, use GitHub Actions ([Quick start](#quick-start-github-actions)).

--- a/README.en.md
+++ b/README.en.md
@@ -52,21 +52,21 @@ River Review's value falls into three axes. All three derive from the same found
 
 ### 1. A capability pack that strengthens an AI agent's review ability
 
-River Review's skill and agent definitions are a **capability pack** that brings your team's review judgment to AI agents such as Claude Code, Cursor, and Codex. In normal use the agent's own model applies the skills, so **no River Review LLM key is required**. A key is needed only for headless execution (GitHub Action / standalone `river run`); mechanically-decidable viewpoints run even without one (see the [FAQ](#faq) for the execution model).
+River Review's skill and agent definitions are a **capability pack** that brings your team's review judgment to AI agents such as Claude Code, Cursor, and Codex. In normal use the agent's own model applies the skills, so **no River Review LLM key is required**. A key is needed only for headless execution (GitHub Action / standalone `river run`); mechanically-decidable perspectives run even without one (see the [FAQ](#faq) for the execution model).
 
 ### 2. Review skills (the Skill Registry)
 
 The foundation is the Skill Registry. Team-specific tacit knowledge — security, accessibility, migration safety, dependency policy, plan conformance, and more — is made explicit as a versioned, repo-owned review asset, then improved continuously with fixtures and golden outputs. See [Core Model](#core-model) for details.
 
-### 3. A review agent plus a viewpoint-based review team
+### 3. A review agent plus a perspective-based review team
 
 River Review offers three review-focused execution shapes.
 
 - **Review agent definition**: `agents/river-review.md`, distributed as a plugin / sub-agent. It works as a skill-routed orchestrator and lets you invoke each specialist skill via `/river-review:<skill>`.
-- **A review team that runs viewpoint-based reviewers in parallel**: roles such as bug-hunter, security-scanner, test-gap, dependency-reviewer, frontend-reviewer, and ci-cd-reviewer run in parallel inside a single orchestrator (`src/lib/reviewer-orchestrator.mjs`), and their findings are merged via connected-components. Pass `--reviewers auto` to select viewpoints automatically from the diff type.
-- **A verdict-bearing critic (the Agent layer)**: in a generate → review → revise loop, it emits findings plus a verdict (decision material). The Reference Loop lives in `examples/loop-reference-agent/`, and the convergence contract in [`pages/reference/loop-convergence-contract.md`](pages/reference/loop-convergence-contract.md) (Agent-layer Epic [#1150](https://github.com/s977043/river-review/issues/1150)).
+- **A review team that runs perspective-based reviewers in parallel**: roles such as bug-hunter, security-scanner, test-gap, dependency-reviewer, frontend-reviewer, and ci-cd-reviewer run in parallel inside a single orchestrator (`src/lib/reviewer-orchestrator.mjs`), and their findings are merged via connected-components. Pass `--reviewers auto` to select perspectives automatically from the diff type.
+- **A verdict-bearing critic (the Agent layer)**: in a generate → review → revise loop, it emits findings plus a verdict (decision material). The Reference Loop lives in `examples/loop-reference-agent/`, and the convergence contract in [`pages/reference/loop-convergence-contract.en.md`](pages/reference/loop-convergence-contract.en.md) (Agent-layer Epic [#1150](https://github.com/s977043/river-review/issues/1150)).
 
-> **Role split and HITL boundary**: the review team emits findings plus a verdict, but the GO / NO-GO decision, iteration, and stopping remain the caller's or human's responsibility. It does not auto-approve or auto-merge. The review team here means "viewpoint-based reviewer roles run in parallel inside one orchestrator with their findings merged," not a set of fully autonomous independent agents. River Review keeps the "River Review reviews / PlanGate stops or passes" role split.
+> **Role split and HITL boundary**: the review team emits findings plus a verdict, but the GO / NO-GO decision, iteration, and stopping remain the caller's or human's responsibility. It does not auto-approve or auto-merge. The review team here means "perspective-based reviewer roles run in parallel inside one orchestrator with their findings merged," not a set of fully autonomous independent agents. River Review keeps the "River Review reviews / PlanGate stops or passes" role split.
 
 ## Getting Started
 
@@ -107,7 +107,7 @@ River Review handles review judgment that **crosses artifacts**:
 
 These usually require context from plans, diffs, tests, prior comments, and team-specific standards. River Review handles that layer with LLM-backed, structured, testable skills.
 
-> **Usually no LLM key is needed**: River Review's skills are a **capability pack that strengthens an AI agent's** (Claude Code / Cursor / Codex …) review ability. In normal use the agent's own model applies the skills, so **no River Review LLM key is required**. A key is needed only for **headless execution (GitHub Action / standalone `river run`)** — and some mechanically-decidable viewpoints run even without one. See [What is River Review § Execution model](pages/explanation/what-is-river-review.en.md).
+> **Usually no LLM key is needed**: River Review's skills are a **capability pack that strengthens an AI agent's** (Claude Code / Cursor / Codex …) review ability. In normal use the agent's own model applies the skills, so **no River Review LLM key is required**. A key is needed only for **headless execution (GitHub Action / standalone `river run`)** — and some mechanically-decidable perspectives run even without one. See [What is River Review § Execution model](pages/explanation/what-is-river-review.en.md).
 
 ### Where does our code and review data go?
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,28 @@ plan / exec ゲートが、適切なタイミングで skill を実行します�
 
 AI 支援ワークフローにおいて、River Review は **チーム所有の監査レイヤー** として機能します。実装エージェントはコードを書けますが、それがチームのルールに従っているかを River Review が検査します。
 
+## 3 つの主軸
+
+River Review が提供する価値は、次の 3 軸で整理できます。いずれも「チームのレビュー判断を versioned / repo-owned な資産にする」という基盤の考えから派生しています。
+
+### 1. AI エージェントのレビュー能力を強化する capability pack
+
+River Review のスキル／エージェント定義は、Claude Code / Cursor / Codex などの AI エージェントに「チームのレビュー判断」を持ち込む **capability pack** です。通常はエージェント自身のモデルがスキルを適用するため、**River Review 用の LLM キーは不要**です。LLM キーが要るのは GitHub Action / standalone `river run` のヘッドレス実行だけで、機械的に判定できる観点はキー無しでも動きます（詳細は [FAQ](#faq) 節を参照）。
+
+### 2. レビュースキルの用意（Skill Registry）
+
+基盤となるのは Skill Registry です。security / a11y / migration safety / dependency policy / plan conformance などチーム固有の暗黙知を versioned / repo-owned なレビュー資産として明示化します。fixture と golden output による継続的な改善も可能です。詳細は [コアモデル](#コアモデル) 節を参照してください。
+
+### 3. レビュー用エージェント + 観点別レビュアーの review team
+
+River Review には、レビューに特化した 3 つの実行形態があります。
+
+- **レビュー用エージェント定義**: プラグイン／サブエージェントとして配布される `agents/river-review.md`。スキルルーティング型のオーケストレーターとして動き、`/river-review:<skill>` で各専門スキルを呼び出せる。
+- **観点別レビュアーを並列実行する review team**: 観点別ロールを 1 つの orchestrator（`src/lib/reviewer-orchestrator.mjs`）内で並列に走らせ findings を connected-components でマージする。ロールは bug-hunter / security-scanner / test-gap / dependency-reviewer / frontend-reviewer / ci-cd-reviewer であり、`--reviewers auto` 指定で差分タイプから自動選択される。
+- **verdict 付きの critic（Agent 層）**: generate → review → revise のループにおいて findings と verdict（判定素材）を出す。Reference Loop は `examples/loop-reference-agent/`、収束契約は [`pages/reference/loop-convergence-contract.md`](pages/reference/loop-convergence-contract.md) にある（Agent 層 Epic [#1150](https://github.com/s977043/river-review/issues/1150)）。
+
+> **役割分担と HITL 境界**: review team は findings + verdict を出力しますが、GO / NO-GO の判断・反復・停止は呼び出し側／人間の責務です。自動承認・自動マージは行いません。ここでの review team は「1 つの orchestrator 内で観点別レビュアーロールを並列実行し findings をマージするもの」であり、完全自律な独立エージェント群ではありません。「River Review = レビューする / PlanGate = 止める・通す」という役割分担を維持しています。
+
 ## はじめる
 
 インストール不要の最短手順は同梱プラグインです。マーケットプレイスを追加し、`river-review` エージェントに現在の差分のレビューを依頼してください（[river-review プラグインの導入](#river-review-プラグインの導入)）。CI では GitHub Actions を使います（[クイックスタート](#クイックスタートgithub-actions)）。

--- a/pages/explanation/river-architecture.en.md
+++ b/pages/explanation/river-architecture.en.md
@@ -25,16 +25,16 @@ flowchart LR
   Runner --> Output[Output schema\nfindings[] + summary]
 ```
 
-## Review Team (parallel viewpoint-specific reviewers)
+## Review Team (parallel perspective-based reviewers)
 
-Beyond a single general-purpose review, the review runner provides **parallel orchestration of viewpoint-specific reviewer roles**, implemented in `src/lib/reviewer-orchestrator.mjs`.
+Beyond a single general-purpose review, the review runner provides **parallel orchestration of perspective-based reviewer roles**, implemented in `src/lib/reviewer-orchestrator.mjs`.
 
 - **Roles**: bug-hunter / security-scanner / test-gap / dependency-reviewer / frontend-reviewer / ci-cd-reviewer, each treated as an independent reviewer.
 - **Automatic selection**: with `--reviewers auto`, `selectRolesAuto` picks roles from the diff content and risk signals. To select explicitly, pass a comma-separated list such as `--reviewers bug-hunter,security-scanner`.
 - **Parallel fan-out**: role × chunk pairs run in parallel via `Promise.allSettled`, so a failure in one role does not discard the results of the others.
 - **Merge**: findings from each role are grouped via connected components, and `mergeFindings` consolidates duplicate or adjacent findings.
 
-This is a single orchestrator running viewpoint-specific roles in parallel and merging the results, not a swarm of autonomous agents. Each role only produces review material; it has no authority to decide or approve.
+This is a single orchestrator running perspective-based roles in parallel and merging the results, not a swarm of autonomous agents. Each role only produces review material; it has no authority to decide or approve.
 
 ```mermaid
 flowchart LR

--- a/pages/explanation/river-architecture.en.md
+++ b/pages/explanation/river-architecture.en.md
@@ -25,6 +25,42 @@ flowchart LR
   Runner --> Output[Output schema\nfindings[] + summary]
 ```
 
+## Review Team (parallel viewpoint-specific reviewers)
+
+Beyond a single general-purpose review, the review runner provides **parallel orchestration of viewpoint-specific reviewer roles**, implemented in `src/lib/reviewer-orchestrator.mjs`.
+
+- **Roles**: bug-hunter / security-scanner / test-gap / dependency-reviewer / frontend-reviewer / ci-cd-reviewer, each treated as an independent reviewer.
+- **Automatic selection**: with `--reviewers auto`, `selectRolesAuto` picks roles from the diff content and risk signals. To select explicitly, pass a comma-separated list such as `--reviewers bug-hunter,security-scanner`.
+- **Parallel fan-out**: role × chunk pairs run in parallel via `Promise.allSettled`, so a failure in one role does not discard the results of the others.
+- **Merge**: findings from each role are grouped via connected components, and `mergeFindings` consolidates duplicate or adjacent findings.
+
+This is a single orchestrator running viewpoint-specific roles in parallel and merging the results, not a swarm of autonomous agents. Each role only produces review material; it has no authority to decide or approve.
+
+```mermaid
+flowchart LR
+  Diff[Diff + chunks] --> Select[selectRolesAuto\n--reviewers auto]
+  Select --> R1[bug-hunter]
+  Select --> R2[security-scanner]
+  Select --> R3[test-gap / dependency /\nfrontend / ci-cd]
+  R1 --> Merge[mergeFindings\nconnected-components]
+  R2 --> Merge
+  R3 --> Merge
+  Merge --> Findings[findings[] + summary]
+```
+
+## Agent layer (generate → review → revise loop)
+
+River Review can be embedded as the **review stage** of a generating agent's **generate → review → revise** loop (Epic #1150).
+
+- River Review acts as a **critic** that returns findings / verdict / `suggestedLoopSignal`.
+- Deciding whether to iterate, stop, or escalate is the **caller's responsibility** (the calling agent). River Review does not run the loop itself; it only returns material for the decision.
+- Findings and verdict are decision material, not auto-approval. The design preserves a human confirmation boundary (HITL).
+
+For the contract and reference implementation, see:
+
+- Contract: [Loop Convergence Contract](../reference/loop-convergence-contract.en.md)
+- Reference implementation: `examples/loop-reference-agent/` (a minimal loop that satisfies the contract)
+
 ## Representative flow (GitHub Actions)
 
 ```mermaid

--- a/pages/explanation/river-architecture.md
+++ b/pages/explanation/river-architecture.md
@@ -23,6 +23,42 @@ flowchart LR
   Runner --> Output[Output schema\nfindings[] + summary]
 ```
 
+## Review Team（観点別レビュアーの並列実行）
+
+Review runner は単一の汎用レビューに加えて、**観点別レビュアーロールの並列オーケストレーション**を持ちます。実装は `src/lib/reviewer-orchestrator.mjs` です。
+
+- **ロール**: bug-hunter / security-scanner / test-gap / dependency-reviewer / frontend-reviewer / ci-cd-reviewer の各観点を、独立したレビュアーとして扱う。
+- **自動選択**: `--reviewers auto` を指定すると `selectRolesAuto` が差分の内容とリスク信号からロールを選ぶ。明示指定する場合は `--reviewers bug-hunter,security-scanner` のようにカンマ区切りで渡す。
+- **並列 fan-out**: role × chunk の組を `Promise.allSettled` で並列実行し、一部のロールが失敗しても他のロールの結果を活かす。
+- **マージ**: 各ロールの findings を connected-components で束ね、`mergeFindings` が重複や近接した指摘を統合する。
+
+これは「1 つの orchestrator が観点別ロールを並列に走らせてマージする」構成であり、自律的に振る舞うエージェント群ではありません。各ロールはレビュー素材を出すだけで、判定や承認の権限は持ちません。
+
+```mermaid
+flowchart LR
+  Diff[Diff + chunks] --> Select[selectRolesAuto\n--reviewers auto]
+  Select --> R1[bug-hunter]
+  Select --> R2[security-scanner]
+  Select --> R3[test-gap / dependency /\nfrontend / ci-cd]
+  R1 --> Merge[mergeFindings\nconnected-components]
+  R2 --> Merge
+  R3 --> Merge
+  Merge --> Findings[findings[] + summary]
+```
+
+## Agent 層（generate → review → revise ループ）
+
+River Review は、生成系エージェントの **generate → review → revise** ループにおける **review ステージ**として組み込めます（Epic #1150）。
+
+- River Review は findings / verdict / `suggestedLoopSignal` を返す **critic** として振る舞う。
+- 反復・停止・エスカレーションの判断は **caller（呼び出し側エージェント）の責務**である。River Review 自身はループを回さず、判定素材を返すだけにとどめる。
+- findings と verdict はあくまで判定素材であり、自動承認はしない。人手の確認境界（HITL）を保つ設計である。
+
+契約と参照実装は次を参照してください。
+
+- 契約: [Loop Convergence Contract](../reference/loop-convergence-contract.md)
+- 参照実装: `examples/loop-reference-agent/`（contract を満たす最小のループ例）
+
 ## 代表フロー（GitHub Actions）
 
 ```mermaid

--- a/pages/explanation/river-architecture.md
+++ b/pages/explanation/river-architecture.md
@@ -56,7 +56,7 @@ River Review は、生成系エージェントの **generate → review → revi
 
 契約と参照実装は次を参照してください。
 
-- 契約: [Loop Convergence Contract](../reference/loop-convergence-contract.md)
+- 契約: [反復収束の契約](../reference/loop-convergence-contract.md)
 - 参照実装: `examples/loop-reference-agent/`（contract を満たす最小のループ例）
 
 ## 代表フロー（GitHub Actions）

--- a/pages/explanation/what-is-river-review.en.md
+++ b/pages/explanation/what-is-river-review.en.md
@@ -5,7 +5,13 @@ title: What is River Review
 
 River Review is a **Context Engineering-driven, Skill Registry-centric code review framework** — a flow-based agent that carries review perspectives along [three phases (Upstream, Midstream, Downstream)](./upstream-midstream-downstream.md) as reusable **Agent Skills**.
 
-By defining team-specific judgment criteria and procedures as version-controlled **Agent Skills**, it makes review findings reproducible while keeping operating costs in check.
+By defining team-specific judgment criteria and procedures as version-controlled **Agent Skills**, it makes review findings reproducible while keeping operating costs in check. River Review is built around three core ideas:
+
+- **Capability pack**: a bundle of skills / agent definitions that strengthens an AI's review ability.
+- **Skill Registry**: a way to share team judgment criteria as versioned, repo-owned Skills.
+- **Review agent and review team**: a dedicated review agent plus a review team that runs perspective-specific reviewers in parallel.
+
+Turning tacit knowledge into versioned, repo-owned Skills as a shared asset stays unchanged. The third axis defines who runs that asset and how.
 
 ## Purpose
 
@@ -26,6 +32,25 @@ River Review's skills are not configuration for River Review to call an LLM itse
 3. **Headless LLM (GitHub Action / standalone `river run`)** — with no interactive agent present, River Review **calls an LLM itself** to execute the skills. **Only this path needs an LLM key** (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GOOGLE_API_KEY`); the mechanical checks (2) still run without one.
 
 > In short: normal AI-driven development needs **no LLM key** because the agent applies the skills. A key is required only for **headless execution (GitHub Action / standalone CLI)** running skills beyond the mechanical checks.
+
+## Review agent and review team
+
+River Review does more than bundle skills — it ships a **dedicated review agent** that runs them. This is a concrete form of the "AI-agent-driven" execution model above.
+
+- **Dedicated review agent** — shipped as a sub-agent definition (`agents/river-review.md`) and invoked via `/review-local` and similar. The host agent loads this definition and runs the review with its own model.
+- **Parallel perspective reviewers with merge (review team)** — `src/lib/reviewer-orchestrator.mjs` runs perspective-specific reviewer roles (bug-hunter / security-scanner / test-gap / dependency-reviewer / frontend-reviewer / ci-cd-reviewer) in parallel, then clusters and merges their findings via connected components. With `--reviewers auto`, the roles relevant to the diff are selected automatically.
+
+Here, "multi-agent" means a single orchestrator running perspective-specific reviewer roles in parallel and merging the results. It is not a set of fully autonomous, independent agents — it is specifically **parallel execution and merge of perspective reviewers**.
+
+## Iteration loop and decision material critic
+
+River Review serves as the **review stage** in a generate → review → revise iteration loop.
+
+- On each pass, it returns review results as **decision material (findings / verdict / suggestedLoopSignal)**.
+- The verdict is decision material only; it does not assert GO / NO-GO, auto-approval, or auto-merge. Whether to keep iterating or stop is the **caller's responsibility**.
+- Mechanisms such as `auto-approve` are advisory and do not bypass human-in-the-loop (HITL) review.
+
+This contract and its reference implementation are defined in the [loop convergence contract](../reference/loop-convergence-contract.md) and the in-repo reference agent (`examples/loop-reference-agent/`).
 
 ## Flow Connection
 

--- a/pages/explanation/what-is-river-review.en.md
+++ b/pages/explanation/what-is-river-review.en.md
@@ -9,7 +9,7 @@ By defining team-specific judgment criteria and procedures as version-controlled
 
 - **Capability pack**: a bundle of skills / agent definitions that strengthens an AI's review ability.
 - **Skill Registry**: a way to share team judgment criteria as versioned, repo-owned Skills.
-- **Review agent and review team**: a dedicated review agent plus a review team that runs perspective-specific reviewers in parallel.
+- **Review agent and review team**: a dedicated review agent plus a review team that runs perspective-based reviewers in parallel.
 
 Turning tacit knowledge into versioned, repo-owned Skills as a shared asset stays unchanged. The third axis defines who runs that asset and how.
 
@@ -28,7 +28,7 @@ River Review does not replace human reviewers. By handling skill-based checks to
 River Review's skills are not configuration for River Review to call an LLM itself — they are a **capability pack (skills / agent definitions) that strengthens an AI's review ability**. There are three ways they get executed, and **whether an LLM key is needed is decided by this model, not by the execution surface**.
 
 1. **AI-agent-driven (primary)** — an agent (Claude Code / Cursor / Codex …) loads the skills (`skills/agent-skills/`) or the sub-agent (`agents/river-review.md`) and **runs the review with its own model**. The agent _is_ the LLM, so **no River Review LLM key is needed**. This covers `/review-local`, sub-agent delegation, loading Agent Skills, etc.
-2. **Mechanical checks (heuristic / no model)** — viewpoints that can be decided deterministically (e.g. via regex) **run with no LLM and no key**. Today this covers security viewpoints (hardcoded secrets / `eval` & XSS / disabled TLS / weak hash / command injection / GitHub Actions risks) plus quality and test viewpoints (silent-catch / leftover `debugger` / merge-conflict markers / type-check suppression / missing tests / focused & disabled tests), handled by five skills across the security / logging / typescript / test domains. More mechanically-decidable viewpoints can be added over time.
+2. **Mechanical checks (heuristic / no model)** — perspectives that can be decided deterministically (e.g. via regex) **run with no LLM and no key**. Today this covers security perspectives (hardcoded secrets / `eval` & XSS / disabled TLS / weak hash / command injection / GitHub Actions risks) plus quality and test perspectives (silent-catch / leftover `debugger` / merge-conflict markers / type-check suppression / missing tests / focused & disabled tests), handled by five skills across the security / logging / typescript / test domains. More mechanically-decidable perspectives can be added over time.
 3. **Headless LLM (GitHub Action / standalone `river run`)** — with no interactive agent present, River Review **calls an LLM itself** to execute the skills. **Only this path needs an LLM key** (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GOOGLE_API_KEY`); the mechanical checks (2) still run without one.
 
 > In short: normal AI-driven development needs **no LLM key** because the agent applies the skills. A key is required only for **headless execution (GitHub Action / standalone CLI)** running skills beyond the mechanical checks.
@@ -38,9 +38,9 @@ River Review's skills are not configuration for River Review to call an LLM itse
 River Review does more than bundle skills — it ships a **dedicated review agent** that runs them. This is a concrete form of the "AI-agent-driven" execution model above.
 
 - **Dedicated review agent** — shipped as a sub-agent definition (`agents/river-review.md`) and invoked via `/review-local` and similar. The host agent loads this definition and runs the review with its own model.
-- **Parallel perspective reviewers with merge (review team)** — `src/lib/reviewer-orchestrator.mjs` runs perspective-specific reviewer roles (bug-hunter / security-scanner / test-gap / dependency-reviewer / frontend-reviewer / ci-cd-reviewer) in parallel, then clusters and merges their findings via connected components. With `--reviewers auto`, the roles relevant to the diff are selected automatically.
+- **Parallel perspective reviewers with merge (review team)** — `src/lib/reviewer-orchestrator.mjs` runs perspective-based reviewer roles (bug-hunter / security-scanner / test-gap / dependency-reviewer / frontend-reviewer / ci-cd-reviewer) in parallel, then clusters and merges their findings via connected components. With `--reviewers auto`, the roles relevant to the diff are selected automatically.
 
-Here, "multi-agent" means a single orchestrator running perspective-specific reviewer roles in parallel and merging the results. It is not a set of fully autonomous, independent agents — it is specifically **parallel execution and merge of perspective reviewers**.
+Here, "multi-agent" means a single orchestrator running perspective-based reviewer roles in parallel and merging the results. It is not a set of fully autonomous, independent agents — it is specifically **parallel execution and merge of perspective reviewers**.
 
 ## Iteration loop and decision material critic
 
@@ -50,7 +50,7 @@ River Review serves as the **review stage** in a generate → review → revise 
 - The verdict is decision material only; it does not assert GO / NO-GO, auto-approval, or auto-merge. Whether to keep iterating or stop is the **caller's responsibility**.
 - Mechanisms such as `auto-approve` are advisory and do not bypass human-in-the-loop (HITL) review.
 
-This contract and its reference implementation are defined in the [loop convergence contract](../reference/loop-convergence-contract.md) and the in-repo reference agent (`examples/loop-reference-agent/`).
+This contract and its reference implementation are defined in the [loop convergence contract](../reference/loop-convergence-contract.en.md) and the in-repo reference agent (`examples/loop-reference-agent/`).
 
 ## Flow Connection
 

--- a/pages/explanation/what-is-river-review.md
+++ b/pages/explanation/what-is-river-review.md
@@ -7,7 +7,13 @@ River Review は、**チーム固有のレビュー判断を、要件・設計�
 
 一般的な AI レビューツールは、PR diff を主な入力として扱います。River Review はそれだけではありません。AI エージェントが実装に入る前の要件・設計・計画もレビュー対象に含め、実装後の差分・テスト・完了レポートまで一貫して確認します。
 
-このアプローチは _Context Engineering_（レビュー判断に必要な文脈を構造化して LLM へ渡す設計手法）とも呼ばれます。その中核となるのが、チームの判断基準を versioned / repo-owned な Skill として管理する _Skill Registry_ です。
+このアプローチは _Context Engineering_（レビュー判断に必要な文脈を構造化して LLM へ渡す設計手法）とも呼ばれます。River Review は次の 3 つを中核に据えています。
+
+- **capability pack**: AI のレビュー能力を強化するスキル / エージェント定義のまとまり。
+- **Skill Registry**: チームの判断基準を versioned / repo-owned な Skill として共有資産化する仕組み。
+- **レビュー用エージェントとレビューチーム**: レビュー専用エージェントと、観点別レビュアーを並列実行する review team。
+
+暗黙知を versioned / repo-owned な Skill へ落とし込み、共有資産として再利用する考え方は変わりません。3 つ目の軸は、その資産を「誰がどう動かすか」を担います。
 
 ## 一言で言うと
 
@@ -47,6 +53,25 @@ River Review のスキルは、River Review 自身が LLM を呼ぶための設�
 3. **ヘッドレス LLM（GitHub Action / standalone `river run`）** — 対話エージェントがいない環境では、River Review が**自前で LLM を呼んで**スキルを実行する。**この経路だけ LLM キー**（`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GOOGLE_API_KEY` のいずれか）が必要になる（機械的チェック (2) はキー無しでも動く）。
 
 > まとめ: 通常の AI 駆動開発ではエージェントがスキルを適用するため **LLM キーは不要**です。LLM キーが要るのは **GitHub Action / standalone CLI のヘッドレス実行**で、かつ機械的チェック以外のスキルを動かす場合だけです。
+
+## レビュー用エージェントとレビューチーム
+
+River Review はスキルを束ねるだけでなく、それを動かす**レビュー専用エージェント**を備えています。これは上の実行モデルのうち「AI エージェント駆動」を具体化したものです。
+
+- **レビュー専用エージェント** — サブエージェント定義（`agents/river-review.md`）として配布され、`/review-local` などから呼び出せる。ホストのエージェントがこの定義を読み込み、自身のモデルでレビューを実行する。
+- **観点別レビュアーの並列実行とマージ（review team）** — `src/lib/reviewer-orchestrator.mjs` が観点別レビュアーロールを並列に走らせ、各 finding を connected-components でマージする。ロールは bug-hunter / security-scanner / test-gap / dependency-reviewer / frontend-reviewer / ci-cd-reviewer の 6 種類。`--reviewers auto` なら差分内容に応じてロールが選ばれる。
+
+ここでいう「マルチエージェント」は、1 つの orchestrator が観点別レビュアーのロールを並列に動かして結果をマージする仕組みです。完全に自律した独立エージェント群ではなく、あくまで**観点別レビュアーの並列実行とマージ**を指します。
+
+## 反復ループと判定素材の critic
+
+River Review は、generate → review → revise の反復ループの中で **review ステージ**を担います。
+
+- ループの各周回で、レビュー結果を **判定素材（findings / verdict / suggestedLoopSignal）**として返す。
+- verdict はあくまで判定素材であり、GO / NO-GO・自動承認・自動マージを主張しない。反復を続けるか止めるかの判断は **caller の責務**である。
+- `auto-approve` のような仕組みも、人間の確認（HITL）をバイパスしない助言である。
+
+この契約と参照実装は、[反復収束の契約](../reference/loop-convergence-contract.md) と、リポジトリ内の参照エージェント（`examples/loop-reference-agent/`）で定義しています。
 
 ## フローの繋がり
 


### PR DESCRIPTION
## What

対外メッセージングを「3つの主軸」を前面化する形に全面更新。**基盤（暗黙知 → versioned/repo-owned な共有スキル資産）は不変**で、その上に3軸を明確化。オーガナイザー（自分）+ surface ごとのサブエージェント並列で実施。

### 3 主軸
1. **AIエージェントのレビュー能力を強化する capability pack**（通常 LLM キー不要、ヘッドレスのみ要）
2. **レビュースキル（Skill Registry）** — 基盤・不変
3. **レビュー用エージェント + 観点別レビュアーの review team** — `agents/river-review.md` / `reviewer-orchestrator.mjs` の観点別ロール並列＋connected-components マージ（`--reviewers auto`）/ generate→review→revise の verdict 付き critic（Agent 層 #1150・Reference Loop）

### 更新ファイル（ja/en パリティ）
- `README.md` / `README.en.md`（「3つの主軸」節を追加）
- `pages/explanation/what-is-river-review.{md,en.md}`（review team / critic を中核に追加、実行モデルは保持）
- `pages/explanation/river-architecture.{md,en.md}`（Review Team / Agent 層を構成要素として追記）

## 正確性ガードレール（誇大表現の禁止・遵守）
- 「マルチエージェント review team」=**1 orchestrator 内の観点別ロール並列＋マージ**であり完全自律エージェント群ではない、と明記。
- **助言 / HITL 境界（#976）維持**: findings + verdict は判定素材で、GO/NO-GO・反復・停止は caller/人間の責務。自動承認・自動マージは主張しない。
- 「River Review = レビュー / PlanGate = 可否判定」の分担維持。既存の実行モデル3通り・LLM キー要否は保持。

## Verification
- `textlint --no-cache`（CI 対象 pages/ 変更分）: clean（README の既存エラーは別箇所・非 CI 対象）
- `prettier --check`（6ファイル）/ `fix:dashes` / `lychee`（相対リンク解決、0 Errors）: pass
- 用語を全6ファイルで統一（capability pack / Skill Registry / review team / connected-components / --reviewers auto / verdict-bearing critic / HITL）
- 記述は実装根拠（reviewer-orchestrator.mjs / agents/river-review.md / examples/loop-reference-agent / #1150）に限定

docs-only のため release 不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)