### PR TITLE
docs: 配布コマンド表に review-team/setup-team を追記し plugin.json と同期する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,8 @@ When a retrospective identifies a recurring mistake or missing guardrail, follow
 | `/skill`                 | Find or create skill definition                                                             |
 | `/review-local`          | Self-review current diff                                                                    |
 | `/challenge`             | Adversarial review (pre-mortem, war game)                                                   |
+| `/review-team`           | Parallel multi-role review with consensusLevel and Tech Lead report                         |
+| `/setup-team`            | Set up River Review in a project (`.river/rules.md`, plugin install, integration mode)      |
 | `/propose-issue`         | Research codebase before creating an issue                                                  |
 | `/plan-merge-order`      | Plan merge order for multiple PRs to minimize rebase cost                                   |
 | `/preflight`             | Verify tasks are not obsolete or in parallel before work                                    |
@@ -84,6 +86,6 @@ When a retrospective identifies a recurring mistake or missing guardrail, follow
 | `/merge-check`           | Run the pre-merge checklist (docs/governance.md) against a PR number                        |
 | `/register-plugin-asset` | Register a new distributed command/agent/agent-skill into the plugin manifests and validate |
 
-Details: distributed commands (`/check` `/pr` `/skill` `/review-local` `/challenge`) live in top-level `commands/` (plugin surface, per #996); repo-dev commands (`/propose-issue` `/plan-merge-order` `/preflight` `/verify-agent-report` `/merge-check` `/register-plugin-asset`) stay in `.claude/commands/`.
+Details: distributed commands (`/check` `/pr` `/skill` `/review-local` `/challenge` `/review-team` `/setup-team`) live in top-level `commands/` (plugin surface, per #996); repo-dev commands (`/propose-issue` `/plan-merge-order` `/preflight` `/verify-agent-report` `/merge-check` `/register-plugin-asset`) stay in `.claude/commands/`.
 
-> Note: the distributed commands resolve only when river-review is **installed as a plugin**. When working inside this repo directly, Claude Code auto-discovers project commands from `.claude/commands/` only — so the five distributed commands are not available as in-repo slash commands (the repo-dev commands are).
+> Note: the distributed commands resolve only when river-review is **installed as a plugin**. When working inside this repo directly, Claude Code auto-discovers project commands from `.claude/commands/` only — so the seven distributed commands are not available as in-repo slash commands (the repo-dev commands are).


### PR DESCRIPTION
# 🌊 River Review Docs Update

## Summary

- River Review レビュー（1.43.1 範囲）で検出した doc ドリフトの修正。対象は CLAUDE.md を読むコントリビューター / エージェント。
- Primary phase focus: **Upstream**（規約ドキュメントの正確性）

## Flow Consistency

- [x] Upstream: concepts/architecture remain accurate（plugin.json を SSoT に整合）
- [x] Midstream: examples and commands match current runner/skills
- [x] Downstream: validation steps and QA guidance are current
- [x] Schema Validation passed?（本変更は skill schema 非対象）
- [x] Skill file structure validated?（skills 変更なし）

## Root Cause & Fix

- **Root cause**: `.claude-plugin/plugin.json` は distributed commands を **7 個**登録（`challenge, check, pr, review-local, review-team, setup-team, skill`）するが、`CLAUDE.md` の Custom Commands 表・Details・Note は **5 個**（`/check /pr /skill /review-local /challenge`）しか記載せず、`/review-team` と `/setup-team` が欠落。コントリビューターが両者を非配布と誤解する doc ドリフト。`plugin:validate`（#1443 逆ドリフト検査）は manifest↔ファイルを見るが CLAUDE.md 散文表は検査対象外のため未検知だった。
- **Fix**:
  1. Custom Commands 表に `/review-team`・`/setup-team` の 2 行を distributed グループに追加。
  2. Details 行の distributed 一覧に 2 コマンドを追加（計 7）。
  3. Note の「the **five** distributed commands」→「**seven**」に更新。

## Changes

- `CLAUDE.md`: Custom Commands 表 + Details + Note の 3 箇所を plugin.json（7 コマンド）に整合。

Language / 言語:

- [x] Japanese（日本語・標準） / [x] 英語混在（原文が英語表記の箇所）

## Validation & Evidence

```bash
npx markdownlint CLAUDE.md        # ✅ clean
# plugin.json 7件 == CLAUDE.md distributed 記述 7件（challenge,check,pr,review-local,review-team,setup-team,skill）
```
本コミットは `--no-verify` を使わず lint-staged フックを通して作成。

## Related Issues

- Related: River Review レビュー（1.43.1 範囲）指摘、#1445（同表の同期テーマ）

## Follow-ups

- 中期的には CLAUDE.md の distributed 一覧を plugin.json から自動検証する `plugin:validate` 拡張が望ましい（本 PR スコープ外）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)