### PR TITLE
docs: record external-listing submission PRs and their status

### DIFF
--- a/docs/growth/external-listings.md
+++ b/docs/growth/external-listings.md
@@ -49,9 +49,9 @@ Codify team review judgment as repo-owned skills; run them as GitHub Action / pl
 ## 申請優先順位
 
 1. **awesome-codex-plugins**—✅ **掲載済み（live on `main`）**。同梱プラグインと manifest が揃っており、外部からの提案もあった
-2. **awesome-actions**—GitHub Action として直球で適合。⏳ 提出済み・マージ待ち（#829）
-3. **awesome-code-review**—ドメイン一致。非宣伝的な説明文を用意。⏳ 提出済み・マージ待ち（#131）
-4. **awesome-ai-devtools**—PR & Code Review Bots カテゴリ。⏳ 提出済み・マージ待ち（#697）
+2. **awesome-actions**—GitHub Action として直球で適合。⏳ 提出済み・マージ待ち（[#829](https://github.com/sdras/awesome-actions/pull/829)）
+3. **awesome-code-review**—ドメイン一致。非宣伝的な説明文を用意。⏳ 提出済み・マージ待ち（[#131](https://github.com/joho/awesome-code-review/pull/131)）
+4. **awesome-ai-devtools**—PR & Code Review Bots カテゴリ。⏳ 提出済み・マージ待ち（[#697](https://github.com/jamesmurdza/awesome-ai-devtools/pull/697)）
 5. **awesome-ai-agents**—位置づけを慎重に検討（優先度低）。未提出
 
 > 提出済み PR の一覧と状態は下記「提出状況（トラッキング）」を参照。

--- a/docs/growth/external-listings.md
+++ b/docs/growth/external-listings.md
@@ -49,16 +49,28 @@ Codify team review judgment as repo-owned skills; run them as GitHub Action / pl
 ## 申請優先順位
 
 1. **awesome-codex-plugins**—✅ **掲載済み（live on `main`）**。同梱プラグインと manifest が揃っており、外部からの提案もあった
-2. **awesome-actions**—GitHub Action として直球で適合
-3. **awesome-code-review**—ドメイン一致。非宣伝的な説明文を用意
-4. **awesome-ai-devtools**—PR & Code Review Bots カテゴリ。PR テンプレートを確認のうえ申請
-5. **awesome-ai-agents**—位置づけを慎重に検討（優先度低）
+2. **awesome-actions**—GitHub Action として直球で適合。⏳ 提出済み・マージ待ち（#829）
+3. **awesome-code-review**—ドメイン一致。非宣伝的な説明文を用意。⏳ 提出済み・マージ待ち（#131）
+4. **awesome-ai-devtools**—PR & Code Review Bots カテゴリ。⏳ 提出済み・マージ待ち（#697）
+5. **awesome-ai-agents**—位置づけを慎重に検討（優先度低）。未提出
+
+> 提出済み PR の一覧と状態は下記「提出状況（トラッキング）」を参照。
+
+## 提出状況（トラッキング）
+
+各リストへの提出 PR と、その時点の状態。状態は変わりうるため、確認時は各 PR / upstream の `main` を直接参照すること（最終確認: 2026-07-04）。
+
+| リスト                | 提出 PR                                                                    | 状態                          | 備考                                                                                      |
+| --------------------- | -------------------------------------------------------------------------- | ----------------------------- | ----------------------------------------------------------------------------------------- |
+| awesome-codex-plugins | [#229](https://github.com/hashgraph-online/awesome-codex-plugins/pull/229) | ✅ 掲載済み（live on `main`） | PR は GitHub 上 CLOSED だが maintainer が別経路で `main` へ反映。掲載成立                 |
+| awesome-actions       | [#829](https://github.com/sdras/awesome-actions/pull/829)                  | ⏳ Open・マージ待ち           | 2026-06-24 提出。mergeable、修正すべき CI 失敗なし（`UNSTABLE` は upstream 側の良性状態） |
+| awesome-code-review   | [#131](https://github.com/joho/awesome-code-review/pull/131)               | ⏳ Open・マージ待ち           | 2026-06-24 提出。mergeable、レビュー未着                                                  |
+| awesome-ai-devtools   | [#697](https://github.com/jamesmurdza/awesome-ai-devtools/pull/697)        | ⏳ Open・マージ待ち           | 2026-06-24 提出（旧 #696 は差し替えのため CLOSED）。mergeable、レビュー未着               |
+| awesome-ai-agents     | —                                                                          | 未提出                        | Marginal 適合のため優先度低（下記参照）                                                   |
 
 ## 提出材料ドラフト
 
-各リストの実際の README / CONTRIBUTING を確認して作成したコピペ用ドラフト。fork → 該当箇所に追記 → PR の流れで使う（外部リポジトリへの操作はリポジトリ管理者が実施）。提出直前に各リストの規約が変わっていないか再確認すること。
-
-> awesome-codex-plugins は**掲載済み**（upstream の `main` に `plugins/s977043/river-review` として反映）。提出 PR [hashgraph-online/awesome-codex-plugins#229](https://github.com/hashgraph-online/awesome-codex-plugins/pull/229) は GitHub 上は CLOSED（merge ボタン経由ではなく maintainer が別経路で main へ取り込み）だが、掲載自体は成立している。
+各リストの実際の README / CONTRIBUTING を確認して作成したコピペ用ドラフト。fork → 該当箇所に追記 → PR の流れで使う（外部リポジトリへの操作はリポジトリ管理者が実施）。提出直前に各リストの規約が変わっていないか再確認すること。提出済み PR の状態は上記「提出状況（トラッキング）」を参照。
 
 ### awesome-actions（sdras/awesome-actions）
 


### PR DESCRIPTION
## What

Add a **提出状況（トラッキング）** table to `docs/growth/external-listings.md` recording which external-listing PRs have been submitted and their current state:

| List | PR | Status |
| --- | --- | --- |
| awesome-codex-plugins | #229 | ✅ live on `main` |
| awesome-actions | [#829](https://github.com/sdras/awesome-actions/pull/829) | ⏳ open, merge-pending |
| awesome-code-review | [#131](https://github.com/joho/awesome-code-review/pull/131) | ⏳ open, merge-pending |
| awesome-ai-devtools | [#697](https://github.com/jamesmurdza/awesome-ai-devtools/pull/697) | ⏳ open, merge-pending |
| awesome-ai-agents | — | not submitted |

Also annotate the 申請優先順位 list with submission status and fold the previously standalone awesome-codex-plugins note into the table.

## Why

The doc only recorded the awesome-codex-plugins submission; the other three PRs (submitted 2026-06-24) were not tracked in-repo, so their status was invisible. This makes the submission state auditable from the repo.

## Verification

- `prettier --check` / `fix-dashes --check` / `markdownlint`: pass
- All three external PR URLs confirmed to resolve (gh api)
- awesome-actions #829 `UNSTABLE` state investigated: no fixable CI failure (empty status rollup, mergeable); it reflects an upstream-side benign state, so no action needed on our entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)