### PR TITLE
refactor: validate-plugin-manifest の isDirectRun ガードを正典形へ統一（#1473 Step 2）

### DIFF
--- a/scripts/validate-plugin-manifest.mjs
+++ b/scripts/validate-plugin-manifest.mjs
@@ -1,6 +1,8 @@
 import fs from 'node:fs/promises';
+import { realpathSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
+import { pathToFileURL } from 'node:url';
 
 const ROOT = path.resolve(import.meta.dirname, '..');
 
@@ -514,9 +516,7 @@ export async function validatePluginManifest() {
 
 // CLI entry point
 const isDirectRun =
-  process.argv[1] &&
-  (process.argv[1].endsWith('validate-plugin-manifest.mjs') ||
-    process.argv[1].endsWith('validate-plugin-manifest'));
+  process.argv[1] && import.meta.url === pathToFileURL(realpathSync(process.argv[1])).href;
 
 if (isDirectRun) {
   validatePluginManifest()


### PR DESCRIPTION
## 目的

refactor: 外部挙動不変。リファクタリング計画（#1473）Wave 1 Step 2。`scripts/validate-plugin-manifest.mjs` の direct-run 判定を、リポジトリ内 14 スクリプトと同じ正典形に統一する。

Related #1473

## 変更内容

`isDirectRun` の判定を `process.argv[1]` の `endsWith` 文字列一致（`'validate-plugin-manifest.mjs'` / `'validate-plugin-manifest'`）から、正典形
```
import.meta.url === pathToFileURL(realpathSync(process.argv[1])).href
```
へ置換。あわせて `node:fs` の `realpathSync` と `node:url` の `pathToFileURL` を import。

- 従来の endsWith 方式は symlink 経由起動で脆弱、かつ同名 basename の別ファイルに誤反応しうる不統一な形だった。
- `validate-skills.mjs:739` ほか 14 スクリプトが採用する形に揃える。

機能変更・文言変更なし（純粋な内部構造変更）。

## 検証（前後比較の実出力）

### `npm run plugin:validate`
変更前:
```
Plugin manifest: OK
exit=0
```
変更後:
```
Plugin manifest: OK
exit=0
```
→ 一致（direct-run 起動でバリデーションが従来どおり実行され OK）。

### `node --test tests/naming-validator-canary.test.mjs`
```
# tests 19
# pass 19
# fail 0
```

### `npm test`（全体）
```
# tests 2039
# pass 2039
# fail 0
```
ベースライン（2039 pass）維持。
