### PR TITLE
docs(skills): unknown-coverage-review の verdict 境界と出力仕様を明確化する

### DIFF
--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -750,7 +750,7 @@
     {
       "id": "unknown-coverage-review",
       "path": "skills/agent-skills/unknown-coverage-review",
-      "checksum": "sha256:1d3e64d147c3ede06d4652aa35875c306b1d3c8fb4ff0cebcc91a6e6cec1707e",
+      "checksum": "sha256:d02ccc015963f15439c4affa6261dc1e154cca7bcdd1405c57128fbfd9f65885",
       "files": 5
     },
     {

--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -750,7 +750,7 @@
     {
       "id": "unknown-coverage-review",
       "path": "skills/agent-skills/unknown-coverage-review",
-      "checksum": "sha256:d02ccc015963f15439c4affa6261dc1e154cca7bcdd1405c57128fbfd9f65885",
+      "checksum": "sha256:48402e1e9b7802a8ea8c76ca89f0b1328f58c9470a8f8c7b417e1a36a90294c7",
       "files": 5
     },
     {

--- a/pages/reference/loop-convergence-contract.md
+++ b/pages/reference/loop-convergence-contract.md
@@ -227,14 +227,16 @@ review-fix cycle の既定回数は reference loop 実装の `resolveIterationLi
 
 Unknown Coverage Review（#1470）が出力する verdict も、新しい語彙を作らず上表と同じ方針で既存信号へ写像されます。残存 Unknown の判定は `gate.decision` と finding の `severity` へ次のとおり対応し、Unknown の存在だけで自動的に `fail` にはしません。証拠不足や解消済みの根拠は [output-format.md](https://github.com/s977043/river-review/blob/main/docs/review/output-format.md) §4「Unverified / Residual Risk」節（Unknown Coverage 下位構造）で表現します。
 
-| Unknown Coverage 出力                   | River Review 既存語彙                                 | 具体マッピング                                                                                    |
-| --------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| `verdict: pass`                         | `GO` / `GO_WITH_OBSERVATION`                          | Blocking Unknown なし・必要証拠あり                                                               |
-| `verdict: needs_review`                 | `ESCALATE`（要人間）                                  | 非 Blocking Unknown / 軽微な証拠不足 → `severity: major` finding ＋ §4 残リスク節に残懸念を明記   |
-| `verdict: fail`                         | `NO_GO`（要修正）                                     | セキュリティ / データ損失 / 互換性 / 不可逆の重大 Blocking Unknown → `severity: critical` finding |
-| `blocking: true / false`                | finding `severity`（critical / major）＋ `confidence` | blocking かつ高確信 → critical。非 blocking → §4 残リスク節（finding 化しづらいものは report 節） |
-| `evidence_checked` / `evidence_missing` | finding `evidence[]` ＋ §4 節本文                     | 不足証拠は §4 の残リスク文と `suggestion`（解消手順）で表現する                                   |
-| `resolved`（解消済み Unknown）          | Good Points 節（§4）＋ 根拠 file / test 参照          | 「解消済みには根拠を関連付ける」受入条件を §4 で満たす                                            |
+| Unknown Coverage 出力                   | River Review 既存語彙                                 | 具体マッピング                                                                                                                    |
+| --------------------------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `verdict: pass`                         | `GO` / `GO_WITH_OBSERVATION`                          | Blocking Unknown なし・必要証拠あり。resolution が merge 後の観測で足りる非 Blocking Unknown のみ残る場合は `GO_WITH_OBSERVATION` |
+| `verdict: needs_review`                 | `ESCALATE`（要人間）                                  | merge 前に解消すべき非 Blocking Unknown / 証拠不足 → `severity: major` finding ＋ §4 残リスク節に残懸念を明記                     |
+| `verdict: fail`                         | `NO_GO`（要修正）                                     | セキュリティ / データ損失 / 互換性 / 不可逆の重大 Blocking Unknown → `severity: critical` finding                                 |
+| `blocking: true / false`                | finding `severity`（critical / major）＋ `confidence` | blocking かつ高確信 → critical。非 blocking → §4 残リスク節（finding 化しづらいものは report 節）                                 |
+| `evidence_checked` / `evidence_missing` | finding `evidence[]` ＋ §4 節本文                     | 不足証拠は §4 の残リスク文と `suggestion`（解消手順）で表現する                                                                   |
+| `resolved`（解消済み Unknown）          | Good Points 節（§4）＋ 根拠 file / test 参照          | 「解消済みには根拠を関連付ける」受入条件を §4 で満たす。分量目安は観点ごとに代表 1 件・1 行に要約する                             |
+
+`pass` と `needs_review` の境界は **resolution の実行タイミング（merge 前 / merge 後）** を判別軸とします。非 Blocking Unknown が1件でも残ることは、それだけで `needs_review` を意味しません。その resolution が merge 後の観測（次回 eval run・運用レビュー等）で足りるなら `pass`（`GO_WITH_OBSERVATION`）、merge 前に解消すべきものが残る場合のみ `needs_review`（`ESCALATE`）へ倒します（#1470 P1 受入後観測）。
 
 `gate.decision` の fail-safe 方向（判定不能・未決 → `NO_GO` / `ESCALATE`）は `src/lib/gate-decision.mjs` の決定論純関数が担い、`severity` × `confidence` × `blocking` の 3 軸で出し分けます。出力スキーマ（`severity: critical / major / minor / info`）は変更せず、後方互換を保ちます。
 

--- a/pages/reference/loop-convergence-contract.md
+++ b/pages/reference/loop-convergence-contract.md
@@ -236,7 +236,7 @@ Unknown Coverage Review（#1470）が出力する verdict も、新しい語彙�
 | `evidence_checked` / `evidence_missing` | finding `evidence[]` ＋ §4 節本文                     | 不足証拠は §4 の残リスク文と `suggestion`（解消手順）で表現する                                                                   |
 | `resolved`（解消済み Unknown）          | Good Points 節（§4）＋ 根拠 file / test 参照          | 「解消済みには根拠を関連付ける」受入条件を §4 で満たす。分量目安は観点ごとに代表 1 件・1 行に要約する                             |
 
-`pass` と `needs_review` の境界は **resolution の実行タイミング（merge 前 / merge 後）** を判別軸とします。非 Blocking Unknown が1件でも残ることは、それだけで `needs_review` を意味しません。その resolution が merge 後の観測（次回 eval run・運用レビュー等）で足りるなら `pass`（`GO_WITH_OBSERVATION`）、merge 前に解消すべきものが残る場合のみ `needs_review`（`ESCALATE`）へ倒します（#1470 P1 受入後観測）。
+`pass` と `needs_review` の境界は **resolution の実行タイミング（merge 前 / merge 後）** を判別軸とします。非 Blocking Unknown が1件でも残ることは、それだけで `needs_review` を意味しません。その resolution が merge 後の観測（次回 eval run・運用レビュー等）で足りるなら `pass`（`GO_WITH_OBSERVATION`）、merge 前に解消すべきものが残る場合のみ `needs_review`（`ESCALATE`）へ倒します（#1470 P1 受入後観測）。`GO_WITH_OBSERVATION` へ写像する非 Blocking Unknown を finding として出す場合、severity は `minor` / `info` に制限します。`major` 以上の finding を伴う `verdict: pass` は `gate.decision` の判定と矛盾するためです。
 
 `gate.decision` の fail-safe 方向（判定不能・未決 → `NO_GO` / `ESCALATE`）は `src/lib/gate-decision.mjs` の決定論純関数が担い、`severity` × `confidence` × `blocking` の 3 軸で出し分けます。出力スキーマ（`severity: critical / major / minor / info`）は変更せず、後方互換を保ちます。
 

--- a/skills/agent-skills/unknown-coverage-review/SKILL.md
+++ b/skills/agent-skills/unknown-coverage-review/SKILL.md
@@ -87,23 +87,32 @@ Issue #1470 の 6 カテゴリを、defect ではなく **evidence-sufficiency �
 report-only 契約に従う。**本観点はマージを止めない**。判定素材を返すだけで、反復・停止・エスカレは caller の責務である。
 
 - 残存 Unknown は [output-format.md](../../../docs/review/output-format.md) §4「Unverified / Residual Risk」の **Unknown Coverage（残存 Unknown / evidence_missing / resolution）** 下位構造へ出力する。各 Unknown は category・severity・blocking・evidence_missing・resolution を持つ。
-- 解消済み Unknown は Good Points 節に根拠（リンク済み受入条件・テスト等）を添えて記録する。
+- 解消済み Unknown は Good Points 節に根拠（リンク済み受入条件・テスト等）を添えて記録する。分量目安は**観点ごとに代表 1 件・1 行に要約**する（低リスク PR では解消済み記録が出力の大半を占めやすいため）。
 - verdict は新語彙を作らず既存 `gate.decision` へ写像する（loop-convergence-contract.md「Unknown Coverage verdict の写像」表が SSoT）。
 
-| verdict        | 既存語彙                     | 条件                                                                                      |
-| -------------- | ---------------------------- | ----------------------------------------------------------------------------------------- |
-| `pass`         | `GO` / `GO_WITH_OBSERVATION` | Blocking Unknown なし・必要証拠あり                                                       |
-| `needs_review` | `ESCALATE`（要人間）         | 非 Blocking Unknown / 軽微な証拠不足 → `severity: major` ＋ §4 残リスク                   |
-| `fail`         | `NO_GO`（要修正）            | セキュリティ / データ損失 / 互換性 / 不可逆の重大 Blocking Unknown → `severity: critical` |
+| verdict        | 既存語彙                     | 条件                                                                                                                              |
+| -------------- | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `pass`         | `GO` / `GO_WITH_OBSERVATION` | Blocking Unknown なし・必要証拠あり。resolution が merge 後の観測で足りる非 Blocking Unknown のみ残る場合は `GO_WITH_OBSERVATION` |
+| `needs_review` | `ESCALATE`（要人間）         | merge 前に解消すべき非 Blocking Unknown / 証拠不足 → `severity: major` ＋ §4 残リスク                                             |
+| `fail`         | `NO_GO`（要修正）            | セキュリティ / データ損失 / 互換性 / 不可逆の重大 Blocking Unknown → `severity: critical`                                         |
+
+判別軸は **resolution の実行タイミング（merge 前 / merge 後）** に置く。非 Blocking Unknown が残ること自体は `needs_review` を意味しない。その resolution が merge 後の観測（次回 eval run・運用レビュー等）で足りるなら `pass`（`GO_WITH_OBSERVATION`）に倒し、merge 前に解消すべきものだけを `needs_review`（`ESCALATE`）に倒す。
 
 - **判定原則**: Unknown の存在だけで自動的に `fail` にはしない。severity・blocking・根拠・復旧可能性で判断し、**未確認と「確認済みでリスク受容」を区別**する。fail-safe（判定不能 → NO_GO / ESCALATE）は `src/lib/gate-decision.mjs` の決定論純関数が担う。
+- **`skippedSkills` の出力例**: `plan` / `review-self` 欠損時は該当観点を `skippedSkills` に記録し、finding は出さずデグレードする（[artifact-input-contract.md](../../../pages/reference/artifact-input-contract.md) と同じ語彙・`review-artifact.md` の `id` / `reasons` スキーマに整合）。例:
+
+  ```json
+  "skippedSkills": [
+    { "id": "unknown-coverage-review#6", "reasons": ["plan artifact missing"] }
+  ]
+  ```
 
 ## False-positive guards
 
 - 指摘の `file:line` は差分内にあること（VERIFICATION の evidence 規則）。差分外の推測に基づく Unknown は finding にせず question として返す。
 - 委譲表に該当する defect は出さない（委譲先 skill の実行に委ねる）。
 - 「証拠が repo 内・別ファイル・PR 本文に存在する可能性」を Grep / artifact 参照で棄却できない場合は、finding ではなく question にする。
-- 低リスク PR（小さな明確なバグ修正・既存パターン踏襲）では過剰な Unknown を出さない。観点ごとに最大 5 件、severity 降順で切り捨てる。
+- 低リスク PR（小さな明確なバグ修正・既存パターン踏襲）では過剰な Unknown を出さない。観点ごとに **finding と question の合算で** 最大 5 件、severity 降順で切り捨てる。
 - correctness bug・セキュリティ欠陥そのものは対象外（defect 系観点の責務）。
 
 ## References

--- a/skills/agent-skills/unknown-coverage-review/SKILL.md
+++ b/skills/agent-skills/unknown-coverage-review/SKILL.md
@@ -98,7 +98,7 @@ report-only 契約に従う。**本観点はマージを止めない**。判定�
 
 判別軸は **resolution の実行タイミング（merge 前 / merge 後）** に置く。非 Blocking Unknown が残ること自体は `needs_review` を意味しない。その resolution が merge 後の観測（次回 eval run・運用レビュー等）で足りるなら `pass`（`GO_WITH_OBSERVATION`）に倒し、merge 前に解消すべきものだけを `needs_review`（`ESCALATE`）に倒す。
 
-- **判定原則**: Unknown の存在だけで自動的に `fail` にはしない。severity・blocking・根拠・復旧可能性で判断し、**未確認と「確認済みでリスク受容」を区別**する。fail-safe（判定不能 → NO_GO / ESCALATE）は `src/lib/gate-decision.mjs` の決定論純関数が担う。
+- **判定原則**: Unknown の存在だけで自動的に `fail` にはしない。severity・blocking・根拠・復旧可能性で判断し、**未確認と「確認済みでリスク受容」を区別**する。fail-safe（判定不能 → NO_GO / ESCALATE）は `src/lib/gate-decision.mjs` の決定論純関数が担う。resolution が merge 後の観測で足りる非 Blocking Unknown を finding として出す場合、severity は **`minor` / `info` に制限**する（`major` 以上を出しながら `verdict: pass` に写像すると矛盾するため）。
 - **`skippedSkills` の出力例**: `plan` / `review-self` 欠損時は該当観点を `skippedSkills` に記録し、finding は出さずデグレードする（[artifact-input-contract.md](../../../pages/reference/artifact-input-contract.md) と同じ語彙・`review-artifact.md` の `id` / `reasons` スキーマに整合）。例:
 
   ```json
@@ -112,7 +112,7 @@ report-only 契約に従う。**本観点はマージを止めない**。判定�
 - 指摘の `file:line` は差分内にあること（VERIFICATION の evidence 規則）。差分外の推測に基づく Unknown は finding にせず question として返す。
 - 委譲表に該当する defect は出さない（委譲先 skill の実行に委ねる）。
 - 「証拠が repo 内・別ファイル・PR 本文に存在する可能性」を Grep / artifact 参照で棄却できない場合は、finding ではなく question にする。
-- 低リスク PR（小さな明確なバグ修正・既存パターン踏襲）では過剰な Unknown を出さない。観点ごとに **finding と question の合算で** 最大 5 件、severity 降順で切り捨てる。
+- 低リスク PR（小さな明確なバグ修正・既存パターン踏襲）では過剰な Unknown を出さない。観点ごとに **finding と question の合算で** 最大 5 件、severity 降順で切り捨てる。question は severity を持たないため **`info` 相当として扱い、切り捨ては findings（severity 降順）→ questions の順**とする。
 - correctness bug・セキュリティ欠陥そのものは対象外（defect 系観点の責務）。
 
 ## References


### PR DESCRIPTION
## 背景

#1470 P1 受入後観測（[issuecomment-4947578972](https://github.com/s977043/river-review/issues/1470#issuecomment-4947578972)）で、実 diff 3件への `unknown-coverage-review` skill 適用結果から SKILL.md 改善提案4件が挙がった。本 PR はそれら4件を1PRで反映する。

## 対応表

| # | 観測コメントの提案 | 対応内容 |
| --- | --- | --- |
| 1 (major) | `pass` / `needs_review` の境界が写像表の字面から読み分けられない | 判別軸を「resolution の実行タイミング（merge 前 / merge 後）」に置き直し、`SKILL.md` Output 節と `pages/reference/loop-convergence-contract.md`「Unknown Coverage verdict の写像」表（SSoT）を同一 PR で同期。`pass` 行 = 「Blocking Unknown なし・必要証拠あり。resolution が merge 後の観測で足りる非 Blocking Unknown のみ残る場合は GO_WITH_OBSERVATION」、`needs_review` 行 = 「merge 前に解消すべき非 Blocking Unknown / 証拠不足」 |
| 2 (minor) | 解消済み Unknown の記録分量に規定がない | False-positive guards 相当箇所（Output 節）に「観点ごとに代表1件・1行に要約する」を追記 |
| 3 (minor) | 「観点ごとに最大5件」が finding のみか question 込みか不明 | 「finding と question の合算で観点ごとに最大5件」と明記 |
| 4 (minor) | `skippedSkills` の出力形式が例示されていない | Output 節に `{ "id": "unknown-coverage-review#6", "reasons": ["plan artifact missing"] }` 相当の出力例を追加。`review-artifact.md` の `skippedSkills`（`id` 必須 / `reasons` 必須・文字列配列）スキーマと `artifact-input-contract.md` の語彙に整合させた |

## SSoT 重複確認

`docs/review/output-format.md` §4 と `pages/reference/review-policy.md`（ja/en）は、いずれも `loop-convergence-contract.md` の写像表への**参照のみ**で、pass/needs_review の境界条件そのものは記述していない（確認済み）。そのため今回は変更していない。

## 検証

- `npm run agent-skills:validate` → `unknown-coverage-review/SKILL.md` ✅
- `npm run skills:manifest:check` → stale 検出 → `npm run skills:manifest` で再生成（`unknown-coverage-review` エントリのみ checksum 差分。並行中の #1500 (`river-review-frontend`) と衝突なし）
- `npx textlint --no-cache pages/reference/loop-convergence-contract.md` → エラーなし
- `npm run fix:dashes` → 変更なし
- `npx prettier --check` → 対象2ファイルとも Prettier 準拠

## 並行 PR について

#1500（`river-review-frontend` エントリ）は本 PR 作成前に main へマージ済み。本ブランチは最新の `origin/main`（`8f38551f`）から作成しており、`docs/data/skill-manifest.json` の diff は `unknown-coverage-review` エントリの checksum 1行のみで competing 変更はない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)