### PR TITLE
docs(loop): Claude Code loop 設計と既存契約の対応表を追記する (#1428)

### DIFF
--- a/pages/reference/loop-convergence-contract.md
+++ b/pages/reference/loop-convergence-contract.md
@@ -208,6 +208,21 @@ echo "MAX ITERATIONS reached: escalate to human" >&2
 exit 4
 ```
 
+## Claude Code loop 設計との対応（#1428）
+
+Claude Code の loop 設計（Goal-based loop / review-fix cycle / stop condition / finding classification）が扱う概念は、River Review では新しい語彙を作らず既存の仕組みへ写像されます。対応関係は次のとおりです。
+
+| Claude Code loop の概念                  | River Review の既存対応                                                                                      |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Goal-based loop の停止条件               | 本ドキュメントの「停止（収束）条件の複合式」（`critical + major == 0` かつ振動なし）が定義する               |
+| 最大 review-fix cycle                    | 「発散ガード」の `STOP_MAX_ITERATIONS`（`iteration_count >= max_iterations`）が上限を執行する                |
+| pass / needs_review / fail               | `gate.decision`（`GO` / `GO_WITH_OBSERVATION` は pass、`NO_GO` は needs_review、`ESCALATE` は fail・要人間） |
+| 指摘分類 blocking / important / optional | severity の `critical` / `major` / `minor`（`info` は参考）が対応する                                        |
+| 指摘分類 accepted-risk / deferred        | Riverbed Memory の suppression / WontFix が対応する                                                          |
+| 指摘分類 out-of-scope                    | 出力フォーマットの Follow-up Issues 節が対応する                                                             |
+
+review-fix cycle の既定回数は reference loop 実装の `resolveIterationLimit`（既定 5）が持ち、呼び出し側が調整します。3 回への固定は運用側の tunable であり、契約としては複合停止条件と上限の両立で過剰レビューを抑制します。Proactive loop（新規 PR のレビュー候補検出など）は本契約の対象外であり、安全境界は ADR-003 の Non-Goals（無承認の自動マージを行わない）が定めます。
+
 ## 関連ドキュメント
 
 - [AI 駆動開発プレイブック（Case 2 / Case 3）](../guides/ai-agent-playbook.md) — ケース別の呼び出し方


### PR DESCRIPTION
## 概要

#1428「Claude Code loop 設計を River Review へ取り込むか検討する」の検討結論 **「一部取り込む」** に基づく最小の明文化。

新規 doc 群（loop-design.md 等 4本）は作らず、`loop-convergence-contract.md` に **既存仕組みへの対応表 1 節** を追記する（#976/#1412 と同じ「新システムを作らず既存を束ねる」原則）。

## 対応写像

| Claude Code loop の概念 | River Review の既存対応 |
| --- | --- |
| Goal-based 停止条件 | 複合停止条件（`critical+major==0` かつ振動なし） |
| 最大 review-fix cycle | `STOP_MAX_ITERATIONS`（発散ガード） |
| pass/needs_review/fail | `gate.decision`（GO/NO_GO/ESCALATE） |
| blocking/important/optional | severity（critical/major/minor） |
| accepted-risk/deferred | Riverbed Memory（suppression/WontFix） |
| out-of-scope | Follow-up Issues 節 |

## 検証

- `textlint --no-cache`（pages/** は CI gate）: pass
- `prettier --check` / `check:dashes`: pass

## 完了

このマージで #1428 の受入基準（既存へのマッピング + 判断記録 + 反映先決定）を満たし、#1428 をクローズする。