### PR TITLE
fix(skills): #1329 レビュー指摘の follow-up — allowlist 誤登録の修正 + ガード拡張 + test

### DIFF
--- a/examples/selection/tdd.yaml
+++ b/examples/selection/tdd.yaml
@@ -9,8 +9,8 @@ selection:
   skills:
     include:
       # 仕様からテスト雛形を生成する upstream skill（スタックに合わせて取捨選択する）
-      - rr-upstream-test-code-unit-ts-jest-001 # TypeScript (Jest/Vitest)
-      - rr-upstream-test-code-react-001 # React コンポーネント (RTL)
+      - test-code-unit-ts-jest # TypeScript (Jest/Vitest)
+      - test-code-react # React コンポーネント (RTL)
       # 実装中〜実装後のテスト品質ゲート
       - test-existence # 変更に対応するテストの存在
       - coverage-gap # カバレッジの穴

--- a/pages/explanation/skills.en.md
+++ b/pages/explanation/skills.en.md
@@ -330,7 +330,7 @@ tests:
 **7. Test:**
 
 ```bash
-cd skills/typescript-nullcheck
+cd skills/midstream/typescript-nullcheck
 npx promptfoo eval
 
 # Review results in eval/results.json
@@ -579,7 +579,7 @@ severity: major
 ### Architecture Skill
 
 ```yaml
-# skills/upstream/adr-decision-quality.md
+# skills/upstream/adr-decision-quality/SKILL.md
 id: adr-decision-quality
 name: ADR Decision Quality
 phase: upstream
@@ -594,7 +594,7 @@ severity: info
 ### Test Coverage Skill
 
 ```yaml
-# skills/downstream/coverage-gap.md
+# skills/downstream/coverage-gap/SKILL.md
 id: coverage-gap
 name: Test Coverage Gap Detection
 phase: downstream

--- a/pages/explanation/skills.md
+++ b/pages/explanation/skills.md
@@ -329,7 +329,7 @@ tests:
 **7. テスト:**
 
 ```bash
-cd skills/typescript-nullcheck
+cd skills/midstream/typescript-nullcheck
 npx promptfoo eval
 
 # eval/results.jsonで結果を確認
@@ -558,7 +558,7 @@ npm run eval:fixtures
 ### セキュリティスキル
 
 ```yaml
-# skills/midstream/security-basic.md（frontmatter）
+# skills/midstream/security-basic/SKILL.md（frontmatter）
 id: security-basic
 name: Baseline Security Checks
 phase: midstream
@@ -573,7 +573,7 @@ severity: major
 ### アーキテクチャスキル
 
 ```yaml
-# skills/upstream/adr-decision-quality.md
+# skills/upstream/adr-decision-quality/SKILL.md
 id: adr-decision-quality
 name: ADR Decision Quality
 phase: upstream
@@ -588,7 +588,7 @@ severity: info
 ### テストカバレッジスキル
 
 ```yaml
-# skills/downstream/coverage-gap.md
+# skills/downstream/coverage-gap/SKILL.md
 id: coverage-gap
 name: Test Coverage Gap Detection
 phase: downstream

--- a/scripts/check-skill-id-references.mjs
+++ b/scripts/check-skill-id-references.mjs
@@ -71,7 +71,14 @@ const ALLOWED_FLAT_PATHS = new Set([
   'skills/upstream/sample-architecture-review.md',
   'skills/midstream/sample-code-quality.md',
   'skills/downstream/sample-test-review.md',
+  // pages/ docs の架空例示スキル（存在しないスキル名）
+  'skills/midstream/my-skill.md',
+  'skills/midstream/old-skill.md',
+  'skills/midstream/my-check.md',
 ]);
+
+// 許容する phase なし cd 引数（意図的な doc 例示・架空スキル名）
+const ALLOWED_CD_DIRS = new Set(['my-skill', 'new-skill']);
 
 function isExcluded(p) {
   return EXCLUDE.some((e) => p.includes(e));
@@ -167,11 +174,13 @@ for (const file of collectFiles()) {
     const cdMatches = line.match(CD_NO_PHASE_RE);
     if (cdMatches) {
       for (const m of cdMatches) {
+        const dirName = m.trim().replace(/^cd\s+skills\//, '');
+        if (ALLOWED_CD_DIRS.has(dirName)) continue;
         pathViolations.push({
           file: relative(ROOT, file),
           line: idx + 1,
           found: m.trim(),
-          fix: `cd skills/<phase>/${m.trim().replace(/^cd\s+skills\//, '')}`,
+          fix: `cd skills/<phase>/${dirName}`,
           kind: 'cd-no-phase',
         });
       }

--- a/scripts/check-skill-id-references.mjs
+++ b/scripts/check-skill-id-references.mjs
@@ -22,13 +22,15 @@ const SCAN_DIRS = [
   'skills',
   'scripts',
   'src',
+  'pages',
   'runners/node-api',
+  'runners/github-action/src',
   '.github',
   'examples',
   'commands',
   'docs',
 ];
-const SCAN_FILES = ['README.md', 'README.en.md', 'CLAUDE.md', 'AGENTS.md'];
+const SCAN_FILES = ['README.md', 'README.en.md', 'CLAUDE.md', 'AGENTS.md', 'GEMINI.md'];
 const EXTS = new Set(['.md', '.mjs', '.js', '.ts', '.cjs', '.yaml', '.yml', '.sh', '.json']);
 
 // 除外 path（履歴 / 生成物 / 意図的 fixture / worktree）
