### PR TITLE
feat(gate): executor の execFile 起動 + exit code 分類を追加する (#1401)

### DIFF
--- a/src/lib/deterministic-command-executor.mjs
+++ b/src/lib/deterministic-command-executor.mjs
@@ -69,9 +69,19 @@ export const DEFAULT_MAX_BUFFER = 1 << 20; // 1 MiB
 function runExecFile(command, args, options) {
   return new Promise((resolve) => {
     // execFile — NO shell. This is the sole process-execution call in the module.
-    execFile(command, args, options, (error, stdout, stderr) => {
-      resolve({ error: error ?? null, stdout: String(stdout ?? ''), stderr: String(stderr ?? '') });
-    });
+    // execFile can throw SYNCHRONOUSLY on malformed options (bad cwd/env); catch
+    // so runExecFile never rejects (gemini #1431). A sync throw is a setup error.
+    try {
+      execFile(command, args, options, (error, stdout, stderr) => {
+        resolve({
+          error: error ?? null,
+          stdout: String(stdout ?? ''),
+          stderr: String(stderr ?? ''),
+        });
+      });
+    } catch (syncError) {
+      resolve({ error: syncError, stdout: '', stderr: '' });
+    }
   });
 }
 
@@ -157,12 +167,18 @@ export async function executeDeterministicCommand({ entry, sandboxDir, env, limi
     return { status: 'pass', reasonCode: DETERMINISTIC_PASS, durationMs, exitCode: 0, stdoutBytes };
   }
 
-  // (2) Timeout / resource kill → unrunnable (ESCALATE). `killed` is set by the
-  //     runtime when the child is SIGKILLed for exceeding `timeout` (or when
-  //     `maxBuffer` overflows). Both are DoS-limit kills → "cannot judge", not a
-  //     violation. Checked BEFORE the numeric-exit-code branch because a killed
-  //     process has no meaningful exit code.
-  if (error.killed === true || error.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER') {
+  // (2) Killed by a signal → unrunnable (ESCALATE). `error.killed` is true when
+  //     the runtime SIGKILLs the child for exceeding `timeout` (or `maxBuffer`
+  //     overflow). An EXTERNAL signal (SIGKILL/SIGTERM/SIGSEGV crash) instead
+  //     sets `error.signal` (a string) but NOT `error.killed` (gemini #1431), so
+  //     check both. A signal-terminated process produced no clean verdict →
+  //     "cannot judge", not a violation. Checked BEFORE the numeric-exit-code
+  //     branch because a killed process has no meaningful exit code.
+  if (
+    error.killed === true ||
+    typeof error.signal === 'string' ||
+    error.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER'
+  ) {
     return {
       status: 'unrunnable',
       reasonCode: DETERMINISTIC_UNRUNNABLE,

--- a/src/lib/deterministic-command-executor.mjs
+++ b/src/lib/deterministic-command-executor.mjs
@@ -1,0 +1,196 @@
+/**
+ * Deterministic command executor — execFile launch + exit-code classification
+ * (#1401 §11.8 (b), the RCE surface).
+ *
+ * SINGLE RESPONSIBILITY: receive one already-validated allowlist entry, launch
+ * it in a caller-prepared clean cwd with a caller-prepared scrubbed env, and
+ * classify the exit code into one of three states (§11.1 / §11.5.1):
+ *   - `pass`       exit 0                → gate adds nothing
+ *   - `fail`       exit non-zero         → STRICT_BLOCK (NO_GO), carries exitCode
+ *   - `unrunnable` spawn error / timeout / invalid entry → DETERMINISTIC_UNRUNNABLE (ESCALATE)
+ *
+ * HARDENING / RCE surface notes:
+ *
+ * - **`execFile` is the ONLY execution point.** `node:child_process`'s `execFile`
+ *   is imported once and called once. `exec` (shell string), `spawn`, and any
+ *   template-string command are deliberately NOT used. `execFile` does not spawn
+ *   a shell (equivalent to `{ shell: false }`), so argv elements are passed
+ *   verbatim to the executable — `;`, `&&`, `$()`, `|` in an argument are inert
+ *   text, never shell metacharacters.
+ * - **stdout / stderr are never returned** (§10.3.2 (B)). Judgement reduces to
+ *   the exit code only. Captured output is discarded; at most its byte length is
+ *   recorded. No captured bytes reach the return value, a finding body, or a PR
+ *   comment, so an attacker cannot steer a finding through stdout.
+ * - **Entry is re-validated at the launch site** with `validateAllowlistEntry`
+ *   (§11.1.2 multi-layer defense). An entry that fails re-validation is NOT
+ *   executed and returns `unrunnable` (`invalid-entry`).
+ * - **DoS limits** (§3.6): `timeout` (default 60s) with `killSignal: 'SIGKILL'`
+ *   and `maxBuffer` (default 1 MiB). Descendant-process containment: `execFile`
+ *   offers limited process-group control, so timeout enforcement relies on
+ *   `killSignal` killing the direct child. Full process-group kill
+ *   (`detached` + negative-PID `kill`) is intentionally NOT implemented here to
+ *   avoid over-engineering; the design accepts this as a Linux-first residual
+ *   (§3.6 / §6.8). CI runs on `ubuntu-latest`.
+ *
+ * DEFAULT OFF / INERT: this module ONLY exports functions. It does not read any
+ * opt-in flag, does not import or touch the gate (`deriveGateDecision`) or CI
+ * (`action.yml`), and nothing runs until a caller explicitly invokes
+ * `executeDeterministicCommand`. Importing this module starts no process.
+ */
+
+import { execFile } from 'node:child_process';
+
+import { validateAllowlistEntry } from './deterministic-command-allowlist.mjs';
+
+/** reasonCode for a clean pass (exit 0). */
+export const DETERMINISTIC_PASS = 'DETERMINISTIC_PASS';
+
+/** reasonCode for a violation: the command ran and exited non-zero (§11.5.1). */
+export const STRICT_BLOCK = 'STRICT_BLOCK';
+
+/** reasonCode for "could not run" (spawn error / timeout / invalid entry). */
+export const DETERMINISTIC_UNRUNNABLE = 'DETERMINISTIC_UNRUNNABLE';
+
+/** Default DoS limits (§3.6). Host-overridable via the `limits` argument. */
+export const DEFAULT_TIMEOUT_MS = 60000;
+export const DEFAULT_MAX_BUFFER = 1 << 20; // 1 MiB
+
+/**
+ * Run `execFile` and resolve with a normalized `{ error, stdout, stderr }`
+ * shape (never rejects). Callback → Promise adapter over the ONE execFile call.
+ * `stdout`/`stderr` are captured only so the length can be recorded; they are
+ * dropped by the caller and never returned to the pipeline.
+ *
+ * @param {string} command absolute path to the executable
+ * @param {string[]} args argv (passed verbatim; no shell)
+ * @param {object} options execFile options ({ cwd, env, timeout, maxBuffer, killSignal })
+ * @returns {Promise<{ error: (Error & { code?: number | string, signal?: string, killed?: boolean }) | null, stdout: string, stderr: string }>}
+ */
+function runExecFile(command, args, options) {
+  return new Promise((resolve) => {
+    // execFile — NO shell. This is the sole process-execution call in the module.
+    execFile(command, args, options, (error, stdout, stderr) => {
+      resolve({ error: error ?? null, stdout: String(stdout ?? ''), stderr: String(stderr ?? '') });
+    });
+  });
+}
+
+/**
+ * Execute one validated deterministic-allowlist entry and classify the result.
+ *
+ * The caller MUST supply:
+ *   - `entry`      — the valid entry from `matchCommand` (absolute-path command,
+ *                    argv `args`, `selfContained: true`). Re-validated here.
+ *   - `sandboxDir` — the clean cwd prepared by the sandbox layer
+ *                    (`makeSandboxTempDir` + `copyReviewTargetToSandbox`).
+ *   - `env`        — the scrubbed child env from `buildSandboxEnv` (SAFE_ENV
+ *                    allowlist only; no secrets, no NODE_OPTIONS).
+ *   - `limits`     — `{ timeoutMs?, maxBuffer? }` (defaults 60000 / 1 MiB).
+ *
+ * @param {{
+ *   entry: { command?: string, args?: string[], selfContained?: boolean, id?: string },
+ *   sandboxDir: string,
+ *   env: Record<string, string>,
+ *   limits?: { timeoutMs?: number, maxBuffer?: number },
+ * }} args
+ * @returns {Promise<{
+ *   status: 'pass' | 'fail' | 'unrunnable',
+ *   exitCode?: number,
+ *   reasonCode: string,
+ *   durationMs: number,
+ *   stdoutBytes?: number,
+ *   unrunnableCause?: 'spawn-error' | 'timeout' | 'invalid-entry',
+ * }>}
+ */
+export async function executeDeterministicCommand({ entry, sandboxDir, env, limits } = {}) {
+  const startedAt = Date.now();
+  const durationSince = () => Date.now() - startedAt;
+
+  // Multi-layer defense (§11.1.2): re-validate the entry at the launch site. An
+  // entry that fails re-validation is never executed.
+  const validation = validateAllowlistEntry(entry);
+  if (!validation.valid) {
+    return {
+      status: 'unrunnable',
+      reasonCode: DETERMINISTIC_UNRUNNABLE,
+      durationMs: durationSince(),
+      unrunnableCause: 'invalid-entry',
+    };
+  }
+
+  if (typeof sandboxDir !== 'string' || sandboxDir.length === 0) {
+    // No clean cwd — do not fall back to process.cwd(); treat as unrunnable.
+    return {
+      status: 'unrunnable',
+      reasonCode: DETERMINISTIC_UNRUNNABLE,
+      durationMs: durationSince(),
+      unrunnableCause: 'invalid-entry',
+    };
+  }
+
+  const timeoutMs =
+    typeof limits?.timeoutMs === 'number' && limits.timeoutMs > 0
+      ? limits.timeoutMs
+      : DEFAULT_TIMEOUT_MS;
+  const maxBuffer =
+    typeof limits?.maxBuffer === 'number' && limits.maxBuffer > 0
+      ? limits.maxBuffer
+      : DEFAULT_MAX_BUFFER;
+
+  const options = {
+    cwd: sandboxDir,
+    // Scrubbed env ONLY — do not merge process.env (would re-introduce secrets).
+    env: env && typeof env === 'object' ? env : {},
+    timeout: timeoutMs,
+    maxBuffer,
+    killSignal: 'SIGKILL',
+    windowsHide: true,
+  };
+
+  const { error, stdout } = await runExecFile(entry.command, entry.args ?? [], options);
+  // Record only the byte length; the captured stdout itself is dropped here.
+  const stdoutBytes = Buffer.byteLength(stdout);
+  const durationMs = durationSince();
+
+  // (1) No error → clean exit 0 → pass. Gate adds nothing.
+  if (error == null) {
+    return { status: 'pass', reasonCode: DETERMINISTIC_PASS, durationMs, exitCode: 0, stdoutBytes };
+  }
+
+  // (2) Timeout / resource kill → unrunnable (ESCALATE). `killed` is set by the
+  //     runtime when the child is SIGKILLed for exceeding `timeout` (or when
+  //     `maxBuffer` overflows). Both are DoS-limit kills → "cannot judge", not a
+  //     violation. Checked BEFORE the numeric-exit-code branch because a killed
+  //     process has no meaningful exit code.
+  if (error.killed === true || error.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER') {
+    return {
+      status: 'unrunnable',
+      reasonCode: DETERMINISTIC_UNRUNNABLE,
+      durationMs,
+      unrunnableCause: 'timeout',
+      stdoutBytes,
+    };
+  }
+
+  // (3) Process ran and exited non-zero → violation → STRICT_BLOCK (NO_GO).
+  //     On a real exit, execFile sets `error.code` to the numeric exit code.
+  if (typeof error.code === 'number') {
+    return {
+      status: 'fail',
+      exitCode: error.code,
+      reasonCode: STRICT_BLOCK,
+      durationMs,
+      stdoutBytes,
+    };
+  }
+
+  // (4) Everything else — spawn failure (ENOENT / EACCES, `error.code` is a
+  //     string errno) — → unrunnable (ESCALATE). The command could not start.
+  return {
+    status: 'unrunnable',
+    reasonCode: DETERMINISTIC_UNRUNNABLE,
+    durationMs,
+    unrunnableCause: 'spawn-error',
+    stdoutBytes,
+  };
+}

--- a/tests/deterministic-command-executor.test.mjs
+++ b/tests/deterministic-command-executor.test.mjs
@@ -1,0 +1,239 @@
+/**
+ * Deterministic command executor tests (#1401 §11.8 (b)).
+ *
+ * Exercises the execFile launch + exit-code classification (§11.5.1) against
+ * TRUSTED OS binaries only (`/usr/bin/true`, `/usr/bin/false`, `/bin/echo`,
+ * `/usr/bin/env`, `/bin/sleep` — detected at runtime; missing ones are skipped).
+ * Nothing untrusted is ever executed.
+ *
+ * Covers: pass (exit 0), fail (STRICT_BLOCK, exit non-zero), spawn-error
+ * (ENOENT), invalid-entry (re-validation blocks execution — no process),
+ * timeout, no-stdout-in-return-value, env scrubbing proven at runtime (child
+ * cannot see GITHUB_TOKEN), and shell-non-invocation (`;` / `$()` args are inert
+ * text, not shell metacharacters).
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+import {
+  executeDeterministicCommand,
+  DETERMINISTIC_PASS,
+  STRICT_BLOCK,
+  DETERMINISTIC_UNRUNNABLE,
+} from '../src/lib/deterministic-command-executor.mjs';
+import { buildSandboxEnv } from '../src/lib/deterministic-command-sandbox.mjs';
+
+/** Return the first existing absolute path from a candidate list, or null. */
+function firstExisting(candidates) {
+  for (const c of candidates) {
+    try {
+      if (fs.statSync(c).isFile()) return c;
+    } catch {
+      // not present on this platform; try next
+    }
+  }
+  return null;
+}
+
+const BIN = {
+  true: firstExisting(['/usr/bin/true', '/bin/true']),
+  false: firstExisting(['/usr/bin/false', '/bin/false']),
+  echo: firstExisting(['/bin/echo', '/usr/bin/echo']),
+  printenv: firstExisting(['/usr/bin/printenv', '/bin/printenv']),
+  sleep: firstExisting(['/bin/sleep', '/usr/bin/sleep']),
+};
+
+/** A minimal valid entry (absolute command, selfContained). */
+function validEntry(command, args = []) {
+  return { command, args, selfContained: true };
+}
+
+describe('executeDeterministicCommand — exit-code classification (§11.5.1)', () => {
+  test('exit 0 → pass (DETERMINISTIC_PASS)', { skip: !BIN.true }, async () => {
+    const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'river-exec-test-'));
+    try {
+      const env = buildSandboxEnv({ PATH: '/usr/bin' }, { home: dir });
+      const result = await executeDeterministicCommand({
+        entry: validEntry(BIN.true),
+        sandboxDir: dir,
+        env,
+      });
+      assert.equal(result.status, 'pass');
+      assert.equal(result.reasonCode, DETERMINISTIC_PASS);
+      assert.equal(result.exitCode, 0);
+      assert.equal(typeof result.durationMs, 'number');
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('exit non-zero → fail (STRICT_BLOCK) with exitCode', { skip: !BIN.false }, async () => {
+    const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'river-exec-test-'));
+    try {
+      const env = buildSandboxEnv({ PATH: '/usr/bin' }, { home: dir });
+      const result = await executeDeterministicCommand({
+        entry: validEntry(BIN.false),
+        sandboxDir: dir,
+        env,
+      });
+      assert.equal(result.status, 'fail');
+      assert.equal(result.reasonCode, STRICT_BLOCK);
+      assert.ok(typeof result.exitCode === 'number' && result.exitCode !== 0);
+      assert.equal(result.unrunnableCause, undefined);
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('nonexistent absolute path → unrunnable (spawn-error)', async () => {
+    const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'river-exec-test-'));
+    try {
+      const env = buildSandboxEnv({ PATH: '/usr/bin' }, { home: dir });
+      const result = await executeDeterministicCommand({
+        entry: validEntry('/nonexistent/river-no-such-binary-xyz'),
+        sandboxDir: dir,
+        env,
+      });
+      assert.equal(result.status, 'unrunnable');
+      assert.equal(result.reasonCode, DETERMINISTIC_UNRUNNABLE);
+      assert.equal(result.unrunnableCause, 'spawn-error');
+      assert.equal(result.exitCode, undefined);
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('invalid entry (no selfContained) is NOT executed → unrunnable (invalid-entry)', async () => {
+    const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'river-exec-test-'));
+    try {
+      const env = buildSandboxEnv({ PATH: '/usr/bin' }, { home: dir });
+      // Point at a binary that WOULD exit 0, to prove re-validation blocks it
+      // before any execution (result must be invalid-entry, not pass).
+      const result = await executeDeterministicCommand({
+        entry: { command: BIN.true ?? '/usr/bin/true', args: [] }, // selfContained missing
+        sandboxDir: dir,
+        env,
+      });
+      assert.equal(result.status, 'unrunnable');
+      assert.equal(result.reasonCode, DETERMINISTIC_UNRUNNABLE);
+      assert.equal(result.unrunnableCause, 'invalid-entry');
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('interpreter entry (node) is NOT executed → unrunnable (invalid-entry)', async () => {
+    const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'river-exec-test-'));
+    try {
+      const env = buildSandboxEnv({ PATH: '/usr/bin' }, { home: dir });
+      const result = await executeDeterministicCommand({
+        entry: validEntry('/usr/bin/node', ['-e', 'process.exit(0)']),
+        sandboxDir: dir,
+        env,
+      });
+      assert.equal(result.status, 'unrunnable');
+      assert.equal(result.unrunnableCause, 'invalid-entry');
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('timeout → unrunnable (timeout)', { skip: !BIN.sleep }, async () => {
+    const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'river-exec-test-'));
+    try {
+      const env = buildSandboxEnv({ PATH: '/usr/bin' }, { home: dir });
+      const result = await executeDeterministicCommand({
+        entry: validEntry(BIN.sleep, ['5']),
+        sandboxDir: dir,
+        env,
+        limits: { timeoutMs: 100 },
+      });
+      assert.equal(result.status, 'unrunnable');
+      assert.equal(result.reasonCode, DETERMINISTIC_UNRUNNABLE);
+      assert.equal(result.unrunnableCause, 'timeout');
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('executeDeterministicCommand — stdout / env / shell hardening (§10.3, §11.3, §3.4)', () => {
+  test('stdout is NOT included in the return value', { skip: !BIN.echo }, async () => {
+    const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'river-exec-test-'));
+    try {
+      const env = buildSandboxEnv({ PATH: '/usr/bin' }, { home: dir });
+      const secret = 'SENTINEL_STDOUT_abcdef123456';
+      const result = await executeDeterministicCommand({
+        entry: validEntry(BIN.echo, [secret]),
+        sandboxDir: dir,
+        env,
+      });
+      assert.equal(result.status, 'pass');
+      // No field may carry the printed bytes.
+      const serialized = JSON.stringify(result);
+      assert.ok(!serialized.includes(secret), 'return value must not contain stdout');
+      assert.equal(result.stdout, undefined);
+      assert.equal(result.stderr, undefined);
+      // Only the byte length may be recorded.
+      assert.ok(typeof result.stdoutBytes === 'number');
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('env scrub: child cannot see GITHUB_TOKEN at runtime', { skip: !BIN.printenv }, async () => {
+    const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'river-exec-test-'));
+    try {
+      // buildSandboxEnv drops GITHUB_TOKEN by construction (SAFE_ENV allowlist).
+      const env = buildSandboxEnv(
+        { PATH: '/usr/bin', GITHUB_TOKEN: 'ghp_should_never_reach_child' },
+        { home: dir }
+      );
+      assert.equal(env.GITHUB_TOKEN, undefined, 'precondition: env object is scrubbed');
+      // RUNTIME proof: `printenv GITHUB_TOKEN` exits 0 if the child sees the
+      // variable, non-zero if it does not. The executor never merges
+      // process.env, so the child sees a scrubbed env → non-zero exit → `fail`.
+      // (A leak would surface as `pass` / exitCode 0, which we assert against.)
+      const result = await executeDeterministicCommand({
+        entry: validEntry(BIN.printenv, ['GITHUB_TOKEN']),
+        sandboxDir: dir,
+        env,
+      });
+      assert.equal(result.status, 'fail', 'child must NOT see GITHUB_TOKEN (non-zero exit)');
+      assert.notEqual(result.exitCode, 0);
+      assert.ok(!JSON.stringify(result).includes('ghp_should_never_reach_child'));
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test(
+    'shell metacharacters in args are inert (no shell) — exit 0',
+    { skip: !BIN.echo },
+    async () => {
+      const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'river-exec-test-'));
+      try {
+        const env = buildSandboxEnv({ PATH: '/usr/bin' }, { home: dir });
+        // A shell would interpret `;` and `$(...)`; execFile passes them as
+        // literal argv text, so echo just prints them and exits 0. A canary file
+        // proves no side-effect subshell ran.
+        const canary = path.join(dir, 'canary-should-not-exist');
+        const result = await executeDeterministicCommand({
+          entry: validEntry(BIN.echo, [`; touch ${canary}`, '$(touch ' + canary + ')', '&&', '|']),
+          sandboxDir: dir,
+          env,
+        });
+        assert.equal(result.status, 'pass');
+        assert.equal(result.exitCode, 0);
+        assert.equal(fs.existsSync(canary), false, 'no subshell side-effect may occur');
+      } finally {
+        await fsp.rm(dir, { recursive: true, force: true });
+      }
+    }
+  );
+});


### PR DESCRIPTION
Refs #1401（executor 増分 §11.8(b): 起動層・**既定 OFF・gate/CI 非接続 = inert**）

## 概要

#1401 executor の実際の起動層。**RCE 面の本体だが、既定 OFF で inert**（gate にも CI にも接続せず、どこからも import されないため、呼ばれるまで一切起動しない）。実運用で動くのは (c) gate 接続 + (d) CI 配線が揃い、opt-in + allowlist が用意された後。

## 変更（2ファイル・新 module）

`src/lib/deterministic-command-executor.mjs`: `executeDeterministicCommand({entry, sandboxDir, env, limits})`
- 起動前に `validateAllowlistEntry` で**再検証**（多層）→ invalid は実行せず unrunnable
- **`execFile`（唯一の実行点・非 shell）** で `entry.command`/`args` を sandbox cwd + scrub 済み env で起動
- **stdout 非返却**（`stdoutBytes` 長のみ、§10.3）/ `process.env` 非マージ / `sandboxDir` 無ければ `process.cwd()` に**フォールバックしない**

## 結果分類（§11.5.1）

| 結果 | status / reasonCode |
|---|---|
| exit 0 | pass / DETERMINISTIC_PASS |
| exit 非0（走った） | fail / STRICT_BLOCK（+exitCode） |
| killed・timeout・maxBuffer | unrunnable / timeout |
| spawn 失敗（ENOENT/EACCES） | unrunnable / spawn-error |
| invalid entry・sandboxDir 無し | unrunnable / invalid-entry |

killed を exit-code 判定より**先に**チェック（killed は有効な exit code を持たない）。timeout 60s / maxBuffer 1MiB / SIGKILL。

## セキュリティ（RCE 面・逐行レビュー済み）

- **child_process = `execFile` の 1 import + 1 call のみ**（`exec`/`spawn`/shell 文字列なし）
- **shell 非経由を実行時実証**: `; touch`・`$()`・`&&`・`|` を argv に渡し、canary が作られず exit 0（metachar は inert）
- **env スクラブを実行時実証**: 子プロセスが `GITHUB_TOKEN` を見られない
- **stdout 非返却を実証**（sentinel が結果に現れない、`result.stdout` undefined）
- **既定 OFF / inert**: opt-in フラグ読取なし・gate/CI 参照なし・自動呼び出しなし・未 import（dist 非該当）

## 検証

- `tests/deterministic-command-executor.test.mjs` **9 pass**（信頼 OS バイナリのみ使用）
- full **1968 pass / 0 fail** / format:check green / lint:code green

## 次（別 PR・承認後）

(c) gate 接続（rule 5c・合成順 5b>5c）→ (d) CI 配線（`persist-credentials:false`・opt-in・既定 OFF）。**これらが揃うまで実運用で起動しない。** §11 DoD + 承認が前提。

🤖 Generated with [Claude Code](https://claude.com/claude-code)