### PR TITLE
ci(test): test-isolation=none で node:test IPC flake を根治する (#1415)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x]
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -45,21 +45,17 @@ jobs:
       - uses: ./.github/actions/setup-node-deps
         with:
           node-version: ${{ matrix.node-version }}
-      # Coverage is only uploaded for 22.x (see the Codecov step below), so
-      # collect it only there. Setting NODE_V8_COVERAGE enlarges the node:test
-      # child→parent IPC payload and aggravates a structured-clone deserialize
-      # flake ("Unable to deserialize cloned data"); the 20.x run gained nothing
-      # from coverage but paid that flake cost (#1415).
-      - name: Run unit tests (coverage on 22.x only)
-        run: |
-          if [ "${{ matrix.node-version }}" = "22.x" ]; then
-            NODE_V8_COVERAGE=coverage npm test
-          else
-            npm test
-          fi
+      # #1415 root fix: the "Unable to deserialize cloned data" flake is a
+      # node:test child→parent IPC (structured-clone) bug that is independent of
+      # coverage. `--experimental-test-isolation=none` runs every test file in a
+      # single process, removing the child→parent IPC entirely — the root cause,
+      # not just the coverage aggravator. This flag does not exist on Node 20.x,
+      # which is EOL (2026-04), so the matrix is pinned to 22.x. The full suite
+      # passes under single-process isolation (verified: no shared-state
+      # pollution). Coverage is safe to collect now (no children to serialize).
+      - name: Run unit tests (single-process isolation, #1415)
+        run: NODE_V8_COVERAGE=coverage node --experimental-test-isolation=none --test
       - name: Upload coverage to Codecov
-        # Coverage from one Node version is enough; skip the duplicate upload.
-        if: matrix.node-version == '22.x'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           directory: coverage

--- a/README.en.md
+++ b/README.en.md
@@ -235,7 +235,7 @@ Latest release: [v1.41.0](https://github.com/s977043/river-review/releases/lates
 
 ## Quick start (local)
 
-1. Environment: Node 22 required (`package.json` engines is `22.x`; CI runs on Node 22)
+1. Environment: Node 22 required (`package.json` `engines.node` is `22.x`; CI runs on Node 22)
 2. Install dependencies: `npm install`
 3. Validate skills: `npm run skills:validate`
 4. Validate Agent Skills (optional): `npm run agent-skills:validate`

--- a/README.en.md
+++ b/README.en.md
@@ -235,7 +235,7 @@ Latest release: [v1.41.0](https://github.com/s977043/river-review/releases/lates
 
 ## Quick start (local)
 
-1. Environment: Node 22+ recommended (CI runs on Node 22; Unit tests also validate Node 20.x)
+1. Environment: Node 22 required (`package.json` engines is `22.x`; CI runs on Node 22)
 2. Install dependencies: `npm install`
 3. Validate skills: `npm run skills:validate`
 4. Validate Agent Skills (optional): `npm run agent-skills:validate`

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ GitHub Actions では:
 
 ## クイックスタート（ローカル）
 
-1. 環境: Node 22 必須（`package.json` の engines は `22.x`、CI も Node 22 で運用）
+1. 環境: Node 22 必須（`package.json` の `engines.node` は `22.x`、CI も Node 22 で運用）
 2. 依存導入: `npm install`
 3. スキル検証: `npm run skills:validate`
 4. Agent Skills 検証（任意）: `npm run agent-skills:validate`

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ GitHub Actions では:
 
 ## クイックスタート（ローカル）
 
-1. 環境: Node 22+ 推奨（CI は主に Node 22 系で運用、Unit tests は 20.x も検証）
+1. 環境: Node 22 必須（`package.json` の engines は `22.x`、CI も Node 22 で運用）
 2. 依存導入: `npm install`
 3. スキル検証: `npm run skills:validate`
 4. Agent Skills 検証（任意）: `npm run agent-skills:validate`


### PR DESCRIPTION
## 概要

#1415 の flaky Unit tests（`Unable to deserialize cloned data`）を**根治**する。

## 根本原因と対処

この flake は node:test の **child→parent IPC（structured-clone）バグ**で、coverage 非依存（M1 適用後も 20.x で再発）。`--experimental-test-isolation=none` で全テストを**単一プロセス実行**し、子プロセス IPC 自体を排除する＝根治。

## 変更点

| 項目 | 変更 |
| --- | --- |
| matrix | `[20.x, 22.x]` → `[22.x]` |
| test 実行 | `NODE_V8_COVERAGE=coverage node --experimental-test-isolation=none --test` |
| README (ja/en) | 「Unit tests は 20.x も検証」→ Node 22 のみへ訂正 |

## Node 20.x drop の妥当性

- isolation フラグは **Node 20.x に存在しない**（根治不可）
- **Node 20 は 2026-04 EOL 済み**
- `package.json` engines は**既に `22.x`**（20.x テストは engines と不整合だった）
- branch protection の required から `Unit tests (20.x)` は**削除済み**（本 PR マージ前に実施）

## 検証（ローカル node@22）

- `node --experimental-test-isolation=none --test`: **2000/2000 pass**（状態汚染なし）
- `NODE_V8_COVERAGE=coverage` 併用: **2000/2000 pass、coverage 36 ファイル生成**

## 残（監視）

長期での再発は今後の CI 実行で確認。単一プロセス化で子プロセス IPC は構造的に消えるため、同署名の再発は起きない見込み。