### PR TITLE
docs: plugin アセット登録 checklist と /register-plugin-asset コマンドを追加する

### DIFF
--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -2,13 +2,14 @@
 
 Repo-development slash commands (NOT part of the distributed plugin surface).
 
-| Command                | File                     | Purpose                                                                 |
-| ---------------------- | ------------------------ | ----------------------------------------------------------------------- |
-| `/propose-issue`       | `propose-issue.md`       | Research codebase before creating an issue                              |
-| `/plan-merge-order`    | `plan-merge-order.md`    | Plan merge order for multiple PRs to minimize rebase cost               |
-| `/preflight`           | `preflight.md`           | Verify tasks are not obsolete or in parallel before work                |
-| `/verify-agent-report` | `verify-agent-report.md` | Verify agent completion reports against real branches, PRs, and commits |
-| `/merge-check`         | `merge-check.md`         | Run the pre-merge checklist (docs/governance.md) against a PR number    |
+| Command                  | File                       | Purpose                                                                                     |
+| ------------------------ | -------------------------- | ------------------------------------------------------------------------------------------- |
+| `/propose-issue`         | `propose-issue.md`         | Research codebase before creating an issue                                                  |
+| `/plan-merge-order`      | `plan-merge-order.md`      | Plan merge order for multiple PRs to minimize rebase cost                                   |
+| `/preflight`             | `preflight.md`             | Verify tasks are not obsolete or in parallel before work                                    |
+| `/verify-agent-report`   | `verify-agent-report.md`   | Verify agent completion reports against real branches, PRs, and commits                     |
+| `/merge-check`           | `merge-check.md`           | Run the pre-merge checklist (docs/governance.md) against a PR number                        |
+| `/register-plugin-asset` | `register-plugin-asset.md` | Register a new distributed command/agent/agent-skill into the plugin manifests and validate |
 
 > **配布対象のコマンド** (`/check` `/pr` `/skill` `/review-local` `/challenge`) は #996 で top-level [`commands/`](../../commands/) へ分離し、`.claude-plugin/plugin.json` がそこを参照します。本ディレクトリには repo-dev 専用コマンドのみが残ります。
 >

--- a/.claude/commands/register-plugin-asset.md
+++ b/.claude/commands/register-plugin-asset.md
@@ -1,7 +1,7 @@
 ---
 description: 新しい配布 command / agent / agent-skill を plugin manifest に登録し、検証シーケンスまで実行する
 argument-hint: '[command|agent|skill] <name>'
-allowed-tools: Bash(npm run plugin:validate:*), Bash(npm run plugin:sync:check:*), Bash(npm run agent-skills:validate:*), Bash(npm run meta:validate:*), Bash(ls:*), Bash(git status:*), Bash(git diff:*), Read, Edit
+allowed-tools: Bash(npm run plugin:validate:*), Bash(npm run plugin:sync*), Bash(npm run agent-skills:validate:*), Bash(npm run meta:validate:*), Bash(ls:*), Bash(git status:*), Bash(git diff:*), Read, Edit
 ---
 
 新しい配布アセット（command / agent / agent-skill）を plugin manifest に登録し、検証まで通す。手順の SSoT は `docs/development/plugin-asset-registration-checklist.md` にあり、本コマンドはその実行手順の具体化のみを担う。$ARGUMENTS で種別と名前を受け取る（省略時は `git status` の差分から種別を推定する）。

--- a/.claude/commands/register-plugin-asset.md
+++ b/.claude/commands/register-plugin-asset.md
@@ -1,7 +1,7 @@
 ---
 description: 新しい配布 command / agent / agent-skill を plugin manifest に登録し、検証シーケンスまで実行する
 argument-hint: '[command|agent|skill] <name>'
