### PR TITLE
feat(skills): explicit Plan Alignment finding taxonomy in exec-conformance (#1223)

### DIFF
--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -606,8 +606,8 @@
     {
       "id": "rr-upstream-plangate-exec-conformance-001",
       "path": "skills/upstream/rr-upstream-plangate-exec-conformance-001",
-      "checksum": "sha256:b06c4f4be64056aa6d55f5019726ff72813b7d1d68a1e9c296207c4c69b474a3",
-      "files": 10
+      "checksum": "sha256:b21927eda900769a580921a64e234b6f35de5a9a6ac24cc5e5db4b994364ab90",
+      "files": 14
     },
     {
       "id": "rr-upstream-plangate-gc-deterministic-001",

--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -606,7 +606,7 @@
     {
       "id": "rr-upstream-plangate-exec-conformance-001",
       "path": "skills/upstream/rr-upstream-plangate-exec-conformance-001",
-      "checksum": "sha256:b21927eda900769a580921a64e234b6f35de5a9a6ac24cc5e5db4b994364ab90",
+      "checksum": "sha256:fb4f97492bc020f2532c90bf335018d1e1b3451303ca69bb7d67c8e58018630d",
       "files": 14
     },
     {

--- a/skills/upstream/rr-upstream-plangate-exec-conformance-001/SKILL.md
+++ b/skills/upstream/rr-upstream-plangate-exec-conformance-001/SKILL.md
@@ -84,6 +84,26 @@ Why: plan/todo/test-cases を基準として差分を突き合わせる照合型
 5. 不確実性の扱い
    - plan / todo / test-cases の記述が曖昧で整合性判断が分かれる場合は、断定せず `[q]` として質問形式で返す。
 
+## Finding 分類（taxonomy）
+
+各指摘には、追跡しやすさのため次の **finding-id** を `[id=...]` として付与してよい（任意。出力形式は従来どおり `<file>:<line>: <message>` を維持する）。id は既存ルールに対応し、新しい artifact を要求しない。
+
+| finding-id                    | 意味                                                                      | 既定 severity     | 対応ルール |
+| ----------------------------- | ------------------------------------------------------------------------- | ----------------- | ---------- |
+| `planned-but-missing`         | 計画した task / 受入項目が実装されていない（todo `[x]` だが差分に無い等） | blocker           | Rule 2     |
+| `implemented-but-not-planned` | plan / todo に無い挙動が差分に追加されている                              | warning           | Rule 1 / 2 |
+| `target-file-violation`       | 変更ファイルが plan の影響範囲を正当化なく超えている                      | warning           | Rule 4     |
+| `out-of-scope-change`         | plan で明示的に除外された領域に変更が及んでいる                           | blocker           | Rule 2 / 4 |
+| `design-deviation`            | plan に記載された設計判断・境界に実装が矛盾している                       | warning / blocker | Rule 1     |
+| `test-contract-missing`       | test-cases 宣言分のテストが差分 / `junit` に無い                          | warning           | Rule 3     |
+| `unexpected-dependency-added` | plan の根拠なく新規依存が追加されている                                   | warning           | Rule 1     |
+| `unjustified-abstraction`     | plan の根拠なく新規の抽象 / モジュールが導入されている                    | nit / warning     | Rule 1     |
+
+補足:
+
+- `design-deviation` は **plan に書かれた設計判断との突合**に限定する。独立した `design.md` / ADR を入力にした厳密な設計逸脱検出は、artifact 契約への `design` 追加を要する将来拡張（本 skill の現スコープ外）。
+- finding-id は内部分類であり、付与は任意。severity マッピング（blocker/warning/nit）と出力形式は下記 Output に従う。
+
 ## Evidence / 根拠の取り方
 
 - 指摘は差分側の `<file>:<line>` と、根拠となる artifact 側の見出し・行・チェックリスト項目をペアで示す。
@@ -100,7 +120,7 @@ Why: plan/todo/test-cases を基準として差分を突き合わせる照合型
   - severity 省略: 参考情報や補足の質問。
 - サマリ行: `(summary):1: 方針整合 <件数> / todo 網羅 <件数> / テスト整合 <件数> / 質問 <件数>`
 - 個別 finding の推奨構造:
-  - Finding: 何がどの artifact とどう食い違うか（1 文）。
+  - Finding: 何がどの artifact とどう食い違うか（1 文）。任意で先頭に `[id=<finding-id>]`（上記 taxonomy のいずれか）を付けて分類を明示してよい。
   - Evidence: `diff: <file>:<line>` と `plan|todo|test-cases: <見出しまたは行>`。
   - Fix: 最小の是正案（実装追加 / plan 追記 / スコープ分割など）。
 - 質問は `(questions):1: [q] <確認したいこと>` のように疑似ファイル名付きで 1 件 1 行で出力する（パーサが `<file>:<line>: <message>` 形式のみ抽出するため、自由文の別セクションは無視される）。

--- a/skills/upstream/rr-upstream-plangate-exec-conformance-001/eval/promptfoo.yaml
+++ b/skills/upstream/rr-upstream-plangate-exec-conformance-001/eval/promptfoo.yaml
@@ -53,6 +53,40 @@ tests:
       - type: contains
         value: 'rr-upstream-plangate-exec-conformance-001'
 
+  # Test case 4: True positive — a todo item marked done is missing from the diff
+  - description: 'Detect planned-but-missing (completed todo not in diff)'
+    vars:
+      diff: file://../fixtures/04-true-positive-planned-but-missing.md
+    assert:
+      - type: contains-any
+        value:
+          - 'planned-but-missing'
+          - 'auth.ts'
+          - 'リセット'
+          - 'todo'
+      - type: contains-any
+        value:
+          - 'blocker'
+          - 'severity=blocker'
+          - 'critical'
+
+  # Test case 5: True positive — a declared test case has no corresponding test
+  - description: 'Detect test-contract-missing (declared TC2 not tested)'
+    vars:
+      diff: file://../fixtures/05-true-positive-test-contract-missing.md
+    assert:
+      - type: contains-any
+        value:
+          - 'test-contract-missing'
+          - 'TC2'
+          - 'テスト整合'
+          - '有効期限'
+      - type: contains-any
+        value:
+          - 'warning'
+          - 'severity=warning'
+          - 'major'
+
 outputPath: ./output.json
 
 defaultTest:

--- a/skills/upstream/rr-upstream-plangate-exec-conformance-001/fixtures/04-true-positive-planned-but-missing.md
+++ b/skills/upstream/rr-upstream-plangate-exec-conformance-001/fixtures/04-true-positive-planned-but-missing.md
@@ -56,7 +56,7 @@ index 0000000..3333333
 +
 +export function isLockedOut(user) {
 +  if (user.failedAttempts < MAX_ATTEMPTS) return false;
-+  if (!user.lockedUntil) return true;
++  if (!user.lockedUntil) return false;
 +  return Date.now() < new Date(user.lockedUntil).getTime();
 +}
 +

--- a/skills/upstream/rr-upstream-plangate-exec-conformance-001/fixtures/04-true-positive-planned-but-missing.md
+++ b/skills/upstream/rr-upstream-plangate-exec-conformance-001/fixtures/04-true-positive-planned-but-missing.md
@@ -1,0 +1,68 @@
+# Test Case: Planned But Missing (Should Trigger Finding)
+
+`todo.md` で `[x]` 完了済みとマークされた作業項目が `diff` に実装されていないケース。SKILL.md Rule 2「作業項目の網羅 (todo → diff)」違反で `critical` (blocker) 指摘、finding-id `planned-but-missing` が期待される。
+
+## Input Artifacts
+
+### plan.md
+
+```markdown
+# 計画: ログイン失敗時のロックアウト
+
+## 方針
+
+- 連続ログイン失敗が 5 回に達したアカウントを 15 分ロックする。
+- 失敗カウントとロック解除時刻はユーザーレコードに保存する。
+
+## 影響範囲
+
+- `src/services/auth.ts`
+- `src/services/lockout.ts` (新規)
+```
+
+### todo.md
+
+```markdown
+# TODO
+
+- [x] `src/services/lockout.ts` にロックアウト判定を実装
+- [x] `src/services/auth.ts` にロック解除時刻のリセット処理を追加
+- [ ] 単体テスト追加
+```
+
+### test-cases.md
+
+```markdown
+# Test Cases
+
+| ID  | シナリオ           | 期待結果           |
+| --- | ------------------ | ------------------ |
+| TC1 | 5 回連続失敗       | 15 分ロックされる  |
+| TC2 | ロック中の成功試行 | 拒否される         |
+| TC3 | ロック解除後の成功 | カウントがリセット |
+```
+
+### diff
+
+```diff
+diff --git a/src/services/lockout.ts b/src/services/lockout.ts
+new file mode 100644
+index 0000000..3333333
+--- /dev/null
++++ b/src/services/lockout.ts
+@@ -0,0 +1,12 @@
++export const MAX_ATTEMPTS = 5;
++export const LOCK_MINUTES = 15;
++
++export function isLockedOut(user) {
++  if (user.failedAttempts < MAX_ATTEMPTS) return false;
++  if (!user.lockedUntil) return true;
++  return Date.now() < new Date(user.lockedUntil).getTime();
++}
++
++export function registerFailure(user) {
++  user.failedAttempts = (user.failedAttempts ?? 0) + 1;
++}
+```
+
+`src/services/auth.ts` への「ロック解除時刻のリセット処理」(`- [x]` 完了済みマーク) に対応する差分が存在しない。

--- a/skills/upstream/rr-upstream-plangate-exec-conformance-001/fixtures/05-true-positive-test-contract-missing.md
+++ b/skills/upstream/rr-upstream-plangate-exec-conformance-001/fixtures/05-true-positive-test-contract-missing.md
@@ -1,0 +1,71 @@
+# Test Case: Test Contract Missing (Should Trigger Finding)
+
+`test-cases.md` で宣言されたケースに対応するテストが `diff` に存在しないケース。SKILL.md Rule 3「テスト整合 (test-cases → diff / junit)」違反で `major` (warning) 指摘、finding-id `test-contract-missing` が期待される。
+
+## Input Artifacts
+
+### plan.md
+
+```markdown
+# 計画: 割引コード適用
+
+## 方針
+
+- チェックアウト時に割引コードを適用する。
+- 有効期限切れコードは拒否する。
+
+## 影響範囲
+
+- `src/services/discount.ts` (新規)
+- `src/services/discount.test.ts` (新規)
+```
+
+### todo.md
+
+```markdown
+# TODO
+
+- [x] `src/services/discount.ts` 実装
+- [x] 単体テスト追加
+```
+
+### test-cases.md
+
+```markdown
+# Test Cases
+
+| ID  | シナリオ               | 期待結果         |
+| --- | ---------------------- | ---------------- |
+| TC1 | 有効なコード適用       | 価格が割引される |
+| TC2 | 有効期限切れコード適用 | 拒否される       |
+```
+
+### diff
+
+```diff
+diff --git a/src/services/discount.ts b/src/services/discount.ts
+new file mode 100644
+index 0000000..4444444
+--- /dev/null
++++ b/src/services/discount.ts
+@@ -0,0 +1,9 @@
++export function applyDiscount(price, code, now = new Date()) {
++  if (code.expiresAt && now > new Date(code.expiresAt)) {
++    throw new Error('discount code expired');
++  }
++  return price * (1 - code.rate);
++}
+diff --git a/src/services/discount.test.ts b/src/services/discount.test.ts
+new file mode 100644
+index 0000000..5555555
+--- /dev/null
++++ b/src/services/discount.test.ts
+@@ -0,0 +1,7 @@
++import { applyDiscount } from './discount';
++
++test('TC1: 有効なコードで価格が割引される', () => {
++  expect(applyDiscount(1000, { rate: 0.1 })).toBe(900);
++});
+```
+
+`test-cases.md` の TC2「有効期限切れコード適用 → 拒否される」に対応するテストが `discount.test.ts` に存在しない（TC1 のみ）。

--- a/skills/upstream/rr-upstream-plangate-exec-conformance-001/golden/04-true-positive-planned-but-missing.md
+++ b/skills/upstream/rr-upstream-plangate-exec-conformance-001/golden/04-true-positive-planned-but-missing.md
@@ -1,0 +1,9 @@
+# Expected Output: Planned But Missing
+
+## Summary
+
+(summary):1: 方針整合 0 / todo 網羅 1 / テスト整合 0 / 質問 0
+
+## Findings
+
+- `src/services/auth.ts:1`: [severity=blocker] [id=planned-but-missing] `todo.md` で `- [x]` 完了済みとマークされた「`src/services/auth.ts` にロック解除時刻のリセット処理を追加」に対応する差分が存在しない。完了宣言と実装の齟齬。Evidence — diff: `src/services/lockout.ts` のみ（auth.ts への変更なし）、todo: `- [x] src/services/auth.ts にロック解除時刻のリセット処理を追加`。Fix: auth.ts にリセット処理を実装するか、未完了なら `todo` のチェックを外す。

--- a/skills/upstream/rr-upstream-plangate-exec-conformance-001/golden/05-true-positive-test-contract-missing.md
+++ b/skills/upstream/rr-upstream-plangate-exec-conformance-001/golden/05-true-positive-test-contract-missing.md
@@ -1,0 +1,9 @@
+# Expected Output: Test Contract Missing
+
+## Summary
+
+(summary):1: 方針整合 0 / todo 網羅 0 / テスト整合 1 / 質問 0
+
+## Findings
+
+- `src/services/discount.test.ts:1`: [severity=warning] [id=test-contract-missing] `test-cases.md` の TC2「有効期限切れコード適用 → 拒否される」に対応するテストが差分に存在しない（`discount.test.ts` は TC1 のみ）。`applyDiscount` は期限切れで throw する実装だが、その挙動を検証するテストが欠落している。Evidence — diff: `src/services/discount.test.ts:3-5`（TC1 のみ）、test-cases: `| TC2 | 有効期限切れコード適用 | 拒否される |`。Fix: 期限切れコードで `applyDiscount` が throw することを検証する TC2 のテストを追加する。

--- a/skills/upstream/rr-upstream-plangate-exec-conformance-001/prompt/system.md
+++ b/skills/upstream/rr-upstream-plangate-exec-conformance-001/prompt/system.md
@@ -36,4 +36,5 @@ Do NOT flag:
 - severity 内部語彙: `[severity=blocker|warning|nit]` をメッセージの先頭に使用（スキーマ側 critical|major|minor|info は review-core ルールが変換）
 - サマリ行: `(summary):1: 方針整合 <件数> / todo 網羅 <件数> / テスト整合 <件数> / 質問 <件数>`
 - 各 finding は `Evidence — diff: <file>:<line>, <artifact>: <見出し/行/項目>` および `Fix: <最小の是正案>` を含める
+- 任意で finding-id を `[id=...]` として付与してよい（分類の明示。出力形式は変えない）: `planned-but-missing`(blocker) / `implemented-but-not-planned`(warning) / `target-file-violation`(warning) / `out-of-scope-change`(blocker) / `design-deviation`(warning〜blocker, plan の設計判断との突合に限定) / `test-contract-missing`(warning) / `unexpected-dependency-added`(warning) / `unjustified-abstraction`(nit〜warning)
 - 質問は `(questions):1: [q] ...` 形式


### PR DESCRIPTION
## Summary

#1223（Superpowers 由来）の **Plan Alignment Review** を、schema 変更なしのスライスとして着地。dedup 調査で exec-conformance が 8 finding 中 6 を既にカバー済みと判明したため、**語彙の明示化 + 不足 fixture の追加**に絞った。

### 変更
- **SKILL.md**: `Finding 分類（taxonomy）` 表を追加し、8 finding-id（planned-but-missing / implemented-but-not-planned / target-file-violation / out-of-scope-change / design-deviation / test-contract-missing / unexpected-dependency-added / unjustified-abstraction）を既存ルール + 内部 severity に対応づけ。`design-deviation` は **plan の設計判断との突合に限定**（厳密な design.md/ADR 検出は `design` artifact が必要＝後述の deferred）。finding-id は `[id=...]` で任意付与、出力形式は不変。
- **prompt/system.md**: 任意 finding-id リストをミラー。
- **fixtures/golden 04**（planned-but-missing）+ **05**（test-contract-missing）+ promptfoo エントリ（既存同様の `contains-any` 緩い assertion）。

### 影響範囲
- frontmatter / tags / applyTo / inputContext **不変** → planner-dataset top1Match 1.000 維持、選択ロジック不変。
- golden は既存の `[severity=...]` + 自由文形式を踏襲（finding-id は追加情報）。skill-eval は必須チェックでないため eval への影響もブロックしない。

## Test plan
- [x] `npm run skills:validate` — OK
- [x] `npm run skills:manifest:check` — up to date (118 skills、file count 更新)
- [x] planner-dataset: coverage 1.0 / top1Match 1.000
- [x] `npm test` — 1514 pass / 0 fail
- [x] prettier / markdownlint — clean

## スコープ外（deferred）
**TDD Evidence Review**（#1223 のもう一つの真の空白）は、新規 `tdd-ledger` artifact を `src/config/artifact-resolver.mjs` + `schema.mjs` に追加し dist 再ビルドを伴う **schema-alignment 変更（CLAUDE.md「Always ask」）** のため、別途承認の上でフォローアップ。`design-deviation` の厳密化（`design` artifact 追加）も同様。

## 関連
- 対応 issue: #1223（設計記録は closed PR #1224 + #1223 コメント）
- 既存スキル: `rr-upstream-plangate-exec-conformance-001` を拡張（dedup 結果に基づく）

🤖 Generated with [Claude Code](https://claude.com/claude-code)