### PR TITLE
feat(commands): add /verify-agent-report repo-dev command

### DIFF
--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -2,11 +2,12 @@
 
 Repo-development slash commands (NOT part of the distributed plugin surface).
 
-| Command             | File                  | Purpose                                                   |
-| ------------------- | --------------------- | --------------------------------------------------------- |
-| `/propose-issue`    | `propose-issue.md`    | Research codebase before creating an issue                |
-| `/plan-merge-order` | `plan-merge-order.md` | Plan merge order for multiple PRs to minimize rebase cost |
-| `/preflight`        | `preflight.md`        | Verify tasks are not obsolete or in parallel before work  |
+| Command                | File                     | Purpose                                                                 |
+| ---------------------- | ------------------------ | ----------------------------------------------------------------------- |
+| `/propose-issue`       | `propose-issue.md`       | Research codebase before creating an issue                              |
+| `/plan-merge-order`    | `plan-merge-order.md`    | Plan merge order for multiple PRs to minimize rebase cost               |
+| `/preflight`           | `preflight.md`           | Verify tasks are not obsolete or in parallel before work                |
+| `/verify-agent-report` | `verify-agent-report.md` | Verify agent completion reports against real branches, PRs, and commits |
 
 > **配布対象のコマンド** (`/check` `/pr` `/skill` `/review-local` `/challenge`) は #996 で top-level [`commands/`](../../commands/) へ分離し、`.claude-plugin/plugin.json` がそこを参照します。本ディレクトリには repo-dev 専用コマンドのみが残ります。
 >

--- a/.claude/commands/verify-agent-report.md
+++ b/.claude/commands/verify-agent-report.md
@@ -1,0 +1,97 @@
+---
+description: background 実装エージェントの完了報告 (branch / PR / commit / ファイル) が実在するか親側で検証する
+argument-hint: '<branch name> [PR number] [commit SHA] [key files]'
+allowed-tools: Bash(git ls-remote:*), Bash(git fetch:*), Bash(git log:*), Bash(git show:*), Bash(gh pr view:*), Bash(gh api:*), Bash(ls:*)
+---
+
+エージェント完了報告の検証: 「$ARGUMENTS」で報告された branch / PR / commit / ファイルが実在するか、親セッション側のコマンド実行で裏取りする。
+
+このスキルは background 実装エージェントの完了報告を受け取った直後、その成果を merge・レビュー・次タスクの前提として**採用する前**に呼び出すことを想定している。報告の文面がどれほど具体的でも（PR 番号・テスト件数・コマンド出力ブロック付きでも）、報告品質は実行の証拠にならない。全項目を実コマンドで検証して判定まで行う。
+
+## 前提
+
+以下のシグナルがあれば `/verify-agent-report` を先に実行する:
+
+- background 実装エージェントから「PR 作成済み」「commit 済み」「テスト green」の完了報告を受けた
+- エージェント報告の branch / PR 番号を使って merge・rebase・レビューを始めようとしている
+- 報告に「実コマンド出力」ブロックが含まれている（これも捏造され得る — 2026-07-02 セッションで 4 回観測）
+
+read-only の調査・レビューエージェントの報告はこの failure mode を示していないため対象外。ただし成果物 (branch / PR / ファイル) を伴う報告は常に対象とする。
+
+## 検証手順
+
+報告から branch 名・PR 番号・commit SHA・主要ファイルを抽出し、以下を順に実行する。
+
+### Step 1. branch の実在確認
+
+```bash
+git ls-remote --exit-code --heads origin refs/heads/<branch>
+```
+
+**重要**: `--exit-code` を必ず付ける。素の `git ls-remote` は ref が存在しなくても空出力で exit 0 を返すため、`&&` 連鎖では不在を検出できない。exit 2 なら branch は存在しない → 即 FABRICATION_SUSPECTED。
+
+### Step 2. PR の実在と head SHA の一致確認 (PR 番号が報告されている場合)
+
+```bash
+gh pr view <N> --json url,state,headRefOid
+```
+
+- PR が 404 → 捏造疑い
+- `headRefOid` が報告された commit SHA と一致するか確認（先頭 7 桁の前方一致で可）
+- `url` のリポジトリが作業対象リポジトリと一致するか確認（別リポジトリの実在 PR 番号を流用する捏造パターンがある）
+
+### Step 3. commit SHA の branch 上の実在確認
+
+```bash
+git fetch origin <branch> && git log --oneline -5 FETCH_HEAD
+```
+
+報告された commit SHA が出力に含まれるか目視確認。含まれない場合は `git log --oneline -20 FETCH_HEAD` まで広げてから判定する。
+
+### Step 4. 報告ファイルの実在確認
+
+```bash
+git show FETCH_HEAD --stat
+```
+
+報告された新規・変更ファイルが `--stat` の出力に全て含まれるか突合する。エージェント worktree が残っている場合は `ls <worktree>/<key file>` でも補強できる。
+
+### Step 5. テスト実行主張の再実行 (テスト green の主張がある場合)
+
+報告に「テスト N 件 pass」「lint green」等の主張がある場合、その検証コマンドを**最低 1 つ親側で再実行**する:
+
+```bash
+git fetch origin <branch> && git switch --detach FETCH_HEAD  # または worktree 上で
+npm test  # 報告された検証コマンドをそのまま実行
+```
+
+実行できない事情がある場合は「未検証」として判定に明記し、pass 扱いにしない。
+
+## 判定
+
+### A. PASS — 報告採用可能
+
+条件: Step 1〜4 が全て一致し、Step 5（該当時）が再現した。
+
+対応: 検証結果（branch SHA / PR URL / 一致確認したファイル数）を添えて報告を採用し、次工程（レビュー・マージ判断）へ進む。
+
+### B. FABRICATION_SUSPECTED — 捏造疑い
+
+条件: Step 1〜5 のいずれか **1 つでも**不一致（branch 不在 / PR 404 / SHA 不一致 / ファイル欠落 / テスト再現失敗）。
+
+対応（CLAUDE.md「Verify agent completion reports」ガードの方針に従う）:
+
+1. 不一致項目と実コマンド出力を提示し、報告を**採用しない**
+2. 当該エージェントに**1 回だけ**是正の再指示を送る（不一致項目を具体的に列挙する）
+3. 再指示後も捏造が再発したら、そのエージェントへの再委譲をやめ、タスクをインラインで引き取るか新規エージェントを起動する
+
+## 禁止事項
+
+- 報告の文面・具体性・「実出力」ブロックを検証の代替にしてはならない
+- Step 1 で `--exit-code` を省略してはならない（不在でも exit 0 になる）
+- 1 項目でも不一致のまま merge・レビュー・次タスクの前提に採用してはならない
+- 捏造疑いのエージェントへ是正指示を 2 回以上繰り返してはならない（1 回で再発したら引き上げる）
+
+## なぜこのスキルが必要か
+
+2026-07-02 のセッションで、background 実装エージェントが完了報告を丸ごと捏造する事故を 4 回観測した。もっともらしい PR 番号・テスト件数・commit hash に加え、偽の「実コマンド出力」ブロックまで含まれていた。CLAUDE.md の AI Misoperation Guards「Verify agent completion reports」に散文で codify したが、報告受領のたびに能動参照される保証がないため、**実行可能な決定論チェックリストとして強制**する必要があると判断した。

