### PR TITLE
feat(gate): executor の clean cwd + env builder を追加する (#1401)

### DIFF
--- a/src/lib/deterministic-command-sandbox.mjs
+++ b/src/lib/deterministic-command-sandbox.mjs
@@ -1,0 +1,253 @@
+/**
+ * Deterministic command sandbox — preparation layer only (#1401 §11.8 (a)).
+ *
+ * PURE PREPARATION LAYER. This module implements increment (a) of the executor
+ * from the #1401 design (§11.2 clean cwd, §11.3 env, §10.2 on-disk secret,
+ * §10.3 stdout exfil / symlink non-following): it builds the scrubbed child
+ * environment and stages review-target files into a clean cwd that contains no
+ * `.git` and follows no symlinks.
+ *
+ * IT DOES NOT EXECUTE ANYTHING. There is deliberately NO import or use of
+ * `child_process` / `spawn` / `execFile` / `exec` here — the RCE surface (the
+ * actual `execFile` launch, increment (b)) lands in a separate PR. Reading and
+ * copying files is allowed; starting processes is not. Keeping this layer
+ * process-free means it has no RCE surface of its own and its symlink-blocking
+ * and env-scrubbing behavior can be exercised freely by canary tests.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+/**
+ * SAFE_ENV allowlist (§11.3 / §3.3). Only these keys are copied from the
+ * parent `process.env` into the child environment. Everything else — including
+ * `NODE_OPTIONS`, `NODE_PATH`, `XDG_CONFIG_HOME`, `*_TOKEN`, `*_SECRET`,
+ * `AWS_*`, `GITHUB_*` — is dropped by construction (allowlist, not denylist, so
+ * a new secret variable name fails safe instead of leaking).
+ */
+export const SAFE_ENV_ALLOWLIST = Object.freeze(['PATH', 'LANG', 'LC_ALL', 'TZ']);
+
+/**
+ * Build the scrubbed environment for a sandboxed child process (§11.3 / §3.3).
+ *
+ * Starts from an empty object and copies ONLY the {@link SAFE_ENV_ALLOWLIST}
+ * keys from `processEnv` (when present). `HOME` is NOT copied from the real
+ * environment — the caller supplies the path to a fresh empty temp directory
+ * via `home`, so `~/.aws` / `~/.npmrc` / `~/.git-credentials` are unreachable
+ * (§10.2). `XDG_CONFIG_HOME` is pinned to the same empty `home` so config
+ * autoload cannot reach the real `~/.config` (§10.1 (D)).
+ *
+ * Does not mutate `processEnv`; returns a fresh object.
+ *
+ * @param {Record<string, string | undefined>} processEnv - source env (e.g. `process.env`)
+ * @param {{ home: string }} options - `home` is a fresh empty temp dir path
+ * @returns {Record<string, string>} new child environment
+ */
+export function buildSandboxEnv(processEnv, { home } = {}) {
+  if (typeof home !== 'string' || home.length === 0) {
+    throw new TypeError('buildSandboxEnv: `home` (empty temp dir path) is required');
+  }
+  const source = processEnv && typeof processEnv === 'object' ? processEnv : {};
+  const childEnv = {};
+  for (const key of SAFE_ENV_ALLOWLIST) {
+    const value = source[key];
+    // Only copy real string values; skip undefined so the child env stays minimal.
+    if (typeof value === 'string') {
+      childEnv[key] = value;
+    }
+  }
+  // HOME / XDG_CONFIG_HOME point at the caller-provided empty temp dir. The real
+  // $HOME and ~/.config are never inherited (on-disk secret blocking, §10.2).
+  childEnv.HOME = home;
+  childEnv.XDG_CONFIG_HOME = home;
+  return childEnv;
+}
+
+/**
+ * True when any component of `relPath` is exactly `.git` (§10.2). Blocks both
+ * `.git` and nested `.git/config` so a persisted GITHUB_TOKEN is never staged.
+ * @param {string} relPath
+ * @returns {boolean}
+ */
+function isGitPath(relPath) {
+  return relPath.split(/[\\/]/).some((segment) => segment === '.git');
+}
+
+/**
+ * True when `relPath` escapes `sourceDir` (absolute, `..` traversal, or empty).
+ * Defensive: staging must never read outside the review target.
+ * @param {string} sourceDir
+ * @param {string} relPath
+ * @returns {boolean}
+ */
+function escapesRoot(sourceDir, relPath) {
+  if (path.isAbsolute(relPath)) return true;
+  const resolved = path.resolve(sourceDir, relPath);
+  const root = path.resolve(sourceDir);
+  const rel = path.relative(root, resolved);
+  return rel === '' || rel === '..' || rel.startsWith(`..${path.sep}`) || path.isAbsolute(rel);
+}
+
+/**
+ * True when any ancestor path component (from `sourceDir` down to, and
+ * including, the full entry) is a symlink (§10.3.2 (A)). Following a symlinked
+ * PARENT directory would also reach outside the review target (e.g. a
+ * `link/credentials` where `link -> ~/.aws`), so every segment is `lstat`ed —
+ * not just the leaf.
+ *
+ * @param {string} sourceDir
+ * @param {string} relPath
+ * @returns {Promise<boolean>}
+ */
+async function pathContainsSymlink(sourceDir, relPath) {
+  const segments = relPath.split(/[\\/]/).filter((s) => s.length > 0);
+  let current = sourceDir;
+  for (const segment of segments) {
+    current = path.join(current, segment);
+    let stat;
+    try {
+      stat = await fs.lstat(current);
+    } catch {
+      // Missing intermediate component: nothing to follow. The leaf copy below
+      // will surface a real ENOENT; treat "cannot stat" as "not a symlink here".
+      return false;
+    }
+    if (stat.isSymbolicLink()) return true;
+  }
+  return false;
+}
+
+/**
+ * Recursively scan `dir` for any residual symlink and return their absolute
+ * paths (§10.3.2 (A) step 3 / §11.2 step 3 — multi-layer TOCTOU re-check). Used
+ * to prove that nothing symlinked survived into the clean cwd.
+ * @param {string} dir
+ * @returns {Promise<string[]>}
+ */
+async function findResidualSymlinks(dir) {
+  const found = [];
+  let entries;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return found;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isSymbolicLink()) {
+      found.push(full);
+    } else if (entry.isDirectory()) {
+      found.push(...(await findResidualSymlinks(full)));
+    }
+  }
+  return found;
+}
+
+/**
+ * Stage review-target files into a clean cwd (§11.2 / §10.3.2 (A)).
+ *
+ * Copies each relative `files` entry from `sourceDir` into `destDir` (which the
+ * caller created with {@link makeSandboxTempDir} / `fs.mkdtemp`). Symlinks are
+ * NOT followed: any entry whose leaf OR any ancestor component is a symlink is
+ * skipped and recorded (blocking `~/.aws`-style exfil). `.git` paths are
+ * excluded (blocking `.git/config` token leak). After copying, `destDir` is
+ * re-scanned for residual symlinks; any found are unlinked and recorded (they
+ * should never occur, since symlinks are never copied — the re-scan is a
+ * multi-layer TOCTOU guard).
+ *
+ * Never starts a process. Copy failures for an individual entry are recorded in
+ * `errors` and do not abort the whole staging pass.
+ *
+ * @param {{ sourceDir: string, destDir: string, files: string[] }} args
+ * @returns {Promise<{
+ *   copied: string[],
+ *   skippedSymlinks: string[],
+ *   skippedGit: string[],
+ *   skippedOutside: string[],
+ *   errors: Array<{ file: string, message: string }>,
+ * }>}
+ */
+export async function copyReviewTargetToSandbox({ sourceDir, destDir, files } = {}) {
+  if (typeof sourceDir !== 'string' || sourceDir.length === 0) {
+    throw new TypeError('copyReviewTargetToSandbox: `sourceDir` is required');
+  }
+  if (typeof destDir !== 'string' || destDir.length === 0) {
+    throw new TypeError('copyReviewTargetToSandbox: `destDir` is required');
+  }
+
+  const copied = [];
+  const skippedSymlinks = [];
+  const skippedGit = [];
+  const skippedOutside = [];
+  const errors = [];
+
+  const list = Array.isArray(files) ? files : [];
+  for (const raw of list) {
+    if (typeof raw !== 'string' || raw.length === 0) {
+      // Ignore non-string / empty entries safely rather than throwing.
+      continue;
+    }
+    const relPath = path.normalize(raw);
+
+    if (isGitPath(relPath)) {
+      skippedGit.push(raw);
+      continue;
+    }
+    if (escapesRoot(sourceDir, relPath)) {
+      skippedOutside.push(raw);
+      continue;
+    }
+    if (await pathContainsSymlink(sourceDir, relPath)) {
+      skippedSymlinks.push(raw);
+      continue;
+    }
+
+    const srcPath = path.join(sourceDir, relPath);
+    const destPath = path.join(destDir, relPath);
+    try {
+      await fs.mkdir(path.dirname(destPath), { recursive: true });
+      // Copy the file contents only. COPYFILE_FICLONE is best-effort; symlinks
+      // were already excluded above, so this always copies a regular file.
+      await fs.copyFile(srcPath, destPath);
+      copied.push(raw);
+    } catch (err) {
+      errors.push({ file: raw, message: err?.message ?? String(err) });
+    }
+  }
+
+  // Multi-layer re-check: prove no symlink survived into the clean cwd.
+  const residual = await findResidualSymlinks(destDir);
+  for (const link of residual) {
+    try {
+      await fs.unlink(link);
+    } catch {
+      // Ignore unlink failure; it is still recorded so the caller can fail safe.
+    }
+    skippedSymlinks.push(path.relative(destDir, link));
+  }
+
+  return { copied, skippedSymlinks, skippedGit, skippedOutside, errors };
+}
+
+/**
+ * Create a fresh empty temp directory for use as a sandbox `HOME` or clean cwd
+ * (`RIVER_EXEC_ROOT`). Thin wrapper over `fs.mkdtemp`, injectable for tests.
+ *
+ * Cleanup is the CALLER'S responsibility: wrap usage in `try/finally` and
+ * remove the returned directory (e.g. `fs.rm(dir, { recursive: true,
+ * force: true })`) on every path — success, spawn failure, timeout, exception —
+ * so no sandbox directory is ever left behind (§11.2 lifecycle).
+ *
+ * @param {(prefix: string) => Promise<string>} [mkdtempImpl] - defaults to `fs.mkdtemp`
+ * @param {string} [prefix] - path prefix; defaults to `os.tmpdir()/river-sandbox-`
+ * @returns {Promise<string>} absolute path of the new empty directory
+ */
+export function makeSandboxTempDir(mkdtempImpl, prefix) {
+  const impl = typeof mkdtempImpl === 'function' ? mkdtempImpl : fs.mkdtemp;
+  const base =
+    typeof prefix === 'string' && prefix.length > 0
+      ? prefix
+      : path.join(os.tmpdir(), 'river-sandbox-');
+  return impl(base);
+}

