### PR TITLE
feat(skills): secret-credential-scan & doc-hygiene perspectives (#1216)

### DIFF
--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -174,7 +174,7 @@
     {
       "id": "rr-midstream-doc-hygiene-001",
       "path": "skills/midstream/rr-midstream-doc-hygiene-001",
-      "checksum": "sha256:3e86f57ea41d4fa073755858bb4bdfdd01dec6cdc77b64646e839a122dfcecda",
+      "checksum": "sha256:0428cd7f2676792b4b267cab3a77ea27bbce685107ef0dccc7ccea24d729fc3c",
       "files": 1
     },
     {
@@ -342,7 +342,7 @@
     {
       "id": "rr-midstream-secret-credential-scan-001",
       "path": "skills/midstream/rr-midstream-secret-credential-scan-001",
-      "checksum": "sha256:6477bc4f62d0b8f8dfd90aed0dafa944d4f73c517e8a0888fae5c95a52a0e13c",
+      "checksum": "sha256:62369d6b8f9564f26edc1418cefed634bf46d82bd06dcfabdb1e5358529ed0d2",
       "files": 1
     },
     {

--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "description": "Deterministic skill manifest for drift detection by selective adopters. Compare the checksum of your copied skill against this list to notice upstream changes. Regenerate with: npm run skills:manifest",
-  "skillCount": 114,
+  "skillCount": 116,
   "skills": [
     {
       "id": "adversarial-review",
@@ -172,6 +172,12 @@
       "files": 9
     },
     {
+      "id": "rr-midstream-doc-hygiene-001",
+      "path": "skills/midstream/rr-midstream-doc-hygiene-001",
+      "checksum": "sha256:3e86f57ea41d4fa073755858bb4bdfdd01dec6cdc77b64646e839a122dfcecda",
+      "files": 1
+    },
+    {
       "id": "rr-midstream-e2e-wiring-001",
       "path": "skills/midstream/rr-midstream-e2e-wiring-001",
       "checksum": "sha256:1491912a681e83ae5f8cddbb7126994b6ba7c3e557fd902dc60011b416af7d2e",
@@ -331,6 +337,12 @@
       "id": "rr-midstream-review-policy-standard-001",
       "path": "skills/midstream/review-policy-standard",
       "checksum": "sha256:85ba5a9afc56630e8c93d753dbcd8b44a5e15de328009c44163144892987964e",
+      "files": 1
+    },
+    {
+      "id": "rr-midstream-secret-credential-scan-001",
+      "path": "skills/midstream/rr-midstream-secret-credential-scan-001",
+      "checksum": "sha256:6477bc4f62d0b8f8dfd90aed0dafa944d4f73c517e8a0888fae5c95a52a0e13c",
       "files": 1
     },
     {

--- a/skills/midstream/rr-midstream-doc-hygiene-001/SKILL.md
+++ b/skills/midstream/rr-midstream-doc-hygiene-001/SKILL.md
@@ -8,7 +8,6 @@ phase: midstream
 applyTo:
   - '**/*.md'
   - '**/*.mdx'
-  - '**/AGENTS.md'
 tags: [documentation, hygiene, maintainability, midstream]
 severity: major
 inputContext: [diff]
@@ -49,7 +48,7 @@ Why: ドキュメントの役割汚染・内部メモ混入はパターン的に
 
 - 一過性ログを**意図的に置く場所**（`CHANGELOG.md` / `docs/**/retrospectives/**` / `_docs/decisions/**` / 日付付きログファイル）への追記は、その役割に沿う限り指摘しない。
 - 手順書内のコマンド例・出力例として**意図的に引用されたログ**は指摘しない（地の文に紛れ込んだ作業ログのみ対象）。
-- ローカルパスでも、汎用的な例示（`/path/to/...`、`~/project`）は指摘しない。実在の個人パス（`/Users/<name>/`、`/home/<name>/`）のみ対象。
+- ローカルパスでも、汎用的な例示（`/path/to/...`、`~/project`）は指摘しない。実在の個人パス（`/Users/<name>/`、`/home/<name>/`、`C:\Users\<name>\`）のみ対象。
 - 内部向けと明記されたドキュメント（先頭に「内部資料」等の宣言がある）への内部メモは、公開物でない限り指摘しない。
 
 ## Rule / ルール

--- a/skills/midstream/rr-midstream-doc-hygiene-001/SKILL.md
+++ b/skills/midstream/rr-midstream-doc-hygiene-001/SKILL.md
@@ -1,0 +1,99 @@
+---
+id: rr-midstream-doc-hygiene-001
+name: 'Documentation Hygiene ドキュメント衛生'
+description: 'AGENTS.md などの恒久ドキュメントに一過性のタスクログが混入していないか、SOP / decision / log / learned の役割が混同されていないか、公開物（README / docs / 記事）に内部メモ・ローカルパス・AI 会話断片が残っていないかを差分で検出する'
+version: 0.1.0
+category: midstream
+phase: midstream
+applyTo:
+  - '**/*.md'
+  - '**/*.mdx'
+  - '**/AGENTS.md'
+tags: [documentation, hygiene, maintainability, midstream]
+severity: major
+inputContext: [diff]
+outputKind: [findings, questions]
+modelHint: balanced
+dependencies: [code_search]
+---
+
+## Pattern declaration
+
+Primary pattern: Reviewer
+Secondary patterns: Inversion
+Why: ドキュメントの役割汚染・内部メモ混入はパターン的に拾える部分が多いが、恒久 SOP と一過性ログのどちらなのかという文書の意図の判断が要る。ドキュメント差分を含まない変更では実行を止めるゲートが必要。
+
+## Goal / 目的
+
+- 恒久ドキュメント（`AGENTS.md` / SOP / ガイド）に、**一過性のタスクログ・特定 PR 固有の作業記録**が混入していないかを検出する。
+- **SOP / decision / log / learned** の役割が混同されていないか（手順書に決定記録や日次ログを混ぜるなど）を検出する。
+- 公開物（README / docs / 記事）に、**内部メモ・ローカルパス・AI との会話断片・デバッグ出力**が残っていないかを検出する。
+
+## Non-goals / 扱わないこと
+
+- ドキュメントと実装の整合性（`river-review-docs` ルーターの領域）。
+- 日本語の文体・textlint 的な体裁（lint の領域）。
+- 翻訳パリティ（ja/en の対応漏れは docs 系の別観点）。
+- 記事そのものの技術的正しさや SEO（article-reviewer の領域）。
+
+## Pre-execution Gate / 実行前ゲート
+
+このスキルは以下の条件がすべて満たされない限り `NO_REVIEW` を返す。
+
+- [ ] 差分に**ドキュメントファイル**（`*.md` / `*.mdx` / `AGENTS.md` など、恒久ドキュメントまたは公開物）の追加・変更が含まれている
+- [ ] inputContext に diff が含まれ、`code_search`（grep）が利用可能である
+
+ゲート不成立時の出力: `NO_REVIEW: rr-midstream-doc-hygiene-001 — ドキュメントの変更が検出されない`
+
+## False-positive guards / 抑制条件
+
+- 一過性ログを**意図的に置く場所**（`CHANGELOG.md` / `docs/**/retrospectives/**` / `_docs/decisions/**` / 日付付きログファイル）への追記は、その役割に沿う限り指摘しない。
+- 手順書内のコマンド例・出力例として**意図的に引用されたログ**は指摘しない（地の文に紛れ込んだ作業ログのみ対象）。
+- ローカルパスでも、汎用的な例示（`/path/to/...`、`~/project`）は指摘しない。実在の個人パス（`/Users/<name>/`、`/home/<name>/`）のみ対象。
+- 内部向けと明記されたドキュメント（先頭に「内部資料」等の宣言がある）への内部メモは、公開物でない限り指摘しない。
+
+## Rule / ルール
+
+### 検出ロジック
+
+1. **役割の特定**: 変更されたドキュメントが恒久ドキュメント（SOP / ガイド / `AGENTS.md`）か、公開物（README / docs / 記事）か、ログ用（CHANGELOG / retrospective）かを判定する。
+2. **混入の検出**:
+   - 恒久ドキュメントへの一過性タスクログ・特定 PR 固有記述の追記
+   - SOP に decision/log/learned を混ぜる役割混同
+   - 公開物への内部メモ・実在の個人ローカルパス・AI 会話断片（「ユーザー:」「アシスタント:」「以下を実行します」等の対話痕跡）・デバッグ出力の残存
+3. **報告**: 該当箇所を `<file>:<line>` で示し、本来あるべき置き場所（別ファイル・別セクション）または除去を提案する。
+
+### 制約
+
+- 検出は最大 5 件。公開物への内部情報漏洩・恒久ドキュメントの役割汚染など影響の大きいものを優先する。
+- 各指摘に「混入の種別」「あるべき置き場所 / 除去」を必ず含める。
+- 役割の判断が曖昧な場合は断定せず `questions` で確認する。
+
+## Evidence / 根拠の取り方
+
+- 混入箇所は必ず `<file>:<line>` に紐づけ、推測で「ログのようだ」と述べない。
+- 「このファイルは恒久ドキュメント / 公開物であり、ここに一過性ログ / 内部メモが入っている」と役割と混入を対比して具体的に示す。
+
+## Output / 出力フォーマット
+
+すべて日本語。
+
+```text
+(doc-hygiene):1: [要約] 最も重大なドキュメント衛生の問題は〈1文〉
+
+<file>:<line>: [衛生1] <タイトル>
+  種別: <一過性ログ混入 / 役割混同 / 内部メモ残存 / 個人パス / AI会話断片>
+  混入: <恒久ドキュメント・公開物に何が入っているか>(<file>:<line>)
+  影響: <内部情報の公開漏洩 / ドキュメントの陳腐化・役割崩壊>
+  Fix: <あるべき置き場所（別ファイル・別セクション）への移動、または除去>
+```
+
+## 評価指標（Evaluation）
+
+- 合格基準: 恒久ドキュメント・公開物への混入を `<file>:<line>` で示し、あるべき置き場所を具体的に提案している。意図的なログ置き場への追記を誤検出していない。
+- 不合格基準: CHANGELOG/retrospective への正当な追記を誤検出する、汎用例示パスを使った難癖、文体・翻訳・実装整合まで越境した指摘。
+
+## 人間に返す条件（Human Handoff）
+
+- ドキュメントが恒久（SOP）か一過性（ログ）かの役割が、文面からは判断できない場合。
+- 内部メモを公開物に意図的に残しているか（テンプレート等）の判断が必要な場合。

--- a/skills/midstream/rr-midstream-secret-credential-scan-001/SKILL.md
+++ b/skills/midstream/rr-midstream-secret-credential-scan-001/SKILL.md
@@ -1,0 +1,97 @@
+---
+id: rr-midstream-secret-credential-scan-001
+name: 'Secret / Credential Scan 機密情報の混入検出'
+description: '差分に追加された API キー・トークン・credential・秘密鍵・.env 値・個人ローカルパスなどの機密情報を、言語・ファイル種別に依存せず検出する。決定論的に判定できる範囲は CI（gitleaks 等）へ移譲しつつ、レビューで取りこぼしを補足する'
+version: 0.1.0
+category: midstream
+phase: midstream
+applyTo:
+  - '**/*'
+tags: [secret, credential, midstream]
+severity: major
+inputContext: [diff]
+outputKind: [findings, actions]
+modelHint: balanced
+dependencies: [code_search]
+---
+
+## Pattern declaration
+
+Primary pattern: Reviewer
+Secondary patterns: Inversion
+Why: 機密情報の検出はパターン的・決定論で判定できる領域が大きく、本来は CI に委ねるべき。一方で CI 未整備のリポジトリや、CI が見ない種別（個人パス・ローカル設定）を補足する補助レビューとして機能する。秘匿情報を含む追加が無ければ実行を止めるゲートが必要。
+
+## Goal / 目的
+
+- 差分へ**新規追加された**機密情報を、言語やファイル種別を問わず検出する。対象は API キー / トークン / credential / 秘密鍵 / `.env` 値 / 個人ローカルパス / ローカル固有設定とする。
+- 既存の言語限定 secret チェック（`rr-midstream-security-basic-001` は `.ts/.tsx/.js/.jsx`、`rr-midstream-config-json-001` は `.json/.yml`）が見ない種別・ファイルの取りこぼしを補う。
+
+## Non-goals / 扱わないこと
+
+- アプリコード内の SQLi / XSS など機密以外のセキュリティ（`rr-midstream-security-basic-001` の領域）。
+- BaaS のルール/鍵露出（`rr-midstream-firebase-security-rules-001` / `rr-midstream-supabase-rls-policy-001` の領域）。
+- 決定論で完全な判定ができる検出を恒久的な肩代わりとすること（本スキルは CI = gitleaks / trufflehog 等の導入を促し、移譲する）。
+
+## Pre-execution Gate / 実行前ゲート
+
+このスキルは以下の条件がすべて満たされない限り `NO_REVIEW` を返す。
+
+- [ ] 差分の**追加行**に、機密情報の候補（高エントロピー文字列・`API_KEY`/`SECRET`/`TOKEN`/`PASSWORD` 等のキー・`-----BEGIN ... PRIVATE KEY-----`・`/Users/` や `/home/` で始まる個人パス・実値入りの `.env` 行など）が含まれている
+- [ ] inputContext に diff が含まれ、`code_search`（grep）が利用可能である
+
+ゲート不成立時の出力: `NO_REVIEW: rr-midstream-secret-credential-scan-001 — 機密情報の候補が差分に検出されない`
+
+## False-positive guards / 抑制条件
+
+- プレースホルダ・例値（`xxx` / `your-api-key` / `dummy` / `example` / `<...>` / `***`）は指摘しない。
+- `.env.example` / `.env.sample` / `.env.template` などサンプルファイルの**プレースホルダ**は指摘しない（実値が入っていれば指摘する）。
+- テストフィクスチャ・ドキュメントの**明らかな擬似値**は指摘しない。実在しうる形式（本物の鍵長・接頭辞 `sk-` / `ghp_` / `AKIA` 等）の場合のみ指摘する。
+- 既に環境変数参照（`process.env.X` / `os.environ[...]`）に置き換わっている場合は指摘しない。
+- 既存行（差分の文脈行）にあるだけで追加・変更されていない機密は対象外（追加・変更行のみ）。
+
+## Rule / ルール
+
+### 検出ロジック
+
+1. **候補抽出**: 差分の追加行から次の機密候補を抽出する。
+   - 鍵名（`API_KEY`/`SECRET`/`TOKEN`/`PASSWORD`/`CREDENTIAL`）への実値代入
+   - 既知接頭辞（`sk-`/`ghp_`/`AKIA`/`AIza` 等）や `-----BEGIN ... PRIVATE KEY-----`
+   - 高エントロピー文字列、個人パス（`/Users/<name>/`、`/home/<name>/`）、実値入り `.env` 行
+2. **実値判定**: プレースホルダ・例値・環境変数参照を `code_search` で確認して除外し、実在しうる値のみ残す。
+3. **報告**: 該当箇所を `<file>:<line>` で示し、機密の種別と推奨対応（環境変数 / Secrets への移動、コミット履歴からの除去、CI secret-scan の導入）を述べる。値そのものは出力に再掲しない（マスクする）。
+
+### 制約
+
+- 検出は最大 5 件。実害の大きいもの（本物の鍵・credential）を優先する。
+- 各指摘に「種別」「混入箇所」「推奨対応」を必ず含める。
+- 機密の値そのものは出力へ再掲せず、種別と位置のみ示す。
+- 決定論で完全に検出できる範囲は「CI（gitleaks 等）での恒久ガードを推奨」と必ず併記する。
+
+## Evidence / 根拠の取り方
+
+- 混入箇所は必ず `<file>:<line>` に紐づけ、推測で「秘密だ」と断定しない。
+- プレースホルダか実値かの判定根拠（接頭辞・鍵長・形式）を具体的に示す。
+
+## Output / 出力フォーマット
+
+すべて日本語。
+
+```text
+(secret-scan):1: [要約] 最も重大な機密混入は〈1文〉
+
+<file>:<line>: [機密混入1] <タイトル>
+  種別: <API キー / トークン / 秘密鍵 / credential / 個人パス / .env 実値>
+  混入: <どこに何が追加されたか（値はマスク）>(<file>:<line>)
+  影響: <漏洩リスク / 権限奪取 / 環境依存の壊れ>
+  Fix: <環境変数・Secrets への移動／履歴からの除去／CI secret-scan(gitleaks 等) の導入>
+```
+
+## 評価指標（Evaluation）
+
+- 合格基準: 実在しうる機密のみを `<file>:<line>` で示し、プレースホルダ・例値・環境変数参照を誤検出していない。値を再掲していない。
+- 不合格基準: プレースホルダへの誤検出、既存行への指摘、値の再掲、機密と無関係な高エントロピー文字列（ハッシュ・UUID）への難癖。
+
+## 人間に返す条件（Human Handoff）
+
+- 検出値が実在の機密と擬似値のどちらなのか、コードからは断定できない場合。
+- 既にコミット済みの機密について、履歴除去・鍵ローテーションの要否が運用判断を要する場合。

--- a/skills/midstream/rr-midstream-secret-credential-scan-001/SKILL.md
+++ b/skills/midstream/rr-midstream-secret-credential-scan-001/SKILL.md
@@ -36,7 +36,7 @@ Why: 機密情報の検出はパターン的・決定論で判定できる領域
 
 このスキルは以下の条件がすべて満たされない限り `NO_REVIEW` を返す。
 
-- [ ] 差分の**追加行**に、機密情報の候補（高エントロピー文字列・`API_KEY`/`SECRET`/`TOKEN`/`PASSWORD` 等のキー・`-----BEGIN ... PRIVATE KEY-----`・`/Users/` や `/home/` で始まる個人パス・実値入りの `.env` 行など）が含まれている
+- [ ] 差分の**追加行**に、機密情報の候補（高エントロピー文字列・`API_KEY`/`SECRET`/`TOKEN` 等のキー・`-----BEGIN ... PRIVATE KEY-----`・`/Users/` や `/home/`、`C:\Users\` で始まる個人パス・`.env` 実値行）が含まれている
 - [ ] inputContext に diff が含まれ、`code_search`（grep）が利用可能である
 
 ゲート不成立時の出力: `NO_REVIEW: rr-midstream-secret-credential-scan-001 — 機密情報の候補が差分に検出されない`
@@ -56,7 +56,7 @@ Why: 機密情報の検出はパターン的・決定論で判定できる領域
 1. **候補抽出**: 差分の追加行から次の機密候補を抽出する。
    - 鍵名（`API_KEY`/`SECRET`/`TOKEN`/`PASSWORD`/`CREDENTIAL`）への実値代入
    - 既知接頭辞（`sk-`/`ghp_`/`AKIA`/`AIza` 等）や `-----BEGIN ... PRIVATE KEY-----`
-   - 高エントロピー文字列、個人パス（`/Users/<name>/`、`/home/<name>/`）、実値入り `.env` 行
+   - 高エントロピー文字列、個人パス（`/Users/<name>/`、`/home/<name>/`、`C:\Users\<name>\`）、実値入り `.env` 行
 2. **実値判定**: プレースホルダ・例値・環境変数参照を `code_search` で確認して除外し、実在しうる値のみ残す。
 3. **報告**: 該当箇所を `<file>:<line>` で示し、機密の種別と推奨対応（環境変数 / Secrets への移動、コミット履歴からの除去、CI secret-scan の導入）を述べる。値そのものは出力に再掲しない（マスクする）。
 

--- a/skills/registry.yaml
+++ b/skills/registry.yaml
@@ -103,6 +103,28 @@ skills:
     recommended: true
     description: 'Detects common security vulnerabilities'
 
+  - id: rr-midstream-secret-credential-scan-001
+    version: '0.1.0'
+    name: 'Secret / Credential Scan 機密情報の混入検出'
+    path: skills/midstream/rr-midstream-secret-credential-scan-001/SKILL.md
+    category: midstream
+    phase: midstream
+    tags: [secret, credential, midstream]
+    severity: major
+    recommended: true
+    description: 'Detects API keys, tokens, credentials, private keys, .env values, and personal local paths newly added in a diff — language- and filetype-agnostic, complementing CI secret scanners'
+
+  - id: rr-midstream-doc-hygiene-001
+    version: '0.1.0'
+    name: 'Documentation Hygiene ドキュメント衛生'
+    path: skills/midstream/rr-midstream-doc-hygiene-001/SKILL.md
+    category: midstream
+    phase: midstream
+    tags: [documentation, hygiene, maintainability, midstream]
+    severity: major
+    recommended: true
+    description: 'Detects transient task logs leaking into durable docs (AGENTS.md), SOP/decision/log/learned role confusion, and internal memos / local paths / AI-conversation fragments left in published docs'
+
   - id: rr-midstream-logging-observability-001
     version: '0.1.0'
     name: 'Logging & Observability'

--- a/tests/fixtures/execution-plan-midstream.json
+++ b/tests/fixtures/execution-plan-midstream.json
@@ -78,6 +78,13 @@
       "dependencies": []
     },
     {
+      "id": "rr-midstream-secret-credential-scan-001",
+      "phase": "midstream",
+      "modelHint": "balanced",
+      "outputKind": ["findings", "actions"],
+      "dependencies": ["code_search"]
+    },
+    {
       "id": "rr-midstream-ubiquitous-language-naming-001",
       "phase": "midstream",
       "modelHint": "balanced",


### PR DESCRIPTION
## Summary

#1216（AIエージェント開発の反パターン、Zenn記事由来）の dedup 調査で**真の空白と判定した2観点**を新規 skill 化。他観点（Verification/Scope/Decision）は既存 skill（`security-basic`/`config-json`/`pr-description`/`plangate-exec-conformance`/`adr-decision-quality`）で部分カバー済みのため見送り（issue にコメント記録済み）。

### 追加 skill
- **`rr-midstream-secret-credential-scan-001`**: API キー/トークン/credential/秘密鍵/`.env` 値/個人ローカルパスの diff 混入を**言語・ファイル種別非依存**で検出。ファイル限定の `security-basic`(.ts/.js)/`config-json`(.json/.yml) を補完し、決定論的範囲は CI(gitleaks) へ移譲。`applyTo: '**/*'`（安全網）。
- **`rr-midstream-doc-hygiene-001`**: 恒久ドキュメント（AGENTS.md）への一過性ログ混入、SOP/decision/log/learned 役割混同、公開物への内部メモ・ローカルパス・AI会話断片残存を検出。`applyTo` は md のみ。

両 skill は確立済みテンプレ + #1209/#1214 の教訓（狭い Gate / grep 確認必須・推測断定禁止の FP guards / Non-goals 境界 / evidence-bound / max-5 / Human Handoff）に準拠。

### planner-dataset の注記
secret-scan は意図的に汎用 `security` タグを持たせていない。`security` impact tag で `security-basic` と同点になり、id アルファベット順（`secret` < `security`）だけで top-1 を奪って domain reviewer を押しのけるため。タグを `[secret, credential, midstream]` に限定し top1Match を 1.000 に回復。選択（applyTo 駆動）は不変、ランキングのみ調整。

## Test plan
- [x] `npx textlint --no-cache`（両 SKILL.md）— clean
- [x] `npm run skills:validate` — OK
- [x] `npm run skills:manifest:check` — up to date (116 skills)
- [x] planner-dataset: coverage 1.0 / top1Match 1.000（30 cases）
- [x] `npm test` — 1514 pass / 0 fail（midstream snapshot 含む）

## 関連
- 対応 issue: #1216（dedup 結果はコメント記録済み）
- 同型先行: #1209（#169 観点取り込み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)