### PR TITLE
fix(plugin): add composerIcon and .codex-plugin/assets to resolve HOL Scanner warning

### DIFF
--- a/.codex-plugin/assets/icon.svg
+++ b/.codex-plugin/assets/icon.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 140" role="img" aria-labelledby="title desc">
+  <title id="title">River Reviewer</title>
+  <desc id="desc">River Reviewer wordmark with flowing river motif.</desc>
+  <defs>
+    <linearGradient id="river" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#1a75ff" />
+      <stop offset="100%" stop-color="#1fd1a1" />
+    </linearGradient>
+  </defs>
+  <rect width="420" height="140" rx="18" fill="#0b1f33" />
+  <path d="M20 90c40-20 80 20 120 0s80-20 120 0 80 20 120 0" fill="none" stroke="url(#river)" stroke-width="14" stroke-linecap="round" />
+  <text x="30" y="60" font-family="Inter, 'Segoe UI', sans-serif" font-size="32" font-weight="700" fill="#f3f7fb" letter-spacing="0.5">
+    River Reviewer
+  </text>
+  <text x="32" y="112" font-family="Inter, 'Segoe UI', sans-serif" font-size="16" fill="#a9bed2">
+    RR · Review that Flows With You
+  </text>
+</svg>

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -28,6 +28,7 @@
     "capabilities": [
       "Read"
     ],
-    "websiteURL": "https://river-review.the3396.com/"
+    "websiteURL": "https://river-review.the3396.com/",
+    "composerIcon": "./assets/icon.svg"
   }
 }


### PR DESCRIPTION
## Summary

- `.codex-plugin/assets/icon.svg` を追加（`assets/logo/river-review-logo.svg` と同内容）
- `.codex-plugin/plugin.json` の `interface` ブロックに `composerIcon: "./assets/icon.svg"` を追加

## 背景

前セッションで awesome-codex-plugins への掲載 PR 提出のために `composerIcon` を bundle 側の `plugin.json` に追加しましたが、本リポジトリの `.codex-plugin/plugin.json` への反映が漏れていました。

HOL Plugin Scanner の `Interface links and assets valid if declared` チェックが +0（得点なし）になっている原因で、スコアが 98/100 止まりでした。本 PR で修正します。

## Test plan

- [ ] CI の HOL Plugin Scanner ジョブが green になること
- [ ] `Interface links and assets valid if declared` チェックが +点になること（スコア 100/100 以上期待）

🤖 Generated with [Claude Code](https://claude.com/claude-code)