### PR TITLE
feat(ci): auto-rebuild github-action dist on stale PRs

### DIFF
--- a/.github/workflows/auto-rebuild-action-dist.yml
+++ b/.github/workflows/auto-rebuild-action-dist.yml
@@ -1,0 +1,111 @@
+name: Auto Rebuild Action Dist
+
+# Automatically rebuild runners/github-action/dist/ on pull requests when the
+# bundled sources change and the committed dist is stale, then push the
+# rebuild commit back to the PR branch. This replaces the manual
+# "chore(action): rebuild github-action dist" commits (12 in the last 400
+# commits) that contributors had to run locally with an .nvmrc-matched Node.
+#
+# Scope guards:
+# - Same-repo branches only: pushing to fork branches is not possible with
+#   repo-scoped credentials, so fork PRs are excluded and keep relying on the
+#   `Action dist freshness` job in test.yml to flag staleness.
+# - release-please branches are excluded so automated commits never pollute
+#   release PRs (release-please force-updates its branch and would fight any
+#   foreign commit).
+#
+# Token / no-recursion (same policy as release-please-kick.yml): pushes
+# authored by `GITHUB_TOKEN` do NOT trigger `pull_request: synchronize`
+# workflows by GitHub design (no-recursion safety). With strict required
+# status checks, a GITHUB_TOKEN push would leave the new head SHA without CI
+# and block the merge. We therefore prefer `RELEASE_KICK_PAT` (contents:write)
+# so the rebuild commit re-fires CI, and fall back to GITHUB_TOKEN with a loud
+# warning telling the contributor to kick CI manually (e.g. an empty commit or
+# `gh workflow run`). Recursion is naturally bounded either way: the re-run
+# rebuilds, finds no diff, and exits without pushing.
+#
+# Cross-platform determinism: the runner is Linux and `.gitattributes` pins
+# `runners/github-action/dist/*.{mjs,map,cjs} text eol=lf`, plus `npm run build:action`
+# ends with scripts/normalize-dist.mjs — so the bot-built bundle is
+# byte-identical to a compliant local rebuild.
+
+on:
+  pull_request:
+    # Keep in sync with the path set watched by the `Action dist freshness`
+    # job in test.yml (src_ts computation): bundled action sources, src/
+    # modules imported by the action entrypoint, and the lockfile (ncc vendors
+    # production deps into dist/, see #1057).
+    paths:
+      - 'runners/github-action/src/**'
+      - 'src/**'
+      - 'package-lock.json'
+
+permissions: read-all
+
+concurrency:
+  group: auto-rebuild-action-dist-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  rebuild-dist:
+    name: Rebuild dist if stale
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Same-repo PRs only (fork branches are not pushable) and never
+    # release-please branches (automated commits must not pollute release PRs).
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !startsWith(github.event.pull_request.head.ref, 'release-please--')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          # Check out the PR head BRANCH (not the merge ref) so the rebuild
+          # commit can be pushed back to it.
+          ref: ${{ github.event.pull_request.head.ref }}
+          # Prefer RELEASE_KICK_PAT so the push re-triggers pull_request CI;
+          # GITHUB_TOKEN fallback pushes fine but cannot re-fire CI.
+          token: ${{ secrets.RELEASE_KICK_PAT || secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          # .nvmrc is the SSoT for the Node version; ncc output differs across
+          # Node majors (see docs/development/dist-check-rebuild-guide.md).
+          node-version-file: '.nvmrc'
+          cache: npm
+
+      - run: npm ci
+
+      - name: Rebuild dist and detect staleness
+        id: rebuild
+        run: |
+          set -euo pipefail
+          npm run build:action
+          if git diff --quiet -- runners/github-action/dist/; then
+            echo "dist/ is already fresh; nothing to commit."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "dist/ is stale; rebuild produced changes:"
+            git diff --stat -- runners/github-action/dist/
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push rebuilt dist
+        if: steps.rebuild.outputs.changed == 'true'
+        env:
+          USING_PAT: ${{ secrets.RELEASE_KICK_PAT != '' }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add runners/github-action/dist/
+          git commit -m "chore(action): rebuild github-action dist"
+          git push origin "HEAD:${GITHUB_HEAD_REF}"
+          echo "Pushed rebuild commit to ${GITHUB_HEAD_REF}."
+
+          if [ "${USING_PAT}" != "true" ]; then
+            echo "::warning::RELEASE_KICK_PAT is not set; the rebuild commit was pushed with GITHUB_TOKEN."
+            echo "::warning::GitHub blocks GITHUB_TOKEN pushes from re-triggering pull_request workflows (no-recursion safety), so CI will NOT re-run on the new head SHA."
+            echo "::warning::Kick CI manually: push an empty commit to the branch, or close/reopen the PR."
+          fi

--- a/docs/development/dist-check-rebuild-guide.md
+++ b/docs/development/dist-check-rebuild-guide.md
@@ -26,14 +26,14 @@ cat .nvmrc
 
 ## 自動再ビルド（Auto Rebuild Action Dist）
 
-`.github/workflows/auto-rebuild-action-dist.yml` が PR 上で dist の再ビルドを自動化します。bundled sources（`runners/github-action/src/**`、`src/**`、`package-lock.json`）を変更した PR では、workflow が `.nvmrc` の Node で `npm run build:action` を実行します。byte 差分が出た場合のみ `chore(action): rebuild github-action dist` コミットを PR branch に push します。差分が出なければ何も push しません。
+`.github/workflows/auto-rebuild-action-dist.yml` が PR 上で dist の再ビルドを自動化します。bundled sources（`runners/github-action/src/**`、`src/**`、`package-lock.json`）が変更された PR において、workflow は `.nvmrc` の Node により `npm run build:action` を実行します。byte 差分が出た場合のみ `chore(action): rebuild github-action dist` コミットを PR branch に push します。差分が出なければ何も push しません。
 
 対象となる条件は以下のとおりです。
 
-- 同一リポジトリの branch からの PR（fork PR は push 不可能なため対象外、従来どおり `Action dist freshness` job が staleness を検出する）
+- 同一リポジトリ内ブランチからの PR（fork PR は push 不可のため対象外。従来どおり `Action dist freshness` job が staleness を検出する）
 - `release-please--` で始まる branch は対象外（自動コミットが release PR を汚染しないようにするため）
 
-トークンと no-recursion 制約は `release-please-kick.yml` と同じ方針です。`GITHUB_TOKEN` による push は GitHub の no-recursion 制約により `pull_request` workflow を再発火させません。そのため `RELEASE_KICK_PAT`（contents:write）があればそれを優先し、新しい head SHA で CI が再実行されます。fallback の `GITHUB_TOKEN` で push した場合は warning が出るため、empty commit の push などで手動により CI を発火させてください。
+トークンおよび no-recursion 制約の扱いは、`release-please-kick.yml` と同様です。`GITHUB_TOKEN` による push は GitHub の no-recursion 制約により `pull_request` workflow を再発火させません。そのため `RELEASE_KICK_PAT`（contents:write）があればそれを優先し、新しい head SHA で CI が再実行されます。`RELEASE_KICK_PAT` が未設定の場合、fallback push は warning を表示します。その際は empty commit などにより手動で CI を発火させてください。
 
 以下の場合は次節の手動手順を fallback として使います。
 

--- a/docs/development/dist-check-rebuild-guide.md
+++ b/docs/development/dist-check-rebuild-guide.md
@@ -24,7 +24,24 @@ cat .nvmrc
 # → 22.22.2
 ```
 
-## ローカル rebuild 手順
+## 自動再ビルド（Auto Rebuild Action Dist）
+
+`.github/workflows/auto-rebuild-action-dist.yml` が PR 上で dist の再ビルドを自動化します。bundled sources（`runners/github-action/src/**`、`src/**`、`package-lock.json`）を変更した PR では、workflow が `.nvmrc` の Node で `npm run build:action` を実行します。byte 差分が出た場合のみ `chore(action): rebuild github-action dist` コミットを PR branch に push します。差分が出なければ何も push しません。
+
+対象となる条件は以下のとおりです。
+
+- 同一リポジトリの branch からの PR（fork PR は push 不可能なため対象外、従来どおり `Action dist freshness` job が staleness を検出する）
+- `release-please--` で始まる branch は対象外（自動コミットが release PR を汚染しないようにするため）
+
+トークンと no-recursion 制約は `release-please-kick.yml` と同じ方針です。`GITHUB_TOKEN` による push は GitHub の no-recursion 制約により `pull_request` workflow を再発火させません。そのため `RELEASE_KICK_PAT`（contents:write）があればそれを優先し、新しい head SHA で CI が再実行されます。fallback の `GITHUB_TOKEN` で push した場合は warning が出るため、empty commit の push などで手動により CI を発火させてください。
+
+以下の場合は次節の手動手順を fallback として使います。
+
+- fork からの PR
+- release-please branch 上での staleness
+- workflow 自体が失敗した場合
+
+## ローカル rebuild 手順（手動 fallback）
 
 ### 1. Node を `.nvmrc` に合わせる
 


### PR DESCRIPTION
## 概要

`runners/github-action/src/**` 変更時の dist 再ビルド (`npm run build:action`) は手動運用で、直近 400 コミットに 12 件の手動 rebuild コミットがある。既存の「検出 + 自動修正」モデル（`auto-fix-dashes.yml`）に倣い、PR 上で stale dist を自動再ビルドして PR branch に push する workflow を追加する。

## 変更内容

- `.github/workflows/auto-rebuild-action-dist.yml` を新規追加
- `docs/development/dist-check-rebuild-guide.md` に自動再ビルドの節を追記（手動手順は fallback として存置）

## 発火条件

- `pull_request` で以下の paths が変更された場合（test.yml の `Action dist freshness` job の `src_ts` 判定と同じセット）
  - `runners/github-action/src/**`
  - `src/**`
  - `package-lock.json`
- `.nvmrc` の Node（`node-version-file`）で `npm run build:action` を実行し、**byte 差分が出た場合のみ** `chore(action): rebuild github-action dist` を commit して PR branch に push。差分なしなら何もしない

## 除外条件

- **fork PR**: `github.event.pull_request.head.repo.full_name == github.repository` で同一リポジトリ branch のみ対象（fork branch には push できない。従来どおり dist-check job が staleness を検出する）
- **release-please branch**: `!startsWith(head.ref, 'release-please--')` で除外（自動 commit が release PR を汚染しない）

## no-recursion の扱い

`release-please-kick.yml` と同一方針。`GITHUB_TOKEN` による push は GitHub の no-recursion 制約で `pull_request: synchronize` を再発火させないため、strict required checks 下では新 head SHA の CI が走らずマージがブロックされる。

- checkout token に `secrets.RELEASE_KICK_PAT || secrets.GITHUB_TOKEN` を使用。PAT があれば push が CI を再発火する
- PAT 未設定の fallback では push 後に `::warning::` を出し、empty commit 等での手動 CI kick を案内
- 無限ループは構造的に発生しない: bot push 後の再実行（PAT 経由）では rebuild が no-diff になり push せず終了

## 手動 fallback

fork PR / release-please branch / workflow 失敗時は、従来の `docs/development/dist-check-rebuild-guide.md` のローカル rebuild 手順（`nvm use` → `npm ci` → `npm run build:action` → commit）を使う。

## 検証

- `actionlint .github/workflows/auto-rebuild-action-dist.yml` — pass
- `npx textlint --no-cache docs/development/dist-check-rebuild-guide.md` — pass（`npm run fix:dashes` 実行済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)