-allowed-tools: Bash(npm run plugin:validate:*), Bash(npm run plugin:sync*), Bash(npm run agent-skills:validate:*), Bash(npm run meta:validate:*), Bash(ls:*), Bash(git status:*), Bash(git diff:*), Read, Edit
+allowed-tools: Bash(npm run plugin:validate:*), Bash(npm run plugin:sync), Bash(npm run plugin:sync:*), Bash(npm run agent-skills:validate:*), Bash(npm run meta:validate:*), Bash(ls:*), Bash(git status:*), Bash(git diff:*), Read, Edit
 ---
 
 新しい配布アセット（command / agent / agent-skill）を plugin manifest に登録し、検証まで通す。手順の SSoT は `docs/development/plugin-asset-registration-checklist.md` にあり、本コマンドはその実行手順の具体化のみを担う。$ARGUMENTS で種別と名前を受け取る（省略時は `git status` の差分から種別を推定する）。

--- a/.claude/commands/register-plugin-asset.md
+++ b/.claude/commands/register-plugin-asset.md
@@ -1,0 +1,85 @@
+---
+description: 新しい配布 command / agent / agent-skill を plugin manifest に登録し、検証シーケンスまで実行する
+argument-hint: '[command|agent|skill] <name>'
+allowed-tools: Bash(npm run plugin:validate:*), Bash(npm run plugin:sync:check:*), Bash(npm run agent-skills:validate:*), Bash(npm run meta:validate:*), Bash(ls:*), Bash(git status:*), Bash(git diff:*), Read, Edit
+---
+
+新しい配布アセット（command / agent / agent-skill）を plugin manifest に登録し、検証まで通す。手順の SSoT は `docs/development/plugin-asset-registration-checklist.md` にあり、本コマンドはその実行手順の具体化のみを担う。$ARGUMENTS で種別と名前を受け取る（省略時は `git status` の差分から種別を推定する）。
+
+## Step 0. 配布面か非配布面かを判定
+
+```bash
+git status --short
+```
+
+- 追加ファイルが `commands/*.md`・`agents/*.md`・`skills/agent-skills/**` のいずれかを確認する
+- `.claude/commands/*.md` はリポ開発専用で**配布されない**。この場合 manifest 登録は不要と報告して終了する（`skills/{upstream,midstream,downstream}/` も plugin `skills` の対象外＝別系統）
+- 判定基準の詳細は checklist の「配布面と非配布面の区別」表を正とする
+
+## Step 1. 種別ごとの manifest 登録
+
+### command（`commands/<name>.md`）
+
+`.claude-plugin/plugin.json` の `commands[]` に `"./commands/<name>.md"` を追加する（`README.md` は登録しない）。`.codex-plugin/plugin.json` に commands フィールドはないため対応不要。
+
+- CLAUDE.md「Custom Commands」表と `commands/README.md` が列挙形式なら説明を追記する
+
+### agent（`agents/<name>.md`）
+
+`.claude-plugin/plugin.json` の `agents` を確認する。現在は単一文字列（`"./agents/river-review.md"`）のため、2つ目を足すときは**配列化**する:
+
+```jsonc
+"agents": ["./agents/river-review.md", "./agents/<name>.md"]
+```
+
+- 単一文字列のまま新 agent を足すと解決されない。plugin-manifest スキーマ（`$schema`）が配列を許容することを Read で確認する
+
+### agent-skill（`skills/agent-skills/<name>/SKILL.md`）
+
+両 manifest の `skills` は**ディレクトリ参照**（`"./skills/agent-skills/"`）のため、manifest 編集は不要。ディレクトリ配置だけで自動包含される。
+
+- ディレクトリ名が kebab-case で frontmatter `metadata.name` と一致することを Read で確認する
+
+## Step 2. フィールドを追加・変更した場合の追加対応
+
+manifest に新しい「フィールド」を足した／値を変えた場合（ファイル追加だけでなく）:
+
+- 外部 bundle（awesome-codex-plugins fork の `plugin.json`）にも同じ変更を反映する（CLAUDE.md「Plugin bundle mirror」）。反映は同 PR で行う
+- `package.json` SSoT の同期フィールド（keywords / homepage / author / license）は手編集せず、`npm run plugin:sync` で反映する
+
+## Step 3. 検証シーケンス
+
+```bash
+npm run plugin:validate
+npm run plugin:sync:check
+npm run agent-skills:validate   # agent-skill を触った場合のみ
+npm run meta:validate
+```
+
+- 全て pass を確認する。fail は該当項目を修正してから再実行する
+- `plugin:validate` が「参照パス不在」で落ちる＝登録漏れ or パス誤り。`plugin:sync:check` の drift＝同期フィールドの手編集を疑う
+
+## 判定
+
+### A. REGISTERED
+
+条件: Step 1 の manifest 登録が完了し、Step 3 の検証が全て pass。
+
+対応: 追加したアセット種別・manifest の差分（`git diff .claude-plugin/ .codex-plugin/`）・検証結果を添えて報告する。
+
+### B. INCOMPLETE
+
+条件: 登録漏れ or 検証 fail が残る。
+
+対応: 未達を種別付きで全件列挙し、それぞれの解消アクション（manifest 追記 / 配列化 / frontmatter 修正 / bundle mirror）を提示する。解消後に本コマンドを再実行する。
+
+## 禁止事項
+
+- `.claude/commands/` などの非配布アセットを manifest に登録してはならない
+- `commands[]` への追記を忘れたまま REGISTERED と判定してはならない（`plugin:validate` は逆ドリフトを検知しないため、本チェックリストで担保する）
+- 同期フィールド（keywords / homepage / author / license）を manifest 側で手編集してはならない（`plugin:sync` を使う）
+- 本コマンドの手順と `docs/development/plugin-asset-registration-checklist.md` が食い違う場合、checklist を正としてこちらを修正する
+
+## なぜこのコマンドが必要か
+
+plugin manifest はアセット種別ごとに参照方式が異なる（commands=明示列挙 / agents=単一文字列 / skills=ディレクトリ参照）。`plugin:validate` は「参照先の実在」しか見ないため、**ファイルを足したのに manifest へ登録し忘れる逆ドリフト**を機械検知できない。`/merge-check` `/preflight` と同様、登録手順を 1 コマンドの決定論チェックリストに落とすことで、配布アセット追加のたびに登録と検証を確実に通す。

