### PR TITLE
feat(gate): deterministic gate orchestrator を追加する (#1401)

### DIFF
--- a/src/lib/deterministic-command-orchestrator.mjs
+++ b/src/lib/deterministic-command-orchestrator.mjs
@@ -137,9 +137,13 @@ export async function runDeterministicGates({
     // Not on the host-trusted allowlist → never run it.
     if (entry == null) continue;
 
-    const cleanCwd = await makeSandboxTempDir(mkdtempImpl);
-    const emptyHome = await makeSandboxTempDir(mkdtempImpl);
+    // Declared outside try so finally can clean up whichever dirs were created
+    // even if the SECOND makeSandboxTempDir throws (gemini #1433 leak fix).
+    let cleanCwd;
+    let emptyHome;
     try {
+      cleanCwd = await makeSandboxTempDir(mkdtempImpl);
+      emptyHome = await makeSandboxTempDir(mkdtempImpl);
       await copyReviewTargetToSandbox({
         sourceDir: reviewSourceDir,
         destDir: cleanCwd,
@@ -154,9 +158,16 @@ export async function runDeterministicGates({
       if (status === 'unrunnable') deterministicUnrunnable = true;
       results.push({ skillId: gate.skillId, status, reasonCode });
     } finally {
-      // Remove both sandbox temp dirs on every path (success / throw).
-      await fs.rm(cleanCwd, { recursive: true, force: true });
-      await fs.rm(emptyHome, { recursive: true, force: true });
+      // Remove both sandbox temp dirs on every path. Each rm is individually
+      // guarded so a failure removing one still attempts the other (gemini #1433).
+      for (const dir of [cleanCwd, emptyHome]) {
+        if (!dir) continue;
+        try {
+          await fs.rm(dir, { recursive: true, force: true });
+        } catch {
+          // Ignore cleanup errors so the remaining dir is still attempted.
+        }
+      }
     }
   }
 

--- a/src/lib/deterministic-command-orchestrator.mjs
+++ b/src/lib/deterministic-command-orchestrator.mjs
@@ -1,0 +1,164 @@
+/**
+ * Deterministic command orchestrator — the confluence point (#1401 §11.8 (c2a) / §11.5.3).
+ *
+ * Composes the four merged building blocks into a single gate pass:
+ *   allowlist (validate) → sandbox (prepare env + clean cwd) → executor (run)
+ *   → aggregate into the { strictBlock, deterministicUnrunnable } gate inputs
+ *   consumed by `deriveGateDecision` (rules 5b / 5c).
+ *
+ * TRUST BOUNDARY (§11.6). The allowlist is read ONLY from the host-trusted base
+ * checkout (`trustedTree`). The PR head's `.river/deterministic-allowlist.yaml`
+ * is NEVER read — an implementation agent under review must not be able to add
+ * its own command to the allowlist. When `trustedTree` is not supplied or the
+ * base allowlist file is absent, this function runs NOTHING and returns the
+ * safe-default empty result — deterministic gates are opt-in (§11.6).
+ *
+ * INJECTABLE EXECUTOR / INERT BY DEFAULT. The actual process launch is reached
+ * only through the injected `execImpl` (default `executeDeterministicCommand`).
+ * This module itself imports `child_process` transitively via the executor but
+ * starts no process on import: nothing runs until a caller invokes
+ * `runDeterministicGates`, and no caller is wired yet (local-runner / run-gate /
+ * review-plan / action.yml are untouched — wiring lands in a later PR). Tests
+ * inject a mock `execImpl` and `mkdtempImpl` so no real process is spawned.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { loadValidAllowlist, matchCommand } from './deterministic-command-allowlist.mjs';
+import {
+  buildSandboxEnv,
+  copyReviewTargetToSandbox,
+  makeSandboxTempDir,
+} from './deterministic-command-sandbox.mjs';
+import { executeDeterministicCommand } from './deterministic-command-executor.mjs';
+
+/** Relative path of the host-trusted allowlist inside the base checkout (§11.6). */
+export const ALLOWLIST_RELATIVE_PATH = '.river/deterministic-allowlist.yaml';
+
+/** Safe-default empty result: nothing ran, gate learns nothing. */
+function emptyResult() {
+  return { strictBlock: false, deterministicUnrunnable: false, results: [] };
+}
+
+/**
+ * Read + validate the host-trusted allowlist from the base checkout. Returns the
+ * surviving valid entries, or `null` when `trustedTree` is unusable / the file
+ * is missing (safe-default: run nothing). Never reads the PR head allowlist.
+ *
+ * @param {string | undefined} trustedTree base-checkout path
+ * @returns {Promise<Array<object> | null>}
+ */
+async function loadTrustedAllowlist(trustedTree) {
+  if (typeof trustedTree !== 'string' || trustedTree.length === 0) return null;
+  const allowlistPath = path.join(trustedTree, ALLOWLIST_RELATIVE_PATH);
+  let yamlText;
+  try {
+    yamlText = await fs.readFile(allowlistPath, 'utf8');
+  } catch {
+    // Missing / unreadable base allowlist → deterministic gates are not opted in.
+    return null;
+  }
+  return loadValidAllowlist(yamlText).valid;
+}
+
+/**
+ * Extract the deterministic-gate command definitions from the selected skills.
+ * Only skills whose `metadata.deterministicGate` carries a non-empty `command`
+ * are candidates. `args` defaults to `[]`.
+ *
+ * @param {Array<object>} selected
+ * @returns {Array<{ skillId: string, command: string, args: string[] }>}
+ */
+function extractGateCommands(selected) {
+  const list = Array.isArray(selected) ? selected : [];
+  const gates = [];
+  for (const skill of list) {
+    const gate = skill?.metadata?.deterministicGate;
+    if (gate == null || typeof gate !== 'object') continue;
+    if (typeof gate.command !== 'string' || gate.command.length === 0) continue;
+    const args = Array.isArray(gate.args) ? gate.args : [];
+    const skillId = skill?.id ?? skill?.metadata?.id ?? gate.command;
+    gates.push({ skillId, command: gate.command, args });
+  }
+  return gates;
+}
+
+/**
+ * Run the deterministic gates for a review pass and aggregate their verdicts.
+ *
+ * Processing (§11.5.3 confluence):
+ *  1. Read the host-trusted allowlist from `trustedTree`. Absent → run nothing,
+ *     return the safe-default empty result (PR-head allowlist is never read).
+ *  2. Collect each selected skill's `deterministicGate` {command, args}.
+ *  3. Match each against the valid allowlist by EXACT argv equality
+ *     (`matchCommand`). No match → skip (do not run an unlisted command).
+ *  4. For each match: prepare a clean cwd + an empty HOME (two temp dirs),
+ *     stage the changed files, build the scrubbed env, then invoke the injected
+ *     `execImpl`. Temp dirs are removed in `finally` on every path.
+ *  5. Aggregate: any `fail` → strictBlock; any `unrunnable` → deterministicUnrunnable.
+ *     Both can be true at once (the gate composes 5b > 5c).
+ *
+ * @param {object} opts
+ * @param {string} [opts.trustedTree] base-checkout path (host-trusted allowlist source)
+ * @param {Array<object>} [opts.selected] selected skills (metadata.deterministicGate)
+ * @param {string} [opts.reviewSourceDir] dir the changed files are copied FROM
+ * @param {string[]} [opts.changedFiles] relative paths to stage into the clean cwd
+ * @param {Record<string, string | undefined>} [opts.processEnv] source env (e.g. process.env)
+ * @param {(args: object) => Promise<{ status: string, reasonCode: string }>} [opts.execImpl]
+ *   injected executor; defaults to `executeDeterministicCommand`
+ * @param {(prefix: string) => Promise<string>} [opts.mkdtempImpl] injected mkdtemp (tests)
+ * @returns {Promise<{ strictBlock: boolean, deterministicUnrunnable: boolean,
+ *   results: Array<{ skillId: string, status: string, reasonCode: string }> }>}
+ */
+export async function runDeterministicGates({
+  trustedTree,
+  selected,
+  reviewSourceDir,
+  changedFiles,
+  processEnv,
+  execImpl,
+  mkdtempImpl,
+} = {}) {
+  const validEntries = await loadTrustedAllowlist(trustedTree);
+  if (validEntries == null) return emptyResult();
+
+  const gates = extractGateCommands(selected);
+  if (gates.length === 0) return emptyResult();
+
+  const exec = typeof execImpl === 'function' ? execImpl : executeDeterministicCommand;
+
+  let strictBlock = false;
+  let deterministicUnrunnable = false;
+  const results = [];
+
+  for (const gate of gates) {
+    const entry = matchCommand({ command: gate.command, args: gate.args }, validEntries);
+    // Not on the host-trusted allowlist → never run it.
+    if (entry == null) continue;
+
+    const cleanCwd = await makeSandboxTempDir(mkdtempImpl);
+    const emptyHome = await makeSandboxTempDir(mkdtempImpl);
+    try {
+      await copyReviewTargetToSandbox({
+        sourceDir: reviewSourceDir,
+        destDir: cleanCwd,
+        files: Array.isArray(changedFiles) ? changedFiles : [],
+      });
+      const env = buildSandboxEnv(processEnv, { home: emptyHome });
+      const result = await exec({ entry, sandboxDir: cleanCwd, env });
+
+      const status = result?.status;
+      const reasonCode = result?.reasonCode;
+      if (status === 'fail') strictBlock = true;
+      if (status === 'unrunnable') deterministicUnrunnable = true;
+      results.push({ skillId: gate.skillId, status, reasonCode });
+    } finally {
+      // Remove both sandbox temp dirs on every path (success / throw).
+      await fs.rm(cleanCwd, { recursive: true, force: true });
+      await fs.rm(emptyHome, { recursive: true, force: true });
+    }
+  }
+
+  return { strictBlock, deterministicUnrunnable, results };
+}

--- a/tests/deterministic-command-orchestrator.test.mjs
+++ b/tests/deterministic-command-orchestrator.test.mjs
@@ -1,0 +1,322 @@
+/**
+ * Deterministic command orchestrator tests (#1401 §11.8 (c2a) / §11.5.3).
+ *
+ * The orchestrator is the confluence point: allowlist → sandbox → executor →
+ * aggregate into { strictBlock, deterministicUnrunnable }. These tests inject a
+ * mock `execImpl` and `mkdtempImpl`, so NO real process is ever spawned and the
+ * real `executeDeterministicCommand` never runs. The most important case is the
+ * safe default: an unset `trustedTree` executes nothing and returns
+ * { false, false, [] }.
+ *
+ * A real host-trusted allowlist file IS written to a temp dir (the module reads
+ * it via fs), but every command in it is a harmless absolute path that is never
+ * launched because `execImpl` is mocked.
+ */
+
+import { test, describe, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+import {
+  runDeterministicGates,
+  ALLOWLIST_RELATIVE_PATH,
+} from '../src/lib/deterministic-command-orchestrator.mjs';
+
+/** Build a valid host-trusted allowlist YAML for the given entries. */
+function allowlistYaml(entries) {
+  const lines = ['version: 1', 'commands:'];
+  for (const e of entries) {
+    lines.push(`  - command: ${e.command}`);
+    if (Array.isArray(e.args) && e.args.length > 0) {
+      lines.push('    args:');
+      for (const a of e.args) lines.push(`      - ${JSON.stringify(a)}`);
+    }
+    lines.push('    selfContained: true');
+  }
+  return lines.join('\n');
+}
+
+/** Write a trusted-tree base checkout with an allowlist file; return its path. */
+async function makeTrustedTree(entries) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'river-trusted-'));
+  const allowlistPath = path.join(dir, ALLOWLIST_RELATIVE_PATH);
+  await fs.mkdir(path.dirname(allowlistPath), { recursive: true });
+  await fs.writeFile(allowlistPath, allowlistYaml(entries), 'utf8');
+  return dir;
+}
+
+/** A skill with a deterministicGate command definition. */
+function skill(id, command, args) {
+  return { id, metadata: { deterministicGate: { command, args } } };
+}
+
+/** Factory: a mock execImpl returning a fixed status; records its calls. */
+function mockExec(statusByCommand) {
+  const calls = [];
+  const impl = async ({ entry, sandboxDir, env }) => {
+    calls.push({ entry, sandboxDir, env });
+    const status = statusByCommand[entry.command] ?? 'pass';
+    const reasonCode =
+      status === 'fail'
+        ? 'STRICT_BLOCK'
+        : status === 'unrunnable'
+          ? 'DETERMINISTIC_UNRUNNABLE'
+          : 'DETERMINISTIC_PASS';
+    return { status, reasonCode };
+  };
+  return { impl, calls };
+}
+
+/** A source dir with a couple of changed files to stage. */
+async function makeSourceDir() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'river-src-'));
+  await fs.writeFile(path.join(dir, 'a.txt'), 'hello', 'utf8');
+  return dir;
+}
+
+describe('runDeterministicGates — safe default (trustedTree unset)', () => {
+  test('no trustedTree → executes nothing, returns { false, false, [] }', async () => {
+    const { impl, calls } = mockExec({});
+    const result = await runDeterministicGates({
+      selected: [skill('s1', '/usr/bin/tool', [])],
+      execImpl: impl,
+      mkdtempImpl: async () => {
+        throw new Error('mkdtemp must not be called when trustedTree is unset');
+      },
+    });
+    assert.deepEqual(result, { strictBlock: false, deterministicUnrunnable: false, results: [] });
+    assert.equal(calls.length, 0, 'execImpl must not be called');
+  });
+
+  test('trustedTree given but allowlist file absent → { false, false, [] }', async () => {
+    const emptyTree = await fs.mkdtemp(path.join(os.tmpdir(), 'river-empty-'));
+    try {
+      const { impl, calls } = mockExec({});
+      const result = await runDeterministicGates({
+        trustedTree: emptyTree,
+        selected: [skill('s1', '/usr/bin/tool', [])],
+        execImpl: impl,
+      });
+      assert.deepEqual(result, {
+        strictBlock: false,
+        deterministicUnrunnable: false,
+        results: [],
+      });
+      assert.equal(calls.length, 0);
+    } finally {
+      await fs.rm(emptyTree, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('runDeterministicGates — single matching command', () => {
+  let trustedTree;
+  let sourceDir;
+
+  beforeEach(async () => {
+    trustedTree = await makeTrustedTree([{ command: '/usr/bin/tool', args: [] }]);
+    sourceDir = await makeSourceDir();
+  });
+  afterEach(async () => {
+    await fs.rm(trustedTree, { recursive: true, force: true });
+    await fs.rm(sourceDir, { recursive: true, force: true });
+  });
+
+  test('pass → both flags false, execImpl called once', async () => {
+    const { impl, calls } = mockExec({ '/usr/bin/tool': 'pass' });
+    const result = await runDeterministicGates({
+      trustedTree,
+      selected: [skill('s1', '/usr/bin/tool', [])],
+      reviewSourceDir: sourceDir,
+      changedFiles: ['a.txt'],
+      processEnv: { PATH: '/usr/bin' },
+      execImpl: impl,
+    });
+    assert.equal(result.strictBlock, false);
+    assert.equal(result.deterministicUnrunnable, false);
+    assert.deepEqual(result.results, [
+      { skillId: 's1', status: 'pass', reasonCode: 'DETERMINISTIC_PASS' },
+    ]);
+    assert.equal(calls.length, 1);
+    // The executor received the matched entry and a scrubbed env (no secrets).
+    assert.equal(calls[0].entry.command, '/usr/bin/tool');
+    assert.equal(calls[0].env.PATH, '/usr/bin');
+  });
+
+  test('fail → strictBlock true', async () => {
+    const { impl } = mockExec({ '/usr/bin/tool': 'fail' });
+    const result = await runDeterministicGates({
+      trustedTree,
+      selected: [skill('s1', '/usr/bin/tool', [])],
+      reviewSourceDir: sourceDir,
+      changedFiles: ['a.txt'],
+      execImpl: impl,
+    });
+    assert.equal(result.strictBlock, true);
+    assert.equal(result.deterministicUnrunnable, false);
+  });
+
+  test('unrunnable → deterministicUnrunnable true', async () => {
+    const { impl } = mockExec({ '/usr/bin/tool': 'unrunnable' });
+    const result = await runDeterministicGates({
+      trustedTree,
+      selected: [skill('s1', '/usr/bin/tool', [])],
+      reviewSourceDir: sourceDir,
+      changedFiles: ['a.txt'],
+      execImpl: impl,
+    });
+    assert.equal(result.strictBlock, false);
+    assert.equal(result.deterministicUnrunnable, true);
+  });
+});
+
+describe('runDeterministicGates — allowlist matching', () => {
+  test('command NOT on the allowlist is never executed', async () => {
+    const trustedTree = await makeTrustedTree([{ command: '/usr/bin/allowed', args: [] }]);
+    const sourceDir = await makeSourceDir();
+    try {
+      const { impl, calls } = mockExec({});
+      const result = await runDeterministicGates({
+        trustedTree,
+        // skill references a command that is NOT in the trusted allowlist
+        selected: [skill('s1', '/usr/bin/not-allowed', [])],
+        reviewSourceDir: sourceDir,
+        changedFiles: ['a.txt'],
+        execImpl: impl,
+      });
+      assert.deepEqual(result, {
+        strictBlock: false,
+        deterministicUnrunnable: false,
+        results: [],
+      });
+      assert.equal(calls.length, 0, 'unlisted command must not run');
+    } finally {
+      await fs.rm(trustedTree, { recursive: true, force: true });
+      await fs.rm(sourceDir, { recursive: true, force: true });
+    }
+  });
+
+  test('argv mismatch (different args) does not match → not executed', async () => {
+    const trustedTree = await makeTrustedTree([{ command: '/usr/bin/tool', args: ['--check'] }]);
+    const sourceDir = await makeSourceDir();
+    try {
+      const { impl, calls } = mockExec({});
+      const result = await runDeterministicGates({
+        trustedTree,
+        selected: [skill('s1', '/usr/bin/tool', ['--other'])],
+        reviewSourceDir: sourceDir,
+        changedFiles: ['a.txt'],
+        execImpl: impl,
+      });
+      assert.equal(result.results.length, 0);
+      assert.equal(calls.length, 0);
+    } finally {
+      await fs.rm(trustedTree, { recursive: true, force: true });
+      await fs.rm(sourceDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('runDeterministicGates — aggregation over multiple skills', () => {
+  test('one fail + one unrunnable → strictBlock AND deterministicUnrunnable both true', async () => {
+    const trustedTree = await makeTrustedTree([
+      { command: '/usr/bin/tool-fail', args: [] },
+      { command: '/usr/bin/tool-unrunnable', args: [] },
+    ]);
+    const sourceDir = await makeSourceDir();
+    try {
+      const { impl, calls } = mockExec({
+        '/usr/bin/tool-fail': 'fail',
+        '/usr/bin/tool-unrunnable': 'unrunnable',
+      });
+      const result = await runDeterministicGates({
+        trustedTree,
+        selected: [
+          skill('s-fail', '/usr/bin/tool-fail', []),
+          skill('s-unrunnable', '/usr/bin/tool-unrunnable', []),
+        ],
+        reviewSourceDir: sourceDir,
+        changedFiles: ['a.txt'],
+        execImpl: impl,
+      });
+      assert.equal(result.strictBlock, true);
+      assert.equal(result.deterministicUnrunnable, true);
+      assert.equal(calls.length, 2);
+      assert.equal(result.results.length, 2);
+    } finally {
+      await fs.rm(trustedTree, { recursive: true, force: true });
+      await fs.rm(sourceDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('runDeterministicGates — temp dir lifecycle', () => {
+  test('sandbox temp dirs are created and cleaned up (observed via mocks)', async () => {
+    const trustedTree = await makeTrustedTree([{ command: '/usr/bin/tool', args: [] }]);
+    const sourceDir = await makeSourceDir();
+    const created = [];
+    // mkdtempImpl that actually creates real dirs so copy/cleanup can operate.
+    const mkdtempImpl = async (prefix) => {
+      const dir = await fs.mkdtemp(prefix);
+      created.push(dir);
+      return dir;
+    };
+    try {
+      const { impl } = mockExec({ '/usr/bin/tool': 'pass' });
+      await runDeterministicGates({
+        trustedTree,
+        selected: [skill('s1', '/usr/bin/tool', [])],
+        reviewSourceDir: sourceDir,
+        changedFiles: ['a.txt'],
+        execImpl: impl,
+        mkdtempImpl,
+      });
+      // Two temp dirs (clean cwd + empty HOME) created for the one command.
+      assert.equal(created.length, 2, 'clean cwd + empty HOME created');
+      // Both removed in finally.
+      for (const dir of created) {
+        await assert.rejects(() => fs.stat(dir), /ENOENT/, `temp dir ${dir} should be removed`);
+      }
+    } finally {
+      await fs.rm(trustedTree, { recursive: true, force: true });
+      await fs.rm(sourceDir, { recursive: true, force: true });
+    }
+  });
+
+  test('temp dirs cleaned up even when execImpl throws', async () => {
+    const trustedTree = await makeTrustedTree([{ command: '/usr/bin/tool', args: [] }]);
+    const sourceDir = await makeSourceDir();
+    const created = [];
+    const mkdtempImpl = async (prefix) => {
+      const dir = await fs.mkdtemp(prefix);
+      created.push(dir);
+      return dir;
+    };
+    try {
+      const throwingExec = async () => {
+        throw new Error('boom');
+      };
+      await assert.rejects(
+        () =>
+          runDeterministicGates({
+            trustedTree,
+            selected: [skill('s1', '/usr/bin/tool', [])],
+            reviewSourceDir: sourceDir,
+            changedFiles: ['a.txt'],
+            execImpl: throwingExec,
+            mkdtempImpl,
+          }),
+        /boom/
+      );
+      assert.equal(created.length, 2);
+      for (const dir of created) {
+        await assert.rejects(() => fs.stat(dir), /ENOENT/);
+      }
+    } finally {
+      await fs.rm(trustedTree, { recursive: true, force: true });
+      await fs.rm(sourceDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Refs #1401（(c2a): orchestrator・**inert（未配線）**）

## 概要

#1401 executor の部品（検証層・sandbox・executor・gate 契約 rule 5c、いずれもマージ済み）を束ねる orchestrator。**local-runner/run-gate/action.yml に一切配線しない = inert**（呼ぶ側が居ないため実運用で 1 プロセスも起動しない）。実際に起動させる配線 (c2b) と CI (d) は承認後の別 PR。

## 変更（2ファイル・新 module）

`runDeterministicGates({ trustedTree, selected, reviewSourceDir, changedFiles, processEnv, execImpl, mkdtempImpl })`:
- **trusted-tree の `.river/deterministic-allowlist.yaml` のみ**から allowlist を読む。`trustedTree` 未指定/欠如なら即 `{strictBlock:false, deterministicUnrunnable:false, results:[]}`（**PR head の allowlist は絶対に読まない**・既定安全）
- skill の `deterministicGate.command` を `matchCommand` で valid allowlist と **argv 完全一致**突合。非一致は never run
- 一致ごとに clean cwd + 空 HOME を作り `copyReviewTargetToSandbox` + `buildSandboxEnv` + `exec`（**execImpl 注入可能**）。`try/finally` で両 temp dir を全経路後始末
- 集約: `fail`→strictBlock / `unrunnable`→deterministicUnrunnable（両立可、gate 側 5b>5c で合成）

## セキュリティ

- **trustedTree 未指定 → 何も起動しない**（テストで mkdtempImpl throw 仕込み + execImpl 0 回呼び出しを実証）
- **execImpl 注入で実プロセス非起動**（全テスト mock、実 execFile は一度も走らない）
- **inert / 未配線**: local-runner/run-gate/review-plan/action.yml 無変更
- allowlist は host-trusted（trusted-tree）のみ、非一致 command は never run

## 検証

- `tests/deterministic-command-orchestrator.test.mjs` **10 pass**
- full **1983 pass / 0 fail** / format / lint:code green / dist 非該当

## 次（承認後・別 PR）

(c2b) local-runner から opt-in（`RIVER_DETERMINISTIC_EXEC`）+ trusted-tree（`RIVER_TRUSTED_TREE`）の二重ゲートで `runDeterministicGates` を呼び、結果を gate に合流 → (d) CI 配線（`persist-credentials:false` 等）。**これで初めて実運用起動**。§11 DoD + 承認が前提。

🤖 Generated with [Claude Code](https://claude.com/claude-code)