### PR TITLE
refactor: validate-skills の registry read+parse 重複を loadSkillRegistry へ抽出（#1473 Step 3）

### DIFF
--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -256,6 +256,29 @@ export async function validatePacks({
 }
 
 /**
+ * Read and parse skills/registry.yaml once. Returns `{ ok: true, parsed }` on
+ * success (`parsed` is `{}` for an empty file), or `{ ok: false, phase, message }`
+ * where `phase` is 'read' or 'parse'. Callers keep their own error wording so the
+ * existing console messages stay byte-identical.
+ *
+ * @param {string} registryPath absolute/relative path to registry.yaml
+ * @returns {Promise<{ ok: true, parsed: unknown } | { ok: false, phase: 'read' | 'parse', message: string }>}
+ */
+async function loadSkillRegistry(registryPath) {
+  let raw;
+  try {
+    raw = await fs.readFile(registryPath, 'utf8');
+  } catch (err) {
+    return { ok: false, phase: 'read', message: err.message };
+  }
+  try {
+    return { ok: true, parsed: yaml.load(raw) ?? {} };
+  } catch (err) {
+    return { ok: false, phase: 'parse', message: err.message };
+  }
+}
+
+/**
  * Forward-gate: every `recommended: true` skill in skills/registry.yaml must
  * carry quality evidence — an `eval/` or `fixtures/` directory alongside its
  * SKILL.md (#1231). Skills already shipped without such assets are exempted via
@@ -271,20 +294,14 @@ export async function validateRecommendedEvalCoverage({
   repoRoot = defaultPaths.repoRoot,
 } = {}) {
   const registryPath = path.join(skillsDir, 'registry.yaml');
-  let raw;
-  try {
-    raw = await fs.readFile(registryPath, 'utf8');
-  } catch (err) {
-    console.error(`❌ Failed to read skill registry at ${registryPath}: ${err.message}`);
+  const registry = await loadSkillRegistry(registryPath);
+  if (!registry.ok) {
+    console.error(
+      `❌ Failed to ${registry.phase} skill registry at ${registryPath}: ${registry.message}`
+    );
     return false;
   }
-  let parsed;
-  try {
-    parsed = yaml.load(raw) ?? {};
-  } catch (err) {
-    console.error(`❌ Failed to parse skill registry at ${registryPath}: ${err.message}`);
-    return false;
-  }
+  const parsed = registry.parsed;
 
   const skills = Array.isArray(parsed?.skills) ? parsed.skills : [];
   const recommended = skills.filter((s) => s && s.recommended === true);
@@ -350,20 +367,14 @@ export async function validateRegistryPaths({
   repoRoot = defaultPaths.repoRoot,
 } = {}) {
   const registryPath = path.join(skillsDir, 'registry.yaml');
-  let raw;
-  try {
-    raw = await fs.readFile(registryPath, 'utf8');
-  } catch (err) {
-    console.error(`❌ Failed to read skill registry at ${registryPath}: ${err.message}`);
+  const registry = await loadSkillRegistry(registryPath);
+  if (!registry.ok) {
+    console.error(
+      `❌ Failed to ${registry.phase} skill registry at ${registryPath}: ${registry.message}`
+    );
     return false;
   }
-  let parsed;
-  try {
-    parsed = yaml.load(raw) ?? {};
-  } catch (err) {
-    console.error(`❌ Failed to parse skill registry at ${registryPath}: ${err.message}`);
-    return false;
-  }
+  const parsed = registry.parsed;
 
   const skills = Array.isArray(parsed?.skills) ? parsed.skills : [];
   let success = true;
@@ -691,13 +702,12 @@ export function findRegistryNamingCollisions(entries) {
  */
 export async function validateNamingCollisions({ skillsDir = defaultPaths.skillsDir } = {}) {
   const registryPath = path.join(skillsDir, 'registry.yaml');
-  let parsed;
-  try {
-    parsed = yaml.load(await fs.readFile(registryPath, 'utf8')) ?? {};
-  } catch (err) {
-    console.error(`❌ Failed to read/parse skill registry at ${registryPath}: ${err.message}`);
+  const registry = await loadSkillRegistry(registryPath);
+  if (!registry.ok) {
+    console.error(`❌ Failed to read/parse skill registry at ${registryPath}: ${registry.message}`);
     return false;
   }
+  const parsed = registry.parsed;
 
   const ids = (Array.isArray(parsed?.skills) ? parsed.skills : [])
     .map((s) => s?.id)


### PR DESCRIPTION
## 目的

refactor: 外部挙動不変。リファクタリング計画（#1473）Wave 1 Step 3。`scripts/validate-skills.mjs` 内で 3 重複していた registry.yaml の read+parse 同型ブロックを 1 つのローカルヘルパーに集約する（rule of three 充足・intra-file・skill-loader への移設はしない）。

Related #1473

## 変更内容

`validateRecommendedEvalCoverage` / `validateRegistryPaths` / `validateNamingCollisions` の 3 箇所が個別に持っていた `registry.yaml` の read + `yaml.load` を、intra-file の `loadSkillRegistry(registryPath)` に抽出。

- 戻り値は `{ ok: true, parsed }`（空ファイルは `parsed = {}`）または `{ ok: false, phase, message }`（`phase` は `'read'` / `'parse'`）。
- 各呼び出し側は**自前のエラー文言を保持**するため、既存の console メッセージ（`Failed to read` / `Failed to parse` / `Failed to read/parse`）は byte 単位で不変。

機能変更・文言変更なし（純粋な内部構造変更）。

## 検証（前後比較の実出力）

### `npm run skills:validate`（全出力の byte 比較）
変更前後の全出力を `diff` で比較:
```
$ diff skills-validate-before.txt skills-validate-after.txt && echo IDENTICAL
IDENTICAL (no diff)
```
→ ℹ️（skip）/ ✅ / ⚠️ を含む全 130 行超が完全一致。exit 0。

### `npm test`（全体）
```
# tests 2039
# pass 2039
# fail 0
```
ベースライン（2039 pass）維持。

## レビュー観点

- エラーパス（read/parse 失敗）は success-path テストでは踏まないが、`phase` 分岐により従来の 3 種の文言をそのまま再現している。`validateNamingCollisions` の combined 文言（read/parse）も呼び出し側で明示保持。
