### PR TITLE
ci: coverage 収集を 22.x のみに限定し IPC flake を緩和する (#1415)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,8 +45,18 @@ jobs:
       - uses: ./.github/actions/setup-node-deps
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Run unit tests with coverage
-        run: NODE_V8_COVERAGE=coverage npm test
+      # Coverage is only uploaded for 22.x (see the Codecov step below), so
+      # collect it only there. Setting NODE_V8_COVERAGE enlarges the node:test
+      # child→parent IPC payload and aggravates a structured-clone deserialize
+      # flake ("Unable to deserialize cloned data"); the 20.x run gained nothing
+      # from coverage but paid that flake cost (#1415).
+      - name: Run unit tests (coverage on 22.x only)
+        run: |
+          if [ "${{ matrix.node-version }}" = "22.x" ]; then
+            NODE_V8_COVERAGE=coverage npm test
+          else
+            npm test
+          fi
       - name: Upload coverage to Codecov
         # Coverage from one Node version is enough; skip the duplicate upload.
         if: matrix.node-version == '22.x'


### PR DESCRIPTION
Refs #1415（緩和策 M1）

## 背景

Unit tests ジョブは 20.x/22.x 両方で `NODE_V8_COVERAGE=coverage npm test` を実行していたが、**Codecov アップロードは 22.x のみ**（`test.yml` 既存コメント「Coverage from one Node version is enough」）。

`NODE_V8_COVERAGE` は node:test の子プロセス→親 IPC ペイロード（structured clone）を肥大化させ、`Unable to deserialize cloned data due to invalid or unsupported version` の flake を誘発する。**20.x の coverage 収集は使われず捨てられており、flake だけを払っていた**。

## 変更（M1・最小・semantic 変更ゼロ）

- 20.x: 素の `npm test`（coverage なし → IPC ペイロード縮小 → flake 誘因除去）
- 22.x: 従来どおり `NODE_V8_COVERAGE=coverage npm test`（Codecov アップロードは 22.x のみなので不変）

flake 面をマトリクス半分に削減し、無駄な 20.x coverage 収集も除去。

## 検証

- `test.yml` YAML 妥当性 OK
- ローカルで挙動確認: `NODE_V8_COVERAGE=<dir> node --test` は coverage 収集、素の `node --test` は非収集
- Codecov step（`if: matrix.node-version == '22.x'`）は 22.x で従来どおり `coverage/` を取得

## 未確認事項・残リスク

- **22.x の coverage×IPC flake は未対処**。頻度が続くなら M2（coverage を非ブロッキング別ジョブへ分離し gate を両版 coverage-free に）を別途検討
- **coverage 無しでも同 flake が起きるか未確認**。起きるなら本 PR は増悪因子の除去に留まり、`--test-isolation=none` 等の根治策が必要
- flake は間欠的なため、本 PR の効果は今後の複数 CI run で経験的に確認する

## 却下した代替案

- `--test-concurrency=1`: CI 2-3倍遅延のため不採用（M1 が zero-cost）
- `--test-isolation=none`: テスト間汚染リスク + 20.x 非対応のため第一選択にせず

🤖 Generated with [Claude Code](https://claude.com/claude-code)