### PR TITLE
docs: lead README with Review Judgment as Code positioning and Star CTA

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,6 +1,7 @@
 # River Review
 
-**Codify your team's judgment into automated PR gates.**
+**Review Judgment as Code for AI-assisted development.**
+**Codify your team's review judgment as repo-owned skills and run them as automated PR gates.**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Documentation](https://img.shields.io/badge/docs-available-blue)](https://river-review.the3396.com/explanation/intro/)
@@ -24,6 +25,8 @@ River Review helps you answer questions like:
 - Did the implementation agent ignore feedback from a previous review?
 
 > River Review does not replace human review with AI. By executing your team's review criteria as versioned skills, it lets human reviewers focus on the high-risk judgment that truly needs them ([Human Judgment Focus](https://river-review.the3396.com/explanation/human-judgment-focus/)).
+
+> ⭐ If this helps your team's review workflow in AI-assisted development, please [Star the repo](https://github.com/s977043/river-review). It keeps you posted on updates and helps other teams with the same problem find River Review.
 
 ## Why River Review?
 

--- a/README.en.md
+++ b/README.en.md
@@ -26,7 +26,7 @@ River Review helps you answer questions like:
 
 > River Review does not replace human review with AI. By executing your team's review criteria as versioned skills, it lets human reviewers focus on the high-risk judgment that truly needs them ([Human Judgment Focus](https://river-review.the3396.com/explanation/human-judgment-focus/)).
 
-> ⭐ If this helps your team's review workflow in AI-assisted development, please [Star the repo](https://github.com/s977043/river-review). It keeps you posted on updates and helps other teams with the same problem find River Review.
+⭐ If this helps your team's review workflow in AI-assisted development, please [Star the repo](https://github.com/s977043/river-review). It keeps you posted on updates and helps other teams with the same problem find River Review.
 
 ## Why River Review?
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # River Review
 
-**Codify your team's judgment into automated PR gates.**
-**チームのレビュー判断を、自動化された PR ゲートとしてコード化する。**
+**Review Judgment as Code for AI-assisted development.**
+**AI支援開発のための Review Judgment as Code。レビュー判断を repo-owned skill としてコード化します。**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Documentation](https://img.shields.io/badge/docs-available-blue)](https://river-review.the3396.com/explanation/intro/)
@@ -24,6 +24,8 @@ River Review は、こうした問いに答えるためのフレームワーク�
 - 実装エージェントは、過去レビューのフィードバックを無視していないか？
 
 > River Review は人間のレビューを AI で置き換えるのではなく、チームの判断基準を versioned skill として実行することで、人間が本当に見るべき高リスクな判断に集中できる状態を作ります（[Human Judgment Focus](https://river-review.the3396.com/explanation/human-judgment-focus/)）。
+
+> ⭐ AI 支援開発のレビュー運用に役立ちそうなら、[Star](https://github.com/s977043/river-review) で応援してください。更新を追えるほか、同じ課題を持つチームに River Review が届きやすくなります。
 
 ## なぜ River Review か
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ River Review は、こうした問いに答えるためのフレームワーク�
 
 > River Review は人間のレビューを AI で置き換えるのではなく、チームの判断基準を versioned skill として実行することで、人間が本当に見るべき高リスクな判断に集中できる状態を作ります（[Human Judgment Focus](https://river-review.the3396.com/explanation/human-judgment-focus/)）。
 
-> ⭐ AI 支援開発のレビュー運用に役立ちそうなら、[Star](https://github.com/s977043/river-review) で応援してください。更新を追えるほか、同じ課題を持つチームに River Review が届きやすくなります。
+⭐ AI 支援開発のレビュー運用に役立ちそうなら、[Star](https://github.com/s977043/river-review) で応援してください。更新を追えるほか、同じ課題を持つチームに River Review が届きやすくなります。
 
 ## なぜ River Review か
 


### PR DESCRIPTION
## Summary

Improves the README landing experience for OSS discovery (#1277), so first-time visitors grasp River Review's value within seconds.

## Changes

- Lead both `README.md` and `README.en.md` with the explicit **`Review Judgment as Code for AI-assisted development.`** tagline
- Add a natural ⭐ Star CTA in the intro of both READMEs
- Keep the existing 5-minute quickstart link and no-npm onboarding intact (no new npm-install entry path)

## Out of Scope (per #1277)

- npm publish / npm install onboarding / npm badges
- auto-approve / auto-merge messaging

## Acceptance Criteria

- [x] README 冒頭で `Review Judgment as Code` が明確に伝わる
- [x] 「チーム所有のレビュー判断」という位置づけが伝わる（既存の比較表＋本変更）
- [x] 5分導入導線が README 上部にある（既存「はじめる」表を維持）
- [x] npm 前提の導線がない
- [x] Star CTA が自然に入っている
- [x] README / README.en の内容差分が意図的に管理されている
- [x] Markdown lint / format check が通る（prettier `--check` pass）

## Linked Issues

- Closes #1277
- Parent epic: #1276

🤖 Generated with [Claude Code](https://claude.com/claude-code)