--- a/docs/development/plugin-asset-registration-checklist.md
+++ b/docs/development/plugin-asset-registration-checklist.md
@@ -1,0 +1,72 @@
+# Plugin アセット登録チェックリスト
+
+新しい command / agent / agent-skill を追加したとき、plugin manifest（`.claude-plugin/plugin.json` / `.codex-plugin/plugin.json`）への登録と検証を漏れなく行うためのチェックリストです。`/register-plugin-asset` コマンドはこの手順を実行します。
+
+## 背景
+
+配布 plugin の manifest は、参照方式がアセット種別ごとに異なる。
+
+- **commands**: `.claude-plugin/plugin.json` の `commands[]` に `./commands/<name>.md` を**明示列挙**する。追加しても列挙し忘れると、plugin インストール時にそのコマンドが解決されない（silent drop）。
+- **agents**: `.claude-plugin/plugin.json` の `agents` は現在**単一文字列**（`./agents/river-review.md`）。2つ目の配布 agent を足すときは配列化が要る。
+- **skills**: 両 manifest の `skills` は**ディレクトリ参照**（`./skills/agent-skills/`）。配下に新しい agent-skill を足せば自動包含されるが、frontmatter 検証は別途必要。
+
+`npm run plugin:validate` は「manifest が参照するパスの実在」は検査しますが、逆（ファイルを足したのに manifest 未登録）は検査しません。この漏れを防ぐのが本チェックリストの主目的です。
+
+## 配布面と非配布面の区別（最初に確認）
+
+| 置き場所                                  | 配布                     | plugin manifest 登録                                                         |
+| ----------------------------------------- | ------------------------ | ---------------------------------------------------------------------------- |
+| `commands/*.md`（top-level）              | される                   | **必要**（`.claude-plugin` の `commands[]`）                                 |
+| `agents/*.md`（top-level）                | される                   | **必要**（`.claude-plugin` の `agents`）                                     |
+| `skills/agent-skills/<name>/`             | される                   | ディレクトリ参照で**自動**（frontmatter 検証は必要）                         |
+| `.claude/commands/*.md`                   | されない（リポ開発専用） | 不要                                                                         |
+| `skills/{upstream,midstream,downstream}/` | される（Skill Registry） | plugin `skills` の対象外（agent-skills のみ）。`skills/registry.yaml` の対象 |
+
+`#996` により、配布 plugin の command/agent は top-level（`commands/` `agents/`）に置きます。リポ開発専用コマンド（`/merge-check` 等）は `.claude/commands/` に置き、manifest には登録しません。
+
+## チェックリスト
+
+### 新しい配布 command（`commands/<name>.md`）を追加した場合
+
+- [ ] `.claude-plugin/plugin.json` の `commands[]` に `"./commands/<name>.md"` を追加した（`README.md` は登録しない）
+- [ ] `.codex-plugin/plugin.json` には commands フィールドがない（対応不要）
+- [ ] CLAUDE.md「Custom Commands」表と `commands/README.md` に説明を追記した（列挙している場合）
+- [ ] `npm run plugin:validate` が pass する
+
+### 新しい配布 agent（`agents/<name>.md`）を追加した場合
+
+- [ ] `.claude-plugin/plugin.json` の `agents` を配列化し `"./agents/<name>.md"` を追加した（単一文字列のままだと新 agent が解決されない）
+- [ ] plugin-manifest スキーマ（`$schema`）が `agents` の配列形式を許容することを確認した
+- [ ] `npm run plugin:validate` が pass する
+
+### 新しい agent-skill（`skills/agent-skills/<name>/SKILL.md`）を追加した場合
+
+- [ ] ディレクトリ名 `<name>` が kebab-case で、frontmatter `metadata.name` と一致する
+- [ ] `npm run agent-skills:validate` が pass する（frontmatter 必須: `metadata.name` / `metadata.description`）
+- [ ] `skills` はディレクトリ参照のため manifest 編集は不要（新規登録の manifest 差分は出ない）
+- [ ] `npm run plugin:validate` が pass する
+
+### manifest の「フィールド」を追加・変更した場合（ファイル追加だけでなく）
+
+- [ ] 外部 bundle（awesome-codex-plugins fork の `plugin.json`）にも同じフィールドを反映した（CLAUDE.md「Plugin bundle mirror」）
+- [ ] cross-manifest parity 対象フィールド（repository / skills / displayName / composerIcon / homepage↔websiteURL / author.name↔developerName）を両 manifest で一致させた
+- [ ] `package.json` を SSoT とする同期フィールド（keywords / homepage / author / license）は手編集せず `npm run plugin:sync` で反映した
+
+## 検証シーケンス（共通・登録後に必ず実行）
+
+```bash
+npm run plugin:validate       # manifest 参照の実在・parity・allowlist
+npm run plugin:sync:check     # package.json とのフィールド drift 検出
+npm run agent-skills:validate # agent-skill を触った場合
+npm run meta:validate         # メタ整合
+```
+
+いずれかが fail した場合はマージせず、該当項目を修正してから再実行します。
+
+## 関連
+
+- `scripts/validate-plugin-manifest.mjs`（`plugin:validate`）
+- `scripts/sync-plugin-fields.mjs`（`plugin:sync` / `plugin:sync:check`）
+- CLAUDE.md「AI Misoperation Guards」>「Plugin bundle mirror」
+- `release-please-config.json` の `extra-files`（version bump は release-please が両 manifest へ反映）
+- `pages/guides/add-new-skill.md`（skill 本体の作成手順）

