### PR TITLE
ci: river-review を Stage1 ラベル opt-in で LLM レビュー本番化する

### DIFF
--- a/.github/workflows/river-review.yml
+++ b/.github/workflows/river-review.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, labeled]
 
 permissions:
   contents: read
@@ -18,6 +19,9 @@ jobs:
   river-review:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'river-review')
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -28,7 +32,10 @@ jobs:
         uses: ./runners/github-action
         with:
           phase: midstream
-          dry_run: true # set false after verifying secrets/models
+          dry_run: false # LLM review enabled (Stage1: label opt-in)
           debug: true
+          gate: false # advisory only — never fail the job
+          max_cost: '0.50' # safety cap (OPENAI_MODEL とセットで有効)
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_MODEL: gpt-4o-mini # max_cost の見積単価を実モデルに一致させる（見積器既定 gpt-4-turbo のままだと大型PRを誤abortするため必須の結合）


### PR DESCRIPTION
## 背景

`.github/workflows/river-review.yml` の `dry_run: true # set false after verifying secrets/models` が恒久放置され、LLM レビューが一度も本番実行されていない（本セッション T24 で root cause 調査済み）。本 PR は承認済み設計（Stage1/2/3 段階導入プラン）の **Stage1: ラベル opt-in** で dry-run から脱出する。

## 段階導入プラン（要約）

| Stage | 範囲 | 挙動 |
| --- | --- | --- |
| **Stage1（本PR）** | ラベル `river-review` が付いた PR のみ | LLM レビュー advisory（`gate: false`、結果はコメントのみでジョブは失敗させない） |
| Stage2（スコープ外） | 全 PR | advisory のまま全件に拡大 |
| Stage3（スコープ外） | 全 PR | `gate: true` 化（NO_GO/ESCALATE でジョブ失敗） |

## 変更内容（workflow ファイルのみ、`src/` 変更なし）

1. `on.pull_request.types` に `[opened, synchronize, reopened, labeled]` を追加し、ラベル付与イベントでも再評価されるようにする
2. job に opt-in の `if` 条件を追加: `workflow_dispatch` または PR に `river-review` ラベルが付いている場合のみ実行
3. `dry_run: true` → `false`（LLM レビュー有効化）、`gate: false`（advisory 明示）、`max_cost: '0.50'`（安全キャップ）を追加
4. `env.OPENAI_MODEL: gpt-4o-mini` を追加 — `max_cost` の見積は `src/core/cost-estimator.mjs` の `DEFAULT_MODEL = 'gpt-4-turbo'` 単価を使うため、実際に使うモデル（gpt-4o-mini）を明示しないと単価差で大型 PR を誤って abort する可能性がある。この結合は必須。

`river-review` ラベルはリポジトリに未作成だったため、本 PR 作成と合わせて作成済み（`color: 1D76DB`, description: "Opt-in: run LLM-backed river-review on this PR (Stage1)"）。

## OPENAI_API_KEY の現状と fail-safe 挙動

`OPENAI_API_KEY` は現時点で repo secrets に **未設定**（本セッションで gh api により全置き場所を確認済み）。ただし本ツールは fail-safe 設計になっており、キーが空の場合は LLM 呼び出しを skip し、heuristic レビュー + 「LLM 未設定」注記コメントで正常終了する（クラッシュもコストも発生しない）。そのため本 PR は **キー未設定のままでも安全にマージできる**。キー追加後、`river-review` ラベルを付けた最初の PR で実コストの較正が始まる（見積: gpt-4o-mini・単一呼び出し・12k字truncate・maxTokens 600 で 1 PR ≒ $0.001）。

## ロールバック

- `dry_run: false` を `true` に戻す1行、または
- 対象 PR から `river-review` ラベルを外すだけ（advisory・ジョブ非実行に即座に戻る）

## 検証

- [x] `actionlint .github/workflows/river-review.yml` — pass（exit 0）
- [x] YAML 構文検証（js-yaml / python yaml）— pass
- [x] `action.yml` で `gate` / `max_cost` input の存在を確認済み（`runners/github-action/action.yml`）
- [x] `OPENAI_MODEL` が `src/lib/review-engine.mjs` / `src/cli.mjs` / dist バンドルで参照されることを確認済み
- [ ] CI green（本 PR で確認、下記コメントで報告）

関連: dry-run 恒久放置の root cause 調査（本セッション T24）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
