### PR TITLE
fix(ci): scan の HARDCODED_SECRET 誤検出を ignore_paths に追加する

### DIFF
--- a/.plugin-scanner.toml
+++ b/.plugin-scanner.toml
@@ -23,4 +23,5 @@ ignore_paths = [
   "docs/vision.md",
   "pages/explanation/design-philosophy.md",
   "pages/explanation/design-philosophy.en.md",
+  "docs/development/1401-deterministic-command-execution-design.md",
 ]


### PR DESCRIPTION
# 🌊 River Review Bugfix

## Summary

- **何が壊れていたか**: HOL Plugin Scanner（`scan` job）が main を含め恒常的に FAIL していた。全 required チェックが緑でも毎 PR がこの非 required チェックで赤くなり、ノイズ化していた。
- **検出経緯**: PR #1447 のマージ判断時に `scan` の恒常 FAIL を発見 → CI と同一の `codex_plugin_scanner.action_runner`（Python 3.12）をローカル再現して原因特定。
- Primary phase focus: **Downstream**（CI/QA ゲート）

## Flow Consistency

- [x] Upstream: 再発防止のため既存 config の per-file 抑制方針に整合
- [x] Midstream: 副作用なく root cause を修正（1 ファイルを ignore_paths に追加のみ）
- [x] Downstream: CI 同等の再現で before/after を実測
- [x] Schema Validation passed?（本変更は skill schema 非対象。skills 影響なし）
- [x] Skill file structure validated?（skills 変更なし）

## Root Cause & Fix

- **Root cause**: native `HARDCODED_SECRET` ルールが、prose 内の kebab-case ADR スラッグ（`docs/adr/003-risk-tiered-human-supervision.md` への参照）を secret 材料と誤検出する既知 FP。`docs/development/1401-deterministic-command-execution-design.md:529`（ADR 参照リンク行）が `high` 判定され、`fail_on_severity: high` を踏んで job が fail。実ファイルに秘密情報は存在しない（40字hex / ghp_/sk-/BEGIN 等は皆無）。
- **Fix**: 既存 `.plugin-scanner.toml` が同種 FP（`docs/vision.md`, `pages/explanation/design-philosophy.md` ほか）を per-file で抑制済みの方針に合わせ、当該設計 doc を `ignore_paths` に追加。配布 bundle（`skills/` `.codex-plugin/` `.claude-plugin/` `commands/` `agents/`）の秘密検出は維持され、over-suppression にならない。

## Repro & Validation

CI と同一の action runner（`python -m codex_plugin_scanner.action_runner`、`plugin-scanner==2.0.989` / Python 3.12.13、`MODE=scan FAIL_ON=high` 等 CI と同 env）でローカル再現。

| | 修正前 | 修正後 |
| --- | --- | --- |
| exit code | 1（fail） | **0（pass）** |
| Max severity | high | **medium** |
| Findings | 9 | 7（HARDCODED_SECRET high ×2 が消滅） |
| Score / Grade | 85 / B | **93 / A** |

## Related Issues

- Related #1401（誤検出対象の設計 doc）

## Rollout Notes

- **Risk**: 低。1 ファイルを既存の FP 抑制リストに追加するのみ。他ファイルの秘密検出には影響しない。
- **Follow-up**: 同スラッグを参照する prose doc を今後追加すると同 FP が再発しうる（trigger は「kebab-case ADR スラッグを含む prose」というコンテンツ依存で、ディレクトリ glob では網羅困難）。再発時は同様に per-file 追加で対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)