### PR TITLE
feat(skills): Unknown Coverage Review のメタ観点 agent-skill を追加する (#1470 P1)

### DIFF
--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "description": "Deterministic skill manifest for drift detection by selective adopters. Compare the checksum of your copied skill against this list to notice upstream changes. Regenerate with: npm run skills:manifest",
-  "skillCount": 125,
+  "skillCount": 126,
   "skills": [
     {
       "id": "a11y-accessible-name",
@@ -606,7 +606,7 @@
     {
       "id": "river-review",
       "path": "skills/agent-skills/river-review",
-      "checksum": "sha256:f15ab640749db6af07503474a9abd5dbe8f952ed2de6a571512adeaa5924df77",
+      "checksum": "sha256:ba37c22cf43e49672b4883d708c2cc05e21e97c574c22d5a8df07edf4ff6a824",
       "files": 6
     },
     {
@@ -740,6 +740,12 @@
       "path": "skills/midstream/ubiquitous-language-naming",
       "checksum": "sha256:0ceb062d0a31e302689cc4eaf46563bada25a77175bf4a0f26840253eb959282",
       "files": 1
+    },
+    {
+      "id": "unknown-coverage-review",
+      "path": "skills/agent-skills/unknown-coverage-review",
+      "checksum": "sha256:ff4afd3b94252ded2130e15821b87d486870de0b5a629d79fdf57eaa7659cd4b",
+      "files": 5
     },
     {
       "id": "vitest-mock-isolation",

--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -744,7 +744,7 @@
     {
       "id": "unknown-coverage-review",
       "path": "skills/agent-skills/unknown-coverage-review",
-      "checksum": "sha256:ff4afd3b94252ded2130e15821b87d486870de0b5a629d79fdf57eaa7659cd4b",
+      "checksum": "sha256:1d3e64d147c3ede06d4652aa35875c306b1d3c8fb4ff0cebcc91a6e6cec1707e",
       "files": 5
     },
     {

--- a/skills/agent-skills/river-review/SKILL.md
+++ b/skills/agent-skills/river-review/SKILL.md
@@ -92,10 +92,13 @@ review 実行プランを組むときに参照する入力は、以下の優先�
 3. Finding verification
    └─ VERIFICATION.md の 6 項目 self-check を全件通過したものだけ出力
 
-4. Feedback classification（人間/エージェント返答受領後）
+4. Unknown Coverage 合成（finding verification 後のメタ観点）
+   └─ 検証済み finding + artifact を横断し、unknown-coverage-review へ委譲して残存 Unknown / 証拠不足を合成（report-only・マージは止めない・plan 欠損時は skippedSkills でデグレード）
+
+5. Feedback classification（人間/エージェント返答受領後）
    └─ FEEDBACK.md の 7 type で分類
 
-5. Improvement loop handoff
+6. Improvement loop handoff
    └─ IMPROVEMENT_LOOP.md の 9 ステップに従って fixture / reference / suppression / routing を更新
 ```
 

--- a/skills/agent-skills/unknown-coverage-review/SKILL.md
+++ b/skills/agent-skills/unknown-coverage-review/SKILL.md
@@ -1,0 +1,110 @@
+---
+id: unknown-coverage-review
+name: unknown-coverage-review
+description: |
+  完成した差分・PR・検証証拠に残る Unknown（未確認の前提・調査されていない影響・
+  不足している証拠）を横断合成する evidence-sufficiency のメタ観点。個別 defect の
+  検出は既存 skill へ委譲し、本 skill は「そのリスク種別を調査した証拠が残っているか」
+  の meta 評価のみを行う。finding verification 後の合成ステップとして report-only で
+  実行し、残存 Unknown を output-format §4「Unverified / Residual Risk」の Unknown
+  Coverage 下位構造へ、判定を既存 verdict 語彙（GO/ESCALATE/NO_GO）へ写像する。
+  新しい語彙・schema は作らない。
+category: midstream
+phase: [upstream, midstream, downstream]
+severity: major
+applyTo:
+  - 'src/**/*.{ts,tsx,js,jsx,mjs}'
+  - 'runners/**/*.{ts,js,mjs}'
+  - 'scripts/**/*.mjs'
+  - '**/migrations/**'
+  - '**/*.sql'
+inputContext: [diff, fullFile, plan, review-self, review-external, test-cases]
+outputKind: [findings, questions, actions]
+tags:
+  [
+    unknown-coverage,
+    evidence-sufficiency,
+    grill-for-unknowns,
+    unknown-unknowns,
+    map-territory,
+    meta,
+    synthesis,
+  ]
+version: '0.1.0'
+license: MIT
+---
+
+# Unknown Coverage Review（残存 Unknown のメタ観点）
+
+> **由来 / Inspired by**: Thariq「[A Field Guide to Finding Your Unknowns](https://claude.com/blog/a-field-guide-to-claude-fable-finding-your-unknowns)」（The map is not the territory: Plan やプロンプトは現実のコードベースを圧縮した地図であり、地図と土地の差分に Unknown が潜む）と Matt Pocock「[`/grill-me`](https://www.aihero.dev/skills-grill-me)」（実装前に質問を重ね共有理解を作る）から着想した概念の再実装。原著者を名指しする nominative fair use に留め、endorsement は主張しない。
+
+通常のレビューは「壊れている箇所（defect）」を指す。
+本観点は **「そのリスク種別を調査した証拠が残っているか（evidence-sufficiency）」** を、完成した差分を横断して合成する。問いが直交するため、defect 検出とは混載しない。
+
+## 背景 / Background
+
+AI coding agent の実行能力が上がるほど、見逃しは単純なコード品質から **要件・暗黙知・影響範囲・運用条件・移行条件などの「未確認の未知（Unknown）」** へ移る。
+チェックリストを満たしても、レビュー対象外の前提や未確認領域が残れば誤ったマージ判断につながる。
+本観点は大量の質問を生成しない。差分・PR 本文・Plan・テスト・設定・履歴を調査し、以下を構造化して出力する。
+
+1. 何が未確認か
+2. なぜ危険か
+3. どの証拠が不足しているか
+4. 何を確認すれば解消できるか
+5. マージを止めるべきか（既存 verdict 語彙への写像で表現）
+
+## Pre-execution Gate / 発火条件
+
+**最初に判定する**。満たさない場合は以降の観点を実行せず `NO_REVIEW` を返す。
+
+- finding verification 後の **合成ステップ**として呼ばれている（orchestrator の Execution Flow から。keyword routing では呼ばない）。
+- 入力に少なくとも `diff` があり、差分が **リポジトリ内で実行されるコード・migration・schema・公開 API・設定**のいずれかに触れる。docs・コメントのみの差分は対象外とする。
+- ビルド成果物・生成物（`dist/**`・`*.map`・lockfile・自動生成 manifest）は Gate 判定からもレビュー対象からも除外する。
+- **PlanGate 非依存**: `plan` / `review-self` などの artifact が欠損しても動作する。欠損した観点は finding を出さず `skippedSkills` に記録してデグレードする（artifact-input-contract の既定挙動）。
+
+## 6 Unknown 観点 / Perspectives
+
+Issue #1470 の 6 カテゴリを、defect ではなく **evidence-sufficiency の meta 質問**として扱う。各観点の defect 検出は既存 skill へ委譲する（[DELEGATION.md](./references/DELEGATION.md)）。本観点は委譲先が扱わない **残余（証拠が足りているかの合成）のみ**を検出する。
+
+| #   | 観点                           | 核心の meta 問い                                                         |
+| --- | ------------------------------ | ------------------------------------------------------------------------ |
+| 1   | Requirement / Intent Unknowns  | 「曖昧な仕様を推測で実装した箇所に、確認した証拠があるか」               |
+| 2   | Repository / Impact Unknowns   | 「影響範囲を repo 全体で検索・確認した証拠があるか」                     |
+| 3   | Runtime / Operational Unknowns | 「migration・再実行・外部依存・監視を検証した証拠があるか」              |
+| 4   | Security / Data Unknowns       | 「認証境界・入力検証・不可逆変更を確認した証拠があるか」                 |
+| 5   | Validation Unknowns            | 「失敗系・境界・実利用経路を観測した証拠があるか」                       |
+| 6   | Plan / Assumption Traceability | 「Plan の Assumption が解消され、新規 Unknown が記録された証拠があるか」 |
+
+観点 3〜5 は既存の運用・影響・検証系 skill の多くが `applyTo: docs/**`（upstream 設計文書向け）で、**コードのみの diff では空振りする**。本観点はその空白を「証拠の有無」の meta として拾う（設計 §1 の Partial / Gap）。
+
+## 委譲 / Delegation
+
+重複指摘を避けるため、個別 defect の検出は既存 registry skill に委譲し、本観点は **証拠充足の meta 評価のみ**を行う。委譲表・証拠要件・分界は [DELEGATION.md](./references/DELEGATION.md) を SSoT とする。委譲先が finding を出す領域を本観点は重複指摘しない。
+
+## Output / 出力
+
+report-only 契約に従う。**本観点はマージを止めない**。判定素材を返すだけで、反復・停止・エスカレは caller の責務である。
+
+- 残存 Unknown は [output-format.md](https://github.com/s977043/river-review/blob/main/docs/review/output-format.md) §4「Unverified / Residual Risk」の **Unknown Coverage（残存 Unknown / evidence_missing / resolution）** 下位構造へ出力する。各 Unknown は category・severity・blocking・evidence_missing・resolution を持つ。
+- 解消済み Unknown は Good Points 節に根拠（リンク済み受入条件・テスト等）を添えて記録する。
+- verdict は新語彙を作らず既存 `gate.decision` へ写像する（loop-convergence-contract.md「Unknown Coverage verdict の写像」表が SSoT）。
+
+| verdict        | 既存語彙                     | 条件                                                                                      |
+| -------------- | ---------------------------- | ----------------------------------------------------------------------------------------- |
+| `pass`         | `GO` / `GO_WITH_OBSERVATION` | Blocking Unknown なし・必要証拠あり                                                       |
+| `needs_review` | `ESCALATE`（要人間）         | 非 Blocking Unknown / 軽微な証拠不足 → `severity: major` ＋ §4 残リスク                   |
+| `fail`         | `NO_GO`（要修正）            | セキュリティ / データ損失 / 互換性 / 不可逆の重大 Blocking Unknown → `severity: critical` |
+
+- **判定原則**: Unknown の存在だけで自動的に `fail` にはしない。severity・blocking・根拠・復旧可能性で判断し、**未確認と「確認済みでリスク受容」を区別**する。fail-safe（判定不能 → NO_GO / ESCALATE）は `src/lib/gate-decision.mjs` の決定論純関数が担う。
+
+## False-positive guards
+
+- 指摘の `file:line` は差分内にあること（VERIFICATION の evidence 規則）。差分外の推測に基づく Unknown は finding にせず question として返す。
+- 委譲表に該当する defect は出さない（委譲先 skill の実行に委ねる）。
+- 「証拠が repo 内・別ファイル・PR 本文に存在する可能性」を Grep / artifact 参照で棄却できない場合は、finding ではなく question にする。
+- 低リスク PR（小さな明確なバグ修正・既存パターン踏襲）では過剰な Unknown を出さない。観点ごとに最大 5 件、severity 降順で切り捨てる。
+- correctness bug・セキュリティ欠陥そのものは対象外（defect 系観点の責務）。
+
+## References
+
+- [DELEGATION.md](./references/DELEGATION.md) — 既存 skill への委譲表・証拠要件・分界

--- a/skills/agent-skills/unknown-coverage-review/SKILL.md
+++ b/skills/agent-skills/unknown-coverage-review/SKILL.md
@@ -18,6 +18,7 @@ applyTo:
   - 'scripts/**/*.mjs'
   - '**/migrations/**'
   - '**/*.sql'
+  - '**/*.{yaml,yml,json,toml}'
 inputContext: [diff, fullFile, plan, review-self, review-external, test-cases]
 outputKind: [findings, questions, actions]
 tags:
@@ -85,7 +86,7 @@ Issue #1470 の 6 カテゴリを、defect ではなく **evidence-sufficiency �
 
 report-only 契約に従う。**本観点はマージを止めない**。判定素材を返すだけで、反復・停止・エスカレは caller の責務である。
 
-- 残存 Unknown は [output-format.md](https://github.com/s977043/river-review/blob/main/docs/review/output-format.md) §4「Unverified / Residual Risk」の **Unknown Coverage（残存 Unknown / evidence_missing / resolution）** 下位構造へ出力する。各 Unknown は category・severity・blocking・evidence_missing・resolution を持つ。
+- 残存 Unknown は [output-format.md](../../../docs/review/output-format.md) §4「Unverified / Residual Risk」の **Unknown Coverage（残存 Unknown / evidence_missing / resolution）** 下位構造へ出力する。各 Unknown は category・severity・blocking・evidence_missing・resolution を持つ。
 - 解消済み Unknown は Good Points 節に根拠（リンク済み受入条件・テスト等）を添えて記録する。
 - verdict は新語彙を作らず既存 `gate.decision` へ写像する（loop-convergence-contract.md「Unknown Coverage verdict の写像」表が SSoT）。
 

--- a/skills/agent-skills/unknown-coverage-review/fixtures/01-pass-evidence-sufficient.md
+++ b/skills/agent-skills/unknown-coverage-review/fixtures/01-pass-evidence-sufficient.md
@@ -1,0 +1,43 @@
+# Test Case: Evidence Sufficient → pass (GO)
+
+## Description
+
+必要な証拠が差分・テスト・PR 本文に揃っており、Blocking Unknown が残っていないケース。Unknown Coverage Review は解消済み Unknown を記録し、`verdict: pass`（`GO`）へ写像する。過剰な Unknown を出さないこと（低リスク・十分証拠の canary）。
+
+## Input Diff
+
+```diff
+diff --git a/src/config/loader.mjs b/src/config/loader.mjs
+index 1111111..2222222 100644
+--- a/src/config/loader.mjs
++++ b/src/config/loader.mjs
+@@ -10,6 +10,14 @@ export function loadConfig(raw) {
+-  return normalizeV2(raw);
++  // 旧 v1 形式との後方互換を維持する（利用箇所は repo 全体を grep 済み）
++  if (raw.schemaVersion === 1) {
++    return normalizeV2(migrateV1toV2(raw));
++  }
++  return normalizeV2(raw);
+diff --git a/test/config/loader.test.mjs b/test/config/loader.test.mjs
+index 3333333..4444444 100644
+--- a/test/config/loader.test.mjs
++++ b/test/config/loader.test.mjs
+@@ -20,0 +21,8 @@ describe('loadConfig', () => {
++  it('v1 形式を v2 へ移行して読み込む', () => {
++    expect(loadConfig({ schemaVersion: 1, legacy: true })).toEqual(expectedV2);
++  });
+```
+
+## PR 本文 / Artifacts
+
+- plan: 「v1→v2 移行の互換テストを追加する」を Known Unknown として記録し、本 PR で解消。
+- review-self: `git grep schemaVersion` で利用箇所を全数確認した記録あり。
+
+## Expected Behavior
+
+本観点は以下を満たすこと。
+
+1. Blocking Unknown を検出しない（互換テスト・利用箇所検索の証拠が揃っている）。
+2. 解消済み Unknown（U: v1 互換）を Good Points 節に根拠（追加テスト・grep 記録）付きで記録する。
+3. `verdict: pass`（`gate.decision: GO`）へ写像する。
+4. 過剰な質問・低確信の Unknown を出さない。

--- a/skills/agent-skills/unknown-coverage-review/fixtures/02-needs-review-nonblocking-unknown.md
+++ b/skills/agent-skills/unknown-coverage-review/fixtures/02-needs-review-nonblocking-unknown.md
@@ -1,0 +1,34 @@
+# Test Case: Non-blocking Operational Unknown → needs_review (ESCALATE)
+
+## Description
+
+実装は妥当だが、運用系の証拠が不足しているケース。ロールバック手順が PR 本文にも運用文書にもない。データ損失や互換破壊ではないため Blocking ではないが、人間判断が必要。Unknown Coverage Review は非 Blocking Unknown を `severity: major` で出し、§4 残リスクに明記して `verdict: needs_review`（`ESCALATE`）へ写像する。
+
+## Input Diff
+
+```diff
+diff --git a/migrations/2026_07_add_index.sql b/migrations/2026_07_add_index.sql
+new file mode 100644
+index 0000000..5555555
+--- /dev/null
++++ b/migrations/2026_07_add_index.sql
+@@ -0,0 +1,2 @@
++-- 大規模テーブルへのインデックス追加
++CREATE INDEX CONCURRENTLY idx_orders_status ON orders (status);
+```
+
+## PR 本文 / Artifacts
+
+- plan: なし（PlanGate 非依存で動作すること）。
+- review-self: なし。
+- PR 本文にロールバック手順の記載なし。
+
+## Expected Behavior
+
+本観点は以下を満たすこと。
+
+1. Runtime / Operational Unknown を 1 件検出する（ロールバック手順の証拠が不足＝evidence_missing: rollback procedure）。
+2. `blocking: false`・`severity: major` とし、resolution（PR 本文または運用文書へ手順を追記する）を添える。
+3. plan / review-self 欠損を `skippedSkills` に記録し、Plan / Assumption 観点では finding を出さない（デグレード）。
+4. `verdict: needs_review`（`gate.decision: ESCALATE`）へ写像し、§4「Unverified / Residual Risk」へ残リスクを明記する。
+5. migration そのものの安全性（`CONCURRENTLY` の是非等）は `migration-safety` へ委譲し、重複指摘しない。

--- a/skills/agent-skills/unknown-coverage-review/fixtures/03-fail-blocking-compat-unknown.md
+++ b/skills/agent-skills/unknown-coverage-review/fixtures/03-fail-blocking-compat-unknown.md
@@ -1,0 +1,39 @@
+# Test Case: Blocking Compatibility Unknown → fail (NO_GO)
+
+## Description
+
+旧設定形式との互換性が検証されていないまま設定パーサーを差し替えたケース。旧形式を読み込む利用箇所を検索した証拠がなく、互換テストもない。互換破壊は不可逆的な障害につながるため重大な Blocking Unknown。Unknown Coverage Review は `severity: critical`・`blocking: true` で出し、`verdict: fail`（`NO_GO`）へ写像する。
+
+## Input Diff
+
+```diff
+diff --git a/src/config/parser.mjs b/src/config/parser.mjs
+index 6666666..7777777 100644
+--- a/src/config/parser.mjs
++++ b/src/config/parser.mjs
+@@ -1,10 +1,6 @@
+-// 旧 YAML 形式と新 TOML 形式の両方を受け付ける
+-export function parseConfig(text, format) {
+-  if (format === 'yaml') return parseYaml(text);
+-  return parseToml(text);
+-}
++// TOML のみを受け付ける
++export function parseConfig(text) {
++  return parseToml(text);
++}
+```
+
+## PR 本文 / Artifacts
+
+- plan: なし。
+- review-self: なし。
+- 旧 YAML 形式を渡す利用箇所の検索記録なし。互換テストなし。
+
+## Expected Behavior
+
+本観点は以下を満たすこと。
+
+1. Repository / Impact Unknown を Blocking で検出する（旧 YAML 形式の利用箇所を検索した証拠が不足＝evidence_missing: repository-wide usage search, migration compatibility test）。
+2. `blocking: true`・`severity: critical` とし、resolution（旧形式を読み込む利用箇所を検索し、互換テストを追加する）を添える。
+3. `verdict: fail`（`gate.decision: NO_GO`）へ写像する。
+4. `parseYaml` 呼び出し元の残骸そのものは `cross-file-leakage` へ委譲し、本観点は「互換性を確認した証拠の不在」に限定して指摘する。

--- a/skills/agent-skills/unknown-coverage-review/references/DELEGATION.md
+++ b/skills/agent-skills/unknown-coverage-review/references/DELEGATION.md
@@ -1,0 +1,34 @@
+# Delegation 表 — Unknown Coverage の残余切り出し
+
+Unknown Coverage Review は **evidence-sufficiency（証拠が足りているか）の meta 評価**に集中する。個別 defect の検出は既存 registry skill が担うため、本観点は **委譲先が扱わない残余のみ**を検出する。SIMPLIFY 観点と同じく、delegation 表で重複を機械的に抑制する。
+
+## Pre-execution Gate（再掲）
+
+**最初に判定する**。[SKILL.md](../SKILL.md) の Pre-execution Gate を満たさない場合は本表を参照せず `NO_REVIEW` を返す。要点:
+
+- finding verification 後の合成ステップとして呼ばれていること。
+- `diff` があり、実行コード・migration・schema・公開 API・設定に触れること（docs・コメントのみは対象外）。
+- `plan` / `review-self` 欠損時は該当観点を `skippedSkills` に記録してデグレードする（PlanGate 非依存）。
+
+## 証拠要件 / Evidence requirements
+
+- finding の `file:line` は差分内にアンカーする（差分外の推測に基づく Unknown は question として返す）。
+- 「証拠が repo 内・別ファイル・PR 本文・テストに存在する可能性」を Grep / Glob / artifact 参照で棄却できた場合のみ finding 化する。「なさそう」という推測は禁止する。
+- 委譲先が既に finding を出す領域は重複指摘しない。本観点の finding は「証拠の不在（evidence_missing）」に限る。
+
+## 委譲表 / Delegation table
+
+| Unknown 種別（#1470）          | 委譲先（defect 検出）                                                                                                                                                      | 本観点が扱う残余（evidence-sufficiency の meta）                                                   |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Requirement / Intent           | `requirements-acceptance`・`plangate-plan-integrity`・`ai-agent-review-readiness`                                                                                          | plan 無し PR でも残る「仕様推測を確認した証拠の不足」を合成する                                    |
+| Repository / Impact            | `cross-file-leakage`・`hallucinated-reference`・`api-compatibility`・`existing-pattern-conformance`                                                                        | 「影響範囲を repo 全体で検索した証拠があるか」の meta（顕在した漏れは委譲先が検出）                |
+| Runtime / Operational          | `operability-slo`・`failure-modes-observability`・`migration-safety`・`event-driven-semantics`・`external-dependencies`・`cache-strategy-consistency`・`async-correctness` | 運用・影響系は多くが `applyTo: docs/**` で code-only diff では空振りする。その「証拠の不在」を拾う |
+| Security / Data                | `trust-boundaries-authz`・`migration-safety`                                                                                                                               | 「認証境界・入力検証・不可逆変更を確認した証拠があるか」の meta                                    |
+| Validation                     | `coverage-gap`・`test-existence`・`e2e-wiring`・`test-plan-review`                                                                                                         | 「失敗系・境界・実利用経路を観測した証拠があるか」の meta（Missing Tests 節と接続）                |
+| Plan / Assumption Traceability | `plangate-verification-audit`・`architecture-risk-register`・`plangate-plan-integrity`                                                                                     | 「Plan の Assumption が解消された証拠」「実装中に発見した Unknown を記録した証拠」の突合           |
+
+## 分界の原則
+
+- **defect（S）は委譲先、evidence-sufficiency（M）は本観点**。委譲先は「リスクが差分に顕在化した時」に指摘し、本観点は「そのリスク種別を調査した証拠が残っているか」を横断合成する。
+- 委譲先が upstream 設計文書向け（`applyTo: docs/**`）で code-only diff に発火しない場合でも、本観点は defect を代替検出しない。あくまで「証拠の不在」を Unknown として記録し、解消手順（resolution）を添える。
+- 出力・verdict 写像は [SKILL.md](../SKILL.md) の Output 節に従う。新語彙は作らない。


### PR DESCRIPTION
## 目的 / What

Issue #1470「PRレビューに Unknown Coverage Review を導入する」の **P1（メタ観点本体・最小価値）**。完成した差分に残る Unknown（証拠不足・未確認前提・未調査の影響）を横断合成する **evidence-sufficiency のメタ観点 agent-skill** を追加する。受け皿（output-format §4 / verdict 写像）は #1493（P0）で確定済み。

設計 SSoT: 調査設計書 v1 の §2 真ギャップ（G1 evidence-sufficiency 合成）/ §3 推奨（案a メタ観点）/ §6 命名 / §7 P1。#1452 `/simplify` 取り込みと同型（delegation 表で重複回避）。

## 変更内容

- **新規 `skills/agent-skills/unknown-coverage-review/SKILL.md`**
  - dir 名 = `metadata.name` = `unknown-coverage-review`（kebab-case、`<value>-review` family）
  - **由来明記**（冒頭）: Thariq「A Field Guide to Finding Your Unknowns」/ Matt Pocock `/grill-me`（The map is not the territory）+ 検証済みリンク。nominative fair use に留め endorsement は避ける
  - **Pre-execution Gate**（合成ステップとしての発火条件・docs のみ除外・PlanGate 非依存でデグレード）
  - **6 Unknown 観点**（#1470 の 6 カテゴリを evidence-sufficiency の meta 質問として扱う）
  - **委譲**: 個別 defect は既存 registry skill へ委譲し、残余（証拠充足の meta）のみ検出
  - **出力**: output-format §4 の Unknown Coverage 下位構造 + verdict 写像（`pass=GO`/`needs_review=ESCALATE`/`fail=NO_GO`、**新語彙なし**）
  - report-only 契約（マージを止めない）
  - tags: `grill-for-unknowns` / `unknown-unknowns` / `map-territory` 他
- **`references/DELEGATION.md`**: 既存 skill への委譲表（6 カテゴリ × 委譲先 × 本観点の残余）・証拠要件・分界（`river-review-code/references/SIMPLIFY.md` 様式を踏襲、Gate 先頭）。委譲先 skill ID は registry.yaml に実在を確認済み（21 件）
- **`fixtures/`**: pass（証拠十分・過剰出力しない canary）/ needs_review（非 Blocking な運用 Unknown → ESCALATE）/ fail（互換性の重大 Blocking Unknown → NO_GO）各1
- **`skills/agent-skills/river-review/SKILL.md`**: Execution Flow に「finding verification 後の合成ステップ」として unknown-coverage-review への routing を1行追加（keyword routing ではなく post-verification synthesis）
- **`docs/data/skill-manifest.json`**: 再生成（125 → 126 skills）

## 検証（実出力）

- `npm run agent-skills:validate` → `✅ skills/agent-skills/unknown-coverage-review/SKILL.md`（dir=name 一致・references/ あり・警告なし）
- `npm run skills:manifest:check` → `skill manifest is up to date (126 skills).`
- `npm run skills:validate` → registry paths / recommended coverage / naming collisions すべて pass
- `npm run plugin:validate` → `Plugin manifest: OK`（`skills` はディレクトリ参照のため per-skill 登録不要）
- `npx markdownlint --fix` / `npx prettier --write` 適用済み

## レビュー観点 / 人間確認

- P0（#1493）とファイル非重複（P0=docs/pages, P1=skills/）。main 起点で独立。
- `applyTo` は code / migration / schema / sql に限定。実発火制御は Pre-execution Gate が担い、低リスク PR での過剰出力を fixtures の pass canary で抑制する意図（設計 §8）。
- fixtures は narrative 様式（`gha-workflow-security` 等の registry fixtures に準拠）。agent-skill には fixtures 前例がないため `<!-- expected: -->` 埋込ブロックは非採用（`agent-skills:validate` は fixtures を検証しない）。
- textlint は `pages/**` のみ対象で `skills/**` 対象外のため SKILL.md（日本語含む）は textlint 非対象。markdownlint は pass。

🤖 Generated with [Claude Code](https://claude.com/claude-code)