### PR TITLE
ci: add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,42 @@
+name: OpenSSF Scorecard
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '30 1 * * 6' # 毎週土曜 01:30 UTC
+  branch_protection_rule:
+
+permissions: read-all
+
+concurrency:
+  group: scorecard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75b5f72cc2 # v2.4.1
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF results
+        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Summary

OpenSSF Scorecard を導入し、リポジトリのセキュリティ健全性スコアを自動計測・公開する。

- `.github/workflows/scorecard.yml` を追加
- トリガー: main push / 週1スケジュール（土曜 01:30 UTC）/ branch_protection_rule 変更時
- `publish_results: true` で OpenSSF データベースに結果を送信し、バッジが自動更新される
- SARIF 形式で結果を GitHub Security タブにもアップロード

## マージ後の確認

1. Actions タブで `OpenSSF Scorecard` ワークフローが green になることを確認
2. https://scorecard.dev/viewer/?uri=github.com/s977043/river-review でスコアを確認
3. README にバッジを追加する場合は別 PR で対応

## Test plan

- [x] prettier クリーン（lint-staged 通過）
- [ ] CI 全チェックが green になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)