### PR TITLE
feat(plugin): add bundle field allowlist and cross-manifest parity checks

### DIFF
--- a/scripts/validate-plugin-manifest.mjs
+++ b/scripts/validate-plugin-manifest.mjs
@@ -36,12 +36,145 @@ function normalizeRef(ref) {
 }
 
 /**
+ * Distribution-bundle field allowlist for .codex-plugin/plugin.json (#1250).
+ *
+ * The external `awesome-codex-plugins` fork carries a bundle copy of this
+ * manifest that cannot be reached from this repo, so parity with the fork is
+ * enforced indirectly: every field the bundle may carry must be declared here.
+ * A field present in the manifest but absent from this allowlist fails
+ * `npm run plugin:validate`, forcing the mirror rule in CLAUDE.md
+ * ("Plugin bundle mirror") to be applied consciously instead of drifting
+ * silently.
+ */
+export const CODEX_BUNDLE_ALLOWED_FIELDS = [
+  '$schema',
+  'name',
+  'version',
+  'description',
+  'author',
+  'homepage',
+  'repository',
+  'license',
+  'keywords',
+  'skills',
+  'interface',
+];
+
+/** Fields awesome-codex-plugins listing requires in the bundle manifest. */
+export const CODEX_BUNDLE_REQUIRED_FIELDS = [
+  'name',
+  'version',
+  'description',
+  'repository',
+  'license',
+];
+
+export const CODEX_INTERFACE_ALLOWED_FIELDS = [
+  'displayName',
+  'shortDescription',
+  'longDescription',
+  'developerName',
+  'category',
+  'capabilities',
+  'websiteURL',
+  'composerIcon',
+];
+
+/**
+ * Check that the .codex-plugin manifest (the in-repo mirror of the
+ * distribution bundle) only carries allowlisted fields and carries every
+ * field the external listing requires.
+ *
+ * Pure function; returns array of error strings (empty = pass).
+ */
+export function checkBundleFieldAllowlist(codexManifest) {
+  const errors = [];
+
+  for (const field of Object.keys(codexManifest)) {
+    if (!CODEX_BUNDLE_ALLOWED_FIELDS.includes(field)) {
+      errors.push(
+        `.codex-plugin/plugin.json: field "${field}" is not in the bundle allowlist — ` +
+          `add it to CODEX_BUNDLE_ALLOWED_FIELDS in scripts/validate-plugin-manifest.mjs ` +
+          `and mirror it to the distribution bundle in the same PR (#1250)`
+      );
+    }
+  }
+
+  for (const field of CODEX_BUNDLE_REQUIRED_FIELDS) {
+    if (codexManifest[field] === undefined || codexManifest[field] === '') {
+      errors.push(
+        `.codex-plugin/plugin.json: required bundle field "${field}" is missing or empty ` +
+          `(required by the awesome-codex-plugins listing)`
+      );
+    }
+  }
+
+  const iface = codexManifest.interface;
+  if (iface && typeof iface === 'object') {
+    for (const field of Object.keys(iface)) {
+      if (!CODEX_INTERFACE_ALLOWED_FIELDS.includes(field)) {
+        errors.push(
+          `.codex-plugin/plugin.json: interface field "${field}" is not in the bundle allowlist — ` +
+            `add it to CODEX_INTERFACE_ALLOWED_FIELDS in scripts/validate-plugin-manifest.mjs ` +
+            `and mirror it to the distribution bundle in the same PR (#1250)`
+        );
+      }
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Check parity of fields shared between the two canonical manifests that are
+ * NOT owned by `npm run plugin:sync` (which only syncs keywords/homepage/
+ * author/license from package.json). These pairs previously drifted silently
+ * (#1250: composerIcon updated in the bundle only).
+ *
+ * Not compared: description/version (intentionally differ or release-please
+ * owned), keywords/homepage/author/license (plugin:sync owns them).
+ *
+ * Pure function; returns array of error strings (empty = pass).
+ */
+export function checkCrossManifestParity(ccManifest, codexManifest) {
+  const errors = [];
+  const iface =
+    codexManifest.interface && typeof codexManifest.interface === 'object'
+      ? codexManifest.interface
+      : {};
+
+  const pairs = [
+    ['repository', ccManifest.repository, 'repository', codexManifest.repository],
+    ['skills', ccManifest.skills, 'skills', codexManifest.skills],
+    ['displayName', ccManifest.displayName, 'interface.displayName', iface.displayName],
+    ['composerIcon', ccManifest.composerIcon, 'interface.composerIcon', iface.composerIcon],
+    ['homepage', ccManifest.homepage, 'interface.websiteURL', iface.websiteURL],
+    ['author.name', ccManifest.author?.name, 'interface.developerName', iface.developerName],
+  ];
+
+  for (const [ccField, ccVal, codexField, codexVal] of pairs) {
+    if (JSON.stringify(ccVal) !== JSON.stringify(codexVal)) {
+      errors.push(
+        `manifest parity: .claude-plugin "${ccField}" (${JSON.stringify(ccVal)}) !== ` +
+          `.codex-plugin "${codexField}" (${JSON.stringify(codexVal)})`
+      );
+    }
+  }
+
+  return errors;
+}
+
+/**
  * Validate the Claude Code + Codex plugin manifests and the marketplace
  * manifest against the repository:
  *  - every component path referenced by .claude-plugin/plugin.json exists
  *  - .claude-plugin and .codex-plugin manifest versions match package.json
  *  - marketplace plugins[].name matches the plugin manifest name
  *  - the Codex manifest's skills path exists
+ *  - the Codex manifest carries only allowlisted bundle fields and all
+ *    listing-required fields (checkBundleFieldAllowlist)
+ *  - shared fields not owned by plugin:sync match across both canonical
+ *    manifests (checkCrossManifestParity)
  *
  * Returns array of error strings (empty = pass).
  */
@@ -189,6 +322,10 @@ export async function validatePluginManifest() {
         }
       }
     }
+
+    // --- Bundle field allowlist + canonical cross-manifest parity (#1250) ---
+    errors.push(...checkBundleFieldAllowlist(codexManifest));
+    errors.push(...checkCrossManifestParity(ccManifest, codexManifest));
 
     // --- Cross-plugin field parity (synced fields must match package.json) ---
     // repository is excluded: package.json uses {type, url} object; plugins use plain string URL.

--- a/scripts/validate-plugin-manifest.mjs
+++ b/scripts/validate-plugin-manifest.mjs
@@ -101,7 +101,11 @@ export function checkBundleFieldAllowlist(codexManifest) {
   }
 
   for (const field of CODEX_BUNDLE_REQUIRED_FIELDS) {
-    if (codexManifest[field] === undefined || codexManifest[field] === '') {
+    if (
+      codexManifest[field] === undefined ||
+      codexManifest[field] === null ||
+      codexManifest[field] === ''
+    ) {
       errors.push(
         `.codex-plugin/plugin.json: required bundle field "${field}" is missing or empty ` +
           `(required by the awesome-codex-plugins listing)`

--- a/tests/validate-plugin-manifest.test.mjs
+++ b/tests/validate-plugin-manifest.test.mjs
@@ -116,3 +116,11 @@ test('checkBundleFieldAllowlist reports missing listing-required fields', () => 
   assert.match(errors[0], /required bundle field "repository"/);
   assert.match(errors[1], /required bundle field "license"/);
 });
+
+test('checkBundleFieldAllowlist reports null listing-required field', () => {
+  const codex = makeCodexManifest();
+  codex.license = null;
+  const errors = checkBundleFieldAllowlist(codex);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /required bundle field "license"/);
+});

--- a/tests/validate-plugin-manifest.test.mjs
+++ b/tests/validate-plugin-manifest.test.mjs
@@ -1,8 +1,118 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { validatePluginManifest } from '../scripts/validate-plugin-manifest.mjs';
+import {
+  validatePluginManifest,
+  checkBundleFieldAllowlist,
+  checkCrossManifestParity,
+} from '../scripts/validate-plugin-manifest.mjs';
 
 test('validatePluginManifest passes on current repo state', async () => {
   const errors = await validatePluginManifest();
   assert.deepEqual(errors, [], `Expected no errors but got: ${errors.join(', ')}`);
+});
+
+function makeCcManifest() {
+  return {
+    name: 'river-review',
+    displayName: 'River Review',
+    homepage: 'https://example.com/',
+    repository: 'https://github.com/s977043/river-review',
+    author: { name: 'river-review maintainers', url: 'https://example.com/' },
+    skills: './skills/agent-skills/',
+    composerIcon: './assets/icon.svg',
+  };
+}
+
+function makeCodexManifest() {
+  return {
+    name: 'river-review',
+    version: '1.0.0',
+    description: 'desc',
+    author: { name: 'river-review maintainers', url: 'https://example.com/' },
+    homepage: 'https://example.com/',
+    repository: 'https://github.com/s977043/river-review',
+    license: 'MIT',
+    keywords: ['code-review'],
+    skills: './skills/agent-skills/',
+    interface: {
+      displayName: 'River Review',
+      shortDescription: 'short',
+      longDescription: 'long',
+      developerName: 'river-review maintainers',
+      category: 'Developer Tools',
+      capabilities: ['Read'],
+      websiteURL: 'https://example.com/',
+      composerIcon: './assets/icon.svg',
+    },
+  };
+}
+
+test('checkCrossManifestParity passes when shared fields match', () => {
+  const errors = checkCrossManifestParity(makeCcManifest(), makeCodexManifest());
+  assert.deepEqual(errors, [], `Expected no errors but got: ${errors.join(', ')}`);
+});
+
+test('checkCrossManifestParity detects repository drift', () => {
+  const codex = makeCodexManifest();
+  codex.repository = 'https://github.com/other/fork';
+  const errors = checkCrossManifestParity(makeCcManifest(), codex);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /"repository"/);
+});
+
+test('checkCrossManifestParity detects composerIcon drift (regression #1250)', () => {
+  const codex = makeCodexManifest();
+  delete codex.interface.composerIcon;
+  const errors = checkCrossManifestParity(makeCcManifest(), codex);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /interface\.composerIcon/);
+});
+
+test('checkCrossManifestParity detects displayName and websiteURL drift', () => {
+  const codex = makeCodexManifest();
+  codex.interface.displayName = 'Other Name';
+  codex.interface.websiteURL = 'https://elsewhere.example/';
+  const errors = checkCrossManifestParity(makeCcManifest(), codex);
+  assert.equal(errors.length, 2);
+  assert.match(errors[0], /interface\.displayName/);
+  assert.match(errors[1], /interface\.websiteURL/);
+});
+
+test('checkCrossManifestParity detects developerName drift against author.name', () => {
+  const codex = makeCodexManifest();
+  codex.interface.developerName = 'someone else';
+  const errors = checkCrossManifestParity(makeCcManifest(), codex);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /interface\.developerName/);
+});
+
+test('checkBundleFieldAllowlist passes on a conforming manifest', () => {
+  const errors = checkBundleFieldAllowlist(makeCodexManifest());
+  assert.deepEqual(errors, [], `Expected no errors but got: ${errors.join(', ')}`);
+});
+
+test('checkBundleFieldAllowlist rejects unknown top-level field', () => {
+  const codex = makeCodexManifest();
+  codex.marketplaceBadge = 'gold';
+  const errors = checkBundleFieldAllowlist(codex);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /"marketplaceBadge" is not in the bundle allowlist/);
+});
+
+test('checkBundleFieldAllowlist rejects unknown interface field', () => {
+  const codex = makeCodexManifest();
+  codex.interface.heroImage = './assets/hero.png';
+  const errors = checkBundleFieldAllowlist(codex);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /interface field "heroImage" is not in the bundle allowlist/);
+});
+
+test('checkBundleFieldAllowlist reports missing listing-required fields', () => {
+  const codex = makeCodexManifest();
+  delete codex.repository;
+  codex.license = '';
+  const errors = checkBundleFieldAllowlist(codex);
+  assert.equal(errors.length, 2);
+  assert.match(errors[0], /required bundle field "repository"/);
+  assert.match(errors[1], /required bundle field "license"/);
 });


