### PR TITLE
test: parity canary に trigger 形状ケースを追加する (#1399)

### DIFF
--- a/src/lib/skillYamlSchema.mjs
+++ b/src/lib/skillYamlSchema.mjs
@@ -55,15 +55,23 @@ const EvalSchema = z.object({
 });
 
 // Trigger configuration (alternative format)
-const TriggerSchema = z.object({
-  phase: z
-    .union([PhaseEnum, z.array(PhaseEnum)])
-    .optional()
-    .describe('SDLC phase(s)'),
-  files: z.array(z.string().min(1)).optional().describe('File patterns (glob)'),
-  path_patterns: z.array(z.string().min(1)).optional().describe('File patterns (alias)'),
-  applyTo: z.array(z.string().min(1)).optional().describe('File patterns (alias)'),
-});
+// `.strict()` mirrors the ajv side (schemas/skill.schema.json → properties.trigger
+// has `additionalProperties: false`). Without it an unknown trigger sub-field would
+// be accepted here but rejected by ajv, i.e. a trigger field added to only one
+// schema would drift silently — the exact gap the skill-schema-parity canary guards
+// (#1399). Matches the deterministicGate object, the other nested schema that uses
+// `.strict()` to track ajv `additionalProperties: false`.
+const TriggerSchema = z
+  .object({
+    phase: z
+      .union([PhaseEnum, z.array(PhaseEnum)])
+      .optional()
+      .describe('SDLC phase(s)'),
+    files: z.array(z.string().min(1)).optional().describe('File patterns (glob)'),
+    path_patterns: z.array(z.string().min(1)).optional().describe('File patterns (alias)'),
+    applyTo: z.array(z.string().min(1)).optional().describe('File patterns (alias)'),
+  })
+  .strict();
 
 // Main Skill YAML Schema
 export const SkillYamlSchema = z

--- a/tests/skill-schema-parity.test.mjs
+++ b/tests/skill-schema-parity.test.mjs
@@ -186,6 +186,25 @@ describe('known trigger divergences (documented, pinned)', () => {
       ajv: true,
       zod: false,
     },
+    {
+      // #1418 gemini: with NO top-level phase/applyTo, an incomplete trigger
+      // (no file spec) diverges. ajv's allOf/anyOf only requires the `trigger`
+      // key to exist, so it accepts; zod's top-level refine still demands a file
+      // requirement (applyTo/path_patterns) and rejects. This is the top-level
+      // `files` alias / refine gap, not a trigger-container gap — pinned here so
+      // a silent schema change fails loudly. Fixing it needs a coordinated
+      // ajv anyOf + zod refine change (tracked as follow-up).
+      label: 'trigger empty object, no top-level file spec: ajv accepts, zod rejects (refine)',
+      skill: { ...base, phase: undefined, applyTo: undefined, trigger: {} },
+      ajv: true,
+      zod: false,
+    },
+    {
+      label: 'trigger phase only, no top-level file spec: ajv accepts, zod rejects (refine)',
+      skill: { ...base, phase: undefined, applyTo: undefined, trigger: { phase: 'midstream' } },
+      ajv: true,
+      zod: false,
+    },
   ];
 
   for (const { label, skill, ajv: expectAjv, zod: expectZod } of cases) {

--- a/tests/skill-schema-parity.test.mjs
+++ b/tests/skill-schema-parity.test.mjs
@@ -9,8 +9,11 @@
  * was) fails loudly instead of drifting.
  *
  * Note: agreement is only checked on ACCEPTANCE — error details differ by
- * design. The zod schema is stricter about some structures (trigger shape),
- * so fixtures stick to the shared surface.
+ * design. Most trigger shapes ARE part of the shared surface and are covered
+ * by CASES below (#1399). A few trigger constraints still diverge by design
+ * (array minItems vs empty-array, string minLength vs empty-string item);
+ * those are pinned explicitly in the "known trigger divergences" block so a
+ * silent change to them also fails loudly instead of being assumed-in-sync.
  */
 
 import { test, describe } from 'node:test';
@@ -77,6 +80,54 @@ const CASES = [
     skill: { ...base, modelHint: 'gigantic' },
     expectValid: false,
   },
+
+  // --- trigger shape parity (#1399) -------------------------------------
+  // base already carries top-level phase+applyTo, so these exercise the
+  // trigger container's own field validation while both validators accept.
+  {
+    label: 'trigger phase + applyTo',
+    skill: { ...base, trigger: { phase: 'midstream', applyTo: ['docs/**/*.md'] } },
+    expectValid: true,
+  },
+  {
+    label: 'trigger phase + files',
+    skill: { ...base, trigger: { phase: 'midstream', files: ['docs/**/*.md'] } },
+    expectValid: true,
+  },
+  {
+    label: 'trigger phase + path_patterns',
+    skill: { ...base, trigger: { phase: 'midstream', path_patterns: ['docs/**/*.md'] } },
+    expectValid: true,
+  },
+  {
+    label: 'trigger phase array',
+    skill: { ...base, trigger: { phase: ['upstream', 'midstream'], applyTo: ['a/**'] } },
+    expectValid: true,
+  },
+  {
+    label: 'trigger empty object (top-level satisfies conditions)',
+    skill: { ...base, trigger: {} },
+    expectValid: true,
+  },
+  {
+    label: 'trigger invalid phase enum',
+    skill: { ...base, trigger: { phase: 'quantum', applyTo: ['a/**'] } },
+    expectValid: false,
+  },
+  {
+    label: 'trigger applyTo not an array',
+    skill: { ...base, trigger: { phase: 'midstream', applyTo: 'a/**' } },
+    expectValid: false,
+  },
+  {
+    // Guards the exact #1399 gap: an unknown trigger sub-field must be rejected
+    // by BOTH. ajv rejects via trigger.additionalProperties:false; zod rejects
+    // via TriggerSchema.strict(). If either loses that constraint, a trigger
+    // field added to only one schema would drift silently.
+    label: 'trigger with unknown sub-field',
+    skill: { ...base, trigger: { phase: 'midstream', applyTo: ['a/**'], unknownField: true } },
+    expectValid: false,
+  },
 ];
 
 describe('skill schema parity (ajv vs zod)', () => {
@@ -105,4 +156,49 @@ describe('skill schema parity (ajv vs zod)', () => {
     assert.equal(ajvCopy.deterministicGate.failSeverity, 'strict_block');
     assert.equal(zodParsed.data.deterministicGate.failSeverity, 'strict_block');
   });
+});
+
+/**
+ * Known trigger-shape divergences (NOT parity — pinned on purpose).
+ *
+ * These are the residual "zod is stricter about some structures" cases the old
+ * header note alluded to. They are constraint-granularity differences that exist
+ * symmetrically at the TOP LEVEL too (e.g. top-level applyTo: [] and applyTo: ['']
+ * diverge identically), so aligning only the trigger container would introduce a
+ * new inconsistency rather than remove one; a proper fix would touch both levels
+ * of both schemas and is out of scope for #1399 (trigger field parity).
+ *
+ * Instead we pin the current behavior: if either schema silently changes one of
+ * these, the assertion below flips and this test fails loudly. `files` and
+ * `path_patterns` behave identically to `applyTo` on both sides.
+ */
+describe('known trigger divergences (documented, pinned)', () => {
+  const cases = [
+    {
+      label: 'trigger applyTo empty array: ajv rejects (minItems), zod accepts',
+      skill: { ...base, trigger: { phase: 'midstream', applyTo: [] } },
+      ajv: false,
+      zod: true,
+    },
+    {
+      label: 'trigger applyTo empty-string item: ajv accepts, zod rejects (minLength)',
+      skill: { ...base, trigger: { phase: 'midstream', applyTo: [''] } },
+      ajv: true,
+      zod: false,
+    },
+  ];
+
+  for (const { label, skill, ajv: expectAjv, zod: expectZod } of cases) {
+    test(label, () => {
+      const ajvOk = ajvValidate(JSON.parse(JSON.stringify(skill)));
+      const zodOk = SkillYamlSchema.safeParse(skill).success;
+      assert.equal(ajvOk, expectAjv, `ajv expected ${expectAjv} for: ${label}`);
+      assert.equal(zodOk, expectZod, `zod expected ${expectZod} for: ${label}`);
+      assert.notEqual(
+        ajvOk,
+        zodOk,
+        'this case is a documented divergence; if they now agree, promote it into CASES'
+      );
+    });
+  }
 });


### PR DESCRIPTION
Closes #1399

## 概要

`tests/skill-schema-parity.test.mjs`（ajv/zod の accept/reject 一致 canary）に **trigger 形状の parity ケース**を追加。従来コメントが認めていた「zod is stricter about trigger shape」の盲点を塞ぐ。

## 変更

- **`src/lib/skillYamlSchema.mjs`**: zod `TriggerSchema` に `.strict()` 追加。ajv 側 `schemas/skill.schema.json` の `trigger.additionalProperties:false` を鏡写しにし、未知 trigger サブフィールドの片側 drift を検出可能にする（`deterministicGate` の前例に倣う）
- **`tests/skill-schema-parity.test.mjs`**: trigger parity ケース + 既知差分の pinned ブロック追加

## 追加ケース

| 種別 | ケース |
|---|---|
| valid（両者 accept） | phase+applyTo / phase+files / phase+path_patterns / phase 配列 / empty object |
| invalid（両者 reject） | 不正 phase enum / applyTo 非配列 / **未知サブフィールド（#1399 核心）** |

## ajv/zod 差分の分類（両 schema に実入力を通して観測）

| 入力 | ajv | zod | 分類 | 対応 |
|---|---|---|---|---|
| 未知サブフィールド | reject | accept→**reject** | 非意図 drift | zod `.strict()` で解消 → parity 化 |
| 空配列 `[]` | reject(minItems) | accept | 構造的差（top-level と対称） | known divergences で pin |
| 空文字列 item | accept | reject(minLength) | 構造的差（同上） | known divergences で pin |

pinned 差分は `assert.notEqual` で固定し、将来サイレントに一致へ変わったら失敗して CASES への昇格を促す。

## 検証

- `node --test tests/skill-schema-parity.test.mjs`: **18 pass**
- `npm test`: **1865 pass / 0 fail**
- `skills/` に trigger 使用は皆無 → `.strict()` 化は安全（実 skill を壊さない）

## 未確認事項・残リスク

- **top-level `files` alias の drift（未修正・別問題）**: `category+phase+files`（applyTo/path_patterns 無し）が ajv=accept/zod=reject。zod top-level object が `files` を未定義かつ refine が file 要件に数えないため。trigger ではなく top-level object の問題で、修正には zod object+refine 変更が必要。別途対応が望ましい
- 空配列/空文字列 drift の「据え置き」は top-level との対称性を保つ設計判断。trigger を先行して揃える方針なら zod trigger array `.min(1)` + ajv trigger items `minLength:1` で一致可能（top-level 同時対応が望ましい）

🤖 Generated with [Claude Code](https://claude.com/claude-code)