### PR TITLE
feat(tooling): document skill exec paths + forward-gate recommended-skill eval coverage (#1231/#1232)

### DIFF
--- a/docs/development/skill-execution-paths.md
+++ b/docs/development/skill-execution-paths.md
@@ -1,0 +1,53 @@
+# Skill 実行経路と Gate 非強制の差（#1232）
+
+River Review には skill を実行する経路が 2 つあります。両者は skill メタデータのフィルタ範囲と diff の渡し方が異なります。skill 作者はこの差を理解したうえで Gate を設計する必要があります。
+
+## 2 つの実行経路
+
+### 1. deterministic plan 経路
+
+`river review plan` および GitHub Action 経路で使われます。`runners/core/review-runner.mjs` の `selectSkills` / `evaluateSkill` が skill メタデータを機械的にフィルタします。
+
+判定対象は次のとおりです。
+
+- `applyTo`—変更ファイルが glob にマッチするか（`matchesApplyTo`）
+- `phase`—対象フェーズと一致するか（`matchesPhase`）
+- `inputContext`—必要なコンテキストが `availableContexts` に揃っているか（`missingInputContexts`）
+- `dependencies`—必要な依存が `availableDependencies` に揃っているか（`missingDependencies`）
+
+`inputContext` か `dependencies` が欠けた skill は `evaluateSkill` で `skipped` に振り分けられ、実行されません。Gate の一部はコードで決定論的に強制されます。
+
+### 2. midstream dispatcher 経路
+
+`src/core/skill-dispatcher.mjs` の `SkillDispatcher.run()` が使う経路です。フィルタは次の 3 つに限られます。
+
+- `files`（= `applyTo`）—変更ファイルが glob にマッチするか
+- `phase`—対象フェーズと一致するか
+- `exclude`—除外パターンにマッチするか
+
+この経路は `inputContext` / `dependencies` / SKILL.md の Pre-execution Gate を**コードで強制しません**。これらは `buildSystemPrompt` が組み立てる LLM プロンプト本文で*指示*されるのみです。さらに diff を**ファイル単位**で渡します（`getFileDiff(file)` を `reviewFiles` ごとにループ）。
+
+## 帰結と skill 作者への要請
+
+dispatcher 経路では、各 skill の Gate と False-positive guard の判定が LLM 任せになります。リポジトリ全体を要する判定を断片だけで行わせるため、False-positive のリスクが生じます。
+
+たとえば次のような判定はファイル単位の diff だけでは正しく下せません。
+
+- DESIGN.md など別ファイルの有無に依存する Gate
+- 別ファイルに置かれた stories やテストの存在確認
+- 複数ファイルにまたがる整合性チェック
+
+dispatcher 経路では `inputContext` を宣言しても実行はブロックされず、diff も 1 ファイルずつしか渡りません。したがって skill 作者は、Gate を「skill メタデータがコードで止めてくれる前提」で書いてはいけません。Gate と抑制条件を **LLM への明確な指示** として SKILL.md 本文に書き、断片情報での誤検知を抑える文面にする必要があります。
+
+## 参照箇所
+
+行番号は変動するため、パスと関数名で示します。
+
+| 経路                 | パス                             | 関数                                                                                                                          |
+| -------------------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| deterministic plan   | `runners/core/review-runner.mjs` | `selectSkills` / `evaluateSkill`（内部で `matchesApplyTo` / `matchesPhase` / `missingInputContexts` / `missingDependencies`） |
+| midstream dispatcher | `src/core/skill-dispatcher.mjs`  | `SkillDispatcher.run()`（`files` / `phase` / `exclude` のフィルタと `getFileDiff` のファイル単位ループ）                      |
+
+## 出典
+
+- #1232（skill 実行経路の Gate 非強制を文書化）

--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -3,6 +3,7 @@ import path from 'path';
 import fs from 'fs/promises';
 import { realpathSync } from 'fs';
 import { pathToFileURL } from 'url';
+import yaml from 'js-yaml';
 import {
   defaultPaths,
   createSkillValidator,
@@ -12,6 +13,47 @@ import {
   loadPacks,
   loadRecommendationSets,
 } from '../runners/core/skill-loader.mjs';
+
+// #1231: 既存の eval 未整備 recommended skill。新規追加分はこの集合に足さず
+// eval を用意すること（recommended skill は eval/ または fixtures/ を持つこと
+// を validateRecommendedEvalCoverage() で前向きに強制する）。
+const GRANDFATHERED_WITHOUT_EVAL = new Set([
+  'rr-midstream-secret-credential-scan-001',
+  'rr-midstream-doc-hygiene-001',
+  'rr-midstream-review-automation-boundary-001',
+  'rr-midstream-design-source-conformance-001',
+  'rr-midstream-component-variants-states-001',
+  'rr-downstream-test-existence-001',
+  'rr-downstream-coverage-gap-001',
+  'rr-upstream-pre-mortem-001',
+  'rr-midstream-war-game-001',
+  'rr-midstream-logic-torturing-001',
+  'rr-midstream-self-contradiction-001',
+  'rr-midstream-refactor-claim-audit-001',
+  'rr-midstream-cross-file-leakage-001',
+  'rr-midstream-e2e-wiring-001',
+  'rr-midstream-existing-pattern-conformance-001',
+  'rr-upstream-migration-safety-001',
+  'rr-upstream-adr-decision-quality-001',
+  'rr-upstream-api-design-001',
+  'rr-upstream-api-versioning-compat-001',
+  'rr-upstream-architecture-boundaries-001',
+  'rr-upstream-architecture-risk-register-001',
+  'rr-upstream-architecture-traceability-001',
+  'rr-upstream-availability-architecture-001',
+  'rr-upstream-capacity-cost-design-001',
+  'rr-upstream-data-flow-state-ownership-001',
+  'rr-upstream-data-model-db-design-001',
+  'rr-upstream-event-driven-semantics-001',
+  'rr-upstream-external-dependencies-001',
+  'rr-upstream-failure-modes-observability-001',
+  'rr-upstream-integration-contracts-001',
+  'rr-upstream-migration-rollout-rollback-001',
+  'rr-upstream-openapi-contract-001',
+  'rr-upstream-operability-slo-001',
+  'rr-upstream-requirements-acceptance-001',
+  'rr-upstream-trust-boundaries-authz-001',
+]);
 
 function hasSection(text, patterns) {
   return patterns.some((re) => re.test(text));
@@ -204,12 +246,81 @@ export async function validatePacks({
   return success;
 }
 
+/**
+ * Forward-gate: every `recommended: true` skill in skills/registry.yaml must
+ * carry quality evidence — an `eval/` or `fixtures/` directory alongside its
+ * SKILL.md (#1231). Skills already shipped without such assets are exempted via
+ * {@link GRANDFATHERED_WITHOUT_EVAL}; new recommended skills must supply assets
+ * rather than be added to that set.
+ *
+ * @param {{ skillsDir?: string, repoRoot?: string }} [options]
+ * @returns {Promise<boolean>} false (→ exitCode 1) if any non-grandfathered
+ *   recommended skill lacks eval/ and fixtures/.
+ */
+export async function validateRecommendedEvalCoverage({
+  skillsDir = defaultPaths.skillsDir,
+  repoRoot = defaultPaths.repoRoot,
+} = {}) {
+  const registryPath = path.join(skillsDir, 'registry.yaml');
+  let raw;
+  try {
+    raw = await fs.readFile(registryPath, 'utf8');
+  } catch (err) {
+    console.error(`❌ Failed to read skill registry at ${registryPath}: ${err.message}`);
+    return false;
+  }
+  let parsed;
+  try {
+    parsed = yaml.load(raw) ?? {};
+  } catch (err) {
+    console.error(`❌ Failed to parse skill registry at ${registryPath}: ${err.message}`);
+    return false;
+  }
+
+  const skills = Array.isArray(parsed?.skills) ? parsed.skills : [];
+  const recommended = skills.filter((s) => s && s.recommended === true);
+  let success = true;
+  let okCount = 0;
+
+  for (const skill of recommended) {
+    const { id, path: skillPath } = skill;
+    if (!id || typeof skillPath !== 'string') continue;
+
+    const skillDir = path.dirname(path.resolve(repoRoot, skillPath));
+    const entries = await fs.readdir(skillDir).catch(() => []);
+    const hasAssets = entries.some((e) => e === 'eval' || e === 'fixtures');
+    if (hasAssets) {
+      okCount += 1;
+      continue;
+    }
+    if (GRANDFATHERED_WITHOUT_EVAL.has(id)) {
+      okCount += 1;
+      continue;
+    }
+    console.error(
+      `❌ recommended skill "${id}" has no eval/ or fixtures/ directory; ` +
+        'add quality evidence (see #1231) or, only for already-shipped skills, ' +
+        'GRANDFATHERED_WITHOUT_EVAL in scripts/validate-skills.mjs'
+    );
+    success = false;
+  }
+
+  if (success) {
+    console.log(
+      `✅ recommended eval coverage: ${okCount}/${recommended.length} recommended skill(s) ` +
+        `satisfied (incl. ${GRANDFATHERED_WITHOUT_EVAL.size} grandfathered)`
+    );
+  }
+  return success;
+}
+
 const isDirectRun =
   process.argv[1] && import.meta.url === pathToFileURL(realpathSync(process.argv[1])).href;
 if (isDirectRun) {
   const skillsOk = await validateSkills();
   const packsOk = await validatePacks();
-  const ok = skillsOk && packsOk;
+  const evalCoverageOk = await validateRecommendedEvalCoverage();
+  const ok = skillsOk && packsOk && evalCoverageOk;
   if (!ok) {
     process.exitCode = 1;
   }

--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -281,10 +281,19 @@ export async function validateRecommendedEvalCoverage({
   const recommended = skills.filter((s) => s && s.recommended === true);
   let success = true;
   let okCount = 0;
+  let grandfatheredCount = 0;
 
   for (const skill of recommended) {
     const { id, path: skillPath } = skill;
-    if (!id || typeof skillPath !== 'string') continue;
+    // Malformed entry (missing id or non-string path) must not silently bypass the
+    // gate — treat it as a failure so typos in registry.yaml are caught.
+    if (!id || typeof skillPath !== 'string') {
+      console.error(
+        `❌ recommended skill entry is malformed (missing id or non-string path): ${JSON.stringify(skill)}`
+      );
+      success = false;
+      continue;
+    }
 
     const skillDir = path.dirname(path.resolve(repoRoot, skillPath));
     const entries = await fs.readdir(skillDir).catch(() => []);
@@ -295,6 +304,7 @@ export async function validateRecommendedEvalCoverage({
     }
     if (GRANDFATHERED_WITHOUT_EVAL.has(id)) {
       okCount += 1;
+      grandfatheredCount += 1;
       continue;
     }
     console.error(
@@ -308,7 +318,7 @@ export async function validateRecommendedEvalCoverage({
   if (success) {
     console.log(
       `✅ recommended eval coverage: ${okCount}/${recommended.length} recommended skill(s) ` +
-        `satisfied (incl. ${GRANDFATHERED_WITHOUT_EVAL.size} grandfathered)`
+        `satisfied (incl. ${grandfatheredCount} grandfathered)`
     );
   }
   return success;


### PR DESCRIPTION
## 概要

ツール系 follow-up 2 件（#1231 / #1232）を実装します。

### TA-01: skill 実行経路の Gate 非強制を文書化（#1232）
- 新規 `docs/development/skill-execution-paths.md`（日本語）。
- River Review の 2 つの skill 実行経路を明記:
  1. **deterministic plan 経路**（`runners/core/review-runner.mjs` の `selectSkills` / `evaluateSkill`）— `applyTo` / `inputContext` / `dependencies` を機械フィルタ。
  2. **midstream dispatcher 経路**（`src/core/skill-dispatcher.mjs` の `SkillDispatcher.run()`）— `files`(=applyTo) / `phase` / `exclude` のみフィルタし、`inputContext` / `dependencies` / Pre-execution Gate はコードで強制せず LLM プロンプト本文での指示のみ。さらに diff をファイル単位で渡す。
- 帰結（断片だけで全体判定させる FP リスク）と skill 作者への要請（Gate を LLM への明確な指示として書く）を記載。

### TA-04: validate-skills に前向き gate を追加（#1231）
- `scripts/validate-skills.mjs` に `validateRecommendedEvalCoverage()` を追加。
- `recommended: true` の skill は `eval/` か `fixtures/` ディレクトリを持つことを要求。
- 既存 35 本は `GRANDFATHERED_WITHOUT_EVAL`（Set）で grandfather。新規追加分はこの集合に足さず eval を用意する旨をコメントで明記。
- 直接実行ブロックで `validateSkills()` / `validatePacks()` と並んで呼び、結果を `&&` 集約（fail 時 exitCode 1）。

## 検証

- `npm run skills:validate` — pass（`recommended eval coverage: 53/53`、内 35 件 grandfather + 18 件 eval/fixtures 保有）。
- gate 動作確認: grandfather list から 1 ID（`rr-upstream-openapi-contract-001`）を一時的に外すと `console.error` + exitCode 1 を返すこと、戻すと exitCode 0 に復帰することを手で確認（確認後 list は元に戻し済）。
- `npx markdownlint` / `npx prettier --check` / `npx textlint --no-cache` — いずれも clean。
- `npm test` — 1514 件全 pass（fail 0）。

## 関連
- #1231
- #1232

🤖 Generated with [Claude Code](https://claude.com/claude-code)