@@ -53,8 +55,6 @@ const ALLOWED_LEGACY_IDS = new Set([
   'rr-midstream-plan-conformance-001', // plan-conformance-demo の期待値 fixture
   'rr-upstream-design-architecture-001', // setup script（要移行判定）
   'rr-upstream-pr-body-required-sections-001', // plangate-rule-promotion（要移行判定）
-  'rr-upstream-test-code-react-001', // selection/tdd.yaml の例示
-  'rr-upstream-test-code-unit-ts-jest-001', // selection/tdd.yaml の例示
 ]);
 
 const OLD_ID_RE = /rr-(?:upstream|midstream|downstream)-[a-z0-9-]+-\d{3}/g;

--- a/tests/check-skill-id-references.test.mjs
+++ b/tests/check-skill-id-references.test.mjs
@@ -19,14 +19,20 @@ function runIn(dir) {
     execFileSync('node', [SCRIPT], { cwd: dir, stdio: 'pipe' });
     return 0;
   } catch (e) {
-    return e.status ?? 1;
+    if (typeof e.status === 'number') return e.status;
+    throw e;
   }
 }
 
 function fixture(content) {
   const dir = mkdtempSync(join(tmpdir(), 'rr-refs-'));
-  mkdirSync(join(dir, 'skills', 'upstream', 'x'), { recursive: true });
-  writeFileSync(join(dir, 'skills', 'upstream', 'x', 'SKILL.md'), content);
+  try {
+    mkdirSync(join(dir, 'skills', 'upstream', 'x'), { recursive: true });
+    writeFileSync(join(dir, 'skills', 'upstream', 'x', 'SKILL.md'), content);
+  } catch (e) {
+    rmSync(dir, { recursive: true, force: true });
+    throw e;
+  }
   return dir;
 }
 

--- a/tests/check-skill-id-references.test.mjs
+++ b/tests/check-skill-id-references.test.mjs
@@ -1,0 +1,58 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// check-skill-id-references.mjs のガード挙動を、一時 fixture を cwd にして実プロセス実行で検証する。
+const SCRIPT = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'scripts',
+  'check-skill-id-references.mjs'
+);
+
+function runIn(dir) {
+  try {
+    execFileSync('node', [SCRIPT], { cwd: dir, stdio: 'pipe' });
+    return 0;
+  } catch (e) {
+    return e.status ?? 1;
+  }
+}
+
+function fixture(content) {
+  const dir = mkdtempSync(join(tmpdir(), 'rr-refs-'));
+  mkdirSync(join(dir, 'skills', 'upstream', 'x'), { recursive: true });
+  writeFileSync(join(dir, 'skills', 'upstream', 'x', 'SKILL.md'), content);
+  return dir;
+}
+
+test('dangling な旧形式 skill ID を検出して exit 1', () => {
+  const dir = fixture('ref: rr-upstream-api-design-001\n');
+  try {
+    assert.equal(runIn(dir), 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('allowlist 済みの旧 ID のみなら pass（exit 0）', () => {
+  const dir = fixture('ref: rr-midstream-example-001\n');
+  try {
+    assert.equal(runIn(dir), 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('簡素名（現行 ID）のみなら pass（exit 0）', () => {
+  const dir = fixture('ref: api-design\n');
+  try {
+    assert.equal(runIn(dir), 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

PR #1329（skill ID dangling 参照修正 + 再発防止ガード）の**マージ後レビューで確定した指摘**のうち、squash マージのタイミング差で #1329 本体に含まれなかった修正を適用する follow-up。

## 背景

#1329 は `d6617097` 時点で squash マージされたが、直後に push したレビュー修正コミット（`9a751c50`）がマージに含まれず、6 観点レビュー（self / Codex / security / architect / RiverReview / reviewer）で確定した **major 指摘が main に未反映**のまま残った。本 PR でその修正を取り込む。

## 変更

- **M1（major・confirmed）**: `examples/selection/tdd.yaml` の `rr-upstream-test-code-unit-ts-jest-001` / `-test-code-react-001` は registry 実在 skill（`test-code-unit-ts-jest` / `test-code-react`）を指す **dangling 参照**。同 `include` ブロックの他 4 件は簡素名へ改名済みだったのに、この 2 件だけ `ALLOWED_LEGACY_IDS` へ誤退避していた（＝ガードが本来検出すべき対象を allowlist で恒久隠蔽＝ #1329 の目的と矛盾）。**簡素名へリネームし allowlist から 2 件削除**。
- **M3（major）**: ガード `scripts/check-skill-id-references.mjs` の走査対象に `pages/`（skill ID 参照多数）・`runners/github-action/src`・`GEMINI.md` を追加（false-negative の穴を縮小。追加面の旧 ID 0 件を確認済）。
- **m1（minor）**: `tests/check-skill-id-references.test.mjs` を新設（旧 ID→fail / allowlist→pass / clean→pass を実プロセス実行で検証）。

## Verification

- `skills:validate:refs`（guard）PASS / 新規テスト **3/3** / `skills:manifest:check` up-to-date(121) / prettier clean

## 残 follow-up（本 PR 対象外）

- **M2**: ガードを `registry.yaml` 突合の「参照整合性チェック」へ再設計（旧形式・typo・削除参照を一括捕捉、allowlist 縮小）
- **m2**: allowlist の「要移行判定」4 件（`performance-001/002` 等）の個別移行 + tracking issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
