### PR TITLE
test(skill-loader): add coverage for category:stream + phase:array

### DIFF
--- a/tests/skill-loader.test.mjs
+++ b/tests/skill-loader.test.mjs
@@ -523,3 +523,27 @@ test('loadRecommendationSets returns {} when registry is absent', async () => {
     { prefix: TMP_PREFIX }
   );
 });
+
+test('respects explicit multi-phase array when category is a stream value', async () => {
+  await withTempDir(async (tmpDir) => {
+    const validator = await buildValidator();
+    const skillPath = path.join(tmpDir, 'multi-phase.md');
+    const content = `---
+id: multi-phase
+name: 'Multi Phase Skill'
+description: 'Active in upstream and midstream'
+category: upstream
+phase:
+  - upstream
+  - midstream
+applyTo:
+  - 'docs/**/*'
+---
+Body
+`;
+    await writeFile(skillPath, content, 'utf8');
+    const loaded = await loadSkillFile(skillPath, { validator });
+    assert.deepEqual(loaded.metadata.phase, ['upstream', 'midstream']);
+    assert.equal(loaded.metadata.category, 'upstream');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a regression test for the bug where `category: upstream` (or any stream value) combined with `phase: [upstream, midstream]` caused `resolvePhase` to ignore the explicit phase array and collapse to the single category string.
- The fix in `resolvePhase` (the `Array.isArray(metaPhase) && metaPhase.length > 1` guard) was already merged; this test prevents silent regression.
- Bug was originally discovered via S2 eval with coverage=0% for this scenario.

## Test case added (`tests/skill-loader.test.mjs`)

```
respects explicit multi-phase array when category is a stream value
```

Loads a skill with `category: upstream` + `phase: [upstream, midstream]` and asserts:
- `metadata.phase` is `['upstream', 'midstream']` (array, not collapsed to single string)
- `metadata.category` remains `'upstream'`

## Test plan

- [x] `node --test tests/skill-loader.test.mjs` — 21 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)