### PR TITLE
docs: add launch assets (social preview + core-model diagram)

### DIFF
--- a/assets/social/diagram.svg
+++ b/assets/social/diagram.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 520" role="img" aria-labelledby="title desc">
+  <title id="title">River Review core model</title>
+  <desc id="desc">River Review core model: team-owned skills define judgment, gates execute judgment across plan, diff, and tests, and Riverbed remembers judgment. A team-owned audit layer for AI-assisted development.</desc>
+  <defs>
+    <linearGradient id="river" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#1a75ff" />
+      <stop offset="100%" stop-color="#1fd1a1" />
+    </linearGradient>
+  </defs>
+  <rect width="1280" height="520" fill="#0b1f33" />
+  <text x="64" y="80" font-family="Inter, 'Segoe UI', sans-serif" font-size="34" font-weight="700" fill="#f3f7fb">
+    Review Judgment as Code
+  </text>
+  <text x="64" y="120" font-family="Inter, 'Segoe UI', sans-serif" font-size="20" fill="#a9bed2">
+    a team-owned audit layer for AI-assisted development
+  </text>
+
+  <!-- Inputs -->
+  <text x="64" y="210" font-family="Inter, 'Segoe UI', sans-serif" font-size="22" font-weight="600" fill="#7fa6c9">inputs</text>
+  <g font-family="Inter, 'Segoe UI', sans-serif" font-size="22" fill="#f3f7fb">
+    <rect x="64" y="230" width="200" height="56" rx="10" fill="#13314f" />
+    <text x="164" y="266" text-anchor="middle">plan</text>
+    <rect x="64" y="300" width="200" height="56" rx="10" fill="#13314f" />
+    <text x="164" y="336" text-anchor="middle">diff</text>
+    <rect x="64" y="370" width="200" height="56" rx="10" fill="#13314f" />
+    <text x="164" y="406" text-anchor="middle">tests / JUnit / prior reviews</text>
+  </g>
+
+  <path d="M280 328 H 430" fill="none" stroke="url(#river)" stroke-width="6" stroke-linecap="round" />
+
+  <!-- River Review skills -->
+  <rect x="440" y="250" width="360" height="160" rx="16" fill="none" stroke="url(#river)" stroke-width="4" />
+  <text x="620" y="300" text-anchor="middle" font-family="Inter, 'Segoe UI', sans-serif" font-size="26" font-weight="700" fill="#f3f7fb">River Review</text>
+  <text x="620" y="338" text-anchor="middle" font-family="Inter, 'Segoe UI', sans-serif" font-size="19" fill="#a9bed2">repo-owned skills define judgment</text>
+  <text x="620" y="368" text-anchor="middle" font-family="Inter, 'Segoe UI', sans-serif" font-size="19" fill="#a9bed2">gates execute it · Riverbed remembers it</text>
+
+  <path d="M800 328 H 950" fill="none" stroke="url(#river)" stroke-width="6" stroke-linecap="round" />
+
+  <!-- Output -->
+  <text x="970" y="210" font-family="Inter, 'Segoe UI', sans-serif" font-size="22" font-weight="600" fill="#7fa6c9">output</text>
+  <rect x="970" y="280" width="246" height="96" rx="12" fill="#13314f" />
+  <text x="1093" y="322" text-anchor="middle" font-family="Inter, 'Segoe UI', sans-serif" font-size="21" fill="#f3f7fb">findings against</text>
+  <text x="1093" y="350" text-anchor="middle" font-family="Inter, 'Segoe UI', sans-serif" font-size="21" fill="#f3f7fb">team standards</text>
+
+  <text x="64" y="486" font-family="Inter, 'Segoe UI', sans-serif" font-size="19" fill="#7fa6c9">Human-in-the-loop, not auto-merge.</text>
+</svg>

--- a/assets/social/social-preview.svg
+++ b/assets/social/social-preview.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 640" role="img" aria-labelledby="title desc">
+  <title id="title">River Review — Review Judgment as Code</title>
+  <desc id="desc">River Review social preview: Review Judgment as Code for AI-assisted development. A team-owned audit layer with repo-owned skills running across plans, diffs, and tests.</desc>
+  <defs>
+    <linearGradient id="river" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#1a75ff" />
+      <stop offset="100%" stop-color="#1fd1a1" />
+    </linearGradient>
+  </defs>
+  <rect width="1280" height="640" fill="#0b1f33" />
+  <path d="M0 470c160-60 320 60 480 0s320-60 480 0 320 60 320 0" fill="none" stroke="url(#river)" stroke-width="20" stroke-linecap="round" opacity="0.9" />
+  <text x="96" y="190" font-family="Inter, 'Segoe UI', sans-serif" font-size="40" font-weight="600" fill="url(#river)" letter-spacing="1">
+    River Review
+  </text>
+  <text x="92" y="300" font-family="Inter, 'Segoe UI', sans-serif" font-size="84" font-weight="800" fill="#f3f7fb" letter-spacing="0.5">
+    Review Judgment as Code
+  </text>
+  <text x="96" y="372" font-family="Inter, 'Segoe UI', sans-serif" font-size="40" font-weight="500" fill="#a9bed2">
+    for AI-assisted development
+  </text>
+  <text x="96" y="560" font-family="Inter, 'Segoe UI', sans-serif" font-size="28" fill="#7fa6c9" letter-spacing="0.5">
+    repo-owned skills · PR gates · plan-diff-test review
+  </text>
+</svg>