--- a/docs/development/plugin-asset-registration-checklist.md
+++ b/docs/development/plugin-asset-registration-checklist.md
@@ -41,6 +41,7 @@
 
 ### 新しい agent-skill（`skills/agent-skills/<name>/SKILL.md`）を追加した場合
 
+- [ ] ディレクトリに `SKILL.md` が実在する（丸ごと無い / `skill.md` 等の誤名・大小文字違いの dir は `agent-skills:validate` / `plugin:validate` のどちらでも検出されず silent skip となり、スキルが無言で no-ship される）
 - [ ] ディレクトリ名 `<name>` が kebab-case で、frontmatter `metadata.name` と一致する
 - [ ] `npm run agent-skills:validate` が pass する（frontmatter 必須: `metadata.name` / `metadata.description`）
 - [ ] `skills` はディレクトリ参照のため manifest 編集は不要（新規登録の manifest 差分は出ない）
@@ -51,6 +52,14 @@
 - [ ] 外部 bundle（awesome-codex-plugins fork の `plugin.json`）にも同じフィールドを反映した（CLAUDE.md「Plugin bundle mirror」）
 - [ ] cross-manifest parity 対象フィールド（repository / skills / displayName / composerIcon / homepage↔websiteURL / author.name↔developerName）を両 manifest で一致させた
 - [ ] `package.json` を SSoT とする同期フィールド（keywords / homepage / author / license）は手編集せず `npm run plugin:sync` で反映した
