### PR TITLE
fix(dashboard): replace fabricated stats with real, offline-verifiable data

### DIFF
--- a/docs/data/dashboard-stats.json
+++ b/docs/data/dashboard-stats.json
@@ -1,111 +1,56 @@
 {
-  "generatedAt": "2025-12-09T21:12:37.289Z",
+  "generatedAt": "2026-07-04T10:48:09.559Z",
+  "dataSource": "skills/registry.yaml + heuristic detectors (deterministic, offline); operational metrics await live LLM runs",
+  "registry": {
+    "totalSkills": 112,
+    "heuristicSkills": 5,
+    "heuristicDetectors": 13
+  },
   "totals": {
-    "reviews": 29,
-    "filesReviewed": 87,
-    "comments": 116,
-    "averageCostUsd": 0.0293,
-    "tokenEstimate": 38500
+    "skills": 112,
+    "heuristicSkills": 5,
+    "heuristicDetectors": 13
   },
   "phases": [
     {
       "phase": "upstream",
-      "reviews": 4,
-      "comments": 10
+      "skills": 51
     },
     {
       "phase": "midstream",
-      "reviews": 8,
-      "comments": 26
+      "skills": 52
     },
     {
       "phase": "downstream",
-      "reviews": 6,
-      "comments": 14
+      "skills": 10
     }
   ],
   "skills": [
     {
       "id": "security-basic",
-      "name": "Security basic",
-      "findings": 5
+      "name": "Security basics",
+      "detectors": 6
+    },
+    {
+      "id": "coverage-gap",
+      "name": "Coverage gap",
+      "detectors": 3
+    },
+    {
+      "id": "logging-observability",
+      "name": "Logging & observability",
+      "detectors": 3
+    },
+    {
+      "id": "test-existence",
+      "name": "Test existence",
+      "detectors": 3
     },
     {
       "id": "typescript-strict",
       "name": "TypeScript strictness",
-      "findings": 4
-    },
-    {
-      "id": "test-naming",
-      "name": "Test naming",
-      "findings": 3
-    },
-    {
-      "id": "api-design",
-      "name": "API design",
-      "findings": 2
+      "detectors": 1
     }
   ],
-  "costTrend": [
-    {
-      "date": "2025-11-22",
-      "costUsd": 0.04,
-      "tokens": 2500,
-      "requests": 2
-    },
-    {
-      "date": "2025-11-23",
-      "costUsd": 0.05,
-      "tokens": 2800,
-      "requests": 3
-    },
-    {
-      "date": "2025-11-24",
-      "costUsd": 0.06,
-      "tokens": 3100,
-      "requests": 4
-    },
-    {
-      "date": "2025-11-25",
-      "costUsd": 0.07,
-      "tokens": 3400,
-      "requests": 2
-    },
-    {
-      "date": "2025-11-26",
-      "costUsd": 0.08,
-      "tokens": 3700,
-      "requests": 3
-    },
-    {
-      "date": "2025-11-27",
-      "costUsd": 0.09,
-      "tokens": 4000,
-      "requests": 4
-    },
-    {
-      "date": "2025-11-28",
-      "costUsd": 0.1,
-      "tokens": 4300,
-      "requests": 2
-    },
-    {
-      "date": "2025-11-29",
-      "costUsd": 0.11,
-      "tokens": 4600,
-      "requests": 3
-    },
-    {
-      "date": "2025-11-30",
-      "costUsd": 0.12,
-      "tokens": 4900,
-      "requests": 4
-    },
-    {
-      "date": "2025-12-01",
-      "costUsd": 0.13,
-      "tokens": 5200,
-      "requests": 2
-    }
-  ]
+  "costTrend": []
 }

