### PR TITLE
docs(skills): clarify tdd-ledger producer + blocker escalation (review follow-up)

### DIFF
--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -630,7 +630,7 @@
     {
       "id": "rr-upstream-plangate-tdd-evidence-001",
       "path": "skills/upstream/rr-upstream-plangate-tdd-evidence-001",
-      "checksum": "sha256:0501932691d0508b0a2fd97dcd7acb9167604a59f3cf24635473c9ad64f87b6f",
+      "checksum": "sha256:98ba9ba691a47e7ddde626d3e6b94ea9cd3490b8c4f250b00116b501b0bfd3c1",
       "files": 1
     },
     {

--- a/skills/upstream/rr-upstream-plangate-tdd-evidence-001/SKILL.md
+++ b/skills/upstream/rr-upstream-plangate-tdd-evidence-001/SKILL.md
@@ -101,6 +101,8 @@ Why: `tdd-ledger` のフェーズ別証跡を基準として妥当性を突き�
 | `tdd-evidence-not-linked-to-test-case`    | 証跡を計画した test case に対応づけられない            | warning       |
 | `test-does-not-cover-acceptance-criteria` | テストはあるが約束した受入挙動を検証しない             | warning       |
 
+各 finding の既定 severity は warning だが、**TDD が必須要件として宣言された変更で `tdd_red` と `tdd_green` の両証跡が完全に欠落する場合は blocker にエスカレーションする**（下記 Output の severity ガイド参照）。
+
 ## Evidence / 根拠の取り方
 
 - 指摘は `tdd-ledger` の該当 `phases[]` エントリ（`phase` / `exitCode` / `command`）と、対応する `test-cases` のケース ID をペアで示す。
@@ -140,3 +142,9 @@ Why: `tdd-ledger` のフェーズ別証跡を基準として妥当性を突き�
 - 姉妹 skill: `rr-upstream-plangate-exec-conformance-001`（plan/todo/test-cases と差分の整合）
 - 姉妹 skill: `rr-upstream-plangate-verification-audit-001`（既存レビュー文書の W チェック）
 - 出典: Issue #1223（Superpowers 由来の TDD Evidence Review）
+
+### `tdd-ledger` の生成元（producer）について
+
+`tdd-ledger` artifact は River Review が**読み取る** consumer 入力であり、River Review 自身は生成しない（`findings-pool` と同じ consumer-first パターン）。生成は PlanGate などの上流ワークフロー（例: PlanGate の `evidence-ledger`）が exec 中に担う想定である。
+
+したがって **PlanGate 等の producer を併用しない River Review 単体の adopter では、`tdd-ledger` が供給されないため本スキルは常に `NO_REVIEW` を返す**（Pre-execution Gate 不成立）。これは設計上の意図であり欠陥ではない。producer を実装・接続する際は、書き出す `tdd-ledger.json` の形式を本スキルの Gate（`phases[]` ≥ 1）および `pages/reference/artifact-input-contract.md` の `tdd-ledger` 節と必ず突き合わせること。


### PR DESCRIPTION
## Summary

`dda2ed0..9c62e5d` の多視点レビュー（セルフ + 技術 + 一貫性 + 敵対的 + River Review dogfood）で確定した**軽微な doc 改善2点**。全観点が blocker/major 0・1514 pass で「マージ済み品質として妥当」と判定した上での後続。

- **tdd-evidence の producer 明記**（敵対的 P2 / dogfood Minor）: `tdd-ledger` は River Review が生成しない consumer-first artifact（PlanGate の `evidence-ledger` が生成）。単体 adopter では常時 `NO_REVIEW` になる旨を「関連ドキュメント」に明記し、発火条件の再現方法を示した。
- **taxonomy 脚注**（一貫性 Minor / dogfood Info）: 既定 warning だが TDD 必須宣言下の RED+GREEN 同時欠落は blocker にエスカレーションする旨を表に補足（Output ガイドと整合、exec-conformance の併記様式に合わせる）。

## 関連レビューの follow-up 分担
- 本 PR: 上記 doc 2点（schema-safe）。
- 別 issue 化（P0/P1/P2、本 PR 範囲外）: 新規5 skill の fixtures/canary、secret-scan の glob 絞り（schema `exclude` 対応が前提）、SkillDispatcher の Gate/inputContext 非強制の文書化、planner-dataset への新規 skill ケース追加。

## Test plan
- [x] `npm run skills:validate` / `skills:manifest:check`（119）— OK
- [x] markdownlint / prettier — clean
- [x] `npm test` — 1514 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)