### PR TITLE
feat(feedback): feedback:rules に --out artifact 出力を追加する (#1471 増分B)

### DIFF
--- a/scripts/feedback-rule-candidates.mjs
+++ b/scripts/feedback-rule-candidates.mjs
@@ -9,7 +9,8 @@
 // gate fix, or a project rule. Detection only; codification stays a human
 // decision via the improvement flow.
 //
-// Usage: node scripts/feedback-rule-candidates.mjs [--min <n>] [--month YYYY-MM] [--json]
+// Usage: node scripts/feedback-rule-candidates.mjs [--min <n>] [--month YYYY-MM] [--json] [--out <path>]
+import { promises as fs } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { listFeedbackEntries } from '../src/lib/feedback.mjs';
@@ -58,6 +59,39 @@ export function findRuleCandidates(entries, { min = 2 } = {}) {
   return candidates;
 }
 
+/**
+ * Build the structured artifact payload written by `--out`.
+ *
+ * Minimal shape: metadata plus the same per-candidate fields already used by
+ * `--json` stdout (`{skillId, feedbackType, count, prs, suggestedAction}`), so
+ * a future CI artifact / improvement-flow consumer has one contract to read
+ * regardless of which output mode produced it.
+ *
+ * @param {{ entriesCount: number, min: number, candidates: ReturnType<typeof findRuleCandidates>, now?: Date }} options
+ */
+export function buildCandidatesArtifact({ entriesCount, min, candidates, now = new Date() }) {
+  return {
+    generatedAt: now.toISOString(),
+    threshold: min,
+    entries: entriesCount,
+    candidates,
+  };
+}
+
+/**
+ * Write the artifact payload to `outPath` as pretty-printed JSON, creating
+ * parent directories as needed. Pure I/O helper kept separate from
+ * `buildCandidatesArtifact` so tests can validate the JSON shape without
+ * touching the filesystem.
+ *
+ * @param {string} outPath
+ * @param {ReturnType<typeof buildCandidatesArtifact>} payload
+ */
+export async function writeCandidatesArtifact(outPath, payload) {
+  await fs.mkdir(path.dirname(outPath), { recursive: true });
+  await fs.writeFile(outPath, JSON.stringify(payload, null, 2) + '\n', 'utf8');
+}
+
 if (isDirectRun(import.meta.url)) {
   const args = process.argv.slice(2);
   const minIdx = args.indexOf('--min');
@@ -72,8 +106,26 @@ if (isDirectRun(import.meta.url)) {
   }
   const monthIdx = args.indexOf('--month');
   const month = monthIdx >= 0 ? args[monthIdx + 1] : null;
+  const outIdx = args.indexOf('--out');
+  let outPath = null;
+  if (outIdx >= 0) {
+    outPath = args[outIdx + 1];
+    if (!outPath || outPath.startsWith('--')) {
+      console.error('Error: --out requires a file path.');
+      process.exit(2);
+    }
+  }
   const entries = await listFeedbackEntries({ repoRoot, month, warn: (m) => console.warn(m) });
   const candidates = findRuleCandidates(entries, { min });
+  // --out writes a structured artifact alongside whichever stdout mode below
+  // runs; it does not change stdout content or the exit-code-2-on-candidates
+  // behavior (kept for backward compatibility with existing CI usage).
+  if (outPath) {
+    await writeCandidatesArtifact(
+      path.resolve(outPath),
+      buildCandidatesArtifact({ entriesCount: entries.length, min, candidates })
+    );
+  }
   if (args.includes('--json')) {
     console.log(JSON.stringify({ entries: entries.length, candidates }, null, 2));
   } else if (!candidates.length) {

--- a/scripts/feedback-rule-candidates.mjs
+++ b/scripts/feedback-rule-candidates.mjs
@@ -121,10 +121,15 @@ if (isDirectRun(import.meta.url)) {
   // runs; it does not change stdout content or the exit-code-2-on-candidates
   // behavior (kept for backward compatibility with existing CI usage).
   if (outPath) {
-    await writeCandidatesArtifact(
-      path.resolve(outPath),
-      buildCandidatesArtifact({ entriesCount: entries.length, min, candidates })
-    );
+    try {
+      await writeCandidatesArtifact(
+        path.resolve(outPath),
+        buildCandidatesArtifact({ entriesCount: entries.length, min, candidates })
+      );
+    } catch (err) {
+      console.error(`Error: Failed to write artifact to ${outPath}: ${err.message}`);
+      process.exit(1);
+    }
   }
   if (args.includes('--json')) {
     console.log(JSON.stringify({ entries: entries.length, candidates }, null, 2));

--- a/tests/feedback-rule-candidates.test.mjs
+++ b/tests/feedback-rule-candidates.test.mjs
@@ -2,6 +2,8 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'path';
 import fs from 'fs/promises';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 import {
   findRuleCandidates,
@@ -9,6 +11,9 @@ import {
   writeCandidatesArtifact,
 } from '../scripts/feedback-rule-candidates.mjs';
 import { createTempDirAsync, cleanupTempDirAsync } from './helpers/temp-dir.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.resolve(__dirname, '../scripts/feedback-rule-candidates.mjs');
 
 const fp = (skillId, pr) => ({ skillId, feedbackType: 'false_positive', pr });
 
@@ -117,6 +122,28 @@ test('writeCandidatesArtifact writes structured JSON to disk, creating parent di
       'skillId',
       'suggestedAction',
     ]);
+  } finally {
+    await cleanupTempDirAsync(dir);
+  }
+});
+
+test('CLI: --out with an invalid path reports a clean error and exits 1 instead of crashing', async () => {
+  // A blocking file at the parent path makes fs.mkdir(..., {recursive:true})
+  // fail with ENOTDIR/EEXIST — exercising the writeCandidatesArtifact
+  // try/catch in the direct-run block (gemini-code-assist review on #1492).
+  const dir = await createTempDirAsync({ prefix: 'feedback-rule-out-err-' });
+  try {
+    const blockerPath = path.join(dir, 'blocker');
+    await fs.writeFile(blockerPath, 'not a directory', 'utf8');
+    const outPath = path.join(blockerPath, 'out.json');
+
+    const result = spawnSync(process.execPath, [SCRIPT, '--month', '1999-01', '--out', outPath], {
+      encoding: 'utf8',
+    });
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Error: Failed to write artifact to/);
+    assert.doesNotMatch(result.stderr, /at (Object\.|writeFile|async)/); // no raw Node stack trace
   } finally {
     await cleanupTempDirAsync(dir);
   }

--- a/tests/feedback-rule-candidates.test.mjs
+++ b/tests/feedback-rule-candidates.test.mjs
@@ -1,7 +1,14 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import path from 'path';
+import fs from 'fs/promises';
 
-import { findRuleCandidates } from '../scripts/feedback-rule-candidates.mjs';
+import {
+  findRuleCandidates,
+  buildCandidatesArtifact,
+  writeCandidatesArtifact,
+} from '../scripts/feedback-rule-candidates.mjs';
+import { createTempDirAsync, cleanupTempDirAsync } from './helpers/temp-dir.mjs';
 
 const fp = (skillId, pr) => ({ skillId, feedbackType: 'false_positive', pr });
 
@@ -48,4 +55,69 @@ test('custom threshold and count-descending ordering', () => {
   );
   assert.match(candidates[1].suggestedAction, /rules\.md/);
   assert.equal(findRuleCandidates(entries, { min: 3 }).length, 1);
+});
+
+// --out artifact output (#1471 増分B): buildCandidatesArtifact wraps the same
+// per-candidate shape already used by --json stdout, plus metadata so a
+// future CI artifact / improvement-flow consumer has a stable contract.
+test('buildCandidatesArtifact wraps candidates with generatedAt/threshold/entries metadata', () => {
+  const entries = [fp('skill-a', 10), fp('skill-a', 11)];
+  const candidates = findRuleCandidates(entries, { min: 2 });
+  const now = new Date('2026-07-11T00:00:00.000Z');
+  const artifact = buildCandidatesArtifact({
+    entriesCount: entries.length,
+    min: 2,
+    candidates,
+    now,
+  });
+  assert.deepEqual(artifact, {
+    generatedAt: '2026-07-11T00:00:00.000Z',
+    threshold: 2,
+    entries: 2,
+    candidates: [
+      {
+        skillId: 'skill-a',
+        feedbackType: 'false_positive',
+        count: 2,
+        prs: [10, 11],
+        suggestedAction: candidates[0].suggestedAction,
+      },
+    ],
+  });
+});
+
+test('buildCandidatesArtifact preserves the minimal per-candidate shape when there are no candidates', () => {
+  const artifact = buildCandidatesArtifact({ entriesCount: 0, min: 2, candidates: [] });
+  assert.deepEqual(artifact.candidates, []);
+  assert.equal(artifact.entries, 0);
+  assert.equal(artifact.threshold, 2);
+  assert.match(artifact.generatedAt, /^\d{4}-\d{2}-\d{2}T/);
+});
+
+test('writeCandidatesArtifact writes structured JSON to disk, creating parent directories', async () => {
+  const dir = await createTempDirAsync({ prefix: 'feedback-rule-out-' });
+  try {
+    const outPath = path.join(dir, 'nested', 'promotion-candidates.json');
+    const payload = buildCandidatesArtifact({
+      entriesCount: 3,
+      min: 2,
+      candidates: findRuleCandidates([fp('skill-a', 1), fp('skill-a', 2)], { min: 2 }),
+      now: new Date('2026-07-11T00:00:00.000Z'),
+    });
+
+    await writeCandidatesArtifact(outPath, payload);
+
+    const written = JSON.parse(await fs.readFile(outPath, 'utf8'));
+    assert.deepEqual(written, payload);
+    assert.equal(written.candidates.length, 1);
+    assert.deepEqual(Object.keys(written.candidates[0]).sort(), [
+      'count',
+      'feedbackType',
+      'prs',
+      'skillId',
+      'suggestedAction',
+    ]);
+  } finally {
+    await cleanupTempDirAsync(dir);
+  }
 });


### PR DESCRIPTION
## Summary

- #1471 増分B: `npm run feedback:rules` に `--out <path>` を追加し、rule-promotion candidates を構造化 JSON artifact として書き出せるようにする
- `buildCandidatesArtifact` / `writeCandidatesArtifact` を `scripts/feedback-rule-candidates.mjs` にエクスポート。JSON 構造は `{generatedAt, threshold, entries, candidates[]}`。`candidates[]` の要素は既存 `--json` stdout と同じ最小構成 `{skillId, feedbackType, count, prs, suggestedAction}`
- 既存の人間向け stdout（テキスト/`--json`）と exit code 2（候補検出時）の挙動は無変更。`--out` はファイル出力の副作用を追加するのみで後方互換
- 将来の CI artifact 化・PlanGate / ai-second-brain 連携の入力契約になる想定（#1471 コメントの Fit&Gap 分析 増分B に対応）

## Test plan

- [x] `npm test`（`node --test`）— 2089 tests / 234 suites / 0 fail
- [x] `npx prettier --check scripts/feedback-rule-candidates.mjs tests/feedback-rule-candidates.test.mjs` — pass
- [x] `npm run lint:code`（check-code-hygiene）— pass
- [x] 手動スモークテスト: `node scripts/feedback-rule-candidates.mjs --month 1999-01 --out <path>` で `{entries:0, candidates:[]}` を書き出しつつ既存 stdout・exit code 0 を確認。`--out`（値なし）で `Error: --out requires a file path.` / exit 2 を確認
- [ ] レビュー: `src/` 非該当（scripts/tests のみ）— dist 再ビルド不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)