### PR TITLE
feat(skills): secret-scan exclude globs + promptfoo eval seed (#1231/#1232)

### DIFF
--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -354,8 +354,8 @@
     {
       "id": "rr-midstream-secret-credential-scan-001",
       "path": "skills/midstream/rr-midstream-secret-credential-scan-001",
-      "checksum": "sha256:62369d6b8f9564f26edc1418cefed634bf46d82bd06dcfabdb1e5358529ed0d2",
-      "files": 1
+      "checksum": "sha256:18c1ea3f5abc7cdc912c465ac5988dbda9d6c7f69ae2b9c6fe10d2a78867b8a1",
+      "files": 10
     },
     {
       "id": "rr-midstream-security-basic-001",

--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -354,7 +354,7 @@
     {
       "id": "rr-midstream-secret-credential-scan-001",
       "path": "skills/midstream/rr-midstream-secret-credential-scan-001",
-      "checksum": "sha256:18c1ea3f5abc7cdc912c465ac5988dbda9d6c7f69ae2b9c6fe10d2a78867b8a1",
+      "checksum": "sha256:4cc164c52037b458f97f3eb0ef1f3df2496b1a7c5108dd087ec4132b04ef967c",
       "files": 10
     },
     {

--- a/schemas/skill.schema.json
+++ b/schemas/skill.schema.json
@@ -129,6 +129,11 @@
       "items": { "type": "string" },
       "minItems": 1
     },
+    "exclude": {
+      "type": "array",
+      "description": "Glob patterns for files to exclude from this skill even when applyTo matches (honored by the midstream skill-dispatcher; snapshot/planner selection ignores it)",
+      "items": { "type": "string" }
+    },
     "tags": {
       "type": "array",
       "description": "Optional metadata for classification",

--- a/skills/midstream/rr-midstream-secret-credential-scan-001/SKILL.md
+++ b/skills/midstream/rr-midstream-secret-credential-scan-001/SKILL.md
@@ -13,6 +13,15 @@ inputContext: [diff]
 outputKind: [findings, actions]
 modelHint: balanced
 dependencies: [code_search]
+exclude:
+  - '**/package-lock.json'
+  - '**/pnpm-lock.yaml'
+  - '**/yarn.lock'
+  - '**/*.lock'
+  - 'dist/**'
+  - '**/*.min.*'
+  - '**/*.map'
+  - '**/*.snap'
 ---
 
 ## Pattern declaration

--- a/skills/midstream/rr-midstream-secret-credential-scan-001/eval/promptfoo.yaml
+++ b/skills/midstream/rr-midstream-secret-credential-scan-001/eval/promptfoo.yaml
@@ -34,19 +34,21 @@ tests:
           - 'warning'
           - 'gitleaks'
 
-  # Test case 2: False positive — lockfile integrity (sha512 SRI) is not a secret
+  # Test case 2: False positive — lockfile integrity (sha512 SRI) is not a secret.
+  # A correct (healthy) run returns NO_ISSUES and must NOT emit a detection marker.
+  # Asserting NO_ISSUES + absence of the finding markers makes this test actually fail
+  # when the model falsely flags the integrity line (a contains-any on 'integrity' would
+  # have passed even on a false positive, so it is intentionally not used here).
   - description: 'No false positive on lockfile integrity / SRI digest'
     vars:
       diff: file://../fixtures/02-false-positive-lockfile-integrity.md
     assert:
-      - type: contains-any
-        value:
-          - 'NO_ISSUES'
-          - 'integrity'
-          - 'SRI'
-          - 'ダイジェスト'
-          - 'exclude'
-          - '秘密ではない'
+      - type: contains
+        value: 'NO_ISSUES'
+      - type: not-contains
+        value: '[severity='
+      - type: not-contains
+        value: '[機密混入'
 
   # Test case 3: No secret candidate — should return NO_REVIEW
   - description: 'Return NO_REVIEW when no secret candidate exists'

--- a/skills/midstream/rr-midstream-secret-credential-scan-001/eval/promptfoo.yaml
+++ b/skills/midstream/rr-midstream-secret-credential-scan-001/eval/promptfoo.yaml
@@ -1,0 +1,65 @@
+# promptfoo evaluation configuration
+# See https://www.promptfoo.dev/docs/configuration/guide
+
+description: 'Evaluation for Secret / Credential Scan'
+
+providers:
+  - id: openai:gpt-4o-mini
+    config:
+      temperature: 0.1
+
+prompts:
+  - file://../prompt/system.md
+  - file://../prompt/user.md
+
+tests:
+  # Test case 1: True positive — hardcoded API key / credential added in diff
+  - description: 'Detect hardcoded secret (Stripe key / GitHub token / .env value)'
+    vars:
+      diff: file://../fixtures/01-true-positive-hardcoded-key.md
+    assert:
+      - type: contains-any
+        value:
+          - 'sk-live'
+          - 'STRIPE_SECRET_KEY'
+          - 'ghp_'
+          - 'API キー'
+          - '機密'
+          - '環境変数'
+          - 'Secrets'
+      - type: contains-any
+        value:
+          - 'major'
+          - 'severity=major'
+          - 'warning'
+          - 'gitleaks'
+
+  # Test case 2: False positive — lockfile integrity (sha512 SRI) is not a secret
+  - description: 'No false positive on lockfile integrity / SRI digest'
+    vars:
+      diff: file://../fixtures/02-false-positive-lockfile-integrity.md
+    assert:
+      - type: contains-any
+        value:
+          - 'NO_ISSUES'
+          - 'integrity'
+          - 'SRI'
+          - 'ダイジェスト'
+          - 'exclude'
+          - '秘密ではない'
+
+  # Test case 3: No secret candidate — should return NO_REVIEW
+  - description: 'Return NO_REVIEW when no secret candidate exists'
+    vars:
+      diff: file://../fixtures/03-no-review-no-secret.md
+    assert:
+      - type: contains
+        value: 'NO_REVIEW'
+      - type: contains
+        value: 'rr-midstream-secret-credential-scan-001'
+
+outputPath: ./output.json
+
+defaultTest:
+  options:
+    provider: openai:gpt-4o-mini

--- a/skills/midstream/rr-midstream-secret-credential-scan-001/fixtures/01-true-positive-hardcoded-key.md
+++ b/skills/midstream/rr-midstream-secret-credential-scan-001/fixtures/01-true-positive-hardcoded-key.md
@@ -1,0 +1,45 @@
+# Test Case: Hardcoded API Key / Credential (Should Trigger Finding)
+
+実値の API キー・credential が `diff` の追加行に混入したケース。SKILL.md Rule「候補抽出 → 実値判定 → 報告」に従い `major` 相当の機密混入指摘が期待される。値は出力で再掲せずマスクされる。
+
+## Input Artifacts
+
+### diff
+
+```diff
+diff --git a/src/services/payment.ts b/src/services/payment.ts
+index 1111111..2222222 100644
+--- a/src/services/payment.ts
++++ b/src/services/payment.ts
+@@ -1,6 +1,11 @@
+ import Stripe from 'stripe';
+
+-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY ?? '');
++// TODO: move to env later
++const STRIPE_SECRET_KEY = 'sk-live-9fJ2kQ8wZ3xT7bN1pR4sV6yU0aC5dE2gH';
++const stripe = new Stripe(STRIPE_SECRET_KEY);
++
++const GITHUB_TOKEN = 'ghp_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8';
++const AWS_ACCESS_KEY_ID = 'AKIAIOSFODNN7EXAMPLE2';
+
+ export async function charge(amount: number) {
+   return stripe.charges.create({ amount, currency: 'jpy' });
+diff --git a/config/runtime.env b/config/runtime.env
+new file mode 100644
+index 0000000..3333333
+--- /dev/null
++++ b/config/runtime.env
+@@ -0,0 +1,2 @@
++DATABASE_URL=postgres://app:S3cr3tP4ssw0rd@db.internal:5432/prod
++OPENAI_API_KEY=sk-proj-7Hq3Lp9Rt2Wx5Zb8Nm1Kc4Vd6Fg0Js
+```
+
+## Expected Behavior
+
+The skill should detect (value masked in output):
+
+1. `src/services/payment.ts` に `STRIPE_SECRET_KEY` のハードコード値（接頭辞 `sk-live-`、本物の鍵長）→ API キー混入
+2. 同ファイルの `GITHUB_TOKEN`（接頭辞 `ghp_`）→ トークン混入、`AWS_ACCESS_KEY_ID`（接頭辞 `AKIA`）→ credential 混入
+3. `config/runtime.env` の `DATABASE_URL` に実パスワード、`OPENAI_API_KEY`（接頭辞 `sk-proj-`）→ .env 実値混入
+
+各指摘は環境変数 / Secrets への移動、コミット履歴からの除去、CI secret-scan(gitleaks 等) の導入を推奨する。`AKIA...EXAMPLE` は形式的には接頭辞一致だが、実害判定は他の本物鍵を優先して 5 件以内に収める。

--- a/skills/midstream/rr-midstream-secret-credential-scan-001/fixtures/02-false-positive-lockfile-integrity.md
+++ b/skills/midstream/rr-midstream-secret-credential-scan-001/fixtures/02-false-positive-lockfile-integrity.md
@@ -1,0 +1,42 @@
+# Test Case: Lockfile Integrity Hash (Should NOT Trigger Finding)
+
+`package-lock.json` の `integrity: sha512-...` 行は高エントロピー文字列だが、SRI（Subresource Integrity）ダイジェストであり秘密ではない。SKILL.md False-positive guards「ハッシュ・UUID への難癖をしない」に該当し、誤検出してはならない。
+
+加えて、この種のファイルは secret-scan の frontmatter `exclude` グロブ（`**/package-lock.json`, `**/*.lock` 等）により midstream skill-dispatcher の実行経路では本来 per-file 呼び出し対象から除外される。したがって本来このスキルは当該ファイルに発火しないが、万一発火しても `NO_ISSUES` を返すべき、という二重の安全性を示す。
+
+## Input Artifacts
+
+### diff
+
+```diff
+diff --git a/package-lock.json b/package-lock.json
+index 4444444..5555555 100644
+--- a/package-lock.json
++++ b/package-lock.json
+@@ -120,6 +120,14 @@
+     "node_modules/minimatch": {
+       "version": "9.0.5",
+       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whJ8fJVk3J8Pw5MnXHM02Zf6KZh3rEeUUbHaUWmOg==",
++      "integrity": "sha512-OqeFlT4N7DdyCT9oFR1Fl4q6pV4M3k2eF8YzpSv6cF3VqB1cqYQ3jN5pZr2sT8wK0uX1vY4mC7nB9aD3eW6fU==",
+       "dependencies": {
+         "brace-expansion": "^2.0.1"
+       }
+     },
+@@ -200,6 +208,9 @@
++    "node_modules/yaml": {
++      "version": "2.6.0",
++      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
++      "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
++    },
+```
+
+## Expected Behavior
+
+The skill should NOT flag any line:
+
+- `integrity: sha512-...` は npm の SRI ダイジェスト。高エントロピーだが秘密ではない（公開レジストリの内容ハッシュ）→ False-positive guards 該当
+- `resolved` の URL は公開 registry URL → 秘密ではない
+- そもそも `package-lock.json` は secret-scan の `exclude` グロブにより midstream 実行経路では除外対象
+
+期待出力: `NO_ISSUES`（または exclude により未発火）。

--- a/skills/midstream/rr-midstream-secret-credential-scan-001/fixtures/03-no-review-no-secret.md
+++ b/skills/midstream/rr-midstream-secret-credential-scan-001/fixtures/03-no-review-no-secret.md
@@ -1,0 +1,44 @@
+# Test Case: No Secret Candidate (Should Return NO_REVIEW)
+
+差分の追加行に機密候補（高エントロピー文字列・秘密鍵名・接頭辞・個人パス・.env 実値）が一切含まれないケース。SKILL.md の Pre-execution Gate「追加行に機密情報の候補が含まれている」を満たさず、`NO_REVIEW` を返すべき。
+
+## Input Artifacts
+
+### diff
+
+```diff
+diff --git a/src/utils/format.ts b/src/utils/format.ts
+index 6666666..7777777 100644
+--- a/src/utils/format.ts
++++ b/src/utils/format.ts
+@@ -1,5 +1,9 @@
+ export function toTitleCase(input: string): string {
+   return input
+     .toLowerCase()
+     .split(' ')
+     .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+     .join(' ');
+ }
++
++export function truncate(input: string, max = 80): string {
++  return input.length > max ? input.slice(0, max) + '…' : input;
++}
+diff --git a/.env.example b/.env.example
+index 8888888..9999999 100644
+--- a/.env.example
++++ b/.env.example
+@@ -1,2 +1,3 @@
+ DATABASE_URL=postgres://user:your-password@localhost:5432/dev
+ API_KEY=your-api-key-here
++SENTRY_DSN=https://<public-key>@o0.ingest.sentry.io/<project-id>
+```
+
+## Expected Behavior
+
+`diff` の追加行は純粋なロジック追加（`truncate`）と `.env.example` のプレースホルダ行（`<public-key>` / `<project-id>` / `your-...`）のみ。実値の機密は無く、Pre-execution Gate が不成立。
+
+期待出力:
+
+```text
+NO_REVIEW: rr-midstream-secret-credential-scan-001 — 機密情報の候補が差分に検出されない
+```

--- a/skills/midstream/rr-midstream-secret-credential-scan-001/golden/01-true-positive-hardcoded-key.md
+++ b/skills/midstream/rr-midstream-secret-credential-scan-001/golden/01-true-positive-hardcoded-key.md
@@ -1,0 +1,25 @@
+# Expected Output: Hardcoded API Key / Credential
+
+## Summary
+
+(secret-scan):1: [要約] 最も重大な機密混入は `src/services/payment.ts` への Stripe ライブ秘密鍵のハードコード（即時ローテーションと履歴除去が必要）。
+
+## Findings
+
+- `src/services/payment.ts:5`: [severity=major] [機密混入1] Stripe ライブ秘密鍵のハードコード
+  - 種別: API キー
+  - 混入: `STRIPE_SECRET_KEY = 'sk-live-****'`（接頭辞 `sk-live-`・本物の鍵長）が追加(`src/services/payment.ts:5`)
+  - 影響: 決済 API の全権限奪取・不正課金のリスク
+  - Fix: `process.env.STRIPE_SECRET_KEY` 参照に戻し値を Secrets へ移動、コミット履歴から除去して鍵をローテーション、CI に secret-scan(gitleaks 等) を導入
+
+- `src/services/payment.ts:7`: [severity=major] [機密混入2] GitHub Personal Access Token / AWS アクセスキー
+  - 種別: トークン / credential
+  - 混入: `GITHUB_TOKEN = 'ghp_****'`（接頭辞 `ghp_`）および `AWS_ACCESS_KEY_ID = 'AKIA****'`（接頭辞 `AKIA`）が追加(`src/services/payment.ts:7-8`)
+  - 影響: リポジトリ / クラウドリソースへの権限奪取
+  - Fix: 環境変数・Secrets へ移動、トークン/キーを失効・再発行、履歴から除去、CI に secret-scan(gitleaks 等) を導入
+
+- `config/runtime.env:2`: [severity=major] [機密混入3] .env 実値（DB パスワード・OpenAI API キー）
+  - 種別: .env 実値 / credential
+  - 混入: `DATABASE_URL=postgres://app:****@db.internal:5432/prod` と `OPENAI_API_KEY=sk-proj-****`（接頭辞 `sk-proj-`）が新規 `config/runtime.env` に追加(`config/runtime.env:1-2`)
+  - 影響: 本番 DB 認証情報・LLM API キーの漏洩
+  - Fix: `config/runtime.env` をコミット対象から外し（`.gitignore` 追加）Secrets へ移動、DB パスワードと API キーをローテーション、CI に secret-scan(gitleaks 等) を導入

--- a/skills/midstream/rr-midstream-secret-credential-scan-001/golden/02-false-positive-lockfile-integrity.md
+++ b/skills/midstream/rr-midstream-secret-credential-scan-001/golden/02-false-positive-lockfile-integrity.md
@@ -1,0 +1,17 @@
+# Expected Output: Lockfile Integrity Hash
+
+## Summary
+
+機密候補に見える高エントロピー文字列はすべて SRI ダイジェスト（lockfile integrity）であり秘密ではないため、このスキルは指摘しない。
+
+## Findings
+
+NO_ISSUES
+
+この差分は以下の理由で機密混入なしと判定される:
+
+- `integrity: sha512-...` は npm パッケージの内容ハッシュ（Subresource Integrity ダイジェスト）であり、公開情報。高エントロピーだが秘密ではない → False-positive guards「ハッシュ・UUID への難癖をしない」適用
+- `resolved` は公開 registry の URL であり秘密ではない
+- 追加行に API キー / トークン / 秘密鍵 / .env 実値 / 個人パスは存在しない
+
+補足: `package-lock.json` は secret-scan の frontmatter `exclude` グロブ（`**/package-lock.json`, `**/*.lock` 等）により midstream skill-dispatcher の per-file 実行経路では本来除外され、LLM 呼び出し自体が発生しない。

--- a/skills/midstream/rr-midstream-secret-credential-scan-001/golden/03-no-review-no-secret.md
+++ b/skills/midstream/rr-midstream-secret-credential-scan-001/golden/03-no-review-no-secret.md
@@ -1,0 +1,17 @@
+# Expected Output: No Secret Candidate
+
+## Summary
+
+Pre-execution Gate が不成立のため、このスキルはレビューを実行しない。
+
+## Findings
+
+```text
+NO_REVIEW: rr-midstream-secret-credential-scan-001 — 機密情報の候補が差分に検出されない
+```
+
+### Gate 不成立理由
+
+- 追加行は `truncate` 関数のロジック追加と `.env.example` のプレースホルダ（`<public-key>` / `<project-id>` / `your-...`）のみ。
+- 実在しうる機密（接頭辞 `sk-`/`ghp_`/`AKIA` 等・本物の鍵長・実値 .env・個人パス）が追加行に存在しない。
+- SKILL.md「Pre-execution Gate」の 1 項目目「差分の追加行に機密情報の候補が含まれている」を満たさない。

--- a/skills/midstream/rr-midstream-secret-credential-scan-001/prompt/system.md
+++ b/skills/midstream/rr-midstream-secret-credential-scan-001/prompt/system.md
@@ -1,0 +1,46 @@
+# Secret / Credential Scan - System Prompt
+
+You are a secret / credential scanner for River Review. Detect API keys, tokens, credentials, private keys, `.env` values, and personal local paths **newly added** in a `diff`, language- and filetype-agnostic.
+
+Full skill specification (authoritative): see `skills/midstream/rr-midstream-secret-credential-scan-001/SKILL.md`.
+
+## Pre-execution Gate
+
+Return `NO_REVIEW: rr-midstream-secret-credential-scan-001 — 機密情報の候補が差分に検出されない` when **either** holds:
+
+- the diff's **added lines** contain no secret candidate (high-entropy string, `API_KEY`/`SECRET`/`TOKEN` keys, `-----BEGIN ... PRIVATE KEY-----`, `/Users/`・`/home/`・`C:\Users\` personal paths, real-value `.env` lines), OR
+- inputContext does not include a non-empty `diff`, or `code_search` (grep) is unavailable.
+
+## False-positive guards
+
+Do NOT flag:
+
+- placeholders / example values (`xxx` / `your-api-key` / `dummy` / `example` / `<...>` / `***`)
+- placeholders in `.env.example` / `.env.sample` / `.env.template` (flag only if a real value is present)
+- obvious pseudo values in test fixtures / docs (flag only realistic formats: real key length, prefixes `sk-` / `ghp_` / `AKIA` / `AIza`)
+- secrets already replaced by environment-variable references (`process.env.X` / `os.environ[...]`)
+- secrets in context lines that are not added/changed (added/changed lines only)
+- high-entropy strings that are not secrets — hashes, UUIDs, and lockfile `integrity: sha512-...` / SRI digests (these belong to the `exclude` globs: `**/package-lock.json`, `**/*.lock`, etc.)
+
+## Rule summary
+
+1. **候補抽出**: extract secret candidates from added lines — secret key assignments, known prefixes (`sk-`/`ghp_`/`AKIA`/`AIza`), `-----BEGIN ... PRIVATE KEY-----`, high-entropy strings, personal paths, real-value `.env` lines.
+2. **実値判定**: use `code_search` to exclude placeholders / example values / env-var references; keep only realistic values.
+3. **報告**: report each at `<file>:<line>` with type, location (value masked), impact, and Fix. Never re-print the secret value — mask it. Always recommend a CI secret scanner (gitleaks / trufflehog) as the durable guard. Limit to 5 findings, highest-impact first.
+
+## Output
+
+すべて日本語。`<file>:<line>: <message>` 形式。summary 行に続けて、各 finding を次の構造で出力する（値は必ずマスク）:
+
+```text
+(secret-scan):1: [要約] 最も重大な機密混入は〈1文〉
+
+<file>:<line>: [機密混入N] <タイトル>
+  種別: <API キー / トークン / 秘密鍵 / credential / 個人パス / .env 実値>
+  混入: <どこに何が追加されたか（値はマスク）>(<file>:<line>)
+  影響: <漏洩リスク / 権限奪取 / 環境依存の壊れ>
+  Fix: <環境変数・Secrets への移動／履歴からの除去／CI secret-scan(gitleaks 等) の導入>
+```
+
+- 機密候補が無い場合は `NO_REVIEW` 行を返す。
+- 実値が無く健全な場合は `NO_ISSUES` を返す。

--- a/skills/midstream/rr-midstream-secret-credential-scan-001/prompt/system.md
+++ b/skills/midstream/rr-midstream-secret-credential-scan-001/prompt/system.md
@@ -35,11 +35,11 @@ Do NOT flag:
 ```text
 (secret-scan):1: [要約] 最も重大な機密混入は〈1文〉
 
-<file>:<line>: [機密混入N] <タイトル>
-  種別: <API キー / トークン / 秘密鍵 / credential / 個人パス / .env 実値>
-  混入: <どこに何が追加されたか（値はマスク）>(<file>:<line>)
-  影響: <漏洩リスク / 権限奪取 / 環境依存の壊れ>
-  Fix: <環境変数・Secrets への移動／履歴からの除去／CI secret-scan(gitleaks 等) の導入>
+- `<file>:<line>`: [severity=major] [機密混入N] <タイトル>
+  - 種別: <API キー / トークン / 秘密鍵 / credential / 個人パス / .env 実値>
+  - 混入: <どこに何が追加されたか（値はマスク）>(<file>:<line>)
+  - 影響: <漏洩リスク / 権限奪取 / 環境依存の壊れ>
+  - Fix: <環境変数・Secrets への移動／履歴からの除去／CI secret-scan(gitleaks 等) の導入>
 ```
 
 - 機密候補が無い場合は `NO_REVIEW` 行を返す。

--- a/skills/midstream/rr-midstream-secret-credential-scan-001/prompt/user.md
+++ b/skills/midstream/rr-midstream-secret-credential-scan-001/prompt/user.md
@@ -1,0 +1,19 @@
+# Secret / Credential Scan - User Prompt
+
+Scan the implementation `diff` for secrets / credentials newly added on added lines.
+
+## Input
+
+You will receive a single markdown document containing the `diff` (in a fenced block).
+
+```text
+{{diff}}
+```
+
+## Task
+
+1. Evaluate the Pre-execution Gate. If no secret candidate exists on added lines, or `diff` is empty, output the `NO_REVIEW` line and stop.
+2. Apply False-positive guards before emitting a finding (placeholders / example values / env-var references / context-only lines / lockfile integrity & SRI digests / hashes & UUIDs).
+3. Extract secret candidates from **added** lines, judge whether each is a realistic real value, and report at `<file>:<line>` with 種別 / 混入 (value masked) / 影響 / Fix.
+4. Emit a summary line `(secret-scan):1: [要約] ...`, then up to 5 findings, highest-impact first. Always recommend a CI secret scanner (gitleaks 等) in Fix.
+5. If candidates exist but all are placeholders / examples / env references (no real secret), output `NO_ISSUES`. Never re-print the secret value.

--- a/skills/registry.yaml
+++ b/skills/registry.yaml
@@ -113,6 +113,15 @@ skills:
     severity: major
     recommended: true
     description: 'Detects API keys, tokens, credentials, private keys, .env values, and personal local paths newly added in a diff — language- and filetype-agnostic, complementing CI secret scanners'
+    exclude:
+      - '**/package-lock.json'
+      - '**/pnpm-lock.yaml'
+      - '**/yarn.lock'
+      - '**/*.lock'
+      - 'dist/**'
+      - '**/*.min.*'
+      - '**/*.map'
+      - '**/*.snap'
 
   - id: rr-midstream-doc-hygiene-001
     version: '0.1.0'


### PR DESCRIPTION
## 概要

#1231 / #1232 の secret-scan 関連 follow-up 2 件を実装する。

### TA-02: skill schema に `exclude` field 追加 + secret-scan 除外設定
- `schemas/skill.schema.json` に optional な `exclude`（glob 文字列配列）を追加。`applyTo` と同じ型 `{"type":"array","items":{"type":"string"}}`。`additionalProperties:false` 配下のため schema 追加が必須。
- `skills/midstream/rr-midstream-secret-credential-scan-001/SKILL.md` frontmatter と `skills/registry.yaml` の secret-scan エントリに同一の exclude（`**/package-lock.json`, `**/pnpm-lock.yaml`, `**/yarn.lock`, `**/*.lock`, `dist/**`, `**/*.min.*`, `**/*.map`, `**/*.snap`）を追加。
- 背景: midstream 実行経路 `src/core/skill-dispatcher.mjs` は `skill.exclude` を minimatch で honor するため、lockfile 等への per-file LLM 呼び出しコストと integrity hash 誤検出を削減できる。`runners/core/review-runner.mjs` の `selectSkills` は exclude を参照しない（=snapshot/planner 選択に影響なし）。

### TA-03: secret-scan の promptfoo eval seed
exec-conformance skill の eval 構成を模範例として同形式で追加。
- `prompt/system.md` + `prompt/user.md`（SKILL.md の Gate/Rule/Output を要約）
- fixtures 3 件: `01-true-positive-hardcoded-key.md`（実値 API キー/トークン/.env 混入）/ `02-false-positive-lockfile-integrity.md`（lockfile `integrity: sha512-...` = 高エントロピーだが秘密でない FP、exclude 除外も明記）/ `03-no-review-no-secret.md`（候補なし → NO_REVIEW）
- 対応 golden 3 件（exec-conformance の `<file>:<line>: [severity=...]` 形式踏襲、値はマスク）
- `eval/promptfoo.yaml`（`contains-any` の緩い assertion）

`docs/data/skill-manifest.json` を再生成（secret-scan: 1 → 10 files）。

## 検証結果

| 検証 | 結果 |
| --- | --- |
| `npm run skills:validate` | ✅ secret-scan pass / exit 0 |
| `npm run skills:manifest` + `:check` | ✅ up to date (119 skills) |
| `node --test tests/review-runner.snapshot.test.mjs` | ✅ pass（exclude 追加で snapshot 不変 = selectSkills は exclude 非対応） |
| planner-dataset eval | ✅ coverage(avg) 100.0% / top1Match(avg) 100.0%（30 cases） |
| `npm test` | ✅ 1514 / 1514 pass / 0 fail |
| markdownlint（新規 md） | ✅ clean |
| prettier --check | ✅ clean |

## dist 再ビルド要否

schema は実行時読み込みで dist 非バンドル、registry/skill md/manifest も非バンドルのため、本変更は `runners/github-action/dist/` に影響しない。`npm run build:action`（Node 22.22.2）で dist が変化したが、clean な committed dist から再ビルドしても同じ差分が出るため**本変更とは無関係な既存 drift**と判断し、本 PR には含めない。

関連 issue: #1231 #1232

🤖 Generated with [Claude Code](https://claude.com/claude-code)