### PR TITLE
chore: auto-sync CITATION.cff version via release-please

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,15 +1,14 @@
 cff-version: 1.2.0
 title: River Review
-message: "If you use River Review, please cite it using the metadata in this file."
+message: 'If you use River Review, please cite it using the metadata in this file.'
 type: software
-abstract: "River Review is an open-source \"Review Judgment as Code\" framework for AI-assisted code review. Teams codify their review standards as versioned, repo-owned SKILL.md skills and run them across plans, diffs, tests, JUnit, and prior review artifacts, keeping humans in the loop rather than auto-merging."
+abstract: 'River Review is an open-source "Review Judgment as Code" framework for AI-assisted code review. Teams codify their review standards as versioned, repo-owned SKILL.md skills and run them across plans, diffs, tests, JUnit, and prior review artifacts, keeping humans in the loop rather than auto-merging.'
 authors:
-  - name: "River Review maintainers"
-repository-code: "https://github.com/s977043/river-review"
-url: "https://river-review.the3396.com/"
+  - name: 'River Review maintainers'
+repository-code: 'https://github.com/s977043/river-review'
+url: 'https://river-review.the3396.com/'
 license: MIT
-version: "1.39.0"
-date-released: "2026-07-02"
+version: '1.41.0' # x-release-please-version
 keywords:
   - code-review
   - ai-code-review

--- a/pages/reference/how-to-cite.en.md
+++ b/pages/reference/how-to-cite.en.md
@@ -26,6 +26,7 @@ For `version` and `date`, use the `version` in [`CITATION.cff`](https://github.c
   author  = {{River Review maintainers}},
   url     = {https://github.com/s977043/river-review},
   version = {X.Y.Z},
+  date    = {YYYY-MM-DD},
   license = {MIT}
 }
 ```
@@ -33,7 +34,7 @@ For `version` and `date`, use the `version` in [`CITATION.cff`](https://github.c
 ## Plain text
 
 ```text
-River Review maintainers. River Review (Version X.Y.Z) [Software]. https://github.com/s977043/river-review
+River Review maintainers (YYYY). River Review (Version X.Y.Z) [Software]. https://github.com/s977043/river-review
 ```
 
 ## About the DOI

--- a/pages/reference/how-to-cite.en.md
+++ b/pages/reference/how-to-cite.en.md
@@ -18,13 +18,14 @@ On the repository's GitHub page, the right sidebar's **"Cite this repository"** 
 
 ## BibTeX
 
+For `version` and `date`, use the `version` in [`CITATION.cff`](https://github.com/s977043/river-review/blob/main/CITATION.cff) at citation time and the date of the release you used.
+
 ```bibtex
 @software{river_review,
   title   = {River Review},
   author  = {{River Review maintainers}},
   url     = {https://github.com/s977043/river-review},
-  version = {1.39.0},
-  date    = {2026-07-02},
+  version = {X.Y.Z},
   license = {MIT}
 }
 ```
@@ -32,7 +33,7 @@ On the repository's GitHub page, the right sidebar's **"Cite this repository"** 
 ## Plain text
 
 ```text
-River Review maintainers (2026). River Review (Version 1.39.0) [Software]. https://github.com/s977043/river-review
+River Review maintainers. River Review (Version X.Y.Z) [Software]. https://github.com/s977043/river-review
 ```
 
 ## About the DOI

--- a/pages/reference/how-to-cite.md
+++ b/pages/reference/how-to-cite.md
@@ -18,13 +18,14 @@ GitHub のリポジトリページ右サイドバーにある「Cite this reposi
 
 ## BibTeX
 
+`version` と `date` には、引用時点の [`CITATION.cff`](https://github.com/s977043/river-review/blob/main/CITATION.cff) の `version` と、利用したリリースの日付を入れてください。
+
 ```bibtex
 @software{river_review,
   title   = {River Review},
   author  = {{River Review maintainers}},
   url     = {https://github.com/s977043/river-review},
-  version = {1.39.0},
-  date    = {2026-07-02},
+  version = {X.Y.Z},
   license = {MIT}
 }
 ```
@@ -32,7 +33,7 @@ GitHub のリポジトリページ右サイドバーにある「Cite this reposi
 ## プレーンテキスト
 
 ```text
-River Review maintainers (2026). River Review (Version 1.39.0) [Software]. https://github.com/s977043/river-review
+River Review maintainers. River Review (Version X.Y.Z) [Software]. https://github.com/s977043/river-review
 ```
 
 ## DOI について

--- a/pages/reference/how-to-cite.md
+++ b/pages/reference/how-to-cite.md
@@ -26,6 +26,7 @@ GitHub のリポジトリページ右サイドバーにある「Cite this reposi
   author  = {{River Review maintainers}},
   url     = {https://github.com/s977043/river-review},
   version = {X.Y.Z},
+  date    = {YYYY-MM-DD},
   license = {MIT}
 }
 ```
@@ -33,7 +34,7 @@ GitHub のリポジトリページ右サイドバーにある「Cite this reposi
 ## プレーンテキスト
 
 ```text
-River Review maintainers. River Review (Version X.Y.Z) [Software]. https://github.com/s977043/river-review
+River Review maintainers (YYYY). River Review (Version X.Y.Z) [Software]. https://github.com/s977043/river-review
 ```
 
 ## DOI について

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -23,6 +23,10 @@
           "type": "json",
           "path": ".codex-plugin/plugin.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "generic",
+          "path": "CITATION.cff"
         }
       ]
     }


### PR DESCRIPTION
## What

Wires `CITATION.cff` into the existing release automation so the citation version can never drift again:

- **`CITATION.cff`**: bump `1.39.0` → current **1.41.0** and annotate the version line with `# x-release-please-version`; every future release updates it automatically. **Remove `date-released`** — release-please's generic updater has [no date annotation](https://github.com/googleapis/release-please/blob/main/docs/customizing.md) (version-only; verified against upstream docs), so the field could only drift; it is optional in CFF 1.2.0.
- **`release-please-config.json`**: register `CITATION.cff` as a `generic` extra-file — the same mechanism already used for `README.md` / `README.en.md`.
- **`how-to-cite` (ja+en)**: drop the pinned version/date from the BibTeX and plain-text examples in favor of an `X.Y.Z` placeholder plus a pointer to `CITATION.cff`, so the docs can no longer go stale either.

## Why

`CITATION.cff` had already fallen 2 releases behind (1.39.0 vs 1.41.0) because it is in the AGENTS.md **Never-edit** scope and only changes with explicit approval. This wiring makes the file self-maintaining: the one-time marker edit here (maintainer-approved via the recommended-actions flow, following the earlier approved 1.39.0 metadata fix) is the last manual touch; afterwards only the release bot rewrites the version substring.

## Governance note

The Never-edit rule's intent (protect LICENSE/CITATION from tampering) is preserved — agents still don't hand-edit it; the release bot performs a mechanical version substitution on an annotated line. If you'd like AGENTS.md to document this exception explicitly, that's a separate Always-Ask change.

## Verification

- `CITATION.cff` parses as YAML with all CFF-required fields (`cff-version`/`message`/`title`/`authors`); the inline YAML comment is legal and does not affect GitHub's "Cite this repository" parser.
- `release-please-config.json` valid; `CITATION.cff` registered (5 extra-files).
- `prettier` / `textlint --no-cache` / `markdownlint` pass; docs build succeeds (`onBrokenLinks: throw`).
- Takes effect from the next release (1.42.0); current value manually aligned to 1.41.0 in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)