### PR TITLE
fix(plugin): add review-team command to Claude Code plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -23,6 +23,7 @@
   "commands": [
     "./commands/setup-team.md",
     "./commands/review-local.md",
+    "./commands/review-team.md",
     "./commands/challenge.md",
     "./commands/skill.md",
     "./commands/check.md",


### PR DESCRIPTION
## Summary

- `commands/review-team.md` was added in #1309 but not registered in `.claude-plugin/plugin.json`
- Plugin users could not invoke `/review-team` because it was missing from the `commands` array
- Add `./commands/review-team.md` alongside the other 6 distributed commands

## Test plan

- [ ] `npm run plugin:validate` passes
- [ ] `npm run plugin:sync` reports no drift
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)