### PR TITLE
fix(skills): harden security-privacy-design eval assertions for JA output (#1238)

### DIFF
--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -666,7 +666,7 @@
     {
       "id": "rr-upstream-security-privacy-design-001",
       "path": "skills/upstream/rr-upstream-security-privacy-design-001",
-      "checksum": "sha256:dcda4234cc46e611392e5ecc6da023f88dfa25b90586a92d5af95ef336291477",
+      "checksum": "sha256:410f3077e76de9173483741224e2fff537746eb11a9658a4bd769dadcc12337d",
       "files": 9
     },
     {

--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -666,7 +666,7 @@
     {
       "id": "rr-upstream-security-privacy-design-001",
       "path": "skills/upstream/rr-upstream-security-privacy-design-001",
-      "checksum": "sha256:40556bd323f5f7ec600761d8fc2994dfea1370b223067139a2bf9710dc939fd7",
+      "checksum": "sha256:dcda4234cc46e611392e5ecc6da023f88dfa25b90586a92d5af95ef336291477",
       "files": 9
     },
     {

--- a/skills/upstream/rr-upstream-security-privacy-design-001/eval/promptfoo.yaml
+++ b/skills/upstream/rr-upstream-security-privacy-design-001/eval/promptfoo.yaml
@@ -16,7 +16,7 @@ tests:
       - type: contains
         value: '[severity='
       - type: contains-any
-        value: ['保持', 'データ保持', 'バックアップ', retention, backup]
+        value: ['保持', 'データ保持', 'バックアップ', retention, Retention, backup, Backup]
   # FP: a healthy doc returns NO_ISSUES and must NOT emit a [severity=...] finding.
   # not-contains '[severity=' is the real FP guard (fails if the model false-flags);
   # the contains-any only confirms a healthy signal without depending on one literal token.
@@ -27,5 +27,5 @@ tests:
       - type: not-contains
         value: '[severity='
       - type: contains-any
-        value: [NO_ISSUES, '問題ありません', '適切', '網羅']
+        value: [NO_ISSUES, 'no issues', 'properly', '問題ありません', '適切', '網羅']
 outputPath: ./output.json

--- a/skills/upstream/rr-upstream-security-privacy-design-001/eval/promptfoo.yaml
+++ b/skills/upstream/rr-upstream-security-privacy-design-001/eval/promptfoo.yaml
@@ -7,16 +7,25 @@ prompts:
   - file://../prompt/system.md
   - file://../prompt/user.md
 tests:
+  # TP: the skill outputs Japanese with a [severity=...] finding marker (see golden/01).
+  # Assert a finding was raised + a retention/backup concept is mentioned (JA or EN).
   - description: 'Detect missing retention'
     vars:
       document: file://../fixtures/01-missing-retention.md
     assert:
+      - type: contains
+        value: '[severity='
       - type: contains-any
-        value: [retention, Retention, backup, Backup]
+        value: ['保持', 'データ保持', 'バックアップ', retention, backup]
+  # FP: a healthy doc returns NO_ISSUES and must NOT emit a [severity=...] finding.
+  # not-contains '[severity=' is the real FP guard (fails if the model false-flags);
+  # the contains-any only confirms a healthy signal without depending on one literal token.
   - description: 'No false positive'
     vars:
       document: file://../fixtures/02-well-designed.md
     assert:
+      - type: not-contains
+        value: '[severity='
       - type: contains-any
-        value: [NO_ISSUES, no issues, properly]
+        value: [NO_ISSUES, '問題ありません', '適切', '網羅']
 outputPath: ./output.json


### PR DESCRIPTION
## Summary

#1238 の解決。`rr-upstream-security-privacy-design-001` の promptfoo eval が **日本語出力に対して英語キーワード assertion を使っていた**ため real-LLM 実行で flake/fail していた（#1236 の CI で顕在化、非必須チェック）。

- **Test 1（TP）**: `[retention/backup]` 期待だが golden/01 は日本語「データ保持ポリシー」+ `[severity=...]` マーカーを出力 → `contains '[severity='` + `contains-any [保持/データ保持/バックアップ/retention/backup]` に変更。
- **Test 2（FP）**: `[NO_ISSUES, no issues, properly]` はリテラル依存で脆く、誤検出も素通ししうる → `not-contains '[severity='`（誤検出を実捕捉する真の FP guard）+ `contains-any [NO_ISSUES, 問題ありません, 適切, 網羅]` に変更。

#1236 の secret-scan FP-assertion 修正と同型。test config のみ・挙動変更なし。

## Test plan
- [x] yaml 妥当性（tests=2, 各 asserts=2）/ prettier — clean
- [x] `npm run skills:validate` / `skills:manifest:check`（119）— OK
- [x] `npm test` — 1514 pass / 0 fail
- [ ] skill-eval（real-LLM）は CI で検証（非必須・非決定）

## 関連
- 対応 issue: #1238（#1236 CI で顕在化した既存 skill の eval flake）

🤖 Generated with [Claude Code](https://claude.com/claude-code)