### PR TITLE
docs(adr): diff ベース静的検証の境界と視覚評価系レビュー不採用を記録する

### DIFF
--- a/docs/adr/004-diff-based-static-review-boundary.md
+++ b/docs/adr/004-diff-based-static-review-boundary.md
@@ -14,10 +14,10 @@ Accepted—#1455 のレビュー観点カバレッジ拡張で、視覚評価・
 
 一方、River Review のレビュー実行には次の契約がある。
 
-- レビューエージェントのツールは Read / Grep / Glob / Bash のみ（`agents/river-review.md`）
+- レビューエージェントのツールは Read / Grep / Glob / Bash のみ（[agents/river-review.md](../../agents/river-review.md)）
 - GitHub Action ランナー上でも同一の挙動で動作する
-- 指摘は差分内のコードにアンカーする（`pages/reference/review-policy.md` §3.1、`.claude/rules/review-core.md`）
-- スキルは fixtures / golden で回帰検証できる（`pages/guides/add-new-skill.md`）
+- 指摘は差分内のコードにアンカーする（[pages/reference/review-policy.md](../../pages/reference/review-policy.md) §3.1・§3.4、[.claude/rules/review-core.md](../../.claude/rules/review-core.md)）
+- スキルは fixtures / golden で回帰検証できる（[pages/guides/add-new-skill.md](../../pages/guides/add-new-skill.md)）
 
 視覚評価・計測ベース比較は MCP（Figma / Playwright / ブラウザ）と対話的な実行環境を前提とし、この契約のすべてに反する。スクリーンショットは fixtures として決定論的に検証できず、CI ランナーには計測環境がなく、指摘は差分ではなく描画結果にアンカーされる。
 

--- a/docs/adr/004-diff-based-static-review-boundary.md
+++ b/docs/adr/004-diff-based-static-review-boundary.md
@@ -1,0 +1,42 @@
+# ADR-004: diff ベース静的検証の境界—視覚評価・実測系レビューの不採用
+
+## Status
+
+Accepted—#1455 のレビュー観点カバレッジ拡張で、視覚評価・実測系の UI レビュー資産を取り込まないと判断した理由と再参入条件を記録する。
+
+## Context
+
+外部プラグイン（growth-core）のレビュー資産調査（#1455）で、次の3種の UI レビュー機能の取り込みを検討した。
+
+- **視覚評価**: スクリーンショット・Figma URL を入力とするヒューリスティック評価（Nielsen's 10 等）
+- **計測ベース比較**: Figma MCP で設計仕様を取得し、Playwright / ブラウザで実装側の computed style を計測して差分を出す方式
+- **ドメイン固有の複合ゲート**: LP 公開前チェックのような、UX・パフォーマンス・セキュリティを1回で束ねる独立ゲート
+
+一方、River Review のレビュー実行には次の契約がある。
+
+- レビューエージェントのツールは Read / Grep / Glob / Bash のみ（`agents/river-review.md`）
+- GitHub Action ランナー上でも同一の挙動で動作する
+- 指摘は差分内のコードにアンカーする（`pages/reference/review-policy.md` §3.1、`.claude/rules/review-core.md`）
+- スキルは fixtures / golden で回帰検証できる（`pages/guides/add-new-skill.md`）
+
+視覚評価・計測ベース比較は MCP（Figma / Playwright / ブラウザ）と対話的な実行環境を前提とし、この契約のすべてに反する。スクリーンショットは fixtures として決定論的に検証できず、CI ランナーには計測環境がなく、指摘は差分ではなく描画結果にアンカーされる。
+
+## Decision
+
+視覚評価・計測ベース比較・ドメイン固有複合ゲートは **取り込まない**。River Review の UI/UX レビューは、diff から静的に検出できる範囲に限定する。
+
+- 静的に検出できる UI/UX 観点は既存資産で担う: a11y 系・デザイントークン系・状態設計系の registry skill、および `river-review-code` の UX-SAFEGUARD 参照観点（破壊的操作の安全装置・入力エラーの回復支援）
+- 視覚評価・実測は隣接ツール（growth-core の ui-ux-review / figma-design-check 等、MCP を持つ対話的エージェント環境）の責務とし、River Review は結果を競合させない
+
+### 再参入条件
+
+次の両方が成立した時点で、この判断を再検討する。
+
+1. スキルの `inputContext` に視覚資材（例: `designSpec` / `screenshot`）を opt-in 型で追加でき、**入力が提供された場合のみ** Pre-execution Gate を通過する設計が、registry 追加とスキーマ拡張だけで成立する
+2. GitHub Action 経路など視覚入力が存在しない実行環境で、当該スキルが安全に `NO_REVIEW` へ退避することを CI で検証できる
+
+## Consequences
+
+- レビュー品質の守備範囲が明確になる: 「デザインどおりに描画されているか」は River Review の保証範囲外であり、利用者は計測系ツールを併用する
+- スキル資産はすべて fixtures / golden で回帰検証可能なまま保たれ、GitHub Action 経路との挙動差が生まれない
+- 将来 MCP 入力を抽象化する場合も、既存スキル資産を作り直す必要はない（inputContext の拡張で opt-in させる）


### PR DESCRIPTION
## 概要

#1455 の ADR タスク。growth-core の UI レビュー資産（視覚評価・Figma+Playwright 計測比較・LP 複合ゲート）を River Review に取り込まないと判断した理由と、再参入条件を ADR-004 として記録する。明文化しないと将来同じ調査・提案が繰り返されるため（Research before proposing の裏返し）。

## 変更内容

- `docs/adr/004-diff-based-static-review-boundary.md` を新規追加
  - **Context**: 視覚評価・実測系は MCP と対話的実行環境が前提で、River Review の契約（Read/Grep/Glob/Bash のみ・GitHub Action で同一挙動・差分アンカー・fixtures 回帰検証）のすべてに反する
  - **Decision**: 取り込まない。静的に検出できる UI/UX 観点は既存 skill + UX-SAFEGUARD 参照観点（#1460）で担い、視覚評価・実測は MCP を持つ隣接ツールの責務とする
  - **再参入条件**: `inputContext` への視覚資材 opt-in 追加がスキーマ拡張だけで成立し、入力欠如時の `NO_REVIEW` 退避を CI で検証できたとき

## 検証

- `npx textlint --no-cache`: pass
- pre-commit（check:dashes / prettier / markdownlint）: pass

## 関連

- #1455（親計画）。他 PR（#1456〜#1458, #1460）と独立にマージ可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)