### PR TITLE
docs: Unknown Coverage の出力受け皿と verdict 写像を確定する (#1470 P0)

### DIFF
--- a/docs/review/output-format.md
+++ b/docs/review/output-format.md
@@ -33,6 +33,7 @@
 - **Missing Tests（不足テスト）**: 追加すべきテスト観点（正常系で抜けている異常系・境界・回帰）。finding 化しにくい「テストの不在」を可視化する
 - **Follow-up Issues（フォローアップ）**: 本 PR のスコープ外だが別途追跡すべき課題。Blocker でない Major を別 Issue で追う運用と接続する
 - **Unverified / Residual Risk（未確認事項・残リスク）**: レビュー時点で検証しきれなかった前提・観測できなかった挙動・残る懸念を、finding とは別にレポート全体として明示する。判断の限界を後から追跡可能にする
+  - **Unknown Coverage（残存 Unknown / evidence_missing / resolution）**: 残リスク節の下位構造。レビュー時点で残る Unknown を構造化して並べるブロックである。各 Unknown 項目は category・severity・blocking・evidence_missing（不足している証拠）・resolution（解消手順）を持つ。確認済みで受容したリスクと未確認のリスクを区別し、解消済み Unknown には根拠（evidence: リンク済み受入条件・テスト等）を関連付ける。verdict への写像は [loop-convergence-contract.md](../../pages/reference/loop-convergence-contract.md) の写像表に従う（新語彙は作らない）
 
 > これらは人間/エージェントが読む要約セクションであり、機械可読な finding は引き続き Comments（severity 付き）で表現する。
 

--- a/pages/reference/loop-convergence-contract.md
+++ b/pages/reference/loop-convergence-contract.md
@@ -223,6 +223,21 @@ Claude Code の loop 設計（Goal-based loop / review-fix cycle / stop conditio
 
 review-fix cycle の既定回数は reference loop 実装の `resolveIterationLimit`（既定 5）が持ち、呼び出し側が調整します。3 回への固定は運用側の tunable であり、契約としては複合停止条件と上限の両立で過剰レビューを抑制します。Proactive loop（新規 PR のレビュー候補検出など）は本契約の対象外であり、安全境界は ADR-003 の Non-Goals（無承認の自動マージを行わない）が定めます。
 
+### Unknown Coverage verdict の写像（#1470）
+
+Unknown Coverage Review（#1470）が出力する verdict も、新しい語彙を作らず上表と同じ方針で既存信号へ写像されます。残存 Unknown の判定は `gate.decision` と finding の `severity` へ次のとおり対応し、Unknown の存在だけで自動的に `fail` にはしません。証拠不足や解消済みの根拠は [output-format.md](https://github.com/s977043/river-review/blob/main/docs/review/output-format.md) §4「Unverified / Residual Risk」節（Unknown Coverage 下位構造）で表現します。
+
+| Unknown Coverage 出力                   | River Review 既存語彙                                 | 具体マッピング                                                                                    |
+| --------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `verdict: pass`                         | `GO` / `GO_WITH_OBSERVATION`                          | Blocking Unknown なし・必要証拠あり                                                               |
+| `verdict: needs_review`                 | `ESCALATE`（要人間）                                  | 非 Blocking Unknown / 軽微な証拠不足 → `severity: major` finding ＋ §4 残リスク節に残懸念を明記   |
+| `verdict: fail`                         | `NO_GO`（要修正）                                     | セキュリティ / データ損失 / 互換性 / 不可逆の重大 Blocking Unknown → `severity: critical` finding |
+| `blocking: true / false`                | finding `severity`（critical / major）＋ `confidence` | blocking かつ高確信 → critical。非 blocking → §4 残リスク節（finding 化しづらいものは report 節） |
+| `evidence_checked` / `evidence_missing` | finding `evidence[]` ＋ §4 節本文                     | 不足証拠は §4 の残リスク文と `suggestion`（解消手順）で表現する                                   |
+| `resolved`（解消済み Unknown）          | Good Points 節（§4）＋ 根拠 file / test 参照          | 「解消済みには根拠を関連付ける」受入条件を §4 で満たす                                            |
+
+`gate.decision` の fail-safe 方向（判定不能・未決 → `NO_GO` / `ESCALATE`）は `src/lib/gate-decision.mjs` の決定論純関数が担い、`severity` × `confidence` × `blocking` の 3 軸で出し分けます。出力スキーマ（`severity: critical / major / minor / info`）は変更せず、後方互換を保ちます。
+
 ## 関連ドキュメント
 
 - [AI 駆動開発プレイブック（Case 2 / Case 3）](../guides/ai-agent-playbook.md) — ケース別の呼び出し方

--- a/pages/reference/review-policy.en.md
+++ b/pages/reference/review-policy.en.md
@@ -65,6 +65,7 @@ To strengthen the basis for judgment, add the following when useful. All are opt
 - **Missing Tests**: Test angles that should be added (absent error/boundary/regression cases). Surfaces the absence of tests, which is hard to express as a finding.
 - **Follow-up Issues**: Concerns outside this change's scope that should be tracked separately. Connects to the practice of tracking non-blocker Majors in separate issues.
 - **Unverified / Residual Risk**: Assumptions the review could not verify, behavior it could not observe, and concerns that remain — stated for the report as a whole, separately from findings, so the limits of the judgment stay traceable.
+  - **Unknown Coverage (residual Unknowns / evidence_missing / resolution)**: A sub-structure of the residual-risk section that lays out the Unknowns remaining at review time in a structured form. Each Unknown carries category, severity, blocking, evidence_missing (the evidence not yet gathered), and resolution (how to close it). It separates risks that were checked and accepted from risks left unverified, and it associates resolved Unknowns with evidence. The mapping to a verdict follows the table in [loop-convergence-contract.md](./loop-convergence-contract.md) and introduces no new vocabulary.
 
 ## 3. Prohibited Actions
 

--- a/pages/reference/review-policy.md
+++ b/pages/reference/review-policy.md
@@ -65,6 +65,7 @@ AI レビューの出力は以下の構造に従います。
 - **Missing Tests（不足テスト）**：追加すべきテスト観点（抜けている異常系・境界・回帰）。finding 化しにくいテストの不在を可視化する。
 - **Follow-up Issues（フォローアップ）**：本変更のスコープ外だが別途追跡すべき課題。Blocker でない Major を別 Issue で追う運用と接続する。
 - **Unverified / Residual Risk（未確認事項・残リスク）**：レビュー時点で検証しきれなかった前提や、観測できなかった挙動、残る懸念を、finding とは別にレポート全体として明示する。判断の限界を後から追跡できるようにする。
+  - **Unknown Coverage（残存 Unknown / evidence_missing / resolution）**：残リスク節の下位構造として、レビュー時点で残る Unknown を構造化して並べる。各 Unknown 項目は category・severity・blocking・evidence_missing（不足している証拠）・resolution（解消手順）を持つ。確認済みで受容したリスクと未確認のリスクを区別し、解消済み Unknown には根拠（evidence）を関連付ける。verdict への写像は [loop-convergence-contract.md](./loop-convergence-contract.md) の写像表に従い、新しい語彙は作らない。
 
 ## 3. 禁止事項
 


### PR DESCRIPTION
## 目的 / What

Issue #1470「PRレビューに Unknown Coverage Review を導入する」の **P0（受け皿確定・doc のみ）**。Unknown Coverage 出力の home を既存の report 節に明文化し、verdict 写像を確定する。P1（agent-skill メタ観点の本体）は別 PR。

設計 SSoT: 調査設計書 v1 の §5（verdict 写像）/ §7 フェーズ計画 P0。

## 変更内容

- **`docs/review/output-format.md` §4**: 「Unverified / Residual Risk（未確認事項・残リスク）」節の下位構造として **Unknown Coverage（残存 Unknown / evidence_missing / resolution）** を明記。各 Unknown 項目は category・severity・blocking・evidence_missing・resolution を持ち、確認済み受容リスクと未確認リスクを区別する。
- **`pages/reference/loop-convergence-contract.md`**: #1428 写像表付近に「Unknown Coverage verdict の写像（#1470）」表を追記。`pass=GO/GO_WITH_OBSERVATION`、`needs_review=ESCALATE`（severity major + §4 残リスク）、`fail=NO_GO`（severity critical）、`blocking`/`evidence_checked`/`evidence_missing`/`resolved` の既存語彙への対応を定着。**新語彙・schema は導入しない**（後方互換）。
- **SSoT 同期**: `docs/review/output-format.md` は `pages/reference/review-policy.md`（ja/en）を出典宣言しているため、§2.4「補助セクション / Optional Sections」にも同じ Unknown Coverage 下位構造を ja/en 両方へ反映（CLAUDE.md「Review-doc SSoT sync」ガード準拠）。

## 検証

- `npx textlint --no-cache pages/reference/review-policy.md pages/reference/loop-convergence-contract.md` → EXIT=0（CI 対象の pages/** をカバー。`.en.md` は `.textlintignore` で除外）
- `npm run fix:dashes` → 変更なし
- lint-staged（commit 時）: `check:bilingual` / `textlint --no-cache`（pages 3 files）すべて pass

## レビュー観点 / 人間確認

- verdict 写像は設計書 §5 の表をそのまま定着（新語彙なし・既存 gate-decision.mjs の fail-safe 方向と一致）。
- `docs/review/output-format.md` の既存 line 32（Good Points 行）に textlint の no-doubled-joshi 既存違反があるが、本 PR の変更行外かつ `lint:text` の対象 glob（`pages/**`）外のため CI スコープ外。minimal-diff 方針により未修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)