### PR TITLE
feat(plugin): add setup-team command, composerIcon, and plugin field sync

### DIFF
--- a/.claude-plugin/assets/icon.svg
+++ b/.claude-plugin/assets/icon.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 140" role="img" aria-labelledby="title desc">
+  <title id="title">River Reviewer</title>
+  <desc id="desc">River Reviewer wordmark with flowing river motif.</desc>
+  <defs>
+    <linearGradient id="river" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#1a75ff" />
+      <stop offset="100%" stop-color="#1fd1a1" />
+    </linearGradient>
+  </defs>
+  <rect width="420" height="140" rx="18" fill="#0b1f33" />
+  <path d="M20 90c40-20 80 20 120 0s80-20 120 0 80 20 120 0" fill="none" stroke="url(#river)" stroke-width="14" stroke-linecap="round" />
+  <text x="30" y="60" font-family="Inter, 'Segoe UI', sans-serif" font-size="32" font-weight="700" fill="#f3f7fb" letter-spacing="0.5">
+    River Reviewer
+  </text>
+  <text x="32" y="112" font-family="Inter, 'Segoe UI', sans-serif" font-size="16" fill="#a9bed2">
+    RR · Review that Flows With You
+  </text>
+</svg>

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -21,6 +21,7 @@
     "skills"
   ],
   "commands": [
+    "./commands/setup-team.md",
     "./commands/review-local.md",
     "./commands/challenge.md",
     "./commands/skill.md",
@@ -28,5 +29,6 @@
     "./commands/pr.md"
   ],
   "agents": "./agents/river-review.md",
-  "skills": "./skills/agent-skills/"
+  "skills": "./skills/agent-skills/",
+  "composerIcon": "./assets/icon.svg"
 }

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -102,3 +102,16 @@ jobs:
             printf '%s\n\n' "${BODY}"
             printf '%s\n' "${SECTION}"
           } | gh release edit "${TAG}" --notes-file - || echo "Failed to update release notes; continuing."
+
+      - name: Verify plugin field parity
+        # Best-effort: validates that keywords/homepage/repository/author/license
+        # are in sync between package.json and both plugin manifests after the
+        # release bump. Logs a warning but never fails the release workflow.
+        if: ${{ steps.release.outputs.release_created }}
+        run: |
+          set -uo pipefail
+          node --version
+          npm ci --ignore-scripts --silent 2>/dev/null || npm install --ignore-scripts --silent
+          node scripts/sync-plugin-fields.mjs --check \
+            && echo "Plugin field parity: OK" \
+            || echo "::warning::Plugin field parity drift detected — run 'npm run plugin:sync' locally and open a follow-up PR"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -104,14 +104,14 @@ jobs:
           } | gh release edit "${TAG}" --notes-file - || echo "Failed to update release notes; continuing."
 
       - name: Verify plugin field parity
-        # Best-effort: validates that keywords/homepage/repository/author/license
+        # Best-effort: validates that keywords/homepage/author/license
         # are in sync between package.json and both plugin manifests after the
         # release bump. Logs a warning but never fails the release workflow.
         if: ${{ steps.release.outputs.release_created }}
         run: |
           set -uo pipefail
           node --version
-          npm ci --ignore-scripts --silent 2>/dev/null || npm install --ignore-scripts --silent
+          npm ci --ignore-scripts 2>&1 || npm install --ignore-scripts
           node scripts/sync-plugin-fields.mjs --check \
             && echo "Plugin field parity: OK" \
             || echo "::warning::Plugin field parity drift detected — run 'npm run plugin:sync' locally and open a follow-up PR"