--- a/docs/growth/launch-assets.md
+++ b/docs/growth/launch-assets.md
@@ -1,0 +1,64 @@
+# Launch assets
+
+X / Zenn / note / awesome 系で River Review が共有されたとき、画像で一瞬に価値が伝わるようにするためのローンチアセットと、その仕様をまとめます。River Review は概念価値が強い OSS なので、`Review Judgment as Code` を視覚的に伝えます。
+
+> 親エピック: [#1276](https://github.com/s977043/river-review/issues/1276) / 追跡 Issue: [#1279](https://github.com/s977043/river-review/issues/1279)
+
+## ソースアセット（このリポジトリ）
+
+| アセット           | ファイル                                                                       | 用途                              |
+| ------------------ | ------------------------------------------------------------------------------ | --------------------------------- |
+| Social Preview     | [`assets/social/social-preview.svg`](../../assets/social/social-preview.svg)   | GitHub リンク共有 / X 投稿の基図  |
+| 図解（コアモデル） | [`assets/social/diagram.svg`](../../assets/social/diagram.svg)                 | README 理解補助 / Zenn・note hero |
+| ロゴ               | [`assets/logo/river-review-logo.svg`](../../assets/logo/river-review-logo.svg) | 既存ワードマーク                  |
+
+SVG をソースとして保持し、各配信先が要求するラスタ形式（PNG）へ書き出して使います。
+
+## コピー
+
+```text
+River Review
+Review Judgment as Code
+for AI-assisted development
+```
+
+補足ライン:
+
+```text
+repo-owned skills · PR gates · plan-diff-test review
+```
+
+配色はロゴ準拠（背景 `#0b1f33`、river グラデーション `#1a75ff`→`#1fd1a1`、本文 `#f3f7fb`、補助 `#a9bed2`）。
+
+## 各アセットの仕様
+
+| アセット              | 推奨サイズ           | 元                 | 備考                                                                                              |
+| --------------------- | -------------------- | ------------------ | ------------------------------------------------------------------------------------------------- |
+| GitHub Social Preview | 1280×640 PNG         | social-preview.svg | GitHub は 640×320 以上を要求。Settings → Social preview にアップロード（リポジトリ管理者操作）    |
+| README diagram        | 1280×520（横幅可変） | diagram.svg        | README へ図解として埋め込み                                                                       |
+| X 投稿用画像          | 1200×675 PNG         | social-preview.svg | 16:9 にトリミング                                                                                 |
+| Zenn / note hero      | 1200×630 PNG         | diagram.svg        | 記事 OGP / 先頭画像                                                                               |
+| Demo screenshot       | 実画面に依存         | —                  | [plan-conformance デモ](../../examples/plan-conformance-demo/README.md)の実行結果を後日キャプチャ |
+
+## PNG 書き出し手順（例）
+
+ローカルに SVG レンダラがある場合の一例（任意のツールで可）:
+
+```bash
+# 例: rsvg-convert を使う場合
+rsvg-convert -w 1280 -h 640 assets/social/social-preview.svg -o social-preview.png
+rsvg-convert -w 1200 -h 630 assets/social/diagram.svg -o hero.png
+```
+
+書き出した PNG はリポジトリには含めず、配信先（GitHub Settings / 記事 / SNS）へ直接アップロードします。
+
+## 制約（#1279）
+
+- 画像内で npm 前提の表現をしない。
+- 有料広告用クリエイティブ・過剰な自律エージェント化・自動承認/自動マージを想起させる表現は避ける。
+- `Review Judgment as Code` と、`team-owned` / `repo-owned` / `audit layer` のいずれかが必ず伝わるようにする。
+
+## 残作業（リポジトリ管理者 / デザイン）
+
+- SVG → PNG 書き出しと、GitHub Social preview へのアップロード。
+- デモ実行結果のスクリーンショット取得。


### PR DESCRIPTION
## Summary

Adds visual launch assets (#1279) so River Review's value — `Review Judgment as Code` — lands instantly when shared on GitHub, X, Zenn, note, or awesome lists.

## What

- `assets/social/social-preview.svg` (1280×640) — GitHub social preview / X base image
- `assets/social/diagram.svg` — core-model diagram (inputs → repo-owned skills → findings), reusable as README diagram and article hero
- `docs/growth/launch-assets.md` — per-asset spec (copy, recommended size, source, PNG export steps), brand palette (matches the logo), and explicit constraints

Both SVGs reuse the logo's palette (`#0b1f33` bg, `#1a75ff`→`#1fd1a1` river gradient). PNG export and uploading the social preview (Settings → Social preview) remain repo-admin/design tasks and are documented as such. Demo screenshot is left as a follow-up capture.

## Out of Scope (per #1279)

- npm-framed imagery, paid-ad creative, over-automation / auto-merge messaging

## Acceptance Criteria

- [x] Social Preview 画像が用意されている（SVG ソース + サイズ/アップロード手順）
- [x] README 用の図解がある（diagram.svg）
- [x] X 投稿用画像の元がある（social-preview.svg + 仕様）
- [x] Zenn / note 用ヒーロー画像の元がある（diagram.svg + 仕様）
- [x] 画像内で npm 前提の表現がない
- [x] `Review Judgment as Code` が明確
- [x] `team-owned` / `repo-owned` / `audit layer` が伝わる
- [x] roadmap / docs から asset の場所へ導線がある

## Linked Issues

- Closes #1279
- Parent epic: #1276

🤖 Generated with [Claude Code](https://claude.com/claude-code)