### PR TITLE
docs(skills): PlanGate #810 の ledger を plan artifact 経由で接続する (#1470 P3)

### DIFF
--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -120,7 +120,7 @@
     {
       "id": "assumption-resolution-trace",
       "path": "skills/midstream/assumption-resolution-trace",
-      "checksum": "sha256:756fdb5cb0699600e5f322c3191c1b539fcd33d94bea9fb69dad6f809c27d9fe",
+      "checksum": "sha256:e4c53f59bbc6ddbacde1a787a07b670c4ba3c95a68c8a6ec93c5ab17cfd3ba39",
       "files": 3
     },
     {
@@ -762,7 +762,7 @@
     {
       "id": "unknown-coverage-review",
       "path": "skills/agent-skills/unknown-coverage-review",
-      "checksum": "sha256:4034262cec38237bef65b2fe0728cc77a1ac843ca9ca8d1933ff72b72dfd7afe",
+      "checksum": "sha256:89d3debd9720c65e36cbf80d2604905ac8c30af9b7614d444f19c7685cd87564",
       "files": 5
     },
     {

--- a/pages/reference/artifact-input-contract.md
+++ b/pages/reference/artifact-input-contract.md
@@ -49,6 +49,7 @@ River Review が認識する入力アーティファクトは以下の通りで�
 - **形式**: UTF-8 Markdown。見出し構造・箇条書きは自由。
 - **サイズ目安**: 1 ファイルあたり 100KB 以下を推奨。上限を超える場合 River Review は差分最適化（要約・トリム）を適用する場合がある。
 - **欠損時**: 該当 artifact を参照する skill はその観点をスキップし、`skippedSkills` にその旨を記録する。
+- **PlanGate #810 連携（任意）**: PlanGate #810（Unknown Discovery）は assumption / unknown ledger（Assumptions・Known Unknowns・Blocking Unknowns 等の節）を出力する。River Review はこれを専用 artifact を新設せず `plan` artifact 内の追加セクションとして受け取る。欠損時の挙動は本節の「欠損時」と同一であり、PlanGate への依存は必須にしない。
 
 ### `review-self` / `review-external`
 

--- a/skills/agent-skills/unknown-coverage-review/SKILL.md
+++ b/skills/agent-skills/unknown-coverage-review/SKILL.md
@@ -63,6 +63,7 @@ AI coding agent の実行能力が上がるほど、見逃しは単純なコー�
 - ビルド成果物・生成物（`dist/**`・`*.map`・lockfile・自動生成 manifest）は Gate 判定からもレビュー対象からも除外する。
 - **PlanGate 非依存**: `plan` / `review-self` などの artifact が欠損しても動作する。欠損した観点は finding を出さず `skippedSkills` に記録してデグレードする（artifact-input-contract の既定挙動）。
 - **観点6 の plan 代替 evidence**: 観点6（Plan / Assumption）は `plan` artifact 欠損時、**PR 本文へ前提・open question が inline 列挙されていれば列挙分のみ部分評価**する（外部 issue は取得・推測しない）。**計画 issue の bare 参照（`#NNNN`）のみなら skip** し `skippedSkills` に記録する。この分岐は registry skill `assumption-resolution-trace` と同一ルールに揃える。
+- **PlanGate #810 ledger**: PlanGate #810 が assumption/unknown ledger を出力する場合も、専用 artifact を新設しない。`plan` artifact 経由で受け取る同一の artifact-driven パターンに従う（[artifact-input-contract.md](../../../pages/reference/artifact-input-contract.md)）。欠損時は上記と同じデグレード（`skippedSkills`）を適用する。PlanGate への依存は必須にしない。
 
 ## 6 Unknown 観点 / Perspectives
 

--- a/skills/midstream/assumption-resolution-trace/SKILL.md
+++ b/skills/midstream/assumption-resolution-trace/SKILL.md
@@ -143,4 +143,4 @@ plan の前提がいくつか未確認のようです
 ## References
 
 - `skills/agent-skills/unknown-coverage-review/references/DELEGATION.md` — 合成層との分界・委譲表（SSoT。観点6 Plan / Assumption Traceability）
-- `pages/reference/artifact-input-contract.md` — `plan` artifact の入力契約（PlanGate 非依存のデグレード挙動）
+- `pages/reference/artifact-input-contract.md` — `plan` artifact の入力契約（PlanGate 非依存のデグレード挙動、および PlanGate #810 ledger を専用 artifact なしで `plan` 経由に受け取る方針）


### PR DESCRIPTION
## Summary

Issue #1470 の最終フェーズ P3（PlanGate #810 連携の artifact 接続・doc のみ）を実装する。

- `pages/reference/artifact-input-contract.md`: `plan` / `pbi-input` / `todo` / `test-cases` 節に、PlanGate #810（Unknown Discovery）が出力する assumption / unknown ledger（Assumptions・Known Unknowns・Blocking Unknowns 等の節）を**専用 artifact を新設せず** `plan` artifact 内の追加セクションとして受け取る旨を1行追記。欠損時の挙動は既存の「欠損時」節と同一。
- `skills/agent-skills/unknown-coverage-review/SKILL.md`: Pre-execution Gate に、PlanGate #810 ledger が来た場合も `plan` 経由の同一 artifact-driven パターンに従う旨を1文追記（観点6の plan 代替 evidence 規定と揃える）。
- `skills/midstream/assumption-resolution-trace/SKILL.md`: References の artifact-input-contract.md へのリンク説明に #810 方針への言及を追記（このファイルの Non-goals には既に #810 ledger の扱いが1文明記済み — #1503 で先行対応済み）。

## 設計原則の遵守（必須依存にしない）

- 設計書「§4 PlanGate 境界の整合性」は「plan（または専用 artifact ID の追加）」と両論だったが、**既存様式と保守性を優先**し、新規 artifact ID は追加せず既存 `plan` artifact 枠内での受け取りに倒した。PlanGate #810 issue 本文の Plan 出力候補（`## Known Facts` / `## Assumptions` / `## Known Unknowns` などの節見出し）はそもそも `plan.md` 自体の追加セクションとして自然に収まる設計であり、専用 artifact を新設する動機がない。
- PlanGate 側リポジトリへの変更はなし（river-review 側の受け口のみ）。
- 後方互換・新語彙なし。欠損時のデグレード（`skippedSkills` 記録）は既存の artifact-input-contract の既定挙動をそのまま踏襲する。

## Test plan

- [x] `npx textlint --no-cache pages/reference/artifact-input-contract.md` — pass（0 errors）
- [x] `npx textlint --no-cache skills/agent-skills/unknown-coverage-review/SKILL.md` — 追加した行由来の新規違反なし（既存4件のみ残存、baseline と同数であることを stash 比較で確認済み）
- [x] `npx textlint --no-cache skills/midstream/assumption-resolution-trace/SKILL.md` — 追加した行由来の新規違反なし（既存3件のみ残存、baseline と同数）
- [x] `npm run fix:dashes` — No heading/title dash normalizations needed
- [x] `npm run agent-skills:validate` — pass
- [x] `npm run skills:validate` — pass（129 skills, registry paths 118 resolve, eval coverage 55/55, naming collisions 0）
- [x] `npm run skills:manifest:check` — pass（checksum 再生成済み、`docs/data/skill-manifest.json` を同コミットに含める）
- [x] lint-staged（pre-commit hook）— 全ステップ COMPLETED

Closes: 該当なし（Issue #1470 はオーガナイザーが全フェーズ確認後にクローズする方針のため、このPRではクローズしない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)