+
+### その他 validator が検査するサーフェス（種別として明示）
+
+逆ドリフト検査（`checkAssetRegistration`）の対象は commands / agents のみです。以下は主要 asset ではありませんが、変更時に `plugin:validate` が検査するため登録漏れの対象になります。
+
+- **hooks**: manifest に `hooks` フィールドは現状未配布。配布 hooks を足す場合は `hooks` フィールドの登録が要る（逆ドリフト検査は commands/agents のみで、hooks は forward 検査のみ）
+- **marketplace.json**: plugin 名をリネームした場合、`.claude-plugin/marketplace.json` の `plugins[].name` も更新する（`plugin:validate` が不一致を検出する）
+- **assets**: `composerIcon`（`assets/icon.svg`）のパスを変えた場合、両 manifest と実ファイルを一致させる（`plugin:validate` が実在を検査する）
 
 ## 検証シーケンス（共通・登録後に必ず実行）
 


### PR DESCRIPTION
## Summary

新しい配布 command / agent / agent-skill を追加したときに、plugin manifest（\`.claude-plugin/plugin.json\` / \`.codex-plugin/plugin.json\`）への **登録漏れ（逆ドリフト）** を防ぐための決定論チェックリストと、それを実行する repo-dev コマンドを新設する。

「Plugin 更新のための skill / agent / workflow を新設したい」という要望に対する **PR1（skill=コマンド + doc）**。

### 追加物
- \`docs/development/plugin-asset-registration-checklist.md\` — 登録手順の SSoT。配布面/非配布面の区別、種別ごとの manifest 登録方法（commands=明示列挙 / agents=単一文字列→配列化 / skills=ディレクトリ参照で自動包含）、検証シーケンス
- \`.claude/commands/register-plugin-asset.md\` — checklist を実行する \`/register-plugin-asset\` コマンド（\`/merge-check\` \`/preflight\` と同じ repo-dev コマンド枠）
- \`.claude/commands/README.md\` — コマンド一覧に追記

### 背景
\`plugin:validate\` は「manifest が参照するパスの実在」しか検査せず、逆（ファイルを足したのに manifest 未登録）を機械検知しない。この隙間を手順で埋める。逆ドリフトの **CI 自動ガード化は PR2**（\`scripts/validate-plugin-manifest.mjs\` 拡張）として別途提出予定。

### 設計判断
- 「skill」はこのリポの \`skills/\`（レビュー観点 skill・厳格スキーマ）には合わないため、\`.claude/commands/\` のコマンドとして実装（手順系の正しいマッピング）
- agent は原則不要（配布 agent 面はレビュー agent 専用。実行時に general-purpose へ委譲すれば足りる）

## Test plan
- [x] \`npx textlint --no-cache\`（新規 docs + コマンド）→ pass
- [x] \`prettier --check\` → pass
- [x] \`markdownlint\` → pass
- [x] \`node scripts/fix-dashes.mjs --check\` → 正規化不要
- [x] \`node scripts/check-doc-placement.mjs\` → 0 violations

## Follow-up（承認要）
- CLAUDE.md「Custom Commands」表への \`/register-plugin-asset\` 追記（CLAUDE.md は Always-ask スコープのため別途承認後）
- PR2: \`plugin:validate\` への逆ドリフト検査追加（plugin/schema 面のため別 PR）

🤖 Generated with [Claude Code](https://claude.com/claude-code)