### PR TITLE
fix(skills): align conformance registry description with SKILL.md frontmatter

### DIFF
--- a/skills/registry.yaml
+++ b/skills/registry.yaml
@@ -622,7 +622,7 @@ skills:
     tags: [conformance, prior-art, consistency, maintainability, midstream]
     severity: major
     recommended: true
-    description: '新実装が、同種の先行実装に在る防御 / バリデーション / エラー処理 / 規約 / 共通化ロジック / 概念定義を、欠落・重複・食い違いなく継承しているかを grep で先行特定して確認する'
+    description: '新実装が、同種の先行実装（同レイヤ・同責務・同概念）に在る防御 / バリデーション / エラー処理 / 規約 / 共通化ロジック / 概念定義を、欠落・重複・食い違いなく継承しているかを grep で先行特定して確認する'
 
   - id: rr-upstream-migration-safety-001
     version: '0.1.0'


### PR DESCRIPTION
## Summary

`rr-midstream-existing-pattern-conformance-001` の `description` が **registry.yaml と SKILL.md frontmatter で非対称**だったのを一致させる1行修正。registry 側で `（同レイヤ・同責務・同概念）` が脱落していた。

これは #1209（#169 観点取り込み）のマルチ視点セルフレビューで検出。本 PR が追加した「既存パターン準拠」観点を自分自身に適用すると見つかる不整合という象徴的なケース。e2e-wiring 側の description は既に一致していたため、対称性を回復する。

- 影響: manifest checksum は SKILL.md ディレクトリ単位のため description ドリフトを検出できず、adopter が registry だけ見ると skill 意図（同レイヤ・同責務・同概念での先行特定）を取りこぼす。機能影響はなし。

## Test plan
- [x] `npm run skills:validate` — OK
- [x] `npm run skills:manifest:check` — up to date (114 skills, registry 変更は checksum 非影響)
- [x] `npm test` — 1514 pass / 0 fail
- [x] registry と SKILL.md frontmatter の description 完全一致を grep で確認

## 関連
- 対象: #1209 (#169 観点取り込み, dda2ed0)
- フォローアップ issue: P0（guard/eval ケース未整備 = #1070 安全網不在）ほかを別途起票

🤖 Generated with [Claude Code](https://claude.com/claude-code)