--- a/tests/deterministic-command-sandbox.test.mjs
+++ b/tests/deterministic-command-sandbox.test.mjs
@@ -1,0 +1,316 @@
+/**
+ * Deterministic command sandbox preparation-layer tests (#1401 §11.8 (a)).
+ *
+ * Covers env scrubbing (§11.3) and clean-cwd staging (§11.2 / §10.3.2 (A)):
+ * SAFE_ENV allowlist only, secret / NODE_OPTIONS scrub, HOME pinned to an empty
+ * temp dir, processEnv immutability, symlink non-following (including a symlink
+ * aimed at a `~/.aws`-style target and a symlinked parent directory), `.git`
+ * exclusion, and no residual symlink after copy.
+ *
+ * This is a pure preparation layer — no process is ever spawned; the test file
+ * asserts that too (no child_process usage in the module under test).
+ */
+
+import { test, describe, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import fsSync from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+import {
+  buildSandboxEnv,
+  copyReviewTargetToSandbox,
+  makeSandboxTempDir,
+  SAFE_ENV_ALLOWLIST,
+} from '../src/lib/deterministic-command-sandbox.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+describe('buildSandboxEnv — SAFE_ENV allowlist (§11.3)', () => {
+  const home = '/tmp/empty-home-xyz';
+
+  test('only SAFE_ENV keys pass through', () => {
+    const env = buildSandboxEnv(
+      { PATH: '/usr/bin', LANG: 'C', LC_ALL: 'C', TZ: 'UTC', UNLISTED: 'nope' },
+      { home }
+    );
+    assert.equal(env.PATH, '/usr/bin');
+    assert.equal(env.LANG, 'C');
+    assert.equal(env.LC_ALL, 'C');
+    assert.equal(env.TZ, 'UTC');
+    assert.equal(env.UNLISTED, undefined);
+  });
+
+  test('GITHUB_TOKEN / AWS_SECRET_ACCESS_KEY / NODE_OPTIONS are NOT inherited', () => {
+    const parent = {
+      PATH: '/usr/bin',
+      GITHUB_TOKEN: 'ghp_secret',
+      GITHUB_ACTIONS: 'true',
+      AWS_SECRET_ACCESS_KEY: 'akiasecret',
+      AWS_ACCESS_KEY_ID: 'AKIA...',
+      NODE_OPTIONS: '--require ./evil.js',
+      NODE_PATH: '/evil',
+      SOME_TOKEN: 't',
+      SOME_SECRET: 's',
+    };
+    const env = buildSandboxEnv(parent, { home });
+    assert.equal(env.GITHUB_TOKEN, undefined);
+    assert.equal(env.GITHUB_ACTIONS, undefined);
+    assert.equal(env.AWS_SECRET_ACCESS_KEY, undefined);
+    assert.equal(env.AWS_ACCESS_KEY_ID, undefined);
+    assert.equal(env.NODE_OPTIONS, undefined);
+    assert.equal(env.NODE_PATH, undefined);
+    assert.equal(env.SOME_TOKEN, undefined);
+    assert.equal(env.SOME_SECRET, undefined);
+    // Sanity: only allowlisted + HOME/XDG_CONFIG_HOME keys are present.
+    const keys = Object.keys(env).sort();
+    assert.deepEqual(keys, ['HOME', 'PATH', 'XDG_CONFIG_HOME']);
+  });
+
+  test('HOME points at the provided empty temp dir, not the real $HOME', () => {
+    const env = buildSandboxEnv({ HOME: '/home/runner', PATH: '/usr/bin' }, { home });
+    assert.equal(env.HOME, home);
+    assert.notEqual(env.HOME, '/home/runner');
+    // XDG_CONFIG_HOME is pinned to the same empty dir (§10.1 (D)).
+    assert.equal(env.XDG_CONFIG_HOME, home);
+  });
+
+  test('real XDG_CONFIG_HOME from parent is overridden, not inherited', () => {
+    const env = buildSandboxEnv({ XDG_CONFIG_HOME: '/home/runner/.config' }, { home });
+    assert.equal(env.XDG_CONFIG_HOME, home);
+  });
+
+  test('does not mutate processEnv', () => {
+    const parent = { PATH: '/usr/bin', GITHUB_TOKEN: 'ghp_secret' };
+    const snapshot = { ...parent };
+    buildSandboxEnv(parent, { home });
+    assert.deepEqual(parent, snapshot);
+  });
+
+  test('missing home throws (fail-safe)', () => {
+    assert.throws(() => buildSandboxEnv({ PATH: '/usr/bin' }), TypeError);
+    assert.throws(() => buildSandboxEnv({ PATH: '/usr/bin' }, { home: '' }), TypeError);
+  });
+
+  test('non-string SAFE_ENV values are skipped', () => {
+    const env = buildSandboxEnv({ PATH: 12345, LANG: 'C' }, { home });
+    assert.equal(env.PATH, undefined);
+    assert.equal(env.LANG, 'C');
+  });
+
+  test('SAFE_ENV_ALLOWLIST is exactly the four documented keys', () => {
+    assert.deepEqual([...SAFE_ENV_ALLOWLIST], ['PATH', 'LANG', 'LC_ALL', 'TZ']);
+  });
+});
+
+describe('copyReviewTargetToSandbox — clean cwd staging (§11.2)', () => {
+  let sourceDir;
+  let destDir;
+  let secretDir;
+
+  beforeEach(async () => {
+    sourceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'river-src-'));
+    destDir = await fs.mkdtemp(path.join(os.tmpdir(), 'river-dest-'));
+    secretDir = await fs.mkdtemp(path.join(os.tmpdir(), 'river-secret-'));
+  });
+
+  afterEach(async () => {
+    for (const d of [sourceDir, destDir, secretDir]) {
+      await fs.rm(d, { recursive: true, force: true });
+    }
+  });
+
+  test('copies a normal file', async () => {
+    await fs.writeFile(path.join(sourceDir, 'a.txt'), 'hello');
+    const res = await copyReviewTargetToSandbox({ sourceDir, destDir, files: ['a.txt'] });
+    assert.deepEqual(res.copied, ['a.txt']);
+    assert.equal(await fs.readFile(path.join(destDir, 'a.txt'), 'utf8'), 'hello');
+  });
+
+  test('copies a nested file, creating parent dirs', async () => {
+    await fs.mkdir(path.join(sourceDir, 'src'), { recursive: true });
+    await fs.writeFile(path.join(sourceDir, 'src', 'b.js'), 'code');
+    const res = await copyReviewTargetToSandbox({
+      sourceDir,
+      destDir,
+      files: ['src/b.js'],
+    });
+    assert.deepEqual(res.copied, ['src/b.js']);
+    assert.equal(await fs.readFile(path.join(destDir, 'src', 'b.js'), 'utf8'), 'code');
+  });
+
+  test('a symlink pointing at a ~/.aws-style secret is skipped, not copied', async () => {
+    // Simulate `~/.aws/credentials` exfil: the review target is a symlink to it.
+    const secretFile = path.join(secretDir, 'credentials');
+    await fs.writeFile(secretFile, 'aws_secret_access_key=akiasecret');
+    await fs.symlink(secretFile, path.join(sourceDir, 'creds.txt'));
+
+    const res = await copyReviewTargetToSandbox({
+      sourceDir,
+      destDir,
+      files: ['creds.txt'],
+    });
+
+    assert.deepEqual(res.copied, []);
+    assert.deepEqual(res.skippedSymlinks, ['creds.txt']);
+    // The secret must NOT exist in the clean cwd.
+    await assert.rejects(fs.stat(path.join(destDir, 'creds.txt')));
+  });
+
+  test('a file reached THROUGH a symlinked parent directory is skipped', async () => {
+    // `link -> secretDir`; entry `link/credentials` must not follow the parent.
+    await fs.writeFile(path.join(secretDir, 'credentials'), 'secret');
+    await fs.symlink(secretDir, path.join(sourceDir, 'link'));
+
+    const res = await copyReviewTargetToSandbox({
+      sourceDir,
+      destDir,
+      files: ['link/credentials'],
+    });
+
+    assert.deepEqual(res.copied, []);
+    assert.deepEqual(res.skippedSymlinks, ['link/credentials']);
+  });
+
+  test('.git/config is excluded (token leak block)', async () => {
+    await fs.mkdir(path.join(sourceDir, '.git'), { recursive: true });
+    await fs.writeFile(path.join(sourceDir, '.git', 'config'), 'extraheader = token');
+    await fs.writeFile(path.join(sourceDir, 'keep.txt'), 'ok');
+
+    const res = await copyReviewTargetToSandbox({
+      sourceDir,
+      destDir,
+      files: ['.git/config', 'keep.txt'],
+    });
+
+    assert.deepEqual(res.skippedGit, ['.git/config']);
+    assert.deepEqual(res.copied, ['keep.txt']);
+    await assert.rejects(fs.stat(path.join(destDir, '.git', 'config')));
+  });
+
+  test('no residual symlink remains in destDir after copy', async () => {
+    await fs.writeFile(path.join(secretDir, 'x'), 'secret');
+    await fs.symlink(secretDir, path.join(sourceDir, 'link'));
+    await fs.writeFile(path.join(sourceDir, 'ok.txt'), 'fine');
+
+    await copyReviewTargetToSandbox({
+      sourceDir,
+      destDir,
+      files: ['ok.txt', 'link/x'],
+    });
+
+    // Walk destDir and assert nothing is a symlink.
+    async function assertNoSymlink(dir) {
+      const entries = await fs.readdir(dir, { withFileTypes: true });
+      for (const e of entries) {
+        assert.equal(e.isSymbolicLink(), false, `unexpected symlink: ${e.name}`);
+        if (e.isDirectory()) await assertNoSymlink(path.join(dir, e.name));
+      }
+    }
+    await assertNoSymlink(destDir);
+  });
+
+  test('path traversal (..) and absolute paths are skipped', async () => {
+    await fs.writeFile(path.join(secretDir, 'passwd'), 'root');
+    const res = await copyReviewTargetToSandbox({
+      sourceDir,
+      destDir,
+      files: ['../secret-outside', '/etc/passwd'],
+    });
+    assert.deepEqual(res.copied, []);
+    assert.equal(res.skippedOutside.length, 2);
+  });
+
+  test('empty files array yields empty results', async () => {
+    const res = await copyReviewTargetToSandbox({ sourceDir, destDir, files: [] });
+    assert.deepEqual(res, {
+      copied: [],
+      skippedSymlinks: [],
+      skippedGit: [],
+      skippedOutside: [],
+      errors: [],
+    });
+  });
+
+  test('non-array / non-string entries are handled safely', async () => {
+    await fs.writeFile(path.join(sourceDir, 'a.txt'), 'x');
+    const res = await copyReviewTargetToSandbox({
+      sourceDir,
+      destDir,
+      files: ['a.txt', '', null, 123, undefined],
+    });
+    assert.deepEqual(res.copied, ['a.txt']);
+  });
+
+  test('missing source file is recorded as an error, not thrown', async () => {
+    const res = await copyReviewTargetToSandbox({
+      sourceDir,
+      destDir,
+      files: ['does-not-exist.txt'],
+    });
+    assert.deepEqual(res.copied, []);
+    assert.equal(res.errors.length, 1);
+    assert.equal(res.errors[0].file, 'does-not-exist.txt');
+  });
+
+  test('missing sourceDir / destDir throw (fail-safe)', async () => {
+    await assert.rejects(copyReviewTargetToSandbox({ destDir, files: [] }), TypeError);
+    await assert.rejects(copyReviewTargetToSandbox({ sourceDir, files: [] }), TypeError);
+  });
+});
+
+describe('makeSandboxTempDir', () => {
+  test('creates a fresh empty directory under os.tmpdir()', async () => {
+    const dir = await makeSandboxTempDir();
+    try {
+      const stat = await fs.stat(dir);
+      assert.ok(stat.isDirectory());
+      assert.deepEqual(await fs.readdir(dir), []);
+      assert.ok(dir.startsWith(os.tmpdir()));
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('accepts an injected mkdtemp impl (testable)', async () => {
+    let seenPrefix;
+    const fake = async (prefix) => {
+      seenPrefix = prefix;
+      return '/fake/dir-abc';
+    };
+    const dir = await makeSandboxTempDir(fake);
+    assert.equal(dir, '/fake/dir-abc');
+    assert.ok(seenPrefix.includes('river-sandbox-'));
+  });
+
+  test('honors a custom prefix', async () => {
+    let seenPrefix;
+    const fake = async (prefix) => {
+      seenPrefix = prefix;
+      return prefix + 'xyz';
+    };
+    await makeSandboxTempDir(fake, '/custom/pre-');
+    assert.equal(seenPrefix, '/custom/pre-');
+  });
+});
+
+describe('no child process usage in the module (constraint)', () => {
+  test('source imports no child_process / spawn / execFile / exec', () => {
+    const raw = fsSync.readFileSync(
+      path.join(HERE, '..', 'src', 'lib', 'deterministic-command-sandbox.mjs'),
+      'utf8'
+    );
+    // Strip block and line comments so doc comments (which name these banned
+    // APIs to explain their absence) do not trip the check; only real code —
+    // imports and call sites — must be free of them.
+    const code = raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+    assert.doesNotMatch(code, /child_process/);
+    assert.doesNotMatch(code, /\bspawn\s*\(/);
+    assert.doesNotMatch(code, /\bexecFile\s*\(/);
+    assert.doesNotMatch(code, /\bexec\s*\(/);
+    assert.doesNotMatch(code, /from\s+['"](?:node:)?child_process['"]/);
+    assert.doesNotMatch(code, /require\(\s*['"](?:node:)?child_process['"]\s*\)/);
+  });
+});

--- a/tests/deterministic-command-sandbox.test.mjs
+++ b/tests/deterministic-command-sandbox.test.mjs
@@ -29,7 +29,7 @@ import {
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 
 describe('buildSandboxEnv — SAFE_ENV allowlist (§11.3)', () => {
-  const home = '/tmp/empty-home-xyz';
+  const home = path.join(os.tmpdir(), 'empty-home-xyz');
 
   test('only SAFE_ENV keys pass through', () => {
     const env = buildSandboxEnv(


### PR DESCRIPTION
Refs #1401（executor 増分 §11.8(a): 準備層のみ・**実行なし**）

## 概要

#1401 executor を §11.8 の増分で安全に刻む最初の一手 **(a)**。**子プロセスを起動しない純関数の準備層**（clean cwd 配置 + env スクラブ）。実際のコマンド実行 (b)・gate 接続 (c)・CI (d) は**別 PR・承認後**。

## 変更（2ファイル・実行なし）

- **新 module** `src/lib/deterministic-command-sandbox.mjs`:
  - `buildSandboxEnv(processEnv, {home})`: SAFE_ENV allowlist（`PATH`/`LANG`/`LC_ALL`/`TZ`）のみコピー。`HOME`/`XDG_CONFIG_HOME` は呼び出し側の**空一時ディレクトリ**（実 `$HOME` 非継承 → `~/.aws` 等到達不可）。`GITHUB_*`/`AWS_*`/`*_TOKEN`/`*_SECRET`/`NODE_OPTIONS` を allowlist 構造上除外。processEnv 非破壊・`home` 必須（fail-safe throw）
  - `copyReviewTargetToSandbox({sourceDir,destDir,files})`: **symlink 非追跡**（全パス構成要素を `lstat` = 祖先の symlinked dir 経由も遮断）+ `.git` 除外 + path traversal 拒否 + copy 後の**残存 symlink 再検査 & unlink**（多層 TOCTOU ガード）
  - `makeSandboxTempDir`: `fs.mkdtemp` ラッパ（後始末は呼び出し側 try/finally）

## セキュリティ（blocker-2/3 の防御をここで実装）

- **child_process/spawn/execFile を一切使用しない**（import は fs/path/os のみ、テストで機械 assert）→ この層に RCE 面なし
- env スクラブ（blocker-2）: `GITHUB_TOKEN`/`AWS_SECRET_ACCESS_KEY`/`NODE_OPTIONS` が子に渡らないことをテスト実証
- symlink exfil 遮断（blocker-3）: `~/.aws` 相当への symlink・symlinked 親ディレクトリ経由の機密読み出しを skip、残存なしをテスト実証
- on-disk token 遮断（blocker-2）: `.git/config` 除外をテスト実証

## 検証

- `tests/deterministic-command-sandbox.test.mjs` **23 pass**（symlink skip / env スクラブ / .git 除外 / 残存なし）
- full suite **1959 pass / 0 fail** / format:check green / sandbox module 未 import のため dist 非該当

## 次（別 PR・承認後）

(b) execFile 起動 + exit code 分類 → (c) gate 接続（rule 5c・合成順）→ (d) CI 配線。§11 の DoD + 承認が前提。

🤖 Generated with [Claude Code](https://claude.com/claude-code)