### PR TITLE
docs: review-team の実行方法を配布方針（npm 未公開）に整合する (#1446)

### DIFF
--- a/commands/review-team.md
+++ b/commands/review-team.md
@@ -35,7 +35,7 @@ npm run river -- run . --reviewers auto --output json
 npm run river -- run . --reviewers <role1,role2,...> --output json
 ```
 
-CLI が absent または失敗した場合は、スキル駆動のレビューで継続する。
+CLI が存在しない、または失敗した場合は、スキル駆動のレビューで継続する。
 
 ### Step 3: 結果を報告する
 

--- a/commands/review-team.md
+++ b/commands/review-team.md
@@ -1,6 +1,6 @@
 ---
 description: 'Run review-team skill: parallel multi-role review with consensusLevel and Tech Lead report'
-allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git log:*), Bash(river-review:*), Bash(npx river-review:*)
+allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git log:*), Bash(npm run river:*)
 ---
 
 スキル定義: `skills/agent-skills/review-team/SKILL.md`
@@ -21,17 +21,21 @@ allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git log:*), Bash(river
 
 引数でロールが指定された場合はそれを使う。なければ `auto`（差分から自動選択）。
 
-### Step 2: river-review を実行する
+### Step 2: レビューを実行する
+
+River Review は npm 未公開のため `npx river-review` は使えない。**エージェントがこのスキルの手順を直接実行する**（CLI 不要）。上記 Step 1 で決めたロールを並列に走らせ、Union-Find で finding を統合し、consensusLevel と teamLeadReport を生成する。
+
+リポジトリ内で作業していて `river` CLI をアクセラレータとして使える場合のみ、次を利用してよい（任意）。コスト確認が必要なら先に `--dry-run`。
 
 ```bash
 # auto モード（推奨）
-river-review run --reviewers auto --output json
+npm run river -- run . --reviewers auto --output json
 
 # ロール明示指定
-river-review run --reviewers <role1,role2,...> --output json
+npm run river -- run . --reviewers <role1,role2,...> --output json
 ```
 
-`river-review` がなければ `npx river-review` を使う。コスト確認が必要なら先に `--dry-run`。
+CLI が absent または失敗した場合は、スキル駆動のレビューで継続する。
 
 ### Step 3: 結果を報告する
 

--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -576,7 +576,7 @@
     {
       "id": "review-team",
       "path": "skills/agent-skills/review-team",
-      "checksum": "sha256:e9104c2254d3d208a0a64bd450af05da0d60fc74d5e534201ed7075562270a87",
+      "checksum": "sha256:da4bcadd468ce2c6a49d6e0888e167e756c592aae7ffa33e288b7a46661e2f3f",
       "files": 1
     },
     {

--- a/skills/agent-skills/review-team/SKILL.md
+++ b/skills/agent-skills/review-team/SKILL.md
@@ -103,6 +103,9 @@ Claude Code / Codex のプラグイン経由では、**エージェントがこ�
 # 差分から自動選択（推奨）
 npm run river -- run . --reviewers auto
 
+# ロールを明示指定
+npm run river -- run . --reviewers bug-hunter,security-scanner,test-gap
+
 # JSON 出力（teamLeadReport を含む）
 npm run river -- run . --reviewers auto --output json
 
@@ -110,7 +113,7 @@ npm run river -- run . --reviewers auto --output json
 npm run river -- run . --reviewers auto --dry-run
 ```
 
-CLI は必須でない。absent または失敗した場合はスキル駆動のレビューで継続する。
+CLI は必須でない。存在しない、または失敗した場合はスキル駆動のレビューで継続する。
 
 ### GitHub Actions
 

--- a/skills/agent-skills/review-team/SKILL.md
+++ b/skills/agent-skills/review-team/SKILL.md
@@ -86,28 +86,35 @@ Step 4: Tech Lead レポートの生成（追加 LLM コストなし）
 
 ## How to Run / 実行方法
 
-### CLI
+River Review は npm パッケージを公開しない（プロジェクト方針）。したがって `npx river-review` は使えない。実行環境ごとに次の手段を使う。
+
+### プラグイン / エージェント環境（第一手段・CLI 不要）
+
+Claude Code / Codex のプラグイン経由では、**エージェントがこのスキルの手順を直接実行する**。CLI は不要で、上記の Execution Flow（ロール決定 → 並列実行 → consensusLevel 付与 → Tech Lead レポート）をエージェント自身が再現する。
+
+- スラッシュコマンド: `/review-team` または `/review-team bug-hunter,security-scanner`
+- CLI が無くても設計どおり動作する。CLI 実行を試みて失敗しても、スキル駆動のレビューで継続すること。
+
+### コントリビューター（リポジトリ内）
+
+リポジトリ内では `river` CLI をアクセラレータとして使える（任意）。
 
 ```bash
 # 差分から自動選択（推奨）
-river-review run --reviewers auto
-
-# ロールを明示指定
-river-review run --reviewers bug-hunter,security-scanner,test-gap
+npm run river -- run . --reviewers auto
 
 # JSON 出力（teamLeadReport を含む）
-river-review run --reviewers auto --output json
+npm run river -- run . --reviewers auto --output json
 
 # コスト事前確認
-river-review run --reviewers auto --dry-run
+npm run river -- run . --reviewers auto --dry-run
 ```
 
-### Claude Code スラッシュコマンド
+CLI は必須でない。absent または失敗した場合はスキル駆動のレビューで継続する。
 
-```text
-/review-team
-/review-team bug-hunter,security-scanner
-```
+### GitHub Actions
+
+Actions では CLI が実行エンジンとして起動される。ワークフロー設定は Actions 用ドキュメントを参照する。
 
 ## Output Interpretation / 結果の読み方
 


### PR DESCRIPTION
# 🌊 River Review Docs Update

## Summary

- `review-team` skill / `/review-team` コマンドの「実行方法」を配布方針（npm 未公開）に整合させる修正。プラグイン経由のエージェントと、リポジトリ内コントリビューターが対象。
- Primary phase focus: **Midstream**（examples / commands の整合）

## Flow Consistency

- [x] Upstream: concepts/architecture remain accurate（Execution Flow は変更なし）
- [x] Midstream: examples and commands match current runner/skills（`npm run river -- run .` に統一）
- [x] Downstream: validation steps and QA guidance are current
- [x] Schema Validation passed?（`npm run agent-skills:validate` 通過）
- [x] Skill file structure validated?（同上）

## Changes

- `skills/agent-skills/review-team/SKILL.md`: 「How to Run」を再構成。
  - **プラグイン/エージェント環境**を第一手段とし、エージェントが6ロールを直接実行（CLI 不要）することを明記。
  - `npx river-review` は npm 未公開のため使えない旨を追記。
  - コントリビューター向け CLI を `npm run river -- run .` に統一。
  - GitHub Actions を実行エンジンとして記載。
- `commands/review-team.md`: Step 2 の `npx river-review` フォールバックを削除し、エージェント直接実行を第一に。`allowed-tools` を `Bash(npm run river:*)` に更新。

Language / 言語:

- [x] Japanese（日本語・標準）
- [ ] English（英語 / `.en.md` ファイル）

## Validation & Evidence

```bash
npm run agent-skills:validate   # ✅ review-team/SKILL.md OK
npx textlint --no-cache skills/agent-skills/review-team/SKILL.md commands/review-team.md  # ✅ exit 0
npm run plugin:validate         # ✅ Plugin manifest: OK
npm run fix:dashes              # ✅ No normalizations needed
```

## Related Issues

- Closes #1446

## Follow-ups

- issue #1446 が指摘する「他の CLI 案内 skill への横展開確認」は本 PR のスコープ外。別 issue/PR で横断チェックを検討。

🤖 Generated with [Claude Code](https://claude.com/claude-code)