### PR TITLE
feat(plugin): plugin:validate に command/agent の逆ドリフト検査を追加する

### DIFF
--- a/scripts/validate-plugin-manifest.mjs
+++ b/scripts/validate-plugin-manifest.mjs
@@ -200,12 +200,15 @@ export function checkAssetRegistration(ccManifest, { commandFiles = [], agentFil
 
   // Defensive: ccManifest is normally a $schema-validated manifest object, but
   // this is an exported entry point that may receive arbitrary input. Treat a
-  // non-array `commands` / non-string-or-array `agents` as "nothing registered"
-  // rather than throwing on .map.
+  // non-array `commands` / non-string-or-array `agents`, and any non-string
+  // array element, as "nothing registered" rather than throwing on .map.
   const manifest = ccManifest && typeof ccManifest === 'object' ? ccManifest : {};
+  const toRefSet = (value) => {
+    const list = typeof value === 'string' ? [value] : Array.isArray(value) ? value : [];
+    return new Set(list.filter((ref) => typeof ref === 'string').map(normalizeRef));
+  };
 
-  const commandRefs = Array.isArray(manifest.commands) ? manifest.commands : [];
-  const registeredCommands = new Set(commandRefs.map(normalizeRef));
+  const registeredCommands = toRefSet(manifest.commands);
   for (const file of commandFiles) {
     if (file === 'README.md') continue;
     if (!registeredCommands.has(`commands/${file}`)) {
@@ -216,13 +219,7 @@ export function checkAssetRegistration(ccManifest, { commandFiles = [], agentFil
     }
   }
 
-  const agentRefs =
-    typeof manifest.agents === 'string'
-      ? [manifest.agents]
-      : Array.isArray(manifest.agents)
-        ? manifest.agents
-        : [];
-  const registeredAgents = new Set(agentRefs.map(normalizeRef));
+  const registeredAgents = toRefSet(manifest.agents);
   for (const file of agentFiles) {
     if (file === 'README.md') continue;
     if (!registeredAgents.has(`agents/${file}`)) {

--- a/scripts/validate-plugin-manifest.mjs
+++ b/scripts/validate-plugin-manifest.mjs
@@ -36,6 +36,19 @@ function normalizeRef(ref) {
 }
 
 /**
+ * List top-level `*.md` files (not recursing into subdirectories) under a
+ * repo-relative directory. Returns basenames (e.g. "pr.md"). Missing dir → [].
+ */
+async function listMarkdownFiles(dir) {
+  try {
+    const entries = await fs.readdir(path.join(ROOT, dir), { withFileTypes: true });
+    return entries.filter((e) => e.isFile() && e.name.endsWith('.md')).map((e) => e.name);
+  } catch {
+    return [];
+  }
+}
+
+/**
  * Distribution-bundle field allowlist for .codex-plugin/plugin.json (#1250).
  *
  * The external `awesome-codex-plugins` fork carries a bundle copy of this
@@ -169,9 +182,55 @@ export function checkCrossManifestParity(ccManifest, codexManifest) {
 }
 
 /**
+ * Reverse-drift check: every distributed command/agent file on disk must be
+ * registered in the .claude-plugin manifest. `validatePluginManifest` only
+ * checks the forward direction (manifest refs exist), so a newly added
+ * `commands/<name>.md` or `agents/<name>.md` that the author forgot to list is
+ * silently unshipped. This closes that gap (plugin asset registration
+ * checklist: docs/development/plugin-asset-registration-checklist.md).
+ *
+ * `commandFiles` / `agentFiles` are injected basename lists (e.g. "pr.md") to
+ * keep this pure and testable; the caller supplies the real directory listing.
+ * `README.md` is never a distributed asset and is excluded.
+ *
+ * Pure function; returns array of error strings (empty = pass).
+ */
+export function checkAssetRegistration(ccManifest, { commandFiles = [], agentFiles = [] } = {}) {
+  const errors = [];
+
+  const registeredCommands = new Set((ccManifest.commands || []).map(normalizeRef));
+  for (const file of commandFiles) {
+    if (file === 'README.md') continue;
+    if (!registeredCommands.has(`commands/${file}`)) {
+      errors.push(
+        `.claude-plugin/plugin.json: commands/${file} exists but is not registered in "commands[]" — ` +
+          `add "./commands/${file}" (see docs/development/plugin-asset-registration-checklist.md)`
+      );
+    }
+  }
+
+  const agentRefs =
+    typeof ccManifest.agents === 'string' ? [ccManifest.agents] : ccManifest.agents || [];
+  const registeredAgents = new Set(agentRefs.map(normalizeRef));
+  for (const file of agentFiles) {
+    if (file === 'README.md') continue;
+    if (!registeredAgents.has(`agents/${file}`)) {
+      errors.push(
+        `.claude-plugin/plugin.json: agents/${file} exists but is not referenced by "agents" — ` +
+          `add "./agents/${file}" (see docs/development/plugin-asset-registration-checklist.md)`
+      );
+    }
+  }
+
+  return errors;
+}
+
+/**
  * Validate the Claude Code + Codex plugin manifests and the marketplace
  * manifest against the repository:
  *  - every component path referenced by .claude-plugin/plugin.json exists
+ *  - every on-disk distributed command/agent file is registered in the
+ *    manifest (reverse drift; checkAssetRegistration)
  *  - .claude-plugin and .codex-plugin manifest versions match package.json
  *  - marketplace plugins[].name matches the plugin manifest name
  *  - the Codex manifest's skills path exists
@@ -261,6 +320,11 @@ export async function validatePluginManifest() {
       }
     }
   }
+
+  // --- Reverse drift: on-disk command/agent files must be registered ---
+  const commandFiles = await listMarkdownFiles('commands');
+  const agentFiles = await listMarkdownFiles('agents');
+  errors.push(...checkAssetRegistration(ccManifest, { commandFiles, agentFiles }));
 
   // --- Marketplace: plugins[].name matches manifest name ---
   const entry = (marketplace.plugins || []).find((p) => p.name === ccManifest.name);

--- a/scripts/validate-plugin-manifest.mjs
+++ b/scripts/validate-plugin-manifest.mjs
@@ -198,7 +198,14 @@ export function checkCrossManifestParity(ccManifest, codexManifest) {
 export function checkAssetRegistration(ccManifest, { commandFiles = [], agentFiles = [] } = {}) {
   const errors = [];
 
-  const registeredCommands = new Set((ccManifest.commands || []).map(normalizeRef));
+  // Defensive: ccManifest is normally a $schema-validated manifest object, but
+  // this is an exported entry point that may receive arbitrary input. Treat a
+  // non-array `commands` / non-string-or-array `agents` as "nothing registered"
+  // rather than throwing on .map.
+  const manifest = ccManifest && typeof ccManifest === 'object' ? ccManifest : {};
+
+  const commandRefs = Array.isArray(manifest.commands) ? manifest.commands : [];
+  const registeredCommands = new Set(commandRefs.map(normalizeRef));
   for (const file of commandFiles) {
     if (file === 'README.md') continue;
     if (!registeredCommands.has(`commands/${file}`)) {
@@ -210,7 +217,11 @@ export function checkAssetRegistration(ccManifest, { commandFiles = [], agentFil
   }
 
   const agentRefs =
-    typeof ccManifest.agents === 'string' ? [ccManifest.agents] : ccManifest.agents || [];
+    typeof manifest.agents === 'string'
+      ? [manifest.agents]
+      : Array.isArray(manifest.agents)
+        ? manifest.agents
+        : [];
   const registeredAgents = new Set(agentRefs.map(normalizeRef));
   for (const file of agentFiles) {
     if (file === 'README.md') continue;

--- a/tests/validate-plugin-manifest.test.mjs
+++ b/tests/validate-plugin-manifest.test.mjs
@@ -4,6 +4,7 @@ import {
   validatePluginManifest,
   checkBundleFieldAllowlist,
   checkCrossManifestParity,
+  checkAssetRegistration,
 } from '../scripts/validate-plugin-manifest.mjs';
 
 test('validatePluginManifest passes on current repo state', async () => {
@@ -123,4 +124,57 @@ test('checkBundleFieldAllowlist reports null listing-required field', () => {
   const errors = checkBundleFieldAllowlist(codex);
   assert.equal(errors.length, 1);
   assert.match(errors[0], /required bundle field "license"/);
+});
+
+test('checkAssetRegistration passes when every command/agent file is registered', () => {
+  const cc = {
+    commands: ['./commands/pr.md', './commands/check.md'],
+    agents: './agents/river-review.md',
+  };
+  const errors = checkAssetRegistration(cc, {
+    commandFiles: ['pr.md', 'check.md', 'README.md'],
+    agentFiles: ['river-review.md'],
+  });
+  assert.deepEqual(errors, [], `Expected no errors but got: ${errors.join(', ')}`);
+});
+
+test('checkAssetRegistration detects an unregistered command file', () => {
+  const cc = { commands: ['./commands/pr.md'], agents: './agents/river-review.md' };
+  const errors = checkAssetRegistration(cc, {
+    commandFiles: ['pr.md', 'new-cmd.md'],
+    agentFiles: ['river-review.md'],
+  });
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /commands\/new-cmd\.md exists but is not registered/);
+});
+
+test('checkAssetRegistration never flags README.md', () => {
+  const cc = { commands: [], agents: [] };
+  const errors = checkAssetRegistration(cc, {
+    commandFiles: ['README.md'],
+    agentFiles: ['README.md'],
+  });
+  assert.deepEqual(errors, [], `Expected no errors but got: ${errors.join(', ')}`);
+});
+
+test('checkAssetRegistration detects an unregistered agent file', () => {
+  const cc = { commands: [], agents: './agents/river-review.md' };
+  const errors = checkAssetRegistration(cc, {
+    commandFiles: [],
+    agentFiles: ['river-review.md', 'extra-agent.md'],
+  });
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /agents\/extra-agent\.md exists but is not referenced/);
+});
+
+test('checkAssetRegistration accepts agents declared as an array', () => {
+  const cc = {
+    commands: [],
+    agents: ['./agents/river-review.md', './agents/extra-agent.md'],
+  };
+  const errors = checkAssetRegistration(cc, {
+    commandFiles: [],
+    agentFiles: ['river-review.md', 'extra-agent.md'],
+  });
+  assert.deepEqual(errors, [], `Expected no errors but got: ${errors.join(', ')}`);
 });

--- a/tests/validate-plugin-manifest.test.mjs
+++ b/tests/validate-plugin-manifest.test.mjs
@@ -193,4 +193,14 @@ test('checkAssetRegistration tolerates unexpected field/manifest types without t
     const errors = checkAssetRegistration(null, { commandFiles: ['x.md'], agentFiles: [] });
     assert.equal(errors.length, 1);
   });
+  // Non-string array elements are skipped, not passed to normalizeRef (no throw).
+  assert.doesNotThrow(() => {
+    const errors = checkAssetRegistration(
+      { commands: [123, null, './commands/pr.md'], agents: [{}, './agents/river-review.md'] },
+      { commandFiles: ['pr.md', 'other.md'], agentFiles: ['river-review.md'] }
+    );
+    // pr.md / river-review.md registered (valid string refs); only other.md flagged.
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /commands\/other\.md/);
+  });
 });

--- a/tests/validate-plugin-manifest.test.mjs
+++ b/tests/validate-plugin-manifest.test.mjs
@@ -178,3 +178,19 @@ test('checkAssetRegistration accepts agents declared as an array', () => {
   });
   assert.deepEqual(errors, [], `Expected no errors but got: ${errors.join(', ')}`);
 });
+
+test('checkAssetRegistration tolerates unexpected field/manifest types without throwing (gemini #1443)', () => {
+  // commands/agents of unexpected types → treated as "nothing registered".
+  assert.doesNotThrow(() => {
+    const errors = checkAssetRegistration(
+      { commands: { not: 'an array' }, agents: 42 },
+      { commandFiles: ['new-cmd.md'], agentFiles: ['new-agent.md'] }
+    );
+    assert.equal(errors.length, 2);
+  });
+  // null manifest → no throw, no registrations.
+  assert.doesNotThrow(() => {
+    const errors = checkAssetRegistration(null, { commandFiles: ['x.md'], agentFiles: [] });
+    assert.equal(errors.length, 1);
+  });
+});


### PR DESCRIPTION
## Summary

「Plugin 更新のための skill / agent / workflow」要望の **PR2（workflow=CI 自動ガード）**。`#1442`（PR1: 登録 checklist + `/register-plugin-asset` コマンド）を **CI ガードで裏打ち**する。

`validatePluginManifest` は manifest→ディスクの前方向（参照先の実在）しか検査せず、逆（`commands/*.md`・`agents/*.md` を追加したのに `.claude-plugin/plugin.json` へ登録し忘れ）を見逃していた。この場合、配布アセットが silent に unship される。本 PR で逆ドリフトを CI で機械検知する。

### 変更
- \`checkAssetRegistration(ccManifest, { commandFiles, agentFiles })\` — 注入した file リストで判定する **pure 関数**（既存の \`checkCrossManifestParity\` 等と同じテスト容易な設計）
- \`listMarkdownFiles(dir)\` — top-level \`*.md\` を列挙する helper（サブディレクトリは再帰しない）
- \`validatePluginManifest()\` が実ディレクトリ（\`commands/\` \`agents/\`）を読んで注入
- \`README.md\` は配布対象外として除外。\`agents\` は単一文字列/配列の両形式に対応

### テスト（5件追加）
- 全登録済みで pass / 未登録 command 検出 / README.md 除外 / 未登録 agent 検出 / agents 配列形式で pass

## Test plan
- [x] \`npm run plugin:validate\`（現行 main 状態）→ \`Plugin manifest: OK\`（新チェックが既存状態を壊さないことを確認）
- [x] \`node --test tests/validate-plugin-manifest.test.mjs\` → 16/16 pass
- [x] \`npm run lint:code\` → OK
- [x] \`prettier --check\` → OK
- （Node 22.22.2 / npm 10.9.7、.nvmrc 準拠で実行）

## 関連
- PR1: #1442（登録 checklist + \`/register-plugin-asset\` コマンド）
- 責務分界（#1070）: 決定論で判定できる登録漏れは静的解析（本 PR）、意味的整合は AI レビューへ

🤖 Generated with [Claude Code](https://claude.com/claude-code)