### PR TITLE
docs: embed the Review Judgment as Code diagram in README

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -43,6 +43,8 @@ River Review is not another prompt wrapper around a PR diff. It is a way to make
 
 ## Core Model
 
+![River Review core model: plan / diff / tests / JUnit / prior reviews feed repo-owned skills that execute review judgment and emit findings against team standards — a team-owned audit layer](assets/social/diagram.svg)
+
 **Skills define judgment.** A skill describes how a review decision should be made: security policy, accessibility, migration safety, dependency rules, plan conformance, and other team-specific standards.
 
 **Gates execute judgment.** Plan and exec gates run those skills at the right point in the delivery flow — not only after the PR is already complete (a verify gate is planned in [#802](https://github.com/s977043/river-review/issues/802)).

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ River Review は「PR diff にプロンプトを巻いただけのツール」�
 
 ## コアモデル
 
+![River Review のコアモデル: plan / diff / tests / JUnit / 過去レビューを入力に、repo-owned skill がレビュー判断を実行し、チーム基準に対する指摘を出力する team-owned audit layer](assets/social/diagram.svg)
+
 **Skills define judgment.**
 skill は「どんなレビュー判断を行うか」を記述します。security / a11y / migration safety / dependency policy / plan conformance など、チーム固有の基準を載せます。
 


### PR DESCRIPTION
## Summary

Closes #1297. Embeds the existing `assets/social/diagram.svg` (core-model diagram) at the top of the Core Model section in both READMEs, so the model is conveyed visually.

## Changes

- `README.md` / `README.en.md`: add the diagram at the start of コアモデル / Core Model with descriptive alt text (inputs → repo-owned skills → findings; team-owned audit layer)

## Validation

- prettier `--check`, `check:dashes`, markdownlint — green

Closes #1297

🤖 Generated with [Claude Code](https://claude.com/claude-code)