### PR TITLE
docs: add use-case recipe library (ja+en)

### DIFF
--- a/pages/use-cases/enforce-plan-conformance.en.md
+++ b/pages/use-cases/enforce-plan-conformance.en.md
@@ -1,0 +1,49 @@
+---
+id: enforce-plan-conformance-en
+title: Enforce plan conformance (catch implementation drift)
+sidebar_label: Enforce plan conformance (catch implementation drift)
+description: How River Review catches implementation drift from an approved plan using upstream gates and midstream conformance skills, plus a runnable demo.
+keywords:
+  - plan conformance
+  - implementation drift
+  - AIコードレビュー
+  - River Review
+---
+
+When you delegate implementation to an AI agent, the result can quietly drift from the plan you already approved. Validation gets added but the response shape breaks; the promised error code changes; a required test never lands. This kind of drift is easy to miss when you only read the diff, so it becomes a review blind spot.
+
+## How River Review addresses it
+
+River Review keeps its review criteria as repo-owned `SKILL.md` skills and forms its judgment across the plan, the diff, and the tests — not the diff alone. The skills that enforce plan conformance are:
+
+- `plangate-exec-conformance` (upstream) — the core skill: it checks the implementation diff against the `plan` / `todo` / `test-cases` artifacts and flags unplanned changes, unimplemented items, and missing tests as drift.
+- `plangate-plan-integrity` (upstream) — cross-checks the planning artifacts themselves (`plan` / `pbi-input` / `todo` / `test-cases`) for internal consistency, surfacing spec gaps before any code is written, so you measure conformance against a sound plan.
+- `plan-review-gate` (upstream) — gates the plan before autonomous execution, catching dangerous operations, out-of-scope work, over-implementation, and conditions that require human approval.
+- `design-source-conformance` (midstream) — when a design source of truth exists (`DESIGN.md`, design tokens), it verifies that new UI values (color, spacing, font size) conform to the defined scale.
+- `existing-pattern-conformance` (midstream) — greps for prior art of the same layer and responsibility, then checks that its guards, validation, error handling, and conventions are inherited without gaps.
+
+The distinguishing move is layering an upstream gate that reasons about the plan on top of midstream skills that only see the diff.
+
+## Try it
+
+Start with the runnable demo — it needs no API key and no `npm install`, and reads in about five minutes.
+
+- The full fixture set (`plan.md`, `diff.patch`, `test-cases.md`, `expected-findings.json`) lives in [`examples/plan-conformance-demo`](https://github.com/s977043/river-review/tree/main/examples/plan-conformance-demo).
+- Read `plan.md`'s three promises (add validation, keep response compatibility, return 400 on error) side by side with the implementation in `diff.patch`.
+- Open `expected-findings.json`: it lists the three critical/major findings River Review should return — findings you only surface by cross-referencing the `plan`, not from the diff alone.
+
+To run it against your own repository, scope the review by phase. See [Run a phase-specific review](../guides/run-phase-specific-review.en.md) for the exact commands.
+
+## What it does not do
+
+River Review produces decision-support material. It deliberately stops short of the following:
+
+- It is human-in-the-loop. It surfaces findings with severities (critical/major/minor/info) but never decides pass/fail or auto-merges on its own.
+- It does not replace deterministic, syntactic/pattern checks — that remains the job of static analysis and custom linters; the two are complementary.
+- It does not judge the business value or priority of the plan itself; that stays a human decision, outside the skills' scope.
+
+## Related
+
+- [Run a phase-specific review](../guides/run-phase-specific-review.en.md)
+- [Upstream / Midstream / Downstream phases](../explanation/upstream-midstream-downstream.en.md)
+- [plan-conformance demo](https://github.com/s977043/river-review/tree/main/examples/plan-conformance-demo)

--- a/pages/use-cases/enforce-plan-conformance.md
+++ b/pages/use-cases/enforce-plan-conformance.md
@@ -1,0 +1,49 @@
+---
+id: enforce-plan-conformance
+title: 計画（plan）に反した実装を検出する
+sidebar_label: 計画からの逸脱を検出
+description: 承認済みの計画（plan）から実装が逸脱するドリフトを、River Review の upstream ゲートと midstream 照合で検出する使い方を、runnable なデモ付きで解説します。
+keywords:
+  - plan conformance
+  - implementation drift
+  - AIコードレビュー
+  - River Review
+---
+
+AI エージェントへ実装を任せる場面が増えています。すると承認済みの計画（plan）から成果物が静かに逸脱し、ドリフトを生みます。こうしたズレは diff を追うだけで気づくのが難しく、レビューの盲点になりがちです。
+
+## River Review はどう対処するか
+
+River Review は、レビュー基準をリポジトリ所有の SKILL.md として保有します。判断は計画・差分・テストを横断して行われ、diff 単体だと見えないズレも捉えます。plan conformance に効くスキルは次のとおりです。
+
+- `plangate-exec-conformance`（upstream）— 実装差分が plan / todo / test-cases に沿うか検査し、計画外の変更・未実装項目・テスト欠落などのドリフトを検出する中核スキルである。
+- `plangate-plan-integrity`（upstream）— plan / pbi-input / todo / test-cases といった計画アーティファクト間で整合性が保たれているか検査し、実装前に仕様の抜けをあぶり出すスキルである。
+- `plan-review-gate`（upstream）— AI 自律実行の前段でゲートとして働き、plan / pbi-input が抱える危険操作・スコープ外・過実装・人間承認の必要な条件を早期に検出するスキルである。
+- `design-source-conformance`（midstream）— `DESIGN.md` やデザイントークンといった定義を持つリポジトリで、新規 UI の色・余白・フォントサイズが定義スケールに準拠しているか照合するスキルである。
+- `existing-pattern-conformance`（midstream）— grep で同種の先行実装を洗い出し、その防御・バリデーション・エラー処理・規約が新実装に正しく継承されているか確認するスキルである。
+
+diff だけだと見えない計画とのズレを、upstream ゲートと midstream 照合の二層で捉えます。
+
+## やってみる
+
+まずはランナブルなデモで挙動を確認しましょう。API キーや `npm install` は要らず、5 分あれば読み切れます。
+
+- デモ一式（`plan.md` / `diff.patch` / `test-cases.md` / `expected-findings.json`）は [`examples/plan-conformance-demo`](https://github.com/s977043/river-review/tree/main/examples/plan-conformance-demo) にある。
+- `plan.md` が約束する 3 点（バリデーション追加・レスポンス互換維持・エラー時 400）と、`diff.patch` の実装を読み比べる。
+- 機械可読な期待出力 `expected-findings.json` には critical / major の指摘 3 件が並び、`plan` と突き合わせて初めて分かる内容である。
+
+自分のリポジトリで動かす際は、フェーズを絞って実行できます。詳しい手順は [フェーズ固有のレビューを実行する](../guides/run-phase-specific-review.md) にまとまっています。
+
+## できないこと
+
+River Review が提示するのは、あくまで判断材料です。以下のことは担いません。
+
+- River Review はレビューの判断材料を提示するにとどまり、合否や auto-merge の最終決定まで代行しない。
+- 静的解析やカスタム linter が担う構文・パターンの決定論的検査を、River Review は置き換えない。
+- 計画そのものの事業価値や優先順位の妥当性は人間が決める領域であり、スキルの守備範囲外にある。
+
+## 関連
+
+- [フェーズ固有のレビューを実行する](../guides/run-phase-specific-review.md)
+- [上流・中流・下流フェーズ](../explanation/upstream-midstream-downstream.md)
+- [plan-conformance デモ](https://github.com/s977043/river-review/tree/main/examples/plan-conformance-demo)

--- a/pages/use-cases/index.en.md
+++ b/pages/use-cases/index.en.md
@@ -1,0 +1,19 @@
+---
+id: use-cases-index-en
+title: Use-case recipes
+sidebar_label: Use-case recipes
+description: Recipes for applying River Review to common problems, each tied to real skills and runnable demos.
+keywords:
+  - AI code review use cases
+  - River Review use cases
+---
+
+Use-case recipes for applying River Review to common problems. Each recipe names the real skills it uses and, where available, links to a runnable demo.
+
+## Recipes
+
+- [Enforce plan conformance (catch implementation drift)](./enforce-plan-conformance.en.md) — catch drift from an approved plan with upstream gates plus midstream conformance skills.
+- [Review design docs and ADRs upstream](./review-design-adrs-upstream.en.md) — catch gaps and risks at the design/ADR stage, before they become code.
+- [Suppress flaky / false-positive AI review comments](./suppress-flaky-review-comments.en.md) — use Riverbed Memory suppression so known false positives do not recur.
+
+New here? See [What is River Review](../explanation/what-is-river-review.en.md) and the [Quickstart](../guides/quickstart.en.md).

--- a/pages/use-cases/index.md
+++ b/pages/use-cases/index.md
@@ -1,0 +1,19 @@
+---
+id: use-cases-index
+title: ユースケース集
+sidebar_label: ユースケース集
+description: River Review をよくある課題ごとに使うためのレシピ集です。各レシピは実在のスキルと runnable デモに紐づきます。
+keywords:
+  - AIコードレビュー ユースケース
+  - River Review use cases
+---
+
+River Review を「よくある課題」ごとに使う方法をまとめたユースケース集です。各レシピは、対処に使う実在のスキルと、可能なものは runnable なデモへの導線を示します。
+
+## レシピ一覧
+
+- [計画（plan）に反した実装を検出する](./enforce-plan-conformance.md) — 承認済みの計画から実装が逸脱するドリフトを、upstream ゲートと midstream 照合で捉える。
+- [設計・ADR を上流でレビューする](./review-design-adrs-upstream.md) — コードになる前の設計・ADR 段階で、抜けやリスクを検出する。
+- [ブレる／誤検出の AI レビュー指摘を抑制する](./suppress-flaky-review-comments.md) — Riverbed Memory の抑制で、既知の誤検出を再発させない。
+
+はじめての方は [River Review とは](../explanation/what-is-river-review.md) と [クイックスタート](../guides/quickstart.md) もあわせてご覧ください。

--- a/pages/use-cases/review-design-adrs-upstream.en.md
+++ b/pages/use-cases/review-design-adrs-upstream.en.md
@@ -1,0 +1,51 @@
+---
+id: review-design-adrs-upstream-en
+title: Review design docs and ADRs upstream
+sidebar_label: Review design docs and ADRs upstream
+description: Use River Review's upstream skills to review design docs and ADRs before code — catch failure-mode, compatibility, and observability gaps.
+keywords:
+  - ADR review
+  - design review
+  - upstream review
+  - River Review
+---
+
+Want to run an AI review over your design docs? Wrote an ADR and worried you missed a viewpoint? River Review reviews design documents and ADRs in the **upstream** phase — before any code is written — so you catch design gaps before code, not during a diff review when they are expensive to fix.
+
+## The problem
+
+Flaws in a design document or ADR are cheapest to fix before implementation starts. But the highest-risk gaps — undefined failure modes, a missing backward-compatibility plan, no observability — never show up in a code diff. By the time a midstream diff review runs, the design decision is already baked into the code.
+
+## How River Review addresses it
+
+River Review routes the design documents themselves — not the code — to **upstream** skills. When a design plan or ADR appears in the diff, three upstream skills are matched against the changed files and return judgments against your team's design criteria. Each returns `findings` plus concrete follow-up actions.
+
+- `architecture-validation-plan` — flags when a design doc lacks a validation plan: SLO/SLI targets, test plans, rollout/rollback/canary criteria, and observability for the new risks it introduces.
+- `agent-architecture-review` — checks overall design, responsibility separation, dependency direction, and boundary breakage, and asks for an ADR when a decision lacks rationale.
+- `security-privacy-design` — reviews data retention/deletion, backup residency, cross-border transfer, encryption, and privacy-rights flows (erasure/export).
+
+All three run in the `phase: upstream` and surface findings you can only see by reading the design document — not the implementation diff.
+
+## Try it
+
+Start with the no-setup demo — no API key and no `npm install` required. It reviews the design plan for a new webhook-delivery feature and surfaces three findings that never appear in an implementation diff (failure-mode/retry, payload versioning, observability).
+
+Steps:
+
+- Open `examples/upstream-design-review-demo/` ([read it on GitHub](https://github.com/s977043/river-review/tree/main/examples/upstream-design-review-demo)).
+- Compare `design-plan.md` (the review target) against `expected-findings.json` (the expected findings).
+- Then point the same upstream skills at your own ADR or RFC by including it in the diff.
+
+## What it does NOT do
+
+River Review automates the _judgment_, not the merge. Upstream review produces material for a human decision; the final call is always a person's.
+
+- It does not auto-merge or auto-approve. It is human-in-the-loop by design.
+- It is not a replacement for static analysis (linters, type checks, SAST). Syntactic, deterministic checks stay with those tools; upstream skills focus on semantic design validity — scope, boundaries, and acceptance criteria.
+- It does not speculate about code that is not in the diff, and it does not return generic advice with no reference to the actual design.
+
+## Related
+
+- [Upstream / Midstream / Downstream](../explanation/upstream-midstream-downstream.en.md)
+- [What is River Review](../explanation/what-is-river-review.en.md)
+- Demo: [upstream-design-review-demo](https://github.com/s977043/river-review/tree/main/examples/upstream-design-review-demo)

--- a/pages/use-cases/review-design-adrs-upstream.md
+++ b/pages/use-cases/review-design-adrs-upstream.md
@@ -1,0 +1,51 @@
+---
+id: review-design-adrs-upstream
+title: 設計・ADR を上流でレビューする
+sidebar_label: 設計・ADR を上流でレビュー
+description: River Review の上流（upstream）スキルで、設計ドキュメントや ADR をコード実装前にレビューし、失敗設計・互換・可観測性・プライバシーの抜けを見つける方法。
+keywords:
+  - ADR review
+  - design review
+  - upstream review
+  - River Review
+---
+
+設計ドキュメントを AI でレビューするためのレシピです。River Review は、コード実装より前の上流（upstream）フェーズで、設計や ADR をレビューします。設計の抜けをコード実装より前に見つけられるため、手戻りコストが下がります。
+
+## 問題
+
+設計ドキュメントや ADR の欠陥は、コードを書き始めてから気づくと修正コストが跳ね上がります。失敗時の挙動、互換方針、可観測性といった観点は、実装差分に現れず、設計レビューでのみ捕まえられます。midstream の diff レビューが動くころには、設計判断はすでにコードへ焼き込まれています。
+
+## River Review はどう解決するか
+
+River Review は、コードより前段にある設計ドキュメントそのものを、上流（upstream）スキルでレビューします。設計プランや ADR が差分に含まれると、次の 3 つの上流スキルへ自動でルーティングされます。各スキルは設計基準に照らして判断し、指摘（findings）と修正アクションを返します。
+
+- `architecture-validation-plan` — 設計に検証計画（SLO/SLI・テスト・ロールバック/カナリア・可観測性）が欠けていないかを検出する上流スキルである。
+- `agent-architecture-review` — 全体設計・責務分離・依存方向・境界破綻の検知に加え、根拠（ADR）なき決定を問う上流スキルである。
+- `security-privacy-design` — データ保持・削除・バックアップ所在・越境移転・暗号化など、プライバシー設計の抜けをレビューする上流スキルである。
+
+いずれも `phase: upstream` として動き、実装差分ではなく設計ドキュメントを読んで初めて分かる指摘を返します。
+
+## やってみる
+
+まずは API キー不要の最小デモで、上流レビューが出す判断を読んでみましょう。対象は Webhook 配信機能の設計プランです。実装差分に現れない 3 件の指摘（failure-mode/リトライ、ペイロード互換、可観測性）を、デモで確認できます。
+
+手順:
+
+- `examples/upstream-design-review-demo/` を開く（[GitHub で読む](https://github.com/s977043/river-review/tree/main/examples/upstream-design-review-demo)）。
+- `design-plan.md`（レビュー対象）と `expected-findings.json`（期待される指摘）を突き合わせる。
+- 自分の設計プランや ADR が入った差分で、上流レビューを走らせる。
+
+## やらないこと（限界）
+
+River Review が自動化するのは、あくまで設計に対する判断です。マージや承認は自動化せず、最終判断を必ず人間が担います。また、上流スキルは静的解析（linter や型チェック）を置き換えません。構文やパターンで決まる指摘は、静的解析に任せます。上流スキルは、設計・スコープ・受入基準といった意味的な妥当性に集中します。
+
+- 自動マージや自動承認はしない。人間の最終判断（human-in-the-loop）を前提とする。
+- 静的解析（linter・型チェック・SAST）の置き換えではない。意味的な設計レビューに特化する。
+- 差分に無いコードを推測した指摘や、根拠のない一般論は返さない。
+
+## 関連
+
+- [Upstream / Midstream / Downstream の考え方](../explanation/upstream-midstream-downstream.md)
+- [River Review とは](../explanation/what-is-river-review.md)
+- デモ: [upstream-design-review-demo](https://github.com/s977043/river-review/tree/main/examples/upstream-design-review-demo)

--- a/pages/use-cases/suppress-flaky-review-comments.en.md
+++ b/pages/use-cases/suppress-flaky-review-comments.en.md
@@ -1,0 +1,57 @@
+---
+id: suppress-flaky-review-comments-en
+title: Suppress flaky / false-positive AI review comments
+sidebar_label: Suppress flaky / false-positive AI review comments
+description: Reduce flaky, false-positive AI review noise with Riverbed Memory suppression and the suppression-feedback skill. Human-in-the-loop, not auto-merge.
+keywords:
+  - false positive AI review
+  - suppress AI review comments
+  - AIコードレビュー 誤検出
+  - River Review
+---
+
+If you searched for "reduce false positives in AI code review", "suppress noisy AI review comments", or "stable AI review", this recipe is for you.
+
+## The problem
+
+LLM-driven review is non-deterministic: the same diff can surface different comments on each run, and some comments contradict the actual implementation intent. When the same finding re-fires on every PR, reviewers lose trust and developers start ignoring the bot. Left unmanaged, that noise erodes the signal that made the review worth reading.
+
+## How River Review addresses it
+
+River Review splits false-positive handling into two layers:
+
+- **Deterministic detectors** (`security-basic`, `logging-observability`, `test-existence`, `coverage-gap`) are guarded by _canary_ fixtures — a corpus of known false-positive patterns. Once a false positive is fixed, a regression test keeps it fixed. See the [detector evaluation report](../reference/detector-evaluation-report.en.md).
+- **Semantic noise and intent mismatches** are handled in the **midstream** phase by the `suppression-feedback` skill.
+
+`suppression-feedback` does not silently delete findings. It classifies a finding so a reviewer (human or AI) can decide between _suppressing_ and _fixing_ it, then guides the `river suppression add` CLI that records the decision in Riverbed Memory:
+
+- `false_positive` — records a comment that contradicts the implementation intent.
+- `accepted_risk` — records a finding you knowingly keep after weighing the cost.
+- `duplicate` — points at an existing fingerprint instead of repeating the comment.
+- `major` / `critical` findings are **not** auto-suppressed except via `accepted_risk` with a rationale (the HIGH_SEVERITY guard). Everything else is blocked and must be handled manually.
+
+Because the decision lives in Riverbed Memory, the next PR's review can recall it and stop re-firing the same noise.
+
+## Try it
+
+There is no dedicated demo — the workflow runs through Riverbed Memory suppression. To silence a comment you have judged a false positive:
+
+1. Run a review and note the `fingerprint` of the comment you want to suppress.
+2. Decide whether it is a false positive or an accepted risk.
+3. Record it with `river suppression add`:
+
+```bash
+river suppression add \
+  --fingerprint <fp> \
+  --feedback false_positive \
+  --rationale "one or two sentences on why this is a false positive"
+```
+
+For the full storage flow into `.river/memory/index.json`, see [Use Riverbed Memory](../guides/use-riverbed-memory.en.md). For the design rationale, see [Riverbed Memory](../explanation/riverbed-memory.en.md).
+
+## What it does NOT do
+
+- It does not auto-generate suppression entries. Writing to the CLI and to Riverbed Memory requires human approval.
+- It is human-in-the-loop, not auto-merge — River Review never merges around a finding on its own; a human makes the final call.
+- It is not a replacement for static analysis or your custom linters. The deterministic layer is guarded by canary fixtures; `suppression-feedback` focuses only on the semantic judgment those tools cannot make.
+- It does not blanket-suppress `major` / `critical` findings. Auto-suppression is allowed only when both `accepted_risk` and a rationale are present.

--- a/pages/use-cases/suppress-flaky-review-comments.en.md
+++ b/pages/use-cases/suppress-flaky-review-comments.en.md
@@ -28,7 +28,7 @@ River Review splits false-positive handling into two layers:
 - `false_positive` — records a comment that contradicts the implementation intent.
 - `accepted_risk` — records a finding you knowingly keep after weighing the cost.
 - `duplicate` — points at an existing fingerprint instead of repeating the comment.
-- `major` / `critical` findings are **not** auto-suppressed except via `accepted_risk` with a rationale (the HIGH_SEVERITY guard). Everything else is blocked and must be handled manually.
+- `major` / `critical` findings are **not** auto-suppressed unless the classification is `accepted_risk` with a rationale (the HIGH_SEVERITY guard); lower-severity `minor` / `info` noise is auto-suppressed for any classification.
 
 Because the decision lives in Riverbed Memory, the next PR's review can recall it and stop re-firing the same noise.
 

--- a/pages/use-cases/suppress-flaky-review-comments.md
+++ b/pages/use-cases/suppress-flaky-review-comments.md
@@ -25,7 +25,7 @@ River Review は誤検出への対処を 2 つの層に分けています。決�
 - `false_positive`: 実装意図に対する誤検知として記録する区分である。
 - `accepted_risk`: リスクを認識したうえで残すと決めた指摘に付ける区分である。
 - `duplicate`: 既存 fingerprint の指摘と重複するときに参照を張る区分である。
-- major / critical の指摘は `accepted_risk` 以外で自動抑制されない（HIGH_SEVERITY guard）。
+- major / critical の指摘は、`accepted_risk` として根拠つきで区分した場合を除き、自動抑制されない（HIGH_SEVERITY guard）。minor / info のノイズはどの区分でも自動抑制される。
 
 この判断が Riverbed Memory に残ると、後続 PR のレビューは同じノイズの再燃を防げます。
 

--- a/pages/use-cases/suppress-flaky-review-comments.md
+++ b/pages/use-cases/suppress-flaky-review-comments.md
@@ -1,0 +1,54 @@
+---
+id: suppress-flaky-review-comments
+title: ブレる／誤検出の AI レビュー指摘を抑制する
+sidebar_label: 誤検出の指摘を抑制
+description: AI コードレビューのブレや誤検出を、Riverbed Memory の suppression と suppression-feedback スキルで抑制する使い方。人間承認を前提に、決定論検出器の canary と責務を分けます。
+keywords:
+  - false positive AI review
+  - suppress AI review comments
+  - AIコードレビュー 誤検出
+  - River Review
+---
+
+「reduce false positives AI code review」「suppress noisy AI review comments」「stable AI review」で検索してたどり着いた方向けのレシピです。
+
+## 課題
+
+AI のコードレビューは、実行するたびに指摘内容が揺れたり、実装意図と食い違う誤検出を出したりします。同じ指摘が PR ごとに再燃すると、レビュー全体の信頼性を損ないます。やがて開発者は通知そのものを読み飛ばすようになります。River Review はこの揺れや誤検出を、レビュー判断の記録として抑制の対象に変えます。
+
+## River Review はどう抑制するか
+
+River Review は誤検出への対処を 2 つの層に分けています。決定論的な検出器は canary（誤検出パターン集）で守られ、一度直した誤検出が再発しないことを機械的に保証します。意味的なノイズや実装意図との食い違いは、midstream フェーズの `suppression-feedback` スキルが扱います。
+
+`suppression-feedback` スキルは、検出された指摘を 4 つの区分に整理します。機械的な削除はせず、レビュアーが抑制か修正かを選べるよう補助します。判断結果は `river suppression add` を通じて Riverbed Memory に記録されます。
+
+- `false_positive`: 実装意図に対する誤検知として記録する区分である。
+- `accepted_risk`: リスクを認識したうえで残すと決めた指摘に付ける区分である。
+- `duplicate`: 既存 fingerprint の指摘と重複するときに参照を張る区分である。
+- major / critical の指摘は `accepted_risk` 以外で自動抑制されない（HIGH_SEVERITY guard）。
+
+この判断が Riverbed Memory に残ると、後続 PR のレビューは同じノイズの再燃を防げます。
+
+## やってみる
+
+専用のデモはありませんが、Riverbed Memory の suppression で同じ流れを試せます。次の手順で、誤検出と判断した指摘を記録します。
+
+1. レビュー実行後、抑制したい指摘の fingerprint を控える。
+2. その指摘が誤検知か、リスク受容かを判断する。
+3. `river suppression add` で区分と根拠を記録する。
+
+```bash
+river suppression add \
+  --fingerprint <fp> \
+  --feedback false_positive \
+  --rationale "なぜ誤検知と判断したかを 1〜2 文で残す"
+```
+
+登録後の挙動と保存手順は、[Riverbed Memory を使用する](../guides/use-riverbed-memory.md) にまとまっています。決定論的な検出器がどこまで誤検出を防ぐかは、[検出器の評価レポート](../reference/detector-evaluation-report.md) で確認できます。設計思想は [Riverbed Memory](../explanation/riverbed-memory.md) を参照してください。
+
+## やらないこと
+
+- suppression entry を自動生成しない。書き込みは人間の承認を必要とする。
+- 指摘を勝手にマージ判断へ反映しない。River Review は auto-merge せず、最終判断を人間に委ねる。
+- 静的解析やカスタム linter の置き換えではない。決定論的な領域は canary が守り、意味的な判断だけを `suppression-feedback` に任せる。
+- major / critical の指摘を無条件には抑制しない。`accepted_risk` と根拠がそろって初めて自動抑制を許す。

--- a/sidebars.js
+++ b/sidebars.js
@@ -6,6 +6,16 @@ module.exports = {
     'comparison/ai-code-review-tools',
     {
       type: 'category',
+      label: 'ユースケース',
+      items: [
+        'use-cases/use-cases-index',
+        'use-cases/enforce-plan-conformance',
+        'use-cases/review-design-adrs-upstream',
+        'use-cases/suppress-flaky-review-comments',
+      ],
+    },
+    {
+      type: 'category',
       label: 'チュートリアル',
       items: [
         'tutorials/getting-started',


### PR DESCRIPTION
## What

Adds a query-shaped **use-case recipe** section — awareness backlog **#7** — under `pages/use-cases/`: an index plus 3 recipes (ja + en each), registered in `sidebars.js` under a new ユースケース category.

- **enforce-plan-conformance** → `plan-review-gate` / `plangate-plan-integrity` / `plangate-exec-conformance` / `design-source-conformance` / `existing-pattern-conformance` + the runnable `plan-conformance-demo`
- **review-design-adrs-upstream** → `architecture-validation-plan` / `agent-architecture-review` / `security-privacy-design` + the runnable `upstream-design-review-demo`
- **suppress-flaky-review-comments** → `suppression-feedback` + Riverbed Memory

## Why

Developers search "how do I enforce plan conformance / review ADRs / reduce false positives with AI code review". This section captures that long-tail intent with concrete recipes tied to **real shipped skills** and, where available, a **no-API-key runnable demo** — not thin SEO filler. Each recipe is honest about what it does **not** do (human-in-the-loop, not auto-merge; not a static-analysis replacement).

## How it was built

A `draft → verify` workflow drafted ja+en per recipe from a ground-truth list of real skills/demos, then a verifier confirmed **every referenced skill id exists in `skills/registry.yaml`** and every internal link resolves. Finalization converted site-absolute links to relative `.md`/`.en.md` (lychee requirement per prior guidance) and enforced textlint.

## Verification

- `npm run build` (Docusaurus, `onBrokenLinks: throw`) **succeeds** — all 8 pages compile, internal links + sidebar resolve.
- `textlint --no-cache` (fixed a doubled-particle and a 7+ kanji run), `prettier --check`, `markdownlint` (fixed duplicate-H1 from body/frontmatter), `fix-dashes` all pass.
- All skill ids verified against the registry; all relative link targets (incl. `.en.md`) confirmed to exist.

## Backlog

Priority order so far: #1 comparison (#1390), #5 eval report (#1391), #6 dashboard real data (#1389), **#7 this**. #4 skipped (existing skills-catalog + no author metadata). Remaining high-value items are mostly external submissions (#2 awesome-claude-code, #3 AlternativeTo, #8 awesome-devsecops, #9 Zenodo) that need maintainer accounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)