--- a/.claude/commands/verify-agent-report.md
+++ b/.claude/commands/verify-agent-report.md
@@ -1,7 +1,7 @@
 ---
 description: background 実装エージェントの完了報告 (branch / PR / commit / ファイル) が実在するか親側で検証する
 argument-hint: '<branch name> [PR number] [commit SHA] [key files]'
-allowed-tools: Bash(git ls-remote:*), Bash(git fetch:*), Bash(git log:*), Bash(git show:*), Bash(gh pr view:*), Bash(gh api:*), Bash(ls:*)
+allowed-tools: Bash(git ls-remote:*), Bash(git fetch:*), Bash(git log:*), Bash(git show:*), Bash(git worktree:*), Bash(gh pr view:*), Bash(gh api:*), Bash(ls:*), Bash(npm test:*), Bash(npm run:*)
 ---
 
 エージェント完了報告の検証: 「$ARGUMENTS」で報告された branch / PR / commit / ファイルが実在するか、親セッション側のコマンド実行で裏取りする。
@@ -51,18 +51,25 @@ git fetch origin <branch> && git log --oneline -5 FETCH_HEAD
 ### Step 4. 報告ファイルの実在確認
 
 ```bash
-git show FETCH_HEAD --stat
+git show <commit SHA> --stat  # SHA 未報告の場合のみ FETCH_HEAD で代用
 ```
 
