### PR TITLE
docs: fix CITATION.cff metadata and add a how-to-cite page (ja+en)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,10 +1,19 @@
 cff-version: 1.2.0
-title: "River Review"
-message: "Cite River Review when referencing this repository."
+title: River Review
+message: "If you use River Review, please cite it using the metadata in this file."
+type: software
+abstract: "River Review is an open-source \"Review Judgment as Code\" framework for AI-assisted code review. Teams codify their review standards as versioned, repo-owned SKILL.md skills and run them across plans, diffs, tests, JUnit, and prior review artifacts, keeping humans in the loop rather than auto-merging."
 authors:
-  - family-names: "River Review"
-    given-names: "Maintainers"
-version: "2025.10"
-date-released: "2025-10-26"
+  - name: "River Review maintainers"
 repository-code: "https://github.com/s977043/river-review"
-doi: ""
+url: "https://river-review.the3396.com/"
+license: MIT
+version: "1.39.0"
+date-released: "2026-07-02"
+keywords:
+  - code-review
+  - ai-code-review
+  - review-judgment-as-code
+  - skill-registry
+  - human-in-the-loop
+# doi: 10.5281/zenodo.XXXXXXX  # add after enabling the Zenodo–GitHub integration and minting a DOI

--- a/pages/reference/how-to-cite.en.md
+++ b/pages/reference/how-to-cite.en.md
@@ -1,0 +1,47 @@
+---
+id: how-to-cite-en
+title: How to cite River Review
+sidebar_label: How to cite
+description: How to cite River Review in research or articles. The single source of truth for the citation metadata is the repository's CITATION.cff.
+keywords:
+  - citation
+  - CITATION.cff
+  - cite River Review
+  - how to cite
+---
+
+Here is how to cite River Review in research or articles. The single source of truth for the citation metadata is [`CITATION.cff`](https://github.com/s977043/river-review/blob/main/CITATION.cff) at the repository root.
+
+## GitHub "Cite this repository"
+
+On the repository's GitHub page, the right sidebar's **"Cite this repository"** button generates an APA / BibTeX citation from `CITATION.cff`. This is the easiest path — no manual entry required.
+
+## BibTeX
+
+```bibtex
+@software{river_review,
+  title   = {River Review},
+  author  = {{River Review maintainers}},
+  url     = {https://github.com/s977043/river-review},
+  version = {1.39.0},
+  date    = {2026-07-02},
+  license = {MIT}
+}
+```
+
+## Plain text
+
+```text
+River Review maintainers (2026). River Review (Version 1.39.0) [Software]. https://github.com/s977043/river-review
+```
+
+## About the DOI
+
+- There is no DOI yet.
+- Once the Zenodo–GitHub integration is enabled and a DOI is minted for a release, the `doi` field in `CITATION.cff` and this page will be updated.
+- The version and date change with each release, so treat the values in `CITATION.cff` as authoritative when you cite.
+
+## Related docs
+
+- [`CITATION.cff` (metadata source of truth)](https://github.com/s977043/river-review/blob/main/CITATION.cff)
+- [What is River Review](../explanation/what-is-river-review.en.md)

--- a/pages/reference/how-to-cite.md
+++ b/pages/reference/how-to-cite.md
@@ -1,0 +1,47 @@
+---
+id: how-to-cite
+title: River Review の引用方法
+sidebar_label: 引用方法
+description: 研究や記事で River Review を参照するための引用情報をまとめます。メタデータの単一の情報源はリポジトリの CITATION.cff です。
+keywords:
+  - citation
+  - CITATION.cff
+  - River Review 引用
+  - how to cite
+---
+
+研究や記事で River Review を引用する方法は次のとおりです。引用メタデータの単一の情報源は、リポジトリ直下の [`CITATION.cff`](https://github.com/s977043/river-review/blob/main/CITATION.cff) です。
+
+## GitHub の「Cite this repository」
+
+GitHub のリポジトリページ右サイドバーにある「Cite this repository」から、`CITATION.cff` を基にした APA / BibTeX 形式の引用を生成できます。手入力せずに済むため、最も手軽な方法です。
+
+## BibTeX
+
+```bibtex
+@software{river_review,
+  title   = {River Review},
+  author  = {{River Review maintainers}},
+  url     = {https://github.com/s977043/river-review},
+  version = {1.39.0},
+  date    = {2026-07-02},
+  license = {MIT}
+}
+```
+
+## プレーンテキスト
+
+```text
+River Review maintainers (2026). River Review (Version 1.39.0) [Software]. https://github.com/s977043/river-review
+```
+
+## DOI について
+
+- 現時点で DOI は未発行である。
+- Zenodo と GitHub を連携してリリースへ DOI を付与したのち、`CITATION.cff` の `doi` フィールドと本ページを更新する。
+- バージョンや日付は最新リリースで変わるため、引用時は `CITATION.cff` の値を正とする。
+
+## 関連ドキュメント
+
+- [`CITATION.cff`（メタデータの正）](https://github.com/s977043/river-review/blob/main/CITATION.cff)
+- [River Review とは](../explanation/what-is-river-review.md)

--- a/sidebars.js
+++ b/sidebars.js
@@ -67,6 +67,7 @@ module.exports = {
         'reference/runner-cli-reference',
         'reference/known-limitations',
         'reference/detector-evaluation-report',
+        'reference/how-to-cite',
         'reference/glossary',
       ],
     },


### PR DESCRIPTION
## What

Awareness backlog **#9** (citation model), in-repo portion. **The maintainer approved this one-time edit** of the otherwise "never edit" `CITATION.cff`.

## CITATION.cff fixes

- **Author was malformed**: encoded as a *person* (`family-names: "River Review"` / `given-names: "Maintainers"`). Use the CFF **entity** form `name: "River Review maintainers"`.
- **Stale version**: `2025.10` / `2025-10-26` → real latest release **1.39.0 / 2026-07-02** (from the git tag).
- **Added** `type` / `abstract` / `keywords` / `license` / `url`; **dropped** the empty `doi: ""` and left a commented placeholder for after Zenodo.
- **No fabrication** — no invented DOI, ORCID, or personal names (entity name only, matching the plugin manifest).

## New doc

`pages/reference/how-to-cite.(md|en.md)` — GitHub "Cite this repository", BibTeX, plain-text, and an honest note that the DOI is pending the Zenodo–GitHub integration. Registered in `sidebars.js` under リファレンス.

## Maintainer action remaining

Enabling the Zenodo–GitHub integration and minting a DOI is a maintainer action; afterward, add the `doi:` to `CITATION.cff` (placeholder comment is in place) and update the page.

## Verification

- Validated `CITATION.cff` parses as YAML with all CFF-required fields and the entity-author form; CI does not lint `.cff` (glob excludes it).
- `npm run build` (Docusaurus, `onBrokenLinks: throw`) **succeeds**; `textlint --no-cache`, `prettier --check`, `markdownlint`, `fix-dashes` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)