### PR TITLE
ci: improve OpenSSF Scorecard score

### DIFF
--- a/.github/workflows/auto-fix-dashes.yml
+++ b/.github/workflows/auto-fix-dashes.yml
@@ -4,9 +4,7 @@ on:
   schedule:
     - cron: '0 3 * * 6' # Every Saturday 03:00 UTC (6:00 JST)
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: read-all
 
 concurrency:
   group: auto-fix-dashes
@@ -16,6 +14,9 @@ jobs:
   auto-fix-dashes:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '30 2 * * 1' # 毎週月曜 02:30 UTC
+
+permissions: read-all
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (javascript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@c35d1b164463ee62a100735382aaaa525c5d3496 # codeql-bundle-v2.25.6
+        with:
+          languages: javascript
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@c35d1b164463ee62a100735382aaaa525c5d3496 # codeql-bundle-v2.25.6
+        with:
+          category: /language:javascript

--- a/.github/workflows/hol-plugin-scanner.yml
+++ b/.github/workflows/hol-plugin-scanner.yml
@@ -6,13 +6,14 @@ on:
   pull_request:
     branches: [main]
 
-permissions:
-  contents: read
-  security-events: write
+permissions: read-all
 
 jobs:
   scan:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: HOL Plugin Scanner

--- a/.github/workflows/prose-lint.yml
+++ b/.github/workflows/prose-lint.yml
@@ -2,10 +2,7 @@ name: Prose Lint
 on:
   pull_request:
 
-permissions:
-  contents: read
-  pull-requests: write
-  checks: write
+permissions: read-all
 
 concurrency:
   group: prose-lint-${{ github.ref }}
@@ -15,6 +12,10 @@ jobs:
   vale:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+      checks: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: errata-ai/vale-action@85f9f7f2c5f449ac0ae5b66662961bae3f77ca6a # v2.1.2

--- a/.github/workflows/release-please-kick.yml
+++ b/.github/workflows/release-please-kick.yml
@@ -22,10 +22,7 @@ on:
         required: false
         default: ''
 
-permissions:
-  contents: write
-  pull-requests: read
-  checks: read
+permissions: read-all
 
 concurrency:
   group: release-please-kick
@@ -35,6 +32,10 @@ jobs:
   kick:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: read
+      checks: read
     steps:
       - name: Advance release-please branch by an empty commit
         id: advance

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,9 +5,7 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: read-all
 
 concurrency:
   group: release-please-${{ github.ref }}
@@ -20,6 +18,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Release Please
         id: release

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -30,7 +30,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        uses: ossf/scorecard-action@v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,9 @@
 
 River Review に関する脆弱性の可能性を見つけた場合は、公開 Issue や PR には投稿せず、GitHub のプライベート脆弱性報告機能から非公開で報告してください。
 
-- 報告フォーム: [security/advisories/new](https://github.com/s977043/river-review/security/advisories/new)
+- 報告フォーム: [https://github.com/s977043/river-review/security/advisories/new](https://github.com/s977043/river-review/security/advisories/new)
 - UI から辿る場合: リポジトリの `Security` タブ → `Advisories` → `Report a vulnerability`
+- 公開済みセキュリティアドバイザリ: [https://github.com/s977043/river-review/security/advisories](https://github.com/s977043/river-review/security/advisories)
 
 可能であれば、PoC、影響範囲、再現手順、想定される悪用シナリオ、暫定回避策を含めてください。
 


### PR DESCRIPTION
## Summary

OpenSSF Scorecard スコア（現在 5.6/10）を改善するための対応。

| 項目 | 変更前 | 期待値 | 対応内容 |
|---|---|---|---|
| publish_results | ❌ 失敗 | ✅ 公開 | scorecard-action をタグ参照に変更（SHA pin では publish 不可） |
| Token-Permissions | 0/10 | 8+/10 | 5ワークフローのトップレベル write 権限をジョブレベルへ移動 |
| SAST | 4/10 | 8+/10 | CodeQL ワークフロー追加（push/PR/週次） |
| Security-Policy | 4/10 | 7+/10 | SECURITY.md に完全な URL リンクを追加 |

## 変更ファイル

- `scorecard.yml` — `ossf/scorecard-action@v2.4.3`（タグ参照化）
- `auto-fix-dashes.yml` — top-level `permissions: read-all` + job-level write
- `prose-lint.yml` — 同上
- `hol-plugin-scanner.yml` — 同上
- `release-please.yml` — 同上
- `release-please-kick.yml` — 同上
- `codeql.yml` — 新規追加（CodeQL SAST）
- `SECURITY.md` — advisory URL リンク追加

## 未対応（手動対応が必要）

- **Code-Review (0/10)**: PR に承認者を必須化 → GitHub Settings → Branch protection rules
- **Branch-Protection (3/10)**: 同上
- **CII-Best-Practices (0/10)**: bestpractices.dev への登録
- **Fuzzing (0/10)**: 今後の検討事項

## Test plan

- [ ] CI 全チェック green
- [ ] `OpenSSF Scorecard` ワークフローが成功しスコアが scorecard.dev に反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)