### PR DESCRIPTION
## Summary

CLAUDE.md の AI Misoperation Guards「Plugin bundle mirror」(#1250) が指摘する silent drift を `npm run plugin:validate` で機械的に検出できるようにする。

- `checkBundleFieldAllowlist` (新規): `.codex-plugin/plugin.json`（配布 bundle の in-repo mirror）のフィールドを in-repo allowlist（top-level + `interface`）と突合し、allowlist 外フィールドをエラーにする。あわせて awesome-codex-plugins 掲載要件フィールド（name/version/description/repository/license）の欠落を検出する
- `checkCrossManifestParity` (新規): `plugin:sync` が所有しない共有フィールドの canonical manifest 間 parity を検証する — `repository` / `skills` / `displayName`⇔`interface.displayName` / `composerIcon`⇔`interface.composerIcon` / `homepage`⇔`interface.websiteURL` / `author.name`⇔`interface.developerName`
- 両チェックを `validatePluginManifest()` に配線（`npm run plugin:validate` と既存の test.yml「Meta consistency」job で自動実行）

## 設計判断: 外部 fork の扱い

外部 `awesome-codex-plugins` fork の bundle `plugin.json` はこの repo から参照する仕組みが存在しない（scripts/ 配下に fork を clone / fetch する実装は無く、参照は docs のみ）。fork を clone する新規機構の追加はネットワーク依存・認証・CI 時間のコストに対して得るものが薄いため見送り、到達可能な範囲に絞った:

1. canonical manifest 間 (.claude-plugin ⇔ .codex-plugin) の parity 強化 — #1250 の実事故（`composerIcon` が bundle 側のみ更新）はこの層で検出可能
2. bundle に含めてよいフィールドの allowlist を repo 内 (`scripts/validate-plugin-manifest.mjs`) に定義 — bundle 側で新フィールドを追加して mirror した際、allowlist 未更新なら `plugin:validate` が fail し、mirror ルールの適用を強制する

## 何が検出できるようになったか / 何が依然として手動か

**検出可能になったもの:**

- canonical manifest 間の共有フィールド分岐（repository / skills / displayName / composerIcon / websiteURL / developerName）
- `.codex-plugin/plugin.json` への allowlist 外フィールドの追加（top-level / interface とも）
- 掲載要件フィールドの欠落

**依然として手動のもの:**

- 外部 fork の bundle と本 repo の `.codex-plugin/plugin.json` の直接比較（fork は repo から到達不能）。bundle 側だけを変更して repo に mirror しなかった場合は検出できない — CLAUDE.md の mirror ガード（同一 PR で両方更新）が引き続き必要
- `description` の内容妥当性（platform ごとに意図的に異なるため parity 対象外）

## 検証

- `npm run plugin:validate` → OK（現状の repo state で green）
- 実証: `.codex-plugin/plugin.json` の `interface.composerIcon` を一時変更 + 未知フィールド `badgeColor` を追加 → 3 errors（asset 不在 / allowlist 違反 / parity 違反）を検出、revert 後 OK
- `npm run meta:validate` → OK
- `npm test` → 1765 tests / 1765 pass（unit test 10 本追加: parity 一致系 2 / 分岐検出系 8）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