--- a/commands/setup-team.md
+++ b/commands/setup-team.md
@@ -1,0 +1,74 @@
+---
+description: 'Set up River Review in the current project: create .river/rules.md, confirm plugin install, and check integration mode'
+allowed-tools: Bash(ls:*), Bash(cat:*), Read, Write
+---
+
+## Task
+
+River Review をこのプロジェクトでセットアップします。以下の手順を順に実行してください。
+
+### Step 1: 現状確認
+
+1. `.river/rules.md` が存在するか確認する。
+2. `.river-review.json` / `.river-review.yaml` が存在するか確認する（CLI / GitHub Actions パスの設定ファイル）。
+3. `package.json` の `scripts` に `review` 等のエントリがないか確認する。
+
+```bash
+ls -la .river/ 2>/dev/null || echo ".river/ が見つかりません"
+ls .river-review.* 2>/dev/null || echo ".river-review.* が見つかりません"
+```
+
+### Step 2: .river/rules.md の生成
+
+`.river/rules.md` がなければ作成する。
+テンプレートは `${CLAUDE_PLUGIN_ROOT:-.}/.river/rules.template.md` にある。
+
+```bash
+mkdir -p .river
+```
+
+作成後、ユーザーにプロジェクト固有のルール（アーキテクチャ方針、禁止パターン、セキュリティ要件）を記入するよう案内する。
+
+### Step 3: 統合モードの確認
+
+Adopter Playbook に基づいて、ユーザーに最適な統合モードを提示する:
+
+| モード               | 用途                                       | 設定ファイル         |
+| -------------------- | ------------------------------------------ | -------------------- |
+| Plugin（このモード） | エージェント主導のインタラクティブレビュー | `.river/rules.md`    |
+| GitHub Actions       | PR 自動レビュー                            | `.river-review.json` |
+| CLI (`river run`)    | ローカルまたは任意の CI                    | `.river-review.json` |
+
+現在は **Plugin モード**（インタラクティブレビュー）を使用中です。
+
+### Step 4: インストール確認
+
+Claude Code にプラグインが正しくインストールされているか確認:
+
+```bash
+# Claude Code でインストール済みの場合は以下で確認できる
+cat "${CLAUDE_PLUGIN_ROOT}/package.json" 2>/dev/null | grep '"version"' || echo "プラグイン ROOT が設定されていません"
+```
+
+インストールされていない場合は以下を案内する:
+
+```bash
+claude plugin add s977043/river-review
+```
+
+### Step 5: 動作確認
+
+セットアップが完了したら `/review-local` を実行して動作確認を行う。
+
+## Output
+
+以下のサマリを出力してください:
+
+```text
+## River Review セットアップ結果
+
+- .river/rules.md: [作成済み / 既存 / 作成が必要]
+- .river-review.json: [あり / なし（Plugin モードでは不要）]
+- プラグイン: [インストール済み / 未インストール]
+- 推奨次アクション: [具体的なステップ]
+```

--- a/commands/setup-team.md
+++ b/commands/setup-team.md
@@ -23,9 +23,7 @@ ls .river-review.* 2>/dev/null || echo ".river-review.* が見つかりません
 `.river/rules.md` がなければ作成する。
 テンプレートは `${CLAUDE_PLUGIN_ROOT:-.}/.river/rules.template.md` にある。
 
-```bash
-mkdir -p .river
-```
+テンプレートの内容を `.river/rules.md` として Write ツールで保存する（親ディレクトリは自動作成される）。
 
 作成後、ユーザーにプロジェクト固有のルール（アーキテクチャ方針、禁止パターン、セキュリティ要件）を記入するよう案内する。
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "eval:repo-context": "node scripts/evaluate-repo-wide-fixtures.mjs",
     "meta:validate": "node scripts/validate-meta-consistency.mjs",
     "plugin:validate": "node scripts/validate-plugin-manifest.mjs",
+    "plugin:sync": "node scripts/sync-plugin-fields.mjs",
+    "plugin:sync:check": "node scripts/sync-plugin-fields.mjs --check",
     "eval:all": "node scripts/evaluate-all.mjs",
     "check:bilingual": "node scripts/check-bilingual-pairs.mjs",
     "check:doc-placement": "node scripts/check-doc-placement.mjs",

