### PR TITLE
feat(action): deterministic 実行の opt-in を CI に dark-launch 配線する (#1401)

### DIFF
--- a/docs/development/1401-deterministic-command-execution-design.md
+++ b/docs/development/1401-deterministic-command-execution-design.md
@@ -1102,6 +1102,8 @@ executor をさらに小さく分け、各段を単独でテスト可能にす�
 ```yaml
 steps:
   - uses: actions/checkout@v4 # PR head（レビュー対象）
+    with:
+      persist-credentials: false # 多層防御: .git/config に GITHUB_TOKEN を残さない
   - uses: actions/checkout@v4 # base ref（ホスト信頼）
     with:
       ref: ${{ github.event.pull_request.base.sha }}

--- a/docs/development/1401-deterministic-command-execution-design.md
+++ b/docs/development/1401-deterministic-command-execution-design.md
@@ -1083,11 +1083,36 @@ executor をさらに小さく分け、各段を単独でテスト可能にす�
 3. **(c) gate 接続**: `deriveGateDecision` に rule 5c（`deterministicUnrunnable`）を追加し、
    executor の `fail`/`unrunnable` を `strictBlock` OR / `deterministicUnrunnable` へ合流させる。
    合成順（5b>5c）・inputsHash・パラメータ伝播をこの段で確定する。
-4. **(d) CI 配線 + opt-in**: `action.yml` に `deterministic_exec`（既定 OFF）・`RIVER_TRUSTED_TREE`・
-   `persist-credentials: false`・clean cwd 生成 bash step を足し、advisory（`gate:false`）で dark-launch。
+4. **(d) CI 配線 + opt-in（実装済み）**: `action.yml` に opt-in の `deterministic_exec`（既定 OFF）と
+   `trusted_tree`（既定空）を追加した。両方が揃った（`deterministic_exec=true` かつ `trusted_tree` が
+   実在ディレクトリ）ときだけ `RIVER_DETERMINISTIC_EXEC=1` と `RIVER_TRUSTED_TREE` を export し、
+   欠ければ executor は OFF のまま（fail-safe）である。gate は既定 advisory のままなので、
+   有効化しても `gate=true` を別途指定しない限りジョブは落ちない dark-launch となる。
+   trusted tree は composite action が推測せず、呼び出し側が base ref を別パスに checkout して渡す。
 
 各段は前段の canary を壊さないことを条件に進める。(a)(b) は RCE 面を持たない／持っても gate に
 影響しないため、レビュー負荷を (c)(d) に集中できる。
+
+#### (d) 呼び出し側の利用例
+
+`trusted_tree` はホスト信頼された base checkout を指す必要があります。次のように base ref を
+別パスへ `persist-credentials: false` で checkout して渡します。allowlist はこの tree の
+`.river/deterministic-allowlist.yaml` からのみ読まれ、レビュー対象（PR head）からは決して読まれません。
+
+```yaml
+steps:
+  - uses: actions/checkout@v4 # PR head（レビュー対象）
+  - uses: actions/checkout@v4 # base ref（ホスト信頼）
+    with:
+      ref: ${{ github.event.pull_request.base.sha }}
+      path: .river-trusted
+      persist-credentials: false
+  - uses: your-org/river-review@v1
+    with:
+      deterministic_exec: 'true'
+      trusted_tree: ${{ github.workspace }}/.river-trusted
+      # gate は既定 false のまま（dark-launch）。観測後に true へ。
+```
 
 ### 11.9 まだ設計で詰めきれていない論点（実装時に確定）
 

--- a/runners/github-action/action.yml
+++ b/runners/github-action/action.yml
@@ -106,11 +106,21 @@ runs:
         if [ "${{ inputs.deterministic_exec }}" = "true" ]; then
           trusted_in="${{ inputs.trusted_tree }}"
           if [ -n "${trusted_in}" ] && [ -d "${trusted_in}" ]; then
-            export RIVER_TRUSTED_TREE="$(cd "${trusted_in}" && pwd)"
-            export RIVER_DETERMINISTIC_EXEC=1
-            echo "Deterministic exec: ON (trusted tree: ${RIVER_TRUSTED_TREE})"
+            trusted_abs="$(cd "${trusted_in}" && pwd)"
+            # Defense-in-depth: refuse to treat the reviewed target (PR head) as
+            # the trusted allowlist source. If they resolve to the same path the
+            # author has misconfigured trusted_tree, which would let an author
+            # under review allowlist their own command — the exact RCE this gate
+            # prevents. Stay OFF (fail-safe) rather than trust the PR head.
+            if [ "${trusted_abs}" = "${repo_path}" ]; then
+              echo "::warning::trusted_tree resolves to the reviewed target ('${repo_path}'); it must be a separate host-trusted base checkout. Deterministic command execution stays OFF (fail-safe)."
+            else
+              export RIVER_TRUSTED_TREE="${trusted_abs}"
+              export RIVER_DETERMINISTIC_EXEC=1
+              echo "Deterministic exec: ON (trusted tree: ${RIVER_TRUSTED_TREE})"
+            fi
           else
-            echo "::warning::deterministic_exec=true but trusted_tree is empty or not a directory ('${trusted_in}'); deterministic command execution stays OFF (fail-safe)."
+            echo "::warning::deterministic_exec=true but trusted_tree is empty or not a directory; deterministic command execution stays OFF (fail-safe)."
           fi
         fi
 

--- a/runners/github-action/action.yml
+++ b/runners/github-action/action.yml
@@ -93,6 +93,11 @@ runs:
       env:
         RIVER_REPO_ROOT: ${{ github.action_path }}/../..
         RIVER_OUTPUT_FORMAT: ${{ inputs.output_format }}
+        # Pass the deterministic-exec opt-in inputs via env (not inline ${{ }})
+        # so no input value is expanded into the shell script — the GitHub
+        # hardening pattern against script injection (#1401 (d) review).
+        INPUT_DETERMINISTIC_EXEC: ${{ inputs.deterministic_exec }}
+        INPUT_TRUSTED_TREE: ${{ inputs.trusted_tree }}
       run: |
         set -euo pipefail
         export RIVER_REPO_ROOT="$(cd "${RIVER_REPO_ROOT}" && pwd)"
@@ -103,10 +108,12 @@ runs:
         # (fail-safe): deterministic_exec=true AND trusted_tree resolves to an
         # existing directory. RIVER_TRUSTED_TREE is the SOLE allowlist source
         # (must be a host-trusted base checkout, never the reviewed target).
-        if [ "${{ inputs.deterministic_exec }}" = "true" ]; then
-          trusted_in="${{ inputs.trusted_tree }}"
+        if [ "${INPUT_DETERMINISTIC_EXEC}" = "true" ]; then
+          trusted_in="${INPUT_TRUSTED_TREE}"
           if [ -n "${trusted_in}" ] && [ -d "${trusted_in}" ]; then
-            trusted_abs="$(cd "${trusted_in}" && pwd)"
+            # `cd --` so a trusted_tree value beginning with '-' is treated as a
+            # path, not a cd option.
+            trusted_abs="$(cd -- "${trusted_in}" && pwd)"
             # Defense-in-depth: refuse to treat the reviewed target (PR head) as
             # the trusted allowlist source. If they resolve to the same path the
             # author has misconfigured trusted_tree, which would let an author

--- a/runners/github-action/action.yml
+++ b/runners/github-action/action.yml
@@ -54,6 +54,29 @@ inputs:
       results first, then set gate=true.
     required: false
     default: 'false'
+  deterministic_exec:
+    description: >-
+      Opt in to running skills' deterministicGate.command in a sandbox (#1401).
+      Default false — the command executor is never invoked and behavior is
+      unchanged. When true you MUST also pass trusted_tree; if it is empty or
+      missing, this input is ignored (fail-safe, executor stays off). The
+      allowlist is read ONLY from trusted_tree (the host-trusted base checkout),
+      never from the reviewed target, so an author under review cannot allowlist
+      their own command. Dark-launch: even when enabled the gate stays advisory
+      unless you also set gate=true, so an unrunnable/failed command surfaces as
+      ESCALATE/NO_GO in the report without failing the job.
+    required: false
+    default: 'false'
+  trusted_tree:
+    description: >-
+      Absolute path to a host-trusted BASE checkout of the repository, used only
+      when deterministic_exec=true as the sole source of the deterministic
+      allowlist (.river/deterministic-allowlist.yaml). Check the base ref out to
+      a separate path with actions/checkout (persist-credentials: false) and pass
+      that path here. Leave empty to keep the executor off. Never point this at
+      the PR-head checkout being reviewed (that would break the trust boundary).
+    required: false
+    default: ''
 outputs:
   json_path:
     description: 'Path to the JSON output file (only when output_format=json).'
@@ -74,6 +97,22 @@ runs:
         set -euo pipefail
         export RIVER_REPO_ROOT="$(cd "${RIVER_REPO_ROOT}" && pwd)"
         repo_path="$(cd "${{ inputs.target }}" && pwd)"
+
+        # #1401 §11.8 (d): deterministic-command executor opt-in (dark-launch,
+        # default OFF). Both conditions must hold or the executor stays off
+        # (fail-safe): deterministic_exec=true AND trusted_tree resolves to an
+        # existing directory. RIVER_TRUSTED_TREE is the SOLE allowlist source
+        # (must be a host-trusted base checkout, never the reviewed target).
+        if [ "${{ inputs.deterministic_exec }}" = "true" ]; then
+          trusted_in="${{ inputs.trusted_tree }}"
+          if [ -n "${trusted_in}" ] && [ -d "${trusted_in}" ]; then
+            export RIVER_TRUSTED_TREE="$(cd "${trusted_in}" && pwd)"
+            export RIVER_DETERMINISTIC_EXEC=1
+            echo "Deterministic exec: ON (trusted tree: ${RIVER_TRUSTED_TREE})"
+          else
+            echo "::warning::deterministic_exec=true but trusted_tree is empty or not a directory ('${trusted_in}'); deterministic command execution stays OFF (fail-safe)."
+          fi
+        fi
 
         # Validate output format
         output_fmt="${RIVER_OUTPUT_FORMAT}"


### PR DESCRIPTION
## 概要

#1401 §11.8 **(d)**: `action.yml` に opt-in 入力を追加し、(c) で配線済みの deterministic command executor を CI から利用可能にする。**既定 OFF・advisory の dark-launch**で、既存挙動は不変。

## 変更点

| 追加 input | 既定 | 役割 |
| --- | --- | --- |
| `deterministic_exec` | `'false'` | executor の opt-in。true でも trusted_tree が無ければ OFF |
| `trusted_tree` | `''` | ホスト信頼された **base checkout** パス。allowlist の唯一の読み元 |

CLI step で、`deterministic_exec=true` **かつ** `trusted_tree` が実在ディレクトリのときのみ `RIVER_DETERMINISTIC_EXEC=1` と `RIVER_TRUSTED_TREE` を export。欠ければ warning を出して executor は OFF のまま（fail-safe）。

## セキュリティ設計

- **トラスト境界**: trusted tree は composite action が推測せず、**呼び出し側が base ref を別パスに `persist-credentials: false` で checkout して渡す**。allowlist は base checkout の `.river/deterministic-allowlist.yaml` からのみ読まれ、レビュー対象（PR head）からは決して読まれない。
- **二重ゲート維持**: (c2) の `isDeterministicExecEnabled` 述語が両 env var を厳密検査。action は両 var を揃えるだけ。
- **advisory**: gate は既定 false のまま。`gate=true` を別途指定しない限り、unrunnable/fail はレポートに ESCALATE/NO_GO として出るがジョブは落ちない。

## 検証

- action.yml: YAML parse OK（14 inputs / 4 steps）、`prettier --check` pass
- `Meta consistency`: OK
- fail-safe 述語は既存 `tests/deterministic-exec-gate.test.mjs`（14 ケース）で担保
- action.yml は ncc バンドル対象外 → **dist 変更なし**（dist-bot 非発火）

## 呼び出し側の利用例

設計 doc §11.8 (d) に追記。base ref を別 checkout（`persist-credentials: false`）して `trusted_tree` に渡すパターン。

## これで #1401 の (a)〜(d) が全て完了

- (a) sandbox/env builder ✅ / (b) execFile executor ✅ / (c) gate 接続 ✅（#1432/#1434）/ (d) CI 配線 ✅（本 PR）