--- a/docs/data/dogfooding/README.md
+++ b/docs/data/dogfooding/README.md
@@ -1,0 +1,40 @@
+# Dogfooding run artifacts
+
+このディレクトリは、River Review で River Review 自身の変更をレビューした**実際の実行結果**を蓄積する場所です。ここに置かれた実行成果物は `npm run dashboard:generate` に集計され、ドキュメントサイトの[ダッシュボード](../../../pages/dashboard.md)に反映されます。
+
+## なぜあるか
+
+ダッシュボードの運用系メトリクス（レビュー回数・コメント数・コスト推移）は、**実際の LLM レビュー実行**からしか正しく得られません。合成した見かけのデータは載せません。実行成果物が 1 件も無い間、ダッシュボードは登録スキルと決定論的検出器のカバレッジ（オフラインで再現可能な実データ）のみを表示し、運用系は正直に空表示になります。
+
+## 実行成果物の形式
+
+1 実行 = 1 つの JSON ファイル（`YYYY-MM-DD-<topic>.json`）。`generate-dashboard-data.js` が読む最小フィールド:
+
+```json
+{
+  "date": "2026-07-04",
+  "phase": "midstream",
+  "filesReviewed": 8,
+  "costUsd": 0.0312,
+  "tokens": 41000,
+  "findings": [
+    {
+      "skill": "security-basic",
+      "severity": "major",
+      "file": "src/example.mjs",
+      "line": 42,
+      "message": "…",
+      "disposition": "accepted"
+    }
+  ]
+}
+```
+
+- `findings[].disposition`（`accepted` / `dismissed`）は人間の最終判断を記録する。River Review は人間の判断を置き換えず補助する（human-in-the-loop）ため、指摘の採否は必ず人間が付ける。
+- `costUsd` / `tokens` は実行時の実測値。オフライン（`--offline` / rules-only）実行はコストが発生しないため `0` を記録する。
+
+## 実行結果の追加手順（メンテナ）
+
+1. API キーを設定して実レビューを実行し、JSON を出力する（例: `river run . --output-format json`）。
+2. 上記フォーマットに整形し、人間の `disposition` を付けてこのディレクトリにコミットする。
+3. `npm run dashboard:generate` を実行して `docs/data/dashboard-stats.json` を更新する。

--- a/scripts/generate-dashboard-data.js
+++ b/scripts/generate-dashboard-data.js
@@ -14,7 +14,8 @@ const { pathToFileURL } = require('url');
 const yaml = require('js-yaml');
 
 const REPO_ROOT = path.resolve(__dirname, '..');
-const RUNS_DIR = path.join(REPO_ROOT, 'docs', 'data', 'dogfooding');
+const RUNS_DIR =
+  process.env.RIVER_DASHBOARD_RUNS_DIR || path.join(REPO_ROOT, 'docs', 'data', 'dogfooding');
 
 const PHASE_ORDER = ['upstream', 'midstream', 'downstream'];
 
@@ -79,7 +80,11 @@ async function readRunArtifacts() {
       if (!file.endsWith('.json')) continue;
       try {
         const raw = await fs.readFile(path.join(RUNS_DIR, file), 'utf8');
-        entries.push(JSON.parse(raw));
+        const parsed = JSON.parse(raw);
+        // Ignore null / non-object artifacts so downstream property access is safe.
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          entries.push(parsed);
+        }
       } catch {
         // skip unreadable/invalid artifact
       }
@@ -110,7 +115,7 @@ function buildOperational(runs) {
     perPhase.set(phase, cur);
   }
   const costTrend = runs
