### PR TITLE
test(planner): planner-dataset selection cases for 3 new midstream skills (#1233)

### DIFF
--- a/tests/fixtures/planner-dataset/cases.json
+++ b/tests/fixtures/planner-dataset/cases.json
@@ -369,5 +369,29 @@
     "availableDependencies": ["test_runner", "code_search"],
     "expectedAny": ["rr-downstream-test-plan-review-001"],
     "expectedTop1": ["rr-downstream-flaky-test-001", "rr-downstream-test-plan-review-001"]
+  },
+  {
+    "name": "coverage: midstream doc hygiene (AGENTS.md task log) — #1233",
+    "phase": "midstream",
+    "diffFile": "diffs/midstream-doc-hygiene-agents-log.diff",
+    "availableContexts": ["diff"],
+    "availableDependencies": ["code_search"],
+    "expectedAny": ["rr-midstream-doc-hygiene-001"]
+  },
+  {
+    "name": "coverage: midstream design-source conformance (hardcoded scale) — #1233",
+    "phase": "midstream",
+    "diffFile": "diffs/midstream-design-source-hardcoded-scale.diff",
+    "availableContexts": ["diff"],
+    "availableDependencies": ["code_search"],
+    "expectedAny": ["rr-midstream-design-source-conformance-001"]
+  },
+  {
+    "name": "coverage: midstream new UI component variants/states — #1233",
+    "phase": "midstream",
+    "diffFile": "diffs/midstream-new-ui-component.diff",
+    "availableContexts": ["diff"],
+    "availableDependencies": ["code_search"],
+    "expectedAny": ["rr-midstream-component-variants-states-001"]
   }
 ]

--- a/tests/fixtures/planner-dataset/diffs/midstream-design-source-hardcoded-scale.diff
+++ b/tests/fixtures/planner-dataset/diffs/midstream-design-source-hardcoded-scale.diff
@@ -2,7 +2,7 @@ diff --git a/src/components/PriceCard.tsx b/src/components/PriceCard.tsx
 index 1111111..2222222 100644
 --- a/src/components/PriceCard.tsx
 +++ b/src/components/PriceCard.tsx
-@@ -1,9 +1,11 @@
+@@ -1,10 +1,10 @@
  import React from 'react';
 
  export function PriceCard({ label, price }: { label: string; price: string }) {

--- a/tests/fixtures/planner-dataset/diffs/midstream-design-source-hardcoded-scale.diff
+++ b/tests/fixtures/planner-dataset/diffs/midstream-design-source-hardcoded-scale.diff
@@ -1,0 +1,16 @@
+diff --git a/src/components/PriceCard.tsx b/src/components/PriceCard.tsx
+index 1111111..2222222 100644
+--- a/src/components/PriceCard.tsx
++++ b/src/components/PriceCard.tsx
+@@ -1,9 +1,11 @@
+ import React from 'react';
+
+ export function PriceCard({ label, price }: { label: string; price: string }) {
+   return (
+-    <div className="card">
++    <div style={{ padding: '10px', borderRadius: '7px', color: '#3b82f6' }}>
+       <span>{label}</span>
+       <strong>{price}</strong>
+     </div>
+   );
+ }

--- a/tests/fixtures/planner-dataset/diffs/midstream-doc-hygiene-agents-log.diff
+++ b/tests/fixtures/planner-dataset/diffs/midstream-doc-hygiene-agents-log.diff
@@ -2,7 +2,7 @@ diff --git a/AGENTS.md b/AGENTS.md
 index 1111111..2222222 100644
 --- a/AGENTS.md
 +++ b/AGENTS.md
-@@ -10,6 +10,12 @@ This file documents conventions for AI agents working in this repository.
+@@ -10,5 +10,11 @@ This file documents conventions for AI agents working in this repository.
 
  ## Conventions
 

--- a/tests/fixtures/planner-dataset/diffs/midstream-doc-hygiene-agents-log.diff
+++ b/tests/fixtures/planner-dataset/diffs/midstream-doc-hygiene-agents-log.diff
@@ -1,0 +1,15 @@
+diff --git a/AGENTS.md b/AGENTS.md
+index 1111111..2222222 100644
+--- a/AGENTS.md
++++ b/AGENTS.md
+@@ -10,6 +10,12 @@ This file documents conventions for AI agents working in this repository.
+
+ ## Conventions
+
+ Follow the existing code style and run the test suite before committing.
++
++## 2026-06-21 TASK-1234 作業ログ
++
++- branch を切って実装した。
++- npm test を走らせた（全部 pass）。
++- 次は PR を出す。レビュー待ち。

--- a/tests/fixtures/planner-dataset/diffs/midstream-new-ui-component.diff
+++ b/tests/fixtures/planner-dataset/diffs/midstream-new-ui-component.diff
@@ -1,0 +1,18 @@
+diff --git a/src/components/Badge.tsx b/src/components/Badge.tsx
+new file mode 100644
+index 0000000..3333333
+--- /dev/null
++++ b/src/components/Badge.tsx
+@@ -0,0 +1,12 @@
++import React from 'react';
++
++type BadgeProps = {
++  label: string;
++  tone?: 'info' | 'success' | 'danger';
++};
++
++export function Badge({ label, tone = 'info' }: BadgeProps) {
++  return <span className={`badge badge-${tone}`}>{label}</span>;
++}
++
++export default Badge;


### PR DESCRIPTION
## Summary

#1233（P2、レビュー follow-up）。本セッション追加の新規 skill のうち **applyTo スコープが非自明な3 skill**に planner-dataset の選択検証ケースを追加。将来 applyTo/inputContext の regression でこれらが選択から外れる事故を**決定論的（LLM 非依存）に検出**する。

| ケース | diff | 検証 |
|---|---|---|
| doc-hygiene | `AGENTS.md` 作業ログ追記 | `.md` スコープで選択（code/design skill は不選択） |
| design-source-conformance | component の色/余白/角丸ハードコード | components で選択 |
| component-variants-states | 新規 `.tsx` コンポーネント | tsx/jsx で選択 |

- **expectedAny のみ**（expectedTop1 なし）: これらは他 skill と共存する専門 skill のため、選択（coverage）を検証しランキングは問わない → top1Match 1.000 維持、coverage 1.0、cases 40→43。
- **secret-scan / tdd-evidence は意図的に対象外**: 前者は `**/*`、後者は upstream + 実行時 tdd-ledger gate で**常時選択**＝選択ケースが trivial。これらの実効検証は runtime gate / FP eval（#1231）で行う。

## Test plan
- [x] planner-dataset eval: cases 43 / coverage 1.0 / top1Match 1.000
- [x] `npm test` — 1514 pass / 0 fail
- [x] prettier — clean

test-only、挙動変更なし。

## 関連
- 対応 issue: #1233（`dda2ed0..9c62e5d` レビュー follow-up）

🤖 Generated with [Claude Code](https://claude.com/claude-code)