### PR TITLE
docs: add community and first contributor paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,9 @@ Issue テンプレートは `Issues → New issue` から利用できます（�
 - Documentation: ドキュメントの追加・誤り修正
 - Question: 相談・質問（軽い内容でも`question`ラベルを使ってIssueに投稿）
 
-### 🐞 バグの報告
+### 💬 Discussions とコミュニティ導線
+
+質問・相談・アイデア出し・利用例の共有は Discussions を使ってください。まだ「やること」が固まっていない対話は Discussion から始め、対応方針が固まった段階で Issue 化します。Star のあとの次の一歩・Discussions カテゴリ・`good first issue` 候補は [docs/growth/community.md](docs/growth/community.md) に整理しています。
 
 もしバグを発見した場合は、Issueを作成して報告してください。良いバグ報告には以下の情報が含まれます。
 

--- a/docs/growth/community.md
+++ b/docs/growth/community.md
@@ -1,0 +1,60 @@
+# Community and first contributor paths
+
+River Review に関心を持った人が、Star のあとに質問・相談・小さな貢献へ進めるようにするための導線を整理します。Star で終わらせず、試用 / Issue / Discussion / 小さな貢献につなげることで、継続的な認知を作ります。
+
+> 親エピック: [#1276](https://github.com/s977043/river-review/issues/1276) / 追跡 Issue: [#1280](https://github.com/s977043/river-review/issues/1280)
+
+## Star のあとの次の一歩
+
+1. **試す**: [はじめる](../../README.md#はじめる)（プラグイン / GitHub Actions、API キー不要のデモあり）。
+2. **読む**: [plan-conformance デモ](../../examples/plan-conformance-demo/README.md)で中核価値を 5 分で把握する。
+3. **相談する**: 導入の質問は Discussions の Q&A へ。
+4. **貢献する**: `good first issue` から小さく始める（下記）。
+
+## Issue と Discussion の使い分け
+
+| 種類       | 使う場面                                                                         |
+| ---------- | -------------------------------------------------------------------------------- |
+| Discussion | 質問・相談・アイデア出し・利用例の共有など、まだ「やること」が確定していない対話 |
+| Issue      | バグ・機能提案・タスクなど、対応すべき作業が具体化したもの                       |
+
+迷ったら Discussion から始め、対応方針が固まった段階で Issue 化する運用とします。
+
+## Discussions カテゴリ（提案）
+
+| カテゴリ      | 用途                         |
+| ------------- | ---------------------------- |
+| Announcements | リリース・記事の告知         |
+| Q&A           | 導入・設定の質問             |
+| Show and Tell | River Review の利用例の共有  |
+| Ideas         | skill 案・ユースケースの提案 |
+
+> カテゴリの有効化はリポジトリ管理者の操作です（Settings → Features → Discussions、および各カテゴリ作成）。
+
+## 最初の Discussion 案
+
+Q&A もしくは Ideas に、議論の口火を切る投稿を用意します。
+
+```text
+How would you use River Review in your AI-assisted development workflow?
+```
+
+日本語併記案:
+
+```text
+あなたの AI 支援開発ワークフローで、River Review をどう使いますか？
+```
+
+## good first issue 候補
+
+初めての貢献者が着手しやすい、スコープの小さい候補です（起票はメンテナが行います）。
+
+- `docs: add a README diagram for Review Judgment as Code`（README 図解の追加）
+- `docs: improve GitHub Topics and repository metadata`（Topics / メタデータ整備）
+- `docs: expand examples/ with another minimal scenario`（最小シナリオの追加）
+
+## メンテナンス負荷への配慮
+
+- Discord / Slack など外部コミュニティの常時運用は行わない。
+- 大規模なコントリビューター制度は設けず、Issue / Discussion / CONTRIBUTING の 3 点で導線を完結させる。
+- 常時サポート体制は約束しない。対応は best-effort とし、その旨を明示する。


### PR DESCRIPTION
## Summary

Gives people who Star River Review a clear next step toward questions, discussion, and small contributions (#1280) — without adding heavy maintenance burden.

## What

- `docs/growth/community.md`:
  - Post-star next steps (try → read demo → ask in Q&A → contribute)
  - Issue vs Discussion usage guidance
  - Proposed Discussion categories (Announcements / Q&A / Show and Tell / Ideas) — noting enablement is a repo-admin action
  - First discussion prompt (EN + JA)
  - 3 `good first issue` candidates (to be filed by maintainers)
  - Maintenance-load guardrails (no Discord/Slack ops, no heavy contributor program, best-effort support)
- `CONTRIBUTING.md`: new "Discussions とコミュニティ導線" subsection linking the doc

## Out of Scope (per #1280)

- Large contributor program design, external community (Discord/Slack) ops, npm-based contributor path, always-on support

## Acceptance Criteria

- [x] Discussions の用途が CONTRIBUTING に明記されている
- [x] 初回 Discussion 案が用意されている
- [x] `good first issue` 候補が3件ある
- [x] Issue と Discussion の使い分けが明確
- [x] Star 後に次の行動が分かる導線がある
- [x] メンテナンス負荷が過剰になっていない

## Linked Issues

- Closes #1280
- Parent epic: #1276

🤖 Generated with [Claude Code](https://claude.com/claude-code)