### PR TITLE
docs(growth): add submission drafts for awesome-claude-code, AlternativeTo, awesome-devsecops

### DIFF
--- a/docs/growth/external-listings.md
+++ b/docs/growth/external-listings.md
@@ -58,7 +58,7 @@ Codify team review judgment as repo-owned skills; run them as GitHub Action / pl
 
 ## 提出状況（トラッキング）
 
-各リストへの提出 PR と、その時点の状態。状態は変わりうるため、確認時は各 PR / upstream の `main` を直接参照すること（最終確認: 2026-07-04）。
+各リストへの提出 PR と、その時点の状態。状態は変わりうるため、確認時は各 PR / upstream の `main` を直接参照すること（最終確認: 2026-07-05）。
 
 | リスト                | 提出 PR                                                                    | 状態                          | 備考                                                                                      |
 | --------------------- | -------------------------------------------------------------------------- | ----------------------------- | ----------------------------------------------------------------------------------------- |
@@ -67,10 +67,13 @@ Codify team review judgment as repo-owned skills; run them as GitHub Action / pl
 | awesome-code-review   | [#131](https://github.com/joho/awesome-code-review/pull/131)               | ⏳ Open・マージ待ち           | 2026-06-24 提出。mergeable、レビュー未着                                                  |
 | awesome-ai-devtools   | [#697](https://github.com/jamesmurdza/awesome-ai-devtools/pull/697)        | ⏳ Open・マージ待ち           | 2026-06-24 提出（旧 #696 は差し替えのため CLOSED）。mergeable、レビュー未着               |
 | awesome-ai-agents     | —                                                                          | 未提出                        | Marginal 適合のため優先度低（下記参照）                                                   |
+| awesome-claude-code   | —                                                                          | 未提出（ドラフト準備済み）    | **issue フォーム提出**（PR 不可）。適合 Good。下記ドラフト参照                            |
+| AlternativeTo         | —                                                                          | 未提出（ドラフト準備済み）    | **Web フォーム提出**（PR なし）。新規アカウントは作成後約1週間の待機が必要。下記参照      |
+| awesome-devsecops     | —                                                                          | 未提出（ドラフト準備済み）    | fork+PR。**maintained な TaptuIT/awesome-devsecops** を対象（本家は放置）。適合 Marginal  |
 
 ## 提出材料ドラフト
 
-各リストの実際の README / CONTRIBUTING を確認して作成したコピペ用ドラフト。fork → 該当箇所に追記 → PR の流れで使う（外部リポジトリへの操作はリポジトリ管理者が実施）。提出直前に各リストの規約が変わっていないか再確認すること。提出済み PR の状態は上記「提出状況（トラッキング）」を参照。
+各リストの実際の README / CONTRIBUTING を確認して作成したコピペ用ドラフト。提出方法はリストごとに異なる（fork+PR / issue フォーム / Web フォーム）ため各ドラフト冒頭の「提出方法」に従う。外部リポジトリ・サービスへの操作はリポジトリ管理者が実施する。提出直前に各リストの規約が変わっていないか再確認すること。提出済み PR の状態は上記「提出状況（トラッキング）」を参照。
 
 ### awesome-actions（sdras/awesome-actions）
 
@@ -122,6 +125,64 @@ PR タイトル: `Add River Review to Tools`
 ```
 
 PR タイトル: `Add River Review to PR & Code Review Bots`
+
+### awesome-claude-code（hesreallyhim/awesome-claude-code）
+
+- **提出方法**: **GitHub issue フォームのみ**（[recommend-resource テンプレート](https://github.com/hesreallyhim/awesome-claude-code/issues/new?template=recommend-resource.yml)）。**PR は開かない・`gh` CLI は使わない**（CONTRIBUTING が明記、違反すると一時的な interaction 制限のリスク）。ボットがフォームを検証し、リンク先リポジトリの LICENSE を自動判定する（品質は人間が選別）。
+- 規約: 説明は宣伝でなく事実ベース（読者に呼びかけない）・1〜3 文・10〜500 文字・絵文字なし。README エントリは受理後に `generate_readme.py` が自動生成する。カテゴリは固定 16 択のドロップダウン。同カテゴリ内はアルファベット順。
+- 適合: **Good**（River Review は実際に Claude Code プラグイン）。
+- カテゴリ（推奨）: `Infrastructure & DevOps`（旧「Plugins / Subagents」等のセクションは廃止され話題別に再編済み）。
+
+フォーム記入値（コピペ用）:
+
+```text
+Display Name: River Review
+Category: Infrastructure & DevOps
+Link: https://github.com/s977043/river-review
+Author Name: s977043
+Author Link: https://github.com/s977043
+Description: A "Review Judgment as Code" framework: teams codify their code-review standards as versioned, repo-owned SKILL.md skills and run them over plans, diffs, tests, JUnit, and prior review artifacts. Ships as a Claude Code plugin — a skill-routed review agent plus /river-review:<skill> commands — and as a GitHub Action, keeping humans in the loop rather than auto-merging.
+Checklist: 3 項目すべてチェック（未掲載 / リンク有効 / Claude Code 固有）
+```
+
+> 注意: 説明は「Claude Code 固有」チェックを満たすため Claude Code を前面に出している（Codex プラグイン・CLI は意図的に控えめ）。author 表示は repo owner の `s977043`（manifest 上は "river-review maintainers"、好みで変更可）。提出前に GitHub サイドバーが `MIT` を表示するか確認する（`LICENSE-CODE` / `LICENSE-CONTENT` が併存するため）。
+
+### AlternativeTo（alternativeto.net）
+
+- **提出方法**: **Web フォームのみ**（PR なし）。サインイン → 右上ユーザーアイコン → "Suggest new application" のウィザード。Step 2 の App Store 取り込みは **SKIP**。全提出は公開前に管理者承認（数日〜1 週間）。
+- 規約: **新規アカウントは作成後 約1週間の待機後**に新規アプリ提出可（スパム対策）。プロフィールでの宣伝は禁止（正規の "Add a new application" フローを使う。自作 OSS の自己提出は可）。必須項目: Name / Platforms / License / Description / Tags。
+- 適合: **Good**。「alternative to」関係はページ作成後に各対象ツール（CodeRabbit / Qodo / Greptile / Codacy）のページから別途追加し、コミュニティ投票で確定する。
+
+フォーム記入値（コピペ用。レビュー指摘を反映済み: SAST 誤認を招く `static-code-analysis` タグは除外し、比較的な表現を中立化した）:
+
+```text
+Name: River Review
+Website: https://river-review.the3396.com/
+Source code: https://github.com/s977043/river-review
+License: Open Source — MIT
+Pricing: Free / Open Source
+Platforms: Mac, Windows, Linux, Self-Hosted, Node.JS（GitHub Action / Claude Code・Codex プラグインは説明文で補足）
+Tags: ai, code-review, ai-code-review, developer-tools, continuous-integration, git, open-source, pull-requests, llm
+Short description: Open-source "Review Judgment as Code" framework: teams codify their review standards as versioned, repo-owned skills and run AI-assisted reviews across plans, diffs, tests, JUnit, and prior review artifacts. Human-in-the-loop, not auto-merge.
+Full description: River Review is an open-source (MIT) framework and capability pack for AI-assisted code review. Teams codify their own review standards as versioned, repo-owned SKILL.md skills — covering areas such as security, accessibility, migration safety, dependency policy, and plan conformance — and execute them across software-lifecycle artifacts: implementation plans, diffs, tests, JUnit results, and prior review comments. It ships as a Claude Code / Codex plugin (a skill-routed review agent plus /river-review:<skill> commands, installable via the plugin marketplace) and as a GitHub Action, and can also run headless from a CLI. Reviews are human-in-the-loop by design: it surfaces findings and verdicts, but GO/NO-GO, iteration, and merge decisions stay with the team. It does not auto-merge or replace human reviewers, and it complements — rather than replaces — static analysis.
+Alternative to（ページ作成後に各ツールページから追加）: CodeRabbit, Qodo, Greptile, Codacy
+```
+
+> 注意: `static-code-analysis` タグは River Review を SAST と誤認させるため**外す**（意味的レビュー/ポリシーゲート層であり静的解析の代替ではない）。Platform enum の正確な名称はサインイン後の実フォームで要確認。
+
+### awesome-devsecops（TaptuIT/awesome-devsecops）
+
+- **提出方法**: **fork + PR**。対象は **[TaptuIT/awesome-devsecops](https://github.com/TaptuIT/awesome-devsecops)**（維持されている fork。1.7k stars、community PR を merge）。**本家 `devsecops/awesome-devsecops` は避ける**（star は多いが 2021 以降コミットなし・stale PR 多数で実質放置）。`readme.md` を `main` で編集。
+- 適合: **Marginal**（DevSecOps の shift-left 文脈自体は関連するが、リストは脆弱性検出ツールのカテゴリ構成のため構造的にやや外れる）。提出可否はメンテナ判断。正直に「SAST を置き換えず補完する」と明記する。
+- 追記先: `Tools > Static Analysis > Multi-Language Support` に、既存の `RIPS` と `SemGrep` の間へアルファベット順で挿入。
+
+追記する 1 行:
+
+```md
+- [River Review](https://github.com/s977043/river-review) - _s977043_ - An open-source "Review Judgment as Code" framework that codifies review standards as versioned, repo-owned skills and runs AI-assisted, human-in-the-loop reviews across plans, diffs, tests and JUnit results. Ships security-review skills and policy gates that complement SAST scanners rather than replacing them.
+```
+
+PR タイトル: `Add River Review to the Static Analysis section`
 
 ## 注意点
 


### PR DESCRIPTION
## What

Prepares **copy-paste-ready submission materials** for the top remaining external-listing candidates (awareness backlog **#2 / #3 / #8**) in `docs/growth/external-listings.md`, so the maintainer can submit quickly. Adds tracking rows + per-list drafts.

## Key research findings (each verified against the live list)

- **awesome-claude-code** (#2): submission is an **issue form only** ([recommend-resource.yml](https://github.com/hesreallyhim/awesome-claude-code/issues/new?template=recommend-resource.yml)) — **not** a PR / `gh` CLI (CONTRIBUTING forbids it, with an interaction-restriction risk). Category `Infrastructure & DevOps` (the list was reorganized away from Plugins/Subagents sections). Exact form field values included.
- **AlternativeTo** (#3): **website wizard** ("Suggest new application"), no PR; note the **~1-week new-account wait**. Field values included. **Review fixes applied**: dropped the misleading `static-code-analysis` tag (River Review is not a SAST scanner) and neutralized comparative phrasing.
- **awesome-devsecops** (#8): fork+PR to the **maintained [TaptuIT/awesome-devsecops](https://github.com/TaptuIT/awesome-devsecops)** — the higher-star `devsecops/awesome-devsecops` is abandoned (no commit since 2021, dozens of stale PRs). Fit honestly marked **marginal**; entry frames River Review as **complementing** SAST, not replacing it.

## How it was built

A research + verify workflow drafted each submission and an adversarial verifier checked rule-compliance, accuracy (vs OSS / repo-owned skills / plugin+Action / human-in-the-loop / no-npm / not-a-SAST-scanner), and non-promotional tone. The AlternativeTo draft's two flagged issues were fixed before landing.

## Scope

Docs-only. **Actual submission is a maintainer action** per the repo's external-listing policy ("外部リポジトリ・サービスへの操作はリポジトリ管理者が実施"). This PR only stages the vetted materials.

## Verification

`prettier --check`, `markdownlint`, `fix-dashes --check` pass. External URLs are checked by lychee in CI.

## Backlog

Remaining in-repo item: **#9** — enrich `CITATION.cff` + add a "how to cite" doc (Zenodo DOI activation itself is a maintainer action). Everything else high-value is now either done or staged for maintainer submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)