### PR TITLE
docs: add robots.txt referencing the sitemap for crawlability

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://river-review.the3396.com/sitemap.xml


### PR DESCRIPTION
## What

Adds `static/robots.txt` (served at `/robots.txt`) that allows all crawlers and points to the production sitemap.

## Why

An OSS web-exposure survey found the docs site (river-review.the3396.com) **under-indexed** — it did not surface in searches, which caps organic discovery regardless of content quality. Docusaurus generates `sitemap.xml` but **no `robots.txt`** by default; adding one that references the sitemap helps search engines discover and crawl the docs.

## Verification

- `npm run build` emits `build/robots.txt` with `Sitemap: https://river-review.the3396.com/sitemap.xml`.
- Confirmed the site already generates `sitemap.xml` and has **no `noindex`**; the repo has no stale `river-reviewer` references.

## Follow-up (maintainer actions, not code)

Submit the docs site to Google/Bing Search Console, and add canonical inbound links (README, Qiita/Zenn/note posts) to build crawl paths. These are the higher-impact discoverability levers beyond robots.txt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)