### PR TITLE
refactor: 残存する isDirectRun 亜種5本を正典ヘルパーへ集約する

### DIFF
--- a/scripts/evaluate-all.mjs
+++ b/scripts/evaluate-all.mjs
@@ -25,6 +25,8 @@ import path from 'node:path';
 import process from 'node:process';
 import url from 'node:url';
 
+import { isDirectRun } from './lib/is-direct-run.mjs';
+
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const ROOT = path.join(__dirname, '..');
 
@@ -478,11 +480,7 @@ Options:
 
 export { main as evaluateAll, parseArgs, appendLedger };
 
-const isDirectRun =
-  process.argv[1] &&
-  (process.argv[1].endsWith('evaluate-all.mjs') || process.argv[1].endsWith('evaluate-all'));
-
-if (isDirectRun) {
+if (isDirectRun(import.meta.url)) {
   main()
     .then((code) => {
       if (typeof code === 'number' && code !== 0) {

--- a/scripts/evaluate-review-gate.mjs
+++ b/scripts/evaluate-review-gate.mjs
@@ -2,6 +2,8 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
 
+import { isDirectRun } from './lib/is-direct-run.mjs';
+
 function parseArgs(argv) {
   const args = [...argv];
   const parsed = {
@@ -157,12 +159,7 @@ Options:
 }
 
 // Only run main when executed directly (not imported as a module)
-const isDirectRun =
-  process.argv[1] &&
-  (process.argv[1].endsWith('evaluate-review-gate.mjs') ||
-    process.argv[1].endsWith('evaluate-review-gate'));
-
-if (isDirectRun) {
+if (isDirectRun(import.meta.url)) {
   main().then((code) => {
     if (typeof code === 'number' && code !== 0) {
       process.exitCode = code;

--- a/scripts/generate-audit-report.mjs
+++ b/scripts/generate-audit-report.mjs
@@ -7,6 +7,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import url from 'node:url';
 
+import { isDirectRun } from './lib/is-direct-run.mjs';
+
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const ROOT = path.join(__dirname, '..');
 const LEDGER_PATH = path.join(ROOT, 'artifacts', 'evals', 'results.jsonl');
@@ -164,12 +166,7 @@ async function main() {
   console.log('Audit report written to ' + OUTPUT_PATH);
 }
 
-const isDirectRun =
-  process.argv[1] &&
-  (process.argv[1].endsWith('generate-audit-report.mjs') ||
-    process.argv[1].endsWith('generate-audit-report'));
-
-if (isDirectRun) {
+if (isDirectRun(import.meta.url)) {
   main().catch((err) => {
     console.error('Audit report error: ' + err.message);
     process.exitCode = 1;

--- a/scripts/usage-summary.mjs
+++ b/scripts/usage-summary.mjs
@@ -16,6 +16,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { CostEstimator } from '../src/core/cost-estimator.mjs';
+import { isDirectRun } from './lib/is-direct-run.mjs';
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const DEFAULT_DIR = path.join(SCRIPT_DIR, '..', 'artifacts', 'usage');
@@ -162,7 +163,7 @@ async function main() {
 }
 
 // Only run when invoked as a script (not when imported by tests).
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isDirectRun(import.meta.url)) {
   main().catch((err) => {
     process.stderr.write(`usage-summary failed: ${err?.message || err}\n`);
     process.exit(1);

--- a/scripts/validate-meta-consistency.mjs
+++ b/scripts/validate-meta-consistency.mjs
@@ -2,6 +2,8 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
 
+import { isDirectRun } from './lib/is-direct-run.mjs';
+
 const ROOT = path.resolve(import.meta.dirname, '..');
 
 async function readJson(filePath) {
@@ -90,12 +92,7 @@ export async function validateMeta() {
 }
 
 // CLI entry point
-const isDirectRun =
-  process.argv[1] &&
-  (process.argv[1].endsWith('validate-meta-consistency.mjs') ||
-    process.argv[1].endsWith('validate-meta-consistency'));
-
-if (isDirectRun) {
+if (isDirectRun(import.meta.url)) {
   validateMeta()
     .then((errors) => {
       if (errors.length === 0) {


### PR DESCRIPTION
# 🌊 River Review Pull Request

## Overview / 説明

- #1473 の refactor wave（`scripts/lib/is-direct-run.mjs` 正典ヘルパー確立・13本移行、#1483 でマージ）後、issue コメントに follow-up として記録されていた残存5亜種を正典ヘルパーへ移行する。
- Primary phase focus: Midstream（scripts/ の内部実装）

## 対象と亜種の内訳

`gh issue view 1473 --comments` の記録（#1483 マージ後コメント）と、`scripts/`・`tests/`（dist/ や node_modules は対象外）への自力 grep（`import.meta.url` の比較・`endsWith` 文字列一致・`file://` 直結）で過不足なしを確認した5本:

- **endsWith 文字列一致亜種（4本）**:
  - `scripts/evaluate-review-gate.mjs`
  - `scripts/generate-audit-report.mjs`
  - `scripts/evaluate-all.mjs`
  - `scripts/validate-meta-consistency.mjs`
- **`file://${process.argv[1]}` 直結比較亜種（1本）**:
  - `scripts/usage-summary.mjs`

いずれも #1483 の F-1（`realpathSync` 正典形が stdin import 時に ENOENT でクラッシュする regression）とは別物で、クラッシュはしない別形態のためスコープ外化されていたもの。今回はそれらを `scripts/lib/is-direct-run.mjs` の `isDirectRun(import.meta.url)` へ統一し、単一正典への完全統一を完了させる。

各ファイルとも `import { isDirectRun } from './lib/is-direct-run.mjs';` を追加し、`const isDirectRun = ...; if (isDirectRun) {` ブロックを `if (isDirectRun(import.meta.url)) {` に置換するのみ（#1483 の移行スタイルを踏襲）。src/ 配下に亜種は見つからなかった。

## Validation & Evidence

```bash
# ベースライン（変更前）
npm test
# tests 2090, pass 2090, fail 0

# 変更後
npm test
# tests 2090, pass 2090, fail 0（件数不変 = 挙動不変）

npm run lint
# format:check / check:dashes / lint:code / lint:md / lint:text すべて OK

# 各対象スクリプトの直接実行 smoke（従来どおり動作）
node scripts/evaluate-review-gate.mjs --help        # Usage 表示, exit 0
node scripts/validate-meta-consistency.mjs          # Meta consistency: OK, exit 0
node scripts/usage-summary.mjs                      # no usage records, exit 0
node scripts/evaluate-all.mjs --help                # Usage 表示, exit 0
node scripts/generate-audit-report.mjs              # Usage 表示（引数なしエラー）, exit 1（既存挙動と同一）

# import 経路で main ブロックが走らないことの確認（stdin import 再現、5本とも exit 0 = クラッシュなし）
for f in evaluate-review-gate generate-audit-report evaluate-all validate-meta-consistency usage-summary; do
  printf "import 'file://$(pwd)/scripts/${f}.mjs';" | node --input-type=module -
done
# 全て exit 0

# 各対象スクリプトには専用テストファイルが存在し、import 時に main が実行されないことは
# 既存の evaluate-review-gate.test.mjs / generate-audit-report.test.mjs / evaluate-all.test.mjs /
# validate-meta-consistency.test.mjs / usage-summary.test.mjs が回帰確認している（全 pass）
```

## Checklist / チェックリスト

- [x] Added or updated tests related to the changes.（挙動不変のリファクタで既存テストが回帰確認、新規テスト追加なし）
- [x] Verified that tests pass.（`npm test`: 2090/2090 pass、変更前後で件数不変）
- [ ] Updated documentation or notes if necessary.（scripts/ 内部実装のみのため対象なし）

## Related Issues

- Related #1473

## Reviewer Notes

- #1473 の refactor wave（#1483 で13本移行）の follow-up として issue コメントに記録されていた残存5亜種の統一です。
- スコープは `scripts/` のみ（Editable）。src/ 配下に亜種は見つかりませんでした。

## Deviations / 計画からの逸脱（#1412）

- [x] 計画からの逸脱なし / No deviations from the original plan