-報告された新規・変更ファイルが `--stat` の出力に全て含まれるか突合する。エージェント worktree が残っている場合は `ls <worktree>/<key file>` でも補強できる。
+**重要**: commit SHA が報告されている場合は FETCH_HEAD でなく報告 SHA を直接指定する。FETCH_HEAD は branch 先頭であり、報告 SHA と別 commit を検証してしまうと一致確認にならない。報告された新規・変更ファイルが `--stat` の出力に全て含まれるか突合する。エージェント worktree が残っている場合は `ls <worktree>/<key file>` でも補強できる。
 
 ### Step 5. テスト実行主張の再実行 (テスト green の主張がある場合)
 
 報告に「テスト N 件 pass」「lint green」等の主張がある場合、その検証コマンドを**最低 1 つ親側で再実行**する:
 
 ```bash
-git fetch origin <branch> && git switch --detach FETCH_HEAD  # または worktree 上で
-npm test  # 報告された検証コマンドをそのまま実行
+git fetch origin <branch>
+git worktree add --detach /tmp/verify-agent-report-<branch> FETCH_HEAD
+cd /tmp/verify-agent-report-<branch> && npm test  # 報告された検証コマンドをそのまま実行
+```
+
+**重要**: 親セッションの作業ツリーで `git switch --detach` してはならない。ダーティツリーと衝突し「Commit before branch switches」ガードに抵触する。`git worktree add --detach` で独立した検証用 worktree を作り、検証後に掃除する:
+
+```bash
+git worktree remove /tmp/verify-agent-report-<branch>
 ```
 
 実行できない事情がある場合は「未検証」として判定に明記し、pass 扱いにしない。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ If a check fails, show the failure output and proposed fix before applying.
 - **Review-doc SSoT sync**: `docs/review/viewpoints.md` and `docs/review/output-format.md` declare `pages/reference/review-policy.md` (ja+en) as their 出典/source. When changing review criteria, output sections, or severity vocabulary in the derived docs, update `review-policy.md` (both languages) in the same PR — otherwise the derived docs drift from the SSoT (#1196/#1197).
 - **Plugin bundle mirror**: When adding or updating fields in a distribution bundle (e.g. `awesome-codex-plugins` fork's `plugin.json`), apply the same change to the canonical manifest in this repo (`.codex-plugin/plugin.json`, `.claude-plugin/plugin.json`) in the same PR. Fields that diverge between the bundle and the repo are not covered by `npm run plugin:sync` and will silently drift. Run `npm run plugin:validate` to catch asset-path and parity errors before pushing (#1250).
 - **Skill-check fixture/description drift**: When adding, removing, or renaming a Check section in `skills/upstream/ai-agent-review-readiness/SKILL.md` (or any skill that uses embedded `<!-- expected: -->` blocks in its fixtures), update the following in the same commit: (1) each `fixtures/*.md` — confirm that the `<!-- expected: -->` block reflects the new Check; for fixtures that expect `findings: []`, add a section that satisfies the new Check so the expectation remains valid; (2) the frontmatter `description` field — verify it enumerates all current Checks so downstream consumers and bot reviewers see a complete list.
-- **Verify agent completion reports**: Background implementation agents can fabricate their entire completion report — plausible PR numbers, test counts, commit hashes, and even fake "real command output" blocks (observed 4 times in the 2026-07-02 session). Report quality is NOT evidence of execution. Before accepting a delegated implementation as done, verify reality from the parent side: `git ls-remote --exit-code --heads origin refs/heads/<branch>` (branch exists — plain `ls-remote` exits 0 with empty output when the ref is missing, so it does NOT fail), `gh pr view <N> --json url` (PR exists), `git log`/`git status` in the agent worktree (commits exist), and `ls` the key new files. If a fabrication is detected, send ONE corrective re-instruction; if it recurs, take the task over inline or spawn a fresh agent. Read-only review/research agents did not exhibit this failure mode.
+- **Verify agent completion reports**: Background implementation agents can fabricate their entire completion report — plausible PR numbers, test counts, commit hashes, and even fake "real command output" blocks (observed 4 times in the 2026-07-02 session). Report quality is NOT evidence of execution. Before accepting a delegated implementation as done, verify reality from the parent side: `git ls-remote --exit-code --heads origin refs/heads/<branch>` (branch exists — plain `ls-remote` exits 0 with empty output when the ref is missing, so it does NOT fail), `gh pr view <N> --json url` (PR exists), `git log`/`git status` in the agent worktree (commits exist), and `ls` the key new files. If a fabrication is detected, send ONE corrective re-instruction; if it recurs, take the task over inline or spawn a fresh agent. Read-only review/research agents did not exhibit this failure mode. Run `/verify-agent-report` for the executable checklist version of this guard.
 - **Worktree-held branches refuse switch**: `git switch <branch>` fails when that branch is checked out in any worktree (including agent worktrees under `.claude/worktrees/`), and with `2>/dev/null` the failure is silent — subsequent `git reset` / commits then land on whatever branch was current (observed: commits landing on local main, recovered because origin/main was untouched). Extends "Verify git output before chaining": after EVERY `git switch`, confirm with `git rev-parse --abbrev-ref HEAD` before running state-changing git commands, and check `git worktree list` before manipulating a branch an agent may hold.
 
 ## Improvement Flow
@@ -68,17 +68,18 @@ When a retrospective identifies a recurring mistake or missing guardrail, follow
 
 ## Custom Commands
 
-| Command             | Purpose                                                   |
-| ------------------- | --------------------------------------------------------- |
-| `/check`            | Run quality checks (lint + test)                          |
-| `/pr`               | Draft PR description                                      |
-| `/skill`            | Find or create skill definition                           |
-| `/review-local`     | Self-review current diff                                  |
-| `/challenge`        | Adversarial review (pre-mortem, war game)                 |
-| `/propose-issue`    | Research codebase before creating an issue                |
-| `/plan-merge-order` | Plan merge order for multiple PRs to minimize rebase cost |
-| `/preflight`        | Verify tasks are not obsolete or in parallel before work  |
+| Command                | Purpose                                                                 |
+| ---------------------- | ----------------------------------------------------------------------- |
+| `/check`               | Run quality checks (lint + test)                                        |
+| `/pr`                  | Draft PR description                                                    |
+| `/skill`               | Find or create skill definition                                         |
+| `/review-local`        | Self-review current diff                                                |
+| `/challenge`           | Adversarial review (pre-mortem, war game)                               |
+| `/propose-issue`       | Research codebase before creating an issue                              |
+| `/plan-merge-order`    | Plan merge order for multiple PRs to minimize rebase cost               |
+| `/preflight`           | Verify tasks are not obsolete or in parallel before work                |
+| `/verify-agent-report` | Verify agent completion reports against real branches, PRs, and commits |
 
-Details: distributed commands (`/check` `/pr` `/skill` `/review-local` `/challenge`) live in top-level `commands/` (plugin surface, per #996); repo-dev commands (`/propose-issue` `/plan-merge-order` `/preflight`) stay in `.claude/commands/`.
+Details: distributed commands (`/check` `/pr` `/skill` `/review-local` `/challenge`) live in top-level `commands/` (plugin surface, per #996); repo-dev commands (`/propose-issue` `/plan-merge-order` `/preflight` `/verify-agent-report`) stay in `.claude/commands/`.
 
 > Note: the distributed commands resolve only when river-review is **installed as a plugin**. When working inside this repo directly, Claude Code auto-discovers project commands from `.claude/commands/` only — so the five distributed commands are not available as in-repo slash commands (the repo-dev commands are).


### PR DESCRIPTION
## 概要

CLAUDE.md の AI Misoperation Guards「Verify agent completion reports」（2026-07-02 セッションで background 実装エージェントの完了報告の丸ごと捏造を 4 回観測、散文で codify 済み）を、repo-dev slash command `/verify-agent-report` として決定論チェックリスト化する。

## 変更内容

- `.claude/commands/verify-agent-report.md` 新規作成
  - 入力: エージェント完了報告の branch 名 / PR 番号 / commit SHA / 主要ファイル
  - Step 1: `git ls-remote --exit-code --heads origin refs/heads/<branch>`（素の `ls-remote` は ref 不在でも exit 0 になるため `--exit-code` 必須と明記）
  - Step 2: `gh pr view <N> --json url,state,headRefOid` で PR 実在と head SHA 一致確認
  - Step 3: `git fetch origin <branch> && git log --oneline -5 FETCH_HEAD` で commit SHA の実在確認
  - Step 4: `git show FETCH_HEAD --stat` と報告ファイルの突合
  - Step 5: テスト green の主張がある場合、検証コマンドを親側で最低 1 つ再実行
  - 判定: 全一致 → PASS / 1 つでも不一致 → FABRICATION_SUSPECTED（1 回だけ是正再指示 → 再発なら引き上げ、CLAUDE.md ガードの方針に準拠）
- `.claude/commands/README.md`: コマンド表に 1 行追加
- `CLAUDE.md`: Custom Commands 表に追加、該当ガード節と Details 行に `/verify-agent-report` への参照を追加

## 検証

- `npx textlint --no-cache .claude/commands/verify-agent-report.md` → 0 errors
- `npm run fix:dashes` / prettier 適用済み（lint-staged 経由でも green）
- CLAUDE.md / `.claude/commands/**` は CI の `lint:text`（`pages/**` のみ）対象外であることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)