### PR TITLE
docs: add schema.org SoftwareApplication JSON-LD for AI/search discovery

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -39,7 +39,7 @@ const structuredData = {
   isAccessibleForFree: true,
   keywords:
     'AI code review, code review, review judgment as code, skill registry, human-in-the-loop, GitHub Action, Claude Code plugin',
-  offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  offers: { '@type': 'Offer', price: 0, priceCurrency: 'USD' },
   author: {
     '@type': 'Organization',
     name: 'River Review maintainers',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -22,6 +22,31 @@ const siteUrl = normalizeSiteUrl(resolveSiteUrl());
 const baseUrl = ensureLeadingAndTrailingSlash(resolveBaseUrl());
 const docsRouteBasePath = process.env.DOCS_ROUTE_BASE_PATH ?? '/';
 
+// schema.org structured data (SoftwareApplication) for search engines and AI
+// crawlers. Version is intentionally omitted to avoid drift; the canonical
+// version lives in CITATION.cff / package.json.
+const structuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  name: 'River Review',
+  applicationCategory: 'DeveloperApplication',
+  operatingSystem: 'Cross-platform',
+  description:
+    "River Review is an open-source 'Review Judgment as Code' framework for AI-assisted code review: teams codify their review standards as versioned, repo-owned skills and run them across plans, diffs, tests, JUnit, and prior review artifacts. Human-in-the-loop, not auto-merge.",
+  url: 'https://river-review.the3396.com/',
+  codeRepository: 'https://github.com/s977043/river-review',
+  license: 'https://opensource.org/licenses/MIT',
+  isAccessibleForFree: true,
+  keywords:
+    'AI code review, code review, review judgment as code, skill registry, human-in-the-loop, GitHub Action, Claude Code plugin',
+  offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  author: {
+    '@type': 'Organization',
+    name: 'River Review maintainers',
+    url: 'https://github.com/s977043/river-review',
+  },
+};
+
 module.exports = {
   title: 'River Review',
   url: siteUrl,
@@ -58,6 +83,13 @@ module.exports = {
   },
   markdown: { mermaid: true, hooks: { onBrokenMarkdownLinks: 'throw' } },
   onBrokenLinks: 'throw',
+  headTags: [
+    {
+      tagName: 'script',
+      attributes: { type: 'application/ld+json' },
+      innerHTML: JSON.stringify(structuredData),
+    },
+  ],
   plugins: [
     [require.resolve('./plugins/river-dashboard'), { dataPath: 'docs/data/dashboard-stats.json' }],
   ],


### PR DESCRIPTION
## What

Awareness backlog **#24** (structured capability metadata). Injects site-wide **schema.org `SoftwareApplication` JSON-LD** into the docs site head via Docusaurus `headTags`.

## Why

Search engines and AI crawlers/IDEs use structured data to describe and recommend tools. This gives River Review an accurate, machine-readable identity (name, description, license, repository, author, free/OSS) — complementing the [`llms.txt`](https://github.com/s977043/river-review/blob/main/static/llms.txt) added in #1388. River Review is an AI-native tool, so being legible to AI discovery surfaces is high-leverage.

## Notes

- **Version intentionally omitted** to avoid drift; the canonical version stays in `CITATION.cff` / `package.json`.
- Non-promotional, factual fields only; `isAccessibleForFree: true` + `price: 0` reflect the OSS reality.

## Verification

- `npm run build` (Docusaurus) **succeeds**.
- Confirmed the built `build/index.html` head contains `<script type="application/ld+json">` and it parses as a valid `SoftwareApplication` (name / license / author present).
- `prettier --check` passes.

## Backlog status

Top-ranked in-repo awareness items are complete (#1/#5/#6/#7/#9 merged; #2/#3/#8 drafts staged). This #24 extends the AI-discovery thread. Remaining items are mostly maintainer-gated (external submissions, Zenodo DOI, screencasts, talks) or large (a dedicated MCP server, #21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)