### PR TITLE
docs: L3 の文体を自然な「基盤としている」に戻す (#1369 follow-up)

### DIFF
--- a/pages/explanation/design-philosophy.md
+++ b/pages/explanation/design-philosophy.md
@@ -1,6 +1,6 @@
 # 設計哲学
 
-River Review は、チームの暗黙知を versioned / repo-owned な Skill（Skill Registry）へ落とし込み、共有資産として再利用できる基盤にしている。その基盤の上に、AI エージェントのレビュー能力向上に資する capability pack、共有資産としてのレビュースキル、観点別レビュアーを並列実行する review team という 3 主軸が乗る。以下の原則は、この 3 主軸を支える設計判断をまとめている。
+River Review は、チームの暗黙知を versioned / repo-owned な Skill（Skill Registry）へ落とし込み、共有資産として再利用することを基盤としている。その基盤の上に、AI エージェントのレビュー能力向上に資する capability pack、共有資産としてのレビュースキル、観点別レビュアーを並列実行する review team という 3 主軸が乗る。以下の原則は、この 3 主軸を支える設計判断をまとめている。
 
 River Review は、チームの速度を落とすことなく、タイムリーでフェーズを意識したフィードバックを提供するために構築されている。
 


### PR DESCRIPTION
PR #1419（#1369）の gemini medium 指摘への follow-up。

## 背景
#1419 で ja L3 の「を」重複回避のため「再利用することを基盤にしている」→「再利用できる基盤にしている」と変更した。しかし gemini 指摘のとおり、元の「暗黙知を〜落とし込み／再利用することを〜」の「を」は**異なる節**にあり textlint の二重助詞違反には当たらない（実際、元の文も CI textlint は green だった）。非問題の"修正"がかえって文法的な不自然さ（目的語の曖昧化）を招いていた。

## 変更
- ja L3: 「再利用できる基盤にしている」→「再利用することを基盤としている」（元の意味 + より自然な「としている」+ 英文 `reused as a shared asset` と整合）
- #1419 の他の改善（S2「能力向上に資する」、L18「レビュアーロールによる並列レビューの結果を」）は維持

## 検証
- textlint（`--no-cache`）PASS / markdownlint PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)