### PR TITLE
docs: --no-verify が manifest 自動再生成を bypass する学びを記録する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,14 +57,15 @@ Use **npm**.
 
 Run the applicable checks before handoff. All must pass.
 
-| Changed path                           | Required validation                |
-| -------------------------------------- | ---------------------------------- |
-| `skills/**/*.md`                       | `npm run skills:validate`          |
-| `skills/agent-skills/**`               | `npm run agent-skills:validate`    |
-| `.github/agents/` or `.claude/agents/` | `npm run agents:validate`          |
-| `pages/**/*.md`                        | `npm run check:links:local`        |
-| `src/` changes that affect skills      | Confirm schema and skill alignment |
-| Any file                               | `npm run lint && npm test`         |
+| Changed path                           | Required validation                                                                                                                                                                               |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `skills/**/*.md`                       | `npm run skills:validate`                                                                                                                                                                         |
+| `skills/agent-skills/**`               | `npm run agent-skills:validate`                                                                                                                                                                   |
+| `skills/**/*.md` (manifest freshness)  | `npm run skills:manifest:check` (regen with `npm run skills:manifest`, commit `docs/data/skill-manifest.json`; the lint-staged hook does this automatically unless you commit with `--no-verify`) |
+| `.github/agents/` or `.claude/agents/` | `npm run agents:validate`                                                                                                                                                                         |
+| `pages/**/*.md`                        | `npm run check:links:local`                                                                                                                                                                       |
+| `src/` changes that affect skills      | Confirm schema and skill alignment                                                                                                                                                                |
+| Any file                               | `npm run lint && npm test`                                                                                                                                                                        |
 
 Completion gate: all applicable validations pass. If any fail, fix before handoff.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,15 +57,15 @@ Use **npm**.
 
 Run the applicable checks before handoff. All must pass.
 
-| Changed path                           | Required validation                                                                                                                                                                               |
-| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `skills/**/*.md`                       | `npm run skills:validate`                                                                                                                                                                         |
-| `skills/agent-skills/**`               | `npm run agent-skills:validate`                                                                                                                                                                   |
-| `skills/**/*.md` (manifest freshness)  | `npm run skills:manifest:check` (regen with `npm run skills:manifest`, commit `docs/data/skill-manifest.json`; the lint-staged hook does this automatically unless you commit with `--no-verify`) |
-| `.github/agents/` or `.claude/agents/` | `npm run agents:validate`                                                                                                                                                                         |
-| `pages/**/*.md`                        | `npm run check:links:local`                                                                                                                                                                       |
-| `src/` changes that affect skills      | Confirm schema and skill alignment                                                                                                                                                                |
-| Any file                               | `npm run lint && npm test`                                                                                                                                                                        |
+| Changed path                           | Required validation                                                                  |
+| -------------------------------------- | ------------------------------------------------------------------------------------ |
+| `skills/**/*.md`                       | `npm run skills:validate`                                                            |
+| `skills/agent-skills/**`               | `npm run agent-skills:validate`                                                      |
+| `skills/**/*.md` (manifest freshness)  | `npm run skills:manifest:check` (regenerate with `npm run skills:manifest` if stale) |
+| `.github/agents/` or `.claude/agents/` | `npm run agents:validate`                                                            |
+| `pages/**/*.md`                        | `npm run check:links:local`                                                          |
+| `src/` changes that affect skills      | Confirm schema and skill alignment                                                   |
+| Any file                               | `npm run lint && npm test`                                                           |
 
 Completion gate: all applicable validations pass. If any fail, fix before handoff.
 

--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -63,3 +63,7 @@
   Once the ref advances, the required status checks re-register and the PR transitions BLOCKED → CLEAN.
   - `Applies to`: release-please workflow recovery, fs-loss / sandbox-restricted environments, any case where the branch head must advance without a local checkout.
   - `Evidence`: validated on PR #876 (v0.53.0) during a session where the working tree was inaccessible; the BLOCKED → CLEAN → squash-merge → release-publish flow completed entirely via gh API.
+
+- `2026-07-09`: `git commit --no-verify` skips the lint-staged pre-commit hooks, including the `skills/**/*.md` step that runs `npm run skills:manifest && git add docs/data/skill-manifest.json`. Committing skill-doc edits with `--no-verify` therefore leaves `docs/data/skill-manifest.json` stale, and the CI `Skill schema validation` job (`skills:manifest:check`) fails with "skill manifest is stale". After editing `skills/**/*.md`, either commit without `--no-verify`, or run `npm run skills:manifest` and stage `docs/data/skill-manifest.json` in the same commit. The same bypass also drops `check:dashes` / `prettier --write` / `markdownlint --fix` on `**/*.md` and `textlint --no-cache` on `pages/**`.
+  - `Applies to`: any commit that edits `skills/**/*.md` (especially `skills/agent-skills/**`) and uses `--no-verify`.
+  - `Evidence`: `.lintstagedrc.json` `skills/**/*.md` block; PR #1447's first commit failed CI `Skill schema validation`, fixed by regenerating the manifest in the second commit.


### PR DESCRIPTION
## Summary

直前セッション（#1447 / #1448 のマージ + scan 恒常FAIL 調査）の振り返り（`docs/development/improvement-flow.md` に沿う）から、再発防止の改善 2 件を実装。

### A. ドキュメント追記（1件）
- **`AGENT_LEARNINGS.md`**: `git commit --no-verify` が lint-staged の pre-commit フック（`skills/**/*.md` → `npm run skills:manifest && git add docs/data/skill-manifest.json`）を skip するため、skill doc 編集を `--no-verify` で commit すると `docs/data/skill-manifest.json` が stale のまま push され、CI `Skill schema validation`（`skills:manifest:check`）が「skill manifest is stale」で fail する — という学びを記録。同 bypass は `check:dashes`/`prettier`/`markdownlint`/`textlint` にも及ぶ点も明記。

### B. 自動ガード / 検証ゲート（1件）
- **`AGENTS.md`** Verification Criteria 表に `skills/**/*.md` (manifest freshness) → `npm run skills:manifest:check` 行を追加。lint-staged フックを `--no-verify` で bypass しても、pre-handoff の検証ゲートで manifest 陳腐化に気づける。

## Root Cause（振り返り指摘 #1）

#1447 の 1 コミット目を `--no-verify` で作成 → lint-staged の manifest 自動再生成が走らず → stale manifest で push → CI `Skill schema validation` fail → 2 コミット目で `npm run skills:manifest` を回して解消（手戻り 1 回）。ガード（lint-staged / CI）は存在したが、`--no-verify` 運用が局所的に無効化していた。

## Test plan
- [x] `npx markdownlint AGENTS.md AGENT_LEARNINGS.md` → clean（変更2ファイル）
- [x] `npm run lint` の失敗は `docs/Working/*`（`.gitignore` 対象・CI 非対象）のローカル限定ノイズのみと確認
- [x] 本コミットは **`--no-verify` を使わず**作成し、lint-staged フックが正常発火することを実地確認（学びの実践）
- [x] textlint は `pages/**` のみ対象（AGENTS.md 非対象）を確認

## 関連セッション
- 前回の振り返り PR: #1439
- 対象セッションのマージ済み PR: #1447, #1448
- 手戻り: #1447 の CI `Skill schema validation` fail（1→2 コミット目で解消）

🤖 Generated with [Claude Code](https://claude.com/claude-code)