### PR TITLE
feat(skills): design-source-conformance & component-variants-states perspectives (#1217)

### DIFF
--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "description": "Deterministic skill manifest for drift detection by selective adopters. Compare the checksum of your copied skill against this list to notice upstream changes. Regenerate with: npm run skills:manifest",
-  "skillCount": 116,
+  "skillCount": 118,
   "skills": [
     {
       "id": "adversarial-review",
@@ -148,6 +148,12 @@
       "files": 1
     },
     {
+      "id": "rr-midstream-component-variants-states-001",
+      "path": "skills/midstream/rr-midstream-component-variants-states-001",
+      "checksum": "sha256:b43d7957ea843144eabaffeeca7918bd163bbca26587fbc7dcab76b71981f09e",
+      "files": 1
+    },
+    {
       "id": "rr-midstream-config-json-001",
       "path": "skills/midstream/rr-midstream-config-json-001",
       "checksum": "sha256:06c1948e390ea445d7e78b547f141fd862cbce0b07dd1fa73a7d3bd39be62a4f",
@@ -157,6 +163,12 @@
       "id": "rr-midstream-cross-file-leakage-001",
       "path": "skills/midstream/rr-midstream-cross-file-leakage-001",
       "checksum": "sha256:70834301dc5d9f24247c2a24aca9f9cbdb687a61235d4dc259962bbb7235884b",
+      "files": 1
+    },
+    {
+      "id": "rr-midstream-design-source-conformance-001",
+      "path": "skills/midstream/rr-midstream-design-source-conformance-001",
+      "checksum": "sha256:ce8f0009b4a49a524e81b39dc9b5bfff35250f50322b3eac77343959ca046ef9",
       "files": 1
     },
     {

--- a/skills/midstream/rr-midstream-component-variants-states-001/SKILL.md
+++ b/skills/midstream/rr-midstream-component-variants-states-001/SKILL.md
@@ -1,0 +1,98 @@
+---
+id: rr-midstream-component-variants-states-001
+name: 'Component Variants / States Documentation コンポーネント状態の文書化'
+description: '新規追加された UI コンポーネントに、variants（種類）とインタラクティブ状態（hover / focus / disabled / loading / error）が定義・文書化されているかを確認し、状態設計の欠落を検出する'
+version: 0.1.0
+category: midstream
+phase: midstream
+applyTo:
+  - 'src/**/*.{tsx,jsx}'
+  - 'app/**/*.{tsx,jsx}'
+  - 'components/**/*.{tsx,jsx}'
+tags: [design-system, component, variants, states, midstream]
+severity: minor
+inputContext: [diff]
+outputKind: [findings, questions]
+modelHint: balanced
+dependencies: [code_search]
+---
+
+## Pattern declaration
+
+Primary pattern: Reviewer
+Secondary patterns: Inversion
+Why: 新規コンポーネントの状態網羅はチェックリスト的に確認できるが、対象が「新規 UI コンポーネントの追加」かどうかの判定が必要。新規コンポーネント追加を含まない変更では実行を止めるゲートが必要。
+
+## Goal / 目的
+
+- **新規追加された** UI コンポーネントに、variants（種類・バリエーション）と**インタラクティブ状態**（hover / focus / disabled / loading / error）が定義・文書化されているかを確認する。
+- 「コンポーネントは追加したが、disabled / loading / error の状態設計が欠落し、後から後付けで破綻する」パターンを検出する。
+
+## Non-goals / 扱わないこと
+
+- 既存コンポーネントの再利用可否（`rr-midstream-design-system-component-reuse-001` の領域）。
+- 実行時の loading / error 状態の配線そのもの（mutation 中の loading は `rr-midstream-loading-state-001` の領域。本スキルはコンポーネント定義側の状態網羅を見る）。
+- focus-visible のアクセシビリティ実装（`rr-midstream-modern-web-a11y-interactive-001` の領域）。
+- デザイントークン準拠（design-source / token-enforcement の領域）。
+
+## Pre-execution Gate / 実行前ゲート
+
+このスキルは以下の条件がすべて満たされない限り `NO_REVIEW` を返す。
+
+- [ ] 差分に**新規 UI コンポーネント**（再利用可能な表示要素を export する `.tsx` / `.jsx` の追加）が含まれている
+- [ ] inputContext に diff が含まれ、`code_search`（grep）が利用可能である
+
+ゲート不成立時の出力: `NO_REVIEW: rr-midstream-component-variants-states-001 — 新規 UI コンポーネントの追加が検出されない`
+
+## False-positive guards / 抑制条件
+
+- 状態を持たない純粋な表示コンポーネント（静的なテキスト・アイコン表示など、インタラクションが無い）は指摘しない。
+- variants / states が**別ファイル**（Storybook の `*.stories.*`、型定義、ドキュメント）に定義されている場合は、`code_search` で確認してから指摘する。差分内に見えないだけで断定しない。
+- 既存コンポーネントの軽微な変更（新規追加でないもの）は対象外とする。
+- プロトタイプ・内部限定など、状態網羅が不要と差分内で明記されている場合は抑制する。
+
+## Rule / ルール
+
+### 検出ロジック
+
+1. **新規コンポーネントの特定**: 差分から、新規に追加された再利用可能な UI コンポーネント（export される表示要素）を特定する。
+2. **状態・variants の確認**: そのコンポーネントが受け付けるべき状態を判定し、定義・文書化を確認する。
+   - インタラクティブ要素での disabled / loading / error 状態の扱い
+   - variants（サイズ・種類・トーンなど）の定義
+   - `code_search` で `*.stories.*` や型定義など別ファイルの記載も確認する
+3. **報告**: 欠落している状態・variants を `<file>:<line>` で示し、定義の追加を提案する。
+
+### 制約
+
+- 検出は最大 5 件。実害の大きい状態欠落（disabled / error の欠落）を優先する。
+- 各指摘に「対象コンポーネント」「欠落している状態 / variants」「あるべき定義」を必ず含める。
+- 別ファイルでの定義有無を確認してから報告する（差分内に無いだけで断定しない）。
+
+## Evidence / 根拠の取り方
+
+- 対象コンポーネントと欠落箇所は `<file>:<line>` に紐づけ、推測で状態欠落を述べない。
+- 別ファイル（stories / 型定義）を `code_search` で確認した結果を根拠として示す。
+
+## Output / 出力フォーマット
+
+すべて日本語。
+
+```text
+(component-variants-states):1: [要約] 最も重大な状態設計の欠落は〈1文〉
+
+<file>:<line>: [状態欠落1] <タイトル>
+  対象: <新規コンポーネント名>(<file>:<line>)
+  欠落: <disabled / loading / error / variants のどれか>
+  影響: <後付け対応での破綻 / UX の不整合>
+  Fix: <欠落状態 / variants の定義・文書化（stories や型での明示）>
+```
+
+## 評価指標（Evaluation）
+
+- 合格基準: 新規 UI コンポーネントを `<file>:<line>` で示し、欠落状態を別ファイル確認の上で具体的に説明している。
+- 不合格基準: 既存コンポーネントへの指摘、状態を持たない表示要素への難癖、別ファイル定義の未確認による誤検出、loading 配線・a11y・トークンへの越境。
+
+## 人間に返す条件（Human Handoff）
+
+- どの状態・variants を必須とするかが、プロダクトのデザインシステム方針に依存する場合。
+- 状態網羅の要否が、コンポーネントの用途（内部限定かどうか）の判断を要する場合。

--- a/skills/midstream/rr-midstream-design-source-conformance-001/SKILL.md
+++ b/skills/midstream/rr-midstream-design-source-conformance-001/SKILL.md
@@ -1,0 +1,95 @@
+---
+id: rr-midstream-design-source-conformance-001
+name: 'Design Source-of-Truth Conformance デザイン定義準拠'
+description: 'リポジトリに DESIGN.md やデザイントークン定義が存在する場合に、新規 UI 実装の色・余白・フォントサイズ・角丸・シャドウがその定義済みスケールに準拠しているかを照合する。定義が無ければ実行しない'
+version: 0.1.0
+category: midstream
+phase: midstream
+applyTo:
+  - 'src/**/*.{ts,tsx,js,jsx,css,scss}'
+  - 'app/**/*.{ts,tsx,js,jsx,css,scss}'
+  - 'components/**/*.{ts,tsx,js,jsx,css,scss}'
+tags: [design-system, design-source, conformance, midstream]
+severity: minor
+inputContext: [diff]
+outputKind: [findings, questions]
+modelHint: balanced
+dependencies: [code_search]
+---
+
+## Pattern declaration
+
+Primary pattern: Reviewer
+Secondary patterns: Inversion
+Why: 定義済みスケールとの照合は決定論で判定できる部分が大きいが、まず参照すべきデザイン定義（DESIGN.md / トークン）の所在を grep で特定する必要がある。定義が無ければ実行を止めるゲートが必要。
+
+## Goal / 目的
+
+- リポジトリに**デザイン定義のソース**（`DESIGN.md` / `design-tokens.*` / `tailwind.config.*` の theme / CSS custom properties など）が存在する場合に、新規 UI 実装の値が**その定義済みスケールに準拠**しているかを照合する。
+- 「トークンは存在するのに、定義外のスケール（例: spacing が 4/8/12 と定義されているのに `10px`）を新規導入した」逸脱を検出する。
+
+## Non-goals / 扱わないこと
+
+- デザイン定義が**存在しない**リポジトリでの生値ハードコード検出（`rr-midstream-design-token-enforcement-001` の領域。本スキルは定義との照合に限定する）。
+- 既存コンポーネントの再利用可否（`rr-midstream-design-system-component-reuse-001` の領域）。
+- アクセシビリティやインタラクティブ状態（a11y / loading-state 系の領域）。
+
+## Pre-execution Gate / 実行前ゲート
+
+このスキルは以下の条件がすべて満たされない限り `NO_REVIEW` を返す。
+
+- [ ] リポジトリにデザイン定義のソース（`DESIGN.md` / デザイントークン定義 / `tailwind.config.*` の theme など）が `code_search` で実在確認できる
+- [ ] 差分に UI 実装の値（色・余白・フォントサイズ・角丸・シャドウ）の追加・変更が含まれている
+- [ ] inputContext に diff が含まれ、`code_search`（grep）が利用可能である
+
+ゲート不成立時の出力: `NO_REVIEW: rr-midstream-design-source-conformance-001 — 参照すべきデザイン定義または UI 値の変更が検出されない`
+
+## False-positive guards / 抑制条件
+
+- デザイン定義が grep で見つからない場合は指摘しない（生値検出は token-enforcement に委ねる）。
+- 定義済みスケールに含まれる値は指摘しない（準拠している実装は対象外）。
+- 定義からの逸脱が**差分内で根拠とともに明記**されている場合は抑制する（意図的な例外）。
+- スケール外でも、定義が明示的に任意値を許容している領域は対象外とする。
+
+## Rule / ルール
+
+### 検出ロジック
+
+1. **定義の特定**: `code_search` でデザイン定義のソースを特定し、色・余白・フォントサイズ・角丸・シャドウの**定義済みスケール**を読み取る。
+2. **値の照合**: 差分の新規 UI 値が、定義済みスケールに含まれるか照合する。含まれない値（off-scale）を逸脱候補とする。
+3. **報告**: 逸脱値と参照した定義箇所を両方 `<file>:<line>` で示し、最も近い定義済みスケール値への置き換えを提案する。
+
+### 制約
+
+- 検出は最大 5 件。スケール逸脱の影響が大きいもの（広く使われる色・余白）を優先する。
+- 各指摘に「逸脱値」「参照した定義」「準拠候補」を必ず含める。
+- 定義の読み取りは grep で再現可能にする（検索語を明示する）。
+
+## Evidence / 根拠の取り方
+
+- 逸脱値と参照定義は両方 `<file>:<line>` に紐づけ、推測でスケールを述べない。
+- 「定義ではこのスケール / 新実装はこの値」を対比し、off-scale を具体的に示す。
+
+## Output / 出力フォーマット
+
+すべて日本語。
+
+```text
+(design-source-conformance):1: [要約] 最も重大なスケール逸脱は〈1文〉
+
+<file>:<line>: [スケール逸脱1] <タイトル>
+  定義: <参照したスケール>(検索語: `<grep pattern>`, <file>:<line>)
+  新実装: <off-scale な値>(<file>:<line>)
+  影響: <デザイン不整合 / トークン体系の形骸化>
+  Fix: <最も近い定義済みスケール値への置き換え、または逸脱の根拠を明文化>
+```
+
+## 評価指標（Evaluation）
+
+- 合格基準: デザイン定義が grep 再現可能な検索語 + `<file>:<line>` で示され、off-scale の逸脱が具体的に説明されている。
+- 不合格基準: デザイン定義が無いリポジトリへの指摘、定義済みスケール内の値への難癖、生値検出への越境、根拠ある意図的逸脱への指摘。
+
+## 人間に返す条件（Human Handoff）
+
+- デザイン定義が複数あり、どれを正典とするかの合意が必要な場合。
+- スケール拡張（新しい値を定義へ追加する）の是非が設計判断を要する場合。

--- a/skills/registry.yaml
+++ b/skills/registry.yaml
@@ -421,6 +421,28 @@ skills:
     recommended: true
     description: '既存デザインシステムコンポーネント（Button / Input / Modal / Card 等）を再実装していないかを検出する。'
 
+  - id: rr-midstream-design-source-conformance-001
+    version: '0.1.0'
+    name: 'Design Source-of-Truth Conformance デザイン定義準拠'
+    path: skills/midstream/rr-midstream-design-source-conformance-001/SKILL.md
+    category: midstream
+    phase: midstream
+    tags: [design-system, design-source, conformance, midstream]
+    severity: minor
+    recommended: true
+    description: 'リポジトリに DESIGN.md やデザイントークン定義が存在する場合に、新規 UI 実装の色・余白・フォントサイズ・角丸・シャドウがその定義済みスケールに準拠しているかを照合する。定義が無ければ実行しない'
+
+  - id: rr-midstream-component-variants-states-001
+    version: '0.1.0'
+    name: 'Component Variants / States Documentation コンポーネント状態の文書化'
+    path: skills/midstream/rr-midstream-component-variants-states-001/SKILL.md
+    category: midstream
+    phase: midstream
+    tags: [design-system, component, variants, states, midstream]
+    severity: minor
+    recommended: true
+    description: '新規追加された UI コンポーネントに、variants（種類）とインタラクティブ状態（hover / focus / disabled / loading / error）が定義・文書化されているかを確認し、状態設計の欠落を検出する'
+
   - id: rr-midstream-tailwind-class-hygiene-001
     version: '0.1.0'
     name: 'Tailwind CSS Class Hygiene Review'

--- a/tests/fixtures/execution-plan-midstream.json
+++ b/tests/fixtures/execution-plan-midstream.json
@@ -15,6 +15,13 @@
       "dependencies": ["code_search"]
     },
     {
+      "id": "rr-midstream-design-source-conformance-001",
+      "phase": "midstream",
+      "modelHint": "balanced",
+      "outputKind": ["findings", "questions"],
+      "dependencies": ["code_search"]
+    },
+    {
       "id": "rr-midstream-design-system-component-reuse-001",
       "phase": "midstream",
       "modelHint": "balanced",


### PR DESCRIPTION
## Summary

#1217（UI デザインシステム準拠）の dedup 調査で**真の空白と判定した2観点**を新規 skill 化。raw hex / spacing / radius / component reuse / focus-visible / loading-error / a11y は既存 skill でカバー済み（issue にコメント記録済み）。レスポンシブ破壊検出・動的 severity 分類は静的 diff での実効性が低いため見送り。

### 追加 skill
- **`rr-midstream-design-source-conformance-001`**: `DESIGN.md` / デザイントークン定義 / tailwind theme が**存在する場合に**、新規 UI 値が定義済みスケールに準拠しているか照合（off-scale 検出）。定義が無ければ `NO_REVIEW` — これが `design-token-enforcement`（定義なしで生値検出）との差別化点。applyTo は src/app/components（.ts/.tsx）。
- **`rr-midstream-component-variants-states-001`**: 新規 UI コンポーネントに variants + 状態（disabled/loading/error）が定義・文書化されているか確認。`component-reuse` は Non-goals で除外、`loading-state` は実行時 mutation 配線のみ担当。applyTo は .tsx/.jsx のみ。

両 skill の Non-goals で token-enforcement / component-reuse / loading-state / a11y との境界を明示。

## Test plan
- [x] `npx textlint --no-cache`（両 SKILL.md）— clean
- [x] `npm run skills:validate` — OK
- [x] `npm run skills:manifest:check` — up to date (118 skills)
- [x] planner-dataset: coverage 1.0 / top1Match 1.000（design-scoped タグで domain reviewer と非競合）
- [x] `npm test` — 1514 pass / 0 fail（snapshot: design-source は src/app.ts に発火、variants-states は jsx/tsx 限定で非発火）

## 関連
- 対応 issue: #1217（dedup 結果はコメント記録済み）
- 同型先行: #1209 / #1216

🤖 Generated with [Claude Code](https://claude.com/claude-code)