### PR TITLE
fix(ci): update scorecard-action and codeql-action to valid SHAs

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -30,13 +30,13 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75b5f72cc2 # v2.4.1
+        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload SARIF results
-        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3
+        uses: github/codeql-action/upload-sarif@c35d1b164463ee62a100735382aaaa525c5d3496 # codeql-bundle-v2.25.6
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

PR #1263 でマージした Scorecard ワークフローで、ピン SHA が無効なため実行時にエラーが発生していた。

- `ossf/scorecard-action`: 無効SHA → `99c09fe` (v2.4.3)
- `github/codeql-action/upload-sarif`: 無効SHA → `c35d1b1` (codeql-bundle-v2.25.6)

## Test plan

- [ ] `OpenSSF Scorecard` ワークフローが green になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)