### PR TITLE
refactor: check-code-hygiene の isBuiltin 統一と import matchAll 共有化（#1473 Step 1）

### DIFF
--- a/scripts/check-code-hygiene.mjs
+++ b/scripts/check-code-hygiene.mjs
@@ -20,7 +20,7 @@
 
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join, relative, sep } from 'node:path';
-import { builtinModules } from 'node:module';
+import { isBuiltin } from 'node:module';
 
 const ROOT = process.cwd();
 
@@ -36,7 +36,6 @@ function loadDeclaredDeps() {
   }
 }
 const DECLARED_DEPS = loadDeclaredDeps();
-const NODE_BUILTINS = new Set(builtinModules);
 
 // phantom-dep を判定する scope。src/lib は CLI 本体の production ライブラリで、
 // site（src/components の docusaurus）や生成物（dist）を含めると外部提供前提の
@@ -46,9 +45,9 @@ const PHANTOM_SCAN_PREFIX = `src${sep}lib${sep}`;
 // import 指定子から npm パッケージ名（scope 付きは @scope/pkg）を取り出す。
 // 相対 / 絶対 / node: builtin は対象外（null を返す）。
 function packageBaseOf(spec) {
-  if (spec.startsWith('.') || spec.startsWith('/') || spec.startsWith('node:')) return null;
+  if (spec.startsWith('.') || spec.startsWith('/') || isBuiltin(spec)) return null;
   const base = spec.startsWith('@') ? spec.split('/').slice(0, 2).join('/') : spec.split('/')[0];
-  if (NODE_BUILTINS.has(base)) return null;
+  if (isBuiltin(base)) return null;
   return base;
 }
 
@@ -154,9 +153,13 @@ for (const file of collectFiles()) {
   const rel = relative(ROOT, file);
   const isTestFile = rel.startsWith(`tests${sep}`);
 
+  // import 文は 1 度だけ materialize し、Check 1 / Check 4 で共有する
+  // （同一 IMPORT_RE の二重 matchAll を避ける）。
+  const imports = [...text.matchAll(IMPORT_RE)];
+
   // Check 1: duplicate imports（全 scan 対象）
   const seen = new Map();
-  for (const m of text.matchAll(IMPORT_RE)) {
+  for (const m of imports) {
     const spec = m[1];
     const line = lineOf(text, m.index);
     if (seen.has(spec)) {
@@ -168,7 +171,7 @@ for (const file of collectFiles()) {
 
   // Check 4: phantom-dep（src/lib/** の import が dependencies 未宣言）
   if (DECLARED_DEPS != null && rel.startsWith(PHANTOM_SCAN_PREFIX)) {
-    for (const m of text.matchAll(IMPORT_RE)) {
+    for (const m of imports) {
       const base = packageBaseOf(m[1]);
       if (base == null || DECLARED_DEPS.has(base)) continue;
       phantomDeps.push({ file: rel, line: lineOf(text, m.index), pkg: base });


### PR DESCRIPTION
## 目的

refactor: 外部挙動不変。リファクタリング計画（#1473）Wave 1 Step 1。`scripts/check-code-hygiene.mjs` に残っていた P2 SIMPLIFY findings（#1452 の report-only 検出）2 件を適用する。

Related #1473

## 変更内容

1. **node builtin 判定の統一**: `builtinModules` から自作していた `NODE_BUILTINS` Set と `startsWith('node:')` 分岐を、`node:module` の標準 `isBuiltin()` に置換。`isBuiltin` は `node:` prefix・bare 名・subpath（`fs/promises` / `node:fs/promises`）をすべて網羅するため判定結果は等価。
2. **import matchAll の共有化**: Check1（duplicate-import）と Check4（phantom-dep）で同一 `IMPORT_RE` を二重に `matchAll` していたのを、1 度 `[...text.matchAll(IMPORT_RE)]` で materialize した配列の共有に統合。

機能変更・文言変更なし（純粋な内部構造変更）。

## 検証（前後比較の実出力）

### `npm run lint:code`（対象リポジトリでの検出結果）
変更前:
```
✅ code hygiene OK（duplicate-import / tmp-literal / mkdtemp-cleanup / phantom-dep）
exit=0
```
変更後:
```
✅ code hygiene OK（duplicate-import / tmp-literal / mkdtemp-cleanup / phantom-dep）
exit=0
```
→ 一致。

### `node --test tests/check-code-hygiene.test.mjs`（canary 含む）
```
# tests 14
# pass 14
# fail 0
```

### `npm test`（全体）
```
# tests 2039
# pass 2039
# fail 0
```
ベースライン（2039 pass）維持。

## レビュー観点

- `isBuiltin` の網羅性は実測で確認済み（`node:` prefix / bare / subpath すべて true、npm パッケージは false）。builtin 名と同名の npm パッケージは変更前後どちらも builtin 扱いで skip され挙動一致。
