### PR TITLE
docs: CLAUDE.md の Custom Commands 表に /register-plugin-asset を追記する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,19 +70,20 @@ When a retrospective identifies a recurring mistake or missing guardrail, follow
 
 ## Custom Commands
 
-| Command                | Purpose                                                                 |
-| ---------------------- | ----------------------------------------------------------------------- |
-| `/check`               | Run quality checks (lint + test)                                        |
-| `/pr`                  | Draft PR description                                                    |
-| `/skill`               | Find or create skill definition                                         |
-| `/review-local`        | Self-review current diff                                                |
-| `/challenge`           | Adversarial review (pre-mortem, war game)                               |
-| `/propose-issue`       | Research codebase before creating an issue                              |
-| `/plan-merge-order`    | Plan merge order for multiple PRs to minimize rebase cost               |
-| `/preflight`           | Verify tasks are not obsolete or in parallel before work                |
-| `/verify-agent-report` | Verify agent completion reports against real branches, PRs, and commits |
-| `/merge-check`         | Run the pre-merge checklist (docs/governance.md) against a PR number    |
+| Command                  | Purpose                                                                                     |
+| ------------------------ | ------------------------------------------------------------------------------------------- |
+| `/check`                 | Run quality checks (lint + test)                                                            |
+| `/pr`                    | Draft PR description                                                                        |
+| `/skill`                 | Find or create skill definition                                                             |
+| `/review-local`          | Self-review current diff                                                                    |
+| `/challenge`             | Adversarial review (pre-mortem, war game)                                                   |
+| `/propose-issue`         | Research codebase before creating an issue                                                  |
+| `/plan-merge-order`      | Plan merge order for multiple PRs to minimize rebase cost                                   |
+| `/preflight`             | Verify tasks are not obsolete or in parallel before work                                    |
+| `/verify-agent-report`   | Verify agent completion reports against real branches, PRs, and commits                     |
+| `/merge-check`           | Run the pre-merge checklist (docs/governance.md) against a PR number                        |
+| `/register-plugin-asset` | Register a new distributed command/agent/agent-skill into the plugin manifests and validate |
 
-Details: distributed commands (`/check` `/pr` `/skill` `/review-local` `/challenge`) live in top-level `commands/` (plugin surface, per #996); repo-dev commands (`/propose-issue` `/plan-merge-order` `/preflight` `/verify-agent-report` `/merge-check`) stay in `.claude/commands/`.
+Details: distributed commands (`/check` `/pr` `/skill` `/review-local` `/challenge`) live in top-level `commands/` (plugin surface, per #996); repo-dev commands (`/propose-issue` `/plan-merge-order` `/preflight` `/verify-agent-report` `/merge-check` `/register-plugin-asset`) stay in `.claude/commands/`.
 
 > Note: the distributed commands resolve only when river-review is **installed as a plugin**. When working inside this repo directly, Claude Code auto-discovers project commands from `.claude/commands/` only — so the five distributed commands are not available as in-repo slash commands (the repo-dev commands are).


### PR DESCRIPTION
## Summary

#1442 で追加した repo-dev コマンド `/register-plugin-asset` が `.claude/commands/README.md`（6件）には載る一方、`CLAUDE.md` の「Custom Commands」表（5件）と「Details」の repo-dev 列挙に未反映で乖離していた。マルチエージェントレビュー（規約整合観点）の指摘に基づき、両方に追記して揃える。

### 変更
- `CLAUDE.md`「Custom Commands」表に `/register-plugin-asset` 行を追加
- 同「Details」の repo-dev commands 列挙に `/register-plugin-asset` を追加

これで `.claude/commands/README.md` と `CLAUDE.md` の repo-dev コマンド一覧が一致する。

## Test plan
- [x] `prettier --check CLAUDE.md` → pass（テーブルは formatter が再整形）
- [x] commitlint 準拠（subject-case 対応）

## 関連
- #1442（`/register-plugin-asset` コマンド新設）
- CLAUDE.md「Always ask」スコープのためユーザー承認済みで着手

🤖 Generated with [Claude Code](https://claude.com/claude-code)