### PR TITLE
docs: design-philosophy の bilingual/文体 軽微不整合を修正する (#1369)

### DIFF
--- a/pages/explanation/design-philosophy.en.md
+++ b/pages/explanation/design-philosophy.en.md
@@ -1,6 +1,6 @@
 # Design Philosophy
 
-River Review is grounded in turning a team's tacit knowledge into versioned, repo-owned Skills (the Skill Registry) that are reused as a shared asset. On that foundation sit three core axes: a capability pack that strengthens an AI agent's review ability, review skills shared as the Skill Registry, and a review team that runs perspective-based reviewers in parallel. The principles below are the design decisions that support those three axes.
+River Review is grounded in turning a team's tacit knowledge into versioned, repo-owned Skills (the Skill Registry) that are reused as a shared asset. On that foundation sit three core axes: a capability pack that strengthens an AI agent's review ability, review skills shared as a common asset, and a review team that runs perspective-based reviewers in parallel. The principles below are the design decisions that support those three axes.
 
 River Review is built to deliver timely, phase-aware feedback without slowing teams down.
 
@@ -16,7 +16,7 @@ River Review is built to deliver timely, phase-aware feedback without slowing te
 River Review does **not** aim to be:
 
 - **A general-purpose AI agent framework**: it is a context engineering framework specialized for code review, not a generic task execution platform. The review team, too, is a single orchestrator running perspective-based reviewer roles in parallel and merging their findings via connected-components — not a set of fully autonomous, independent agents.
-- **A replacement for human review judgment**: AI assists by surfacing review perspectives and evidence. Findings and the verdict are decision material only; GO / NO-GO, iteration, and stop decisions remain the responsibility of the caller or a human (HITL). It does not assert auto-approval or auto-merge.
+- **A replacement for human review judgment**: AI assists by surfacing and verifying review perspectives. Findings and the verdict are decision material only; GO / NO-GO, iteration, and stop decisions remain the responsibility of the caller or a human (HITL). It does not assert auto-approval or auto-merge.
 - **An automatic code fixer**: it identifies and reports issues but does not transform or auto-fix code.
 
 ## Direction of travel: risk-tiered human supervision

--- a/pages/explanation/design-philosophy.md
+++ b/pages/explanation/design-philosophy.md
@@ -1,6 +1,6 @@
 # 設計哲学
 
-River Review は、チームの暗黙知を versioned / repo-owned な Skill（Skill Registry）へ落とし込み、共有資産として再利用することを基盤にしている。その基盤の上に、AI エージェントのレビュー能力を強化する capability pack、共有資産としてのレビュースキル、観点別レビュアーを並列実行する review team という 3 主軸が乗る。以下の原則は、この 3 主軸を支える設計判断をまとめている。
+River Review は、チームの暗黙知を versioned / repo-owned な Skill（Skill Registry）へ落とし込み、共有資産として再利用できる基盤にしている。その基盤の上に、AI エージェントのレビュー能力向上に資する capability pack、共有資産としてのレビュースキル、観点別レビュアーを並列実行する review team という 3 主軸が乗る。以下の原則は、この 3 主軸を支える設計判断をまとめている。
 
 River Review は、チームの速度を落とすことなく、タイムリーでフェーズを意識したフィードバックを提供するために構築されている。
 
@@ -15,7 +15,7 @@ River Review は、チームの速度を落とすことなく、タイムリー�
 
 River Review は以下を目指していない:
 
-- **汎用 AI エージェントフレームワーク**: コードレビューに特化した context engineering framework であり、汎用タスク実行基盤ではない。review team も、1 つの orchestrator が観点別レビュアーロールを並列実行して結果を connected-components でマージする仕組みであり、完全に自律した独立エージェント群ではない。
+- **汎用 AI エージェントフレームワーク**: コードレビューに特化した context engineering framework であり、汎用タスク実行基盤ではない。review team も、1 つの orchestrator が観点別レビュアーロールによる並列レビューの結果を connected-components でマージする仕組みであり、完全に自律した独立エージェント群ではない。
 - **人間のレビュー判断の代替**: AI はレビュー観点の提示と検証を支援する。findings と verdict はあくまで判定素材であり、GO / NO-GO・反復・停止の判断は caller や人間（HITL）の責務である。自動承認や自動マージは主張しない。
 - **コード自動修正**: 問題の発見と指摘を行うが、コード変換や自動修正は行わない。
 


### PR DESCRIPTION
Closes #1369

## 概要

PR #1368 のマルチエージェントレビューで検出された、`pages/explanation/design-philosophy.md`/`.en.md` の**差分外の既存不整合**（bilingual parity + 文体）を修正。

## 変更（4行・ja/en 対称）

| 指摘 | 重要度 | 対応 |
|---|---|---|
| en L3「review skills shared as **the Skill Registry**」が ja に無い重複挿入 | major | 「as a common asset」に修正。ja「共有資産としてのレビュースキル」に統一（直前で Skill Registry を定義済み） |
| en L19「evidence」が ja「検証」（動詞的行為）と意訳ずれ | minor | 「and verifying review perspectives」に修正 |
| ja L3/L18 の一文内「を」重複 | minor | 「再利用できる基盤」「能力向上に資する」「レビュアーロールによる並列レビューの結果を」で削減 |

## 判断根拠

- ja L3 末尾は「設計判断の集合である」への変更で textlint `no-mix-dearu-desumasu`（S5 で増えた ですます調との混在）に抵触したため、原文の常体「まとめている」を維持。を重複は textlint 非対象で実害なし、である混在（＝CI 失敗）を避ける判断
- L18 の「であり/ではない」は元から である で問題なし

## 検証

- textlint（`--no-cache`）: PASS（exit 0）
- markdownlint: PASS
- ja/en 対称

## 未確認事項・残リスク

- ja L3 末尾文は「を」2つのまま（である混在回避を優先）。文体ルールの完全準拠より CI green を優先した判断

🤖 Generated with [Claude Code](https://claude.com/claude-code)