--- a/scripts/sync-plugin-fields.mjs
+++ b/scripts/sync-plugin-fields.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * Sync shared metadata fields between package.json and both plugin manifests.
+ *
+ * Source of truth: package.json
+ * Targets: .claude-plugin/plugin.json, .codex-plugin/plugin.json
+ *
+ * Synced fields: keywords, homepage, repository, author, license
+ * Not synced: description (intentionally differs per platform), version (release-please owns it)
+ *
+ * Usage:
+ *   node scripts/sync-plugin-fields.mjs          # sync (writes files if changed)
+ *   node scripts/sync-plugin-fields.mjs --check  # check only (exit 1 if drift found)
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+const ROOT = path.resolve(import.meta.dirname, '..');
+// repository is excluded: package.json uses {type, url} object; plugins use plain string URL.
+const SYNCED_FIELDS = ['keywords', 'homepage', 'author', 'license'];
+
+const CHECK_MODE = process.argv.includes('--check');
+
+async function readJson(rel) {
+  const raw = await fs.readFile(path.join(ROOT, rel), 'utf8');
+  return JSON.parse(raw);
+}
+
+async function writeJson(rel, data) {
+  const out = JSON.stringify(data, null, 2) + '\n';
+  await fs.writeFile(path.join(ROOT, rel), out, 'utf8');
+}
+
+function deepEqual(a, b) {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+async function syncPluginFile(pluginPath, source) {
+  const manifest = await readJson(pluginPath);
+  const drifted = [];
+
+  for (const field of SYNCED_FIELDS) {
+    if (source[field] === undefined) continue;
+    if (!deepEqual(manifest[field], source[field])) {
+      drifted.push(field);
+    }
+  }
+
+  if (drifted.length === 0) {
+    console.log(`  ${pluginPath}: OK (no drift)`);
+    return false;
+  }
+
+  if (CHECK_MODE) {
+    for (const field of drifted) {
+      console.error(`  ${pluginPath}: drift in "${field}"`);
+      console.error(`    package.json: ${JSON.stringify(source[field])}`);
+      console.error(`    plugin.json:  ${JSON.stringify(manifest[field])}`);
+    }
+    return true;
+  }
+
+  for (const field of drifted) {
+    manifest[field] = source[field];
+  }
+  await writeJson(pluginPath, manifest);
+  console.log(`  ${pluginPath}: synced [${drifted.join(', ')}]`);
+  return false;
+}
+
+const pkg = await readJson('package.json');
+
+console.log(CHECK_MODE ? 'Checking plugin field parity...' : 'Syncing plugin fields...');
+const ccDrift = await syncPluginFile('.claude-plugin/plugin.json', pkg);
+const codexDrift = await syncPluginFile('.codex-plugin/plugin.json', pkg);
+
+if (ccDrift || codexDrift) {
+  console.error('\nDrift detected. Run `npm run plugin:sync` to fix.');
+  process.exitCode = 1;
+} else if (!CHECK_MODE) {
+  console.log('Done.');
+}

--- a/scripts/sync-plugin-fields.mjs
+++ b/scripts/sync-plugin-fields.mjs
@@ -5,8 +5,9 @@
  * Source of truth: package.json
  * Targets: .claude-plugin/plugin.json, .codex-plugin/plugin.json
  *
- * Synced fields: keywords, homepage, repository, author, license
- * Not synced: description (intentionally differs per platform), version (release-please owns it)
+ * Synced fields: keywords, homepage, author, license
+ * Not synced: description (intentionally differs per platform), version (release-please owns it),
+ *             repository (package.json uses {type,url} object; plugins use plain string URL)
  *
  * Usage:
  *   node scripts/sync-plugin-fields.mjs          # sync (writes files if changed)

--- a/scripts/validate-plugin-manifest.mjs
+++ b/scripts/validate-plugin-manifest.mjs
@@ -159,6 +159,26 @@ export async function validatePluginManifest() {
         errors.push('.codex-plugin/plugin.json: interface.capabilities must be an array');
       }
     }
+
+    // --- Cross-plugin field parity (synced fields must match package.json) ---
+    // repository is excluded: package.json uses {type, url} object; plugins use plain string URL.
+    const SYNCED_FIELDS = ['keywords', 'homepage', 'author', 'license'];
+    for (const field of SYNCED_FIELDS) {
+      if (pkg[field] === undefined) continue;
+      const ccVal = JSON.stringify(ccManifest[field]);
+      const codexVal = JSON.stringify(codexManifest[field]);
+      const pkgVal = JSON.stringify(pkg[field]);
+      if (ccVal !== pkgVal) {
+        errors.push(
+          `.claude-plugin/plugin.json: "${field}" drifted from package.json — run \`npm run plugin:sync\``
+        );
+      }
+      if (codexVal !== pkgVal) {
+        errors.push(
+          `.codex-plugin/plugin.json: "${field}" drifted from package.json — run \`npm run plugin:sync\``
+        );
+      }
+    }
   }
 
   return errors;


### PR DESCRIPTION
## Summary

- **`/setup-team` コマンド追加**: `commands/setup-team.md` を新規作成し、`.claude-plugin/plugin.json` に登録。ユーザーがプロジェクトで River Review をセットアップする際に `.river/rules.md` 生成・統合モード確認・プラグインインストール確認を案内する。
- **Claude Code プラグイン最新化**: `composerIcon` フィールドと `.claude-plugin/assets/icon.svg` を追加（`.codex-plugin` との完全パリティ）。
- **リリース時の自動同期フロー整備**:
  - `scripts/sync-plugin-fields.mjs`: `package.json` を SSoT として `keywords`/`homepage`/`author`/`license` を両 plugin.json に同期するスクリプト（`--check` で CI 安全モード）
  - `scripts/validate-plugin-manifest.mjs`: クロスプラグインのフィールドパリティチェックを追加（PR CI の `plugin:validate` で検出）
  - `package.json`: `plugin:sync` / `plugin:sync:check` スクリプトを追加
  - `release-please.yml`: リリース後の best-effort パリティ検証ステップを追加（失敗しても release は通過）

## Test plan

- [ ] `npm run plugin:validate` が pass すること
- [ ] `npm run plugin:sync:check` が pass すること
- [ ] `.claude-plugin/plugin.json` に `setup-team` コマンドと `composerIcon` が含まれること
- [ ] CI (test.yml の plugin:validate ジョブ) が green になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)