-    .filter((r) => r.date)
+    .filter((r) => typeof r.date === 'string')
     .map((r) => ({
       date: r.date,
       costUsd: Number(r.costUsd) || 0,
@@ -129,6 +134,21 @@ function buildOperational(runs) {
     phases: Array.from(perPhase.values()),
     costTrend,
   };
+}
+
+// Real findings aggregated per skill from committed run artifacts (used by
+// SkillHeatmap once real runs exist; empty until then).
+function buildSkillFindings(runs, registrySkills) {
+  const counts = new Map();
+  for (const r of runs) {
+    for (const finding of Array.isArray(r.findings) ? r.findings : []) {
+      if (finding?.skill) counts.set(finding.skill, (counts.get(finding.skill) || 0) + 1);
+    }
+  }
+  return Array.from(counts.entries()).map(([id, findings]) => {
+    const registrySkill = registrySkills.find((s) => s.id === id);
+    return { id, name: registrySkill?.name || HEURISTIC_SKILL_NAMES[id] || id, findings };
+  });
 }
 
 async function generateDashboardData() {
@@ -162,8 +182,12 @@ async function generateDashboardData() {
           },
     // PhaseDistribution: real skill inventory per phase (falls back to run phases).
     phases: operational.phases.length > 0 ? operational.phases : inventory.phases,
-    // SkillHeatmap: real deterministic detector coverage per heuristic skill.
-    skills: coverage.skills.map((s) => ({ id: s.id, name: s.name, detectors: s.detectors })),
+    // SkillHeatmap: real findings per skill once runs exist, else deterministic
+    // detector coverage per heuristic skill.
+    skills:
+      runs.length > 0
+        ? buildSkillFindings(runs, registrySkills)
+        : coverage.skills.map((s) => ({ id: s.id, name: s.name, detectors: s.detectors })),
     // CostTrends: only real runs; empty otherwise (honest "no data yet" state).
     costTrend: operational.costTrend,
   };

--- a/scripts/generate-dashboard-data.js
+++ b/scripts/generate-dashboard-data.js
@@ -1,57 +1,177 @@
 #!/usr/bin/env node
+// Generate the docs dashboard data from REAL, offline-derivable sources:
+//   - Skill inventory (count + phase distribution) from skills/registry.yaml
+//   - Deterministic heuristic detector coverage from src/lib/heuristic-review.mjs
+//   - Operational metrics (reviews / comments / cost trend) aggregated from
+//     committed run artifacts under docs/data/dogfooding/*.json, if any.
+// It intentionally does NOT fabricate operational numbers: when no real run
+// artifacts exist, the operational fields stay empty and the dashboard shows
+// its built-in "データがまだありません" states. Cost/token metrics require live
+// LLM runs (an API key), so they only appear once real runs are committed.
 const fs = require('fs/promises');
 const path = require('path');
-const { subDays, formatISO } = require('date-fns');
+const { pathToFileURL } = require('url');
+const yaml = require('js-yaml');
 
-function createFallbackTrend(days = 7) {
-  const today = new Date();
-  return Array.from({ length: days }).map((_, idx) => {
-    const date = subDays(today, days - idx - 1);
-    return {
-      date: formatISO(date, { representation: 'date' }),
-      costUsd: Number((0.04 + idx * 0.01).toFixed(4)),
-      tokens: 2500 + idx * 300,
-      requests: 2 + (idx % 3),
-    };
-  });
+const REPO_ROOT = path.resolve(__dirname, '..');
+const RUNS_DIR = path.join(REPO_ROOT, 'docs', 'data', 'dogfooding');
+
+const PHASE_ORDER = ['upstream', 'midstream', 'downstream'];
+
+// Human-readable names for the heuristic (LLM-free) skills.
+const HEURISTIC_SKILL_NAMES = {
+  'security-basic': 'Security basics',
+  'logging-observability': 'Logging & observability',
+  'typescript-strict': 'TypeScript strictness',
+  'test-existence': 'Test existence',
+  'coverage-gap': 'Coverage gap',
+};
+
+async function readSkillRegistry() {
+  const raw = await fs.readFile(path.join(REPO_ROOT, 'skills', 'registry.yaml'), 'utf8');
+  const parsed = yaml.load(raw) || {};
+  return Array.isArray(parsed.skills) ? parsed.skills : [];
 }
 
-function buildTotals(trend) {
-  const totalCost = trend.reduce((sum, item) => sum + item.costUsd, 0);
-  const totalRequests = trend.reduce((sum, item) => sum + item.requests, 0);
-  const totalTokens = trend.reduce((sum, item) => sum + item.tokens, 0);
+// Real skill inventory: total plus a per-phase membership count. A skill may
+// declare more than one phase (e.g. "upstream,midstream"), so it is counted in
+// each phase it belongs to; the chart is labelled accordingly.
+function buildSkillInventory(skills) {
+  const perPhase = new Map(PHASE_ORDER.map((p) => [p, 0]));
+  for (const skill of skills) {
+    const declared = String(skill?.phase ?? '')
+      .split(',')
+      .map((p) => p.trim())
+      .filter(Boolean);
+    for (const phase of declared) {
+      if (perPhase.has(phase)) perPhase.set(phase, perPhase.get(phase) + 1);
+    }
+  }
   return {
-    reviews: totalRequests,
-    filesReviewed: totalRequests * 3,
-    comments: totalRequests * 4,
-    averageCostUsd: Number((totalCost / Math.max(totalRequests, 1)).toFixed(4)),
-    tokenEstimate: totalTokens,
+    total: skills.length,
+    phases: PHASE_ORDER.map((phase) => ({ phase, skills: perPhase.get(phase) })),
+  };
+}
+
+// Real deterministic detector coverage from the heuristic map (the LLM-free
+// checks that run in offline / --rules-only mode).
+async function buildDetectorCoverage() {
+  const mod = await import(
+    pathToFileURL(path.join(REPO_ROOT, 'src', 'lib', 'heuristic-review.mjs')).href
+  );
+  const map = mod.SKILL_HEURISTIC_MAP ?? {};
+  const uniqueDetectors = new Set();
+  const skills = Object.entries(map).map(([id, fns]) => {
+    fns.forEach((fn) => uniqueDetectors.add(fn));
+    return { id, name: HEURISTIC_SKILL_NAMES[id] ?? id, detectors: fns.length };
+  });
+  skills.sort((a, b) => b.detectors - a.detectors || a.id.localeCompare(b.id));
+  return { skills, detectorCount: uniqueDetectors.size, skillCount: skills.length };
+}
+
+// Aggregate operational metrics from committed real run artifacts, if present.
+// Each artifact is JSON: { phase, filesReviewed, findings: [...], costUsd?, tokens?, date? }.
+async function readRunArtifacts() {
+  let entries = [];
+  try {
+    const files = await fs.readdir(RUNS_DIR);
+    for (const file of files) {
+      if (!file.endsWith('.json')) continue;
+      try {
+        const raw = await fs.readFile(path.join(RUNS_DIR, file), 'utf8');
+        entries.push(JSON.parse(raw));
+      } catch {
+        // skip unreadable/invalid artifact
+      }
+    }
+  } catch {
+    // no dogfooding dir yet — operational metrics stay empty (honest)
+  }
+  return entries;
+}
+
+function buildOperational(runs) {
+  if (!runs.length) {
+    return { totals: {}, phases: [], costTrend: [] };
+  }
+  const totalFindings = runs.reduce(
+    (s, r) => s + (Array.isArray(r.findings) ? r.findings.length : 0),
+    0
+  );
+  const filesReviewed = runs.reduce((s, r) => s + (Number(r.filesReviewed) || 0), 0);
+  const totalCost = runs.reduce((s, r) => s + (Number(r.costUsd) || 0), 0);
+  const totalTokens = runs.reduce((s, r) => s + (Number(r.tokens) || 0), 0);
+  const perPhase = new Map();
+  for (const r of runs) {
+    const phase = r.phase ?? 'unknown';
+    const cur = perPhase.get(phase) ?? { phase, reviews: 0, comments: 0 };
+    cur.reviews += 1;
+    cur.comments += Array.isArray(r.findings) ? r.findings.length : 0;
+    perPhase.set(phase, cur);
+  }
+  const costTrend = runs
+    .filter((r) => r.date)
+    .map((r) => ({
+      date: r.date,
+      costUsd: Number(r.costUsd) || 0,
+      tokens: Number(r.tokens) || 0,
+      requests: 1,
+    }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+  return {
+    totals: {
+      reviews: runs.length,
+      filesReviewed,
+      comments: totalFindings,
+      averageCostUsd: Number((totalCost / Math.max(runs.length, 1)).toFixed(4)),
+      tokenEstimate: totalTokens,
+    },
+    phases: Array.from(perPhase.values()),
+    costTrend,
   };
 }
 
 async function generateDashboardData() {
-  const trend = createFallbackTrend(10);
+  const registrySkills = await readSkillRegistry();
+  const inventory = buildSkillInventory(registrySkills);
+  const coverage = await buildDetectorCoverage();
+  const runs = await readRunArtifacts();
+  const operational = buildOperational(runs);
+
   const data = {
     generatedAt: new Date().toISOString(),
-    totals: buildTotals(trend),
-    phases: [
-      { phase: 'upstream', reviews: 4, comments: 10 },
-      { phase: 'midstream', reviews: 8, comments: 26 },
-      { phase: 'downstream', reviews: 6, comments: 14 },
-    ],
-    skills: [
-      { id: 'security-basic', name: 'Security basic', findings: 5 },
-      { id: 'typescript-strict', name: 'TypeScript strictness', findings: 4 },
-      { id: 'test-naming', name: 'Test naming', findings: 3 },
-      { id: 'api-design', name: 'API design', findings: 2 },
-    ],
-    costTrend: trend,
+    // Registry + detector coverage are deterministic and always real (offline).
+    // Operational metrics (reviews / cost) come only from committed real runs.
+    dataSource:
+      runs.length > 0
+        ? 'skills/registry.yaml + heuristic detectors + committed run artifacts'
+        : 'skills/registry.yaml + heuristic detectors (deterministic, offline); operational metrics await live LLM runs',
+    registry: {
+      totalSkills: inventory.total,
+      heuristicSkills: coverage.skillCount,
+      heuristicDetectors: coverage.detectorCount,
+    },
+    // ReviewStatsCard: real registry / detector facts (offline-verifiable).
+    totals:
+      Object.keys(operational.totals).length > 0
+        ? operational.totals
+        : {
+            skills: inventory.total,
+            heuristicSkills: coverage.skillCount,
+            heuristicDetectors: coverage.detectorCount,
+          },
+    // PhaseDistribution: real skill inventory per phase (falls back to run phases).
+    phases: operational.phases.length > 0 ? operational.phases : inventory.phases,
+    // SkillHeatmap: real deterministic detector coverage per heuristic skill.
+    skills: coverage.skills.map((s) => ({ id: s.id, name: s.name, detectors: s.detectors })),
+    // CostTrends: only real runs; empty otherwise (honest "no data yet" state).
+    costTrend: operational.costTrend,
   };
 
-  const outDir = path.join(process.cwd(), 'docs', 'data');
+  const outDir = path.join(REPO_ROOT, 'docs', 'data');
   await fs.mkdir(outDir, { recursive: true });
   const outPath = path.join(outDir, 'dashboard-stats.json');
-  await fs.writeFile(outPath, JSON.stringify(data, null, 2));
+  await fs.writeFile(outPath, `${JSON.stringify(data, null, 2)}\n`);
   return outPath;
 }
 

--- a/src/components/Dashboard/DashboardPage.jsx
+++ b/src/components/Dashboard/DashboardPage.jsx
@@ -7,12 +7,18 @@ import { useDashboardData } from './useDashboardData';
 
 export default function DashboardPage() {
   const data = useDashboardData();
+  // Until real LLM review runs are committed, the dashboard shows the
+  // deterministic, offline-verifiable Skill Registry + detector coverage.
+  const hasRuns = data.totals?.reviews != null;
 
   return (
     <div className="container margin-vert--lg">
       <h1>River Reviewer ダッシュボード</h1>
       <p className="margin-bottom--md">
-        レビュー実行回数やコストの推移を可視化します。生成日時: {data.generatedAt || 'N/A'}
+        {hasRuns
+          ? 'レビュー実行回数やコストの推移を可視化します。'
+          : 'スキルレジストリと決定論的検出器のカバレッジを表示します。レビュー実行回数・コストは、実際のレビュー実行が記録され次第反映されます。'}
+        生成日時: {data.generatedAt || 'N/A'}
       </p>
 
       <ReviewStatsCard totals={data.totals} />
@@ -21,7 +27,9 @@ export default function DashboardPage() {
         <div className="col col--6">
           <div className="card">
             <div className="card__header">
-              <h3 className="card__title">フェーズ別レビュー数</h3>
+              <h3 className="card__title">
+                {hasRuns ? 'フェーズ別レビュー数' : 'フェーズ別スキル数'}
+              </h3>
             </div>
             <div className="card__body">
               <PhaseDistribution phases={data.phases} />

--- a/src/components/Dashboard/PhaseDistribution.jsx
+++ b/src/components/Dashboard/PhaseDistribution.jsx
@@ -7,6 +7,10 @@ export default function PhaseDistribution({ phases }) {
     return <p>フェーズ別のデータがまだありません。</p>;
   }
 
+  // Real run artifacts carry reviews/comments per phase; the offline registry
+  // inventory carries a skills count per phase. Render whichever is present.
+  const isInventory = phases[0]?.skills != null;
+
   return (
     <BrowserOnly fallback={<p>Chart is loading...</p>}>
       {() => (
@@ -16,8 +20,14 @@ export default function PhaseDistribution({ phases }) {
             <XAxis dataKey="phase" />
             <YAxis allowDecimals={false} />
             <Tooltip />
-            <Bar dataKey="reviews" name="Reviews" fill="#4285f4" />
-            <Bar dataKey="comments" name="Comments" fill="#34a853" />
+            {isInventory ? (
+              <Bar dataKey="skills" name="Skills" fill="#4285f4" />
+            ) : (
+              <>
+                <Bar dataKey="reviews" name="Reviews" fill="#4285f4" />
+                <Bar dataKey="comments" name="Comments" fill="#34a853" />
+              </>
+            )}
           </BarChart>
         </ResponsiveContainer>
       )}

--- a/src/components/Dashboard/ReviewStatsCard.jsx
+++ b/src/components/Dashboard/ReviewStatsCard.jsx
@@ -14,15 +14,25 @@ function Stat({ label, value }) {
 }
 
 export default function ReviewStatsCard({ totals }) {
-  const stats = [
-    { label: 'Reviews', value: totals?.reviews ?? 0 },
-    { label: 'Files reviewed', value: totals?.filesReviewed ?? 0 },
-    { label: 'Comments', value: totals?.comments ?? 0 },
-    {
-      label: 'Avg cost (USD)',
-      value: totals?.averageCostUsd ? `$${totals.averageCostUsd.toFixed(4)}` : '$0.0000',
-    },
-  ];
+  // When real run artifacts exist, `totals` carries operational metrics
+  // (reviews / cost). Until then it carries the deterministic, offline-real
+  // registry + detector facts. Render whichever shape is present.
+  const hasRuns = totals?.reviews != null;
+  const stats = hasRuns
+    ? [
+        { label: 'Reviews', value: totals?.reviews ?? 0 },
+        { label: 'Files reviewed', value: totals?.filesReviewed ?? 0 },
+        { label: 'Comments', value: totals?.comments ?? 0 },
+        {
+          label: 'Avg cost (USD)',
+          value: totals?.averageCostUsd ? `$${totals.averageCostUsd.toFixed(4)}` : '$0.0000',
+        },
+      ]
+    : [
+        { label: 'Skills', value: totals?.skills ?? 0 },
+        { label: 'Heuristic skills', value: totals?.heuristicSkills ?? 0 },
+        { label: 'Deterministic detectors', value: totals?.heuristicDetectors ?? 0 },
+      ];
 
   return (
     <div className="row">

--- a/src/components/Dashboard/SkillHeatmap.jsx
+++ b/src/components/Dashboard/SkillHeatmap.jsx
@@ -5,27 +5,35 @@ export default function SkillHeatmap({ skills }) {
     return <p>スキル別の指摘データがまだありません。</p>;
   }
 
-  const sorted = [...skills].sort((a, b) => (b.findings ?? 0) - (a.findings ?? 0));
+  // Real run artifacts carry a per-skill `findings` count; the offline default
+  // carries `detectors` (deterministic checks each heuristic skill provides).
+  const metric = (skill) => skill.findings ?? skill.detectors ?? 0;
+  const isCoverage = skills[0]?.findings == null;
+  const sorted = [...skills].sort((a, b) => metric(b) - metric(a));
 
   return (
     <div className="card">
       <div className="card__header">
-        <h3 className="card__title">Skill findings</h3>
-        <p className="card__subtitle">頻度の高い指摘スキルを表示します。</p>
+        <h3 className="card__title">{isCoverage ? 'Detector coverage' : 'Skill findings'}</h3>
+        <p className="card__subtitle">
+          {isCoverage
+            ? 'ヒューリスティックスキルが備える決定論的検出器の数（オフラインで再現可能）。'
+            : '頻度の高い指摘スキルを表示します。'}
+        </p>
       </div>
       <div className="card__body">
         <table className="table">
           <thead>
             <tr>
               <th>Skill</th>
-              <th>Findings</th>
+              <th>{isCoverage ? 'Detectors' : 'Findings'}</th>
             </tr>
           </thead>
           <tbody>
             {sorted.map((skill) => (
               <tr key={skill.id}>
                 <td>{skill.name || skill.id}</td>
-                <td>{skill.findings ?? 0}</td>
+                <td>{metric(skill)}</td>
               </tr>
             ))}
           </tbody>


### PR DESCRIPTION
## Problem

The docs-site dashboard shipped **100% fabricated data**: `scripts/generate-dashboard-data.js` invented a cost-escalation trend (`0.04 → 0.13`) and **skill names that don't exist** (`test-naming`, `api-design`). A review tool displaying fake operational metrics on its own site is a credibility problem (surfaced by the "evidence-based dogfooding" awareness thread).

## Fix — make the dashboard truthful (evidence-based)

- **`generate-dashboard-data.js`** now derives **real** numbers:
  - Skill inventory from `skills/registry.yaml` — 112 skills; per-phase counts (upstream 51 / midstream 52 / downstream 10, multi-phase skills counted in each).
  - Deterministic detector coverage from `src/lib/heuristic-review.mjs` — 5 heuristic skills / 13 detectors (offline-verifiable; these run in `--offline`/rules-only mode).
  - Operational metrics (reviews / comments / cost) are aggregated **only** from committed real run artifacts under `docs/data/dogfooding/*.json`. With none yet, those fields stay empty → the components' built-in "データがまだありません" states. **Cost/token data is never fabricated** (it requires live LLM runs).
- **Dashboard components** render whichever data shape is present and are relabeled honestly ("Detector coverage", per-phase skill counts); the cost chart stays empty until real runs exist. The change is backward-compatible: once real run artifacts land, the components switch back to operational labels automatically.
- **Regenerated** `docs/data/dashboard-stats.json` from the real sources.
- **Added** `docs/data/dogfooding/README.md` documenting the run-artifact schema (incl. per-finding human `disposition`) so real, human-in-the-loop reviews feed the dashboard.

## Scope note

Touches `src/components/Dashboard/**` (AGENTS.md "Ask before editing"). These are label/data-shape edits required to present the real data honestly; the maintainer chose the "evidence-based" option for this. No review-pipeline or schema code changed.

## Verification

- `npm run build` (Docusaurus) **succeeds** — components compile and load the real data (end-to-end).
- `node scripts/generate-dashboard-data.js` produces real values; `costTrend: []` (honest empty).
- `format:check`, `check:dashes`, `lint:md`, `check:docs` all pass.
- `npm test`: **1785/1785 pass** excluding 3 pre-existing *environment-dependent* failures (`…without API key` / `review exec` tests) that hit a real OpenAI 401 due to a stray `OPENAI_API_KEY` in the local sandbox; with the key unset they pass 61/61. None reference the dashboard — unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)