### PR TITLE
docs(skills): unknown-coverage-review に不正状態遷移・隠れた副作用の taxonomy を追記する

### DIFF
--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -762,7 +762,7 @@
     {
       "id": "unknown-coverage-review",
       "path": "skills/agent-skills/unknown-coverage-review",
-      "checksum": "sha256:58fbf0e6cac85d250af6f60c9a28541632737851b272573c26c7b5b95a72b4ab",
+      "checksum": "sha256:cea34cbb9f3bc332517f79d44477e63663f17365f8147b2673a4519082940d94",
       "files": 5
     },
     {

--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -762,7 +762,7 @@
     {
       "id": "unknown-coverage-review",
       "path": "skills/agent-skills/unknown-coverage-review",
-      "checksum": "sha256:89d3debd9720c65e36cbf80d2604905ac8c30af9b7614d444f19c7685cd87564",
+      "checksum": "sha256:58fbf0e6cac85d250af6f60c9a28541632737851b272573c26c7b5b95a72b4ab",
       "files": 5
     },
     {

--- a/skills/agent-skills/unknown-coverage-review/SKILL.md
+++ b/skills/agent-skills/unknown-coverage-review/SKILL.md
@@ -80,6 +80,10 @@ Issue #1470 の 6 カテゴリを、defect ではなく **evidence-sufficiency �
 
 観点 3〜5 は既存の運用・影響・検証系 skill の多くが `applyTo: docs/**`（upstream 設計文書向け）で、**コードのみの diff では空振りする**。本観点はその空白を「証拠の有無」の meta として拾う（設計 §1 の Partial / Gap）。
 
+### 追加類型（#1517 由来）
+
+「[AIコードレビューの「見逃し」を3か月ログしたら、5つの盲点タイプに全部収まった](https://zenn.dev/kenimo49/articles/ai-code-review-blind-spots-3month-5-types)」（井本 賢 / 2026-07-06）が報告した5盲点タイプのうち、境界条件・契約違反・意味的矛盾は既存6観点の委譲先に包含される。**状態遷移（不正な遷移）・副作用（隠れた副作用）**の2類型は専用 defect 検出 skill が未整備のため、[DELEGATION.md](./references/DELEGATION.md)「追加 Unknown 種別（#1517 由来）」節に暫定的な evidence-sufficiency の meta 問いとして記録する。中期の軽量 detector 化は issue #1517 を参照。
+
 ## 委譲 / Delegation
 
 重複指摘を避けるため、個別 defect の検出は既存 registry skill に委譲し、本観点は **証拠充足の meta 評価のみ**を行う。委譲表・証拠要件・分界は [DELEGATION.md](./references/DELEGATION.md) を SSoT とする。委譲先が finding を出す領域を本観点は重複指摘しない。

--- a/skills/agent-skills/unknown-coverage-review/SKILL.md
+++ b/skills/agent-skills/unknown-coverage-review/SKILL.md
@@ -82,7 +82,7 @@ Issue #1470 の 6 カテゴリを、defect ではなく **evidence-sufficiency �
 
 ### 追加類型（#1517 由来）
 
-「[AIコードレビューの「見逃し」を3か月ログしたら、5つの盲点タイプに全部収まった](https://zenn.dev/kenimo49/articles/ai-code-review-blind-spots-3month-5-types)」（井本 賢 / 2026-07-06）が報告した5盲点タイプのうち、境界条件・契約違反・意味的矛盾は既存6観点の委譲先に包含される。**状態遷移（不正な遷移）・副作用（隠れた副作用）**の2類型は専用 defect 検出 skill が未整備のため、[DELEGATION.md](./references/DELEGATION.md)「追加 Unknown 種別（#1517 由来）」節に暫定的な evidence-sufficiency の meta 問いとして記録する。中期の軽量 detector 化は issue #1517 を参照。
+「[AIコードレビューの「見逃し」を3か月ログしたら、5つの盲点タイプに全部収まった](https://zenn.dev/kenimo49/articles/ai-code-review-blind-spots-3month-5-types)」（井本 賢 / 2026-07-06）が報告した5盲点タイプのうち、境界条件・契約違反・意味的矛盾は既存の registry skill でカバー済み（対応先は [DELEGATION.md](./references/DELEGATION.md) の「追加 Unknown 種別」節を参照）。**状態遷移（不正な遷移）・副作用（隠れた副作用）**の2類型は専用 defect 検出 skill が未整備のため、[DELEGATION.md](./references/DELEGATION.md)「追加 Unknown 種別（#1517 由来）」節に暫定的な evidence-sufficiency の meta 問いとして記録する。中期の軽量 detector 化は issue #1517 を参照。
 
 ## 委譲 / Delegation
 

--- a/skills/agent-skills/unknown-coverage-review/references/DELEGATION.md
+++ b/skills/agent-skills/unknown-coverage-review/references/DELEGATION.md
@@ -31,7 +31,7 @@ Unknown Coverage Review は **evidence-sufficiency（証拠が足りているか
 
 由来 / Inspired by: 「[AIコードレビューの「見逃し」を3か月ログしたら、5つの盲点タイプに全部収まった](https://zenn.dev/kenimo49/articles/ai-code-review-blind-spots-3month-5-types)」（井本 賢 / 2026-07-06）— AI コードレビューの見逃しを3か月間ログし分類した結果、5つの盲点タイプに収束したという実測記事。原著者を名指しする nominative fair use に留め、本文の転載・endorsement は行わない。
 
-報告された5盲点タイプのうち、境界条件・契約違反・意味的矛盾の3類型は上表の既存委譲先（`nullability-contract`/`coverage-gap`、`api-compatibility`/`existing-pattern-conformance`、`self-contradiction`）で対応済み。残る2類型は #1517 時点で専用 defect 検出 skill が存在しないため、暫定的に本観点（合成層）が直接評価する残余として記録する。専用 detector を作らず、既存の meta 評価（evidence-sufficiency）の対象として言及するに留める。
+報告された5盲点タイプのうち、境界条件・契約違反・意味的矛盾の3類型は既存の委譲先スキル（`nullability-contract`/`coverage-gap`、`api-compatibility`/`existing-pattern-conformance`、`self-contradiction`。一部は上の #1470 表に未掲載だが、いずれもリポジトリ内に registry skill として存在する）で対応済み。残る2類型は #1517 時点で専用 defect 検出 skill が存在しないため、暫定的に本観点（合成層）が直接評価する残余として記録する。専用 detector を作らず、既存の meta 評価（evidence-sufficiency）の対象として言及するに留める。
 
 | Unknown 種別（zenn 5類型） | 委譲先（defect 検出）                                  | 本観点が扱う残余（evidence-sufficiency の meta）                                                                                                    |
 | -------------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/skills/agent-skills/unknown-coverage-review/references/DELEGATION.md
+++ b/skills/agent-skills/unknown-coverage-review/references/DELEGATION.md
@@ -27,6 +27,19 @@ Unknown Coverage Review は **evidence-sufficiency（証拠が足りているか
 | Validation                     | `coverage-gap`・`test-existence`・`e2e-wiring`・`test-plan-review`                                                                                                         | 「失敗系・境界・実利用経路を観測した証拠があるか」の meta（Missing Tests 節と接続）                                                                                                                                                                                         |
 | Plan / Assumption Traceability | `plangate-verification-audit`・`architecture-risk-register`・`plangate-plan-integrity`                                                                                     | 「Plan の Assumption が解消された証拠」「実装中に発見した Unknown を記録した証拠」の突合。diff-time で plan 保有時に単独実行する版は registry skill `assumption-resolution-trace` へ切り出し済みで、合成層はその findings を残余に取り込む                                  |
 
+## 追加 Unknown 種別（#1517 由来）
+
+由来 / Inspired by: 「[AIコードレビューの「見逃し」を3か月ログしたら、5つの盲点タイプに全部収まった](https://zenn.dev/kenimo49/articles/ai-code-review-blind-spots-3month-5-types)」（井本 賢 / 2026-07-06）— AI コードレビューの見逃しを3か月間ログし分類した結果、5つの盲点タイプに収束したという実測記事。原著者を名指しする nominative fair use に留め、本文の転載・endorsement は行わない。
+
+報告された5盲点タイプのうち、境界条件・契約違反・意味的矛盾の3類型は上表の既存委譲先（`nullability-contract`/`coverage-gap`、`api-compatibility`/`existing-pattern-conformance`、`self-contradiction`）で対応済み。残る2類型は #1517 時点で専用 defect 検出 skill が存在しないため、暫定的に本観点（合成層）が直接評価する残余として記録する。専用 detector を作らず、既存の meta 評価（evidence-sufficiency）の対象として言及するに留める。
+
+| Unknown 種別（zenn 5類型） | 委譲先（defect 検出）                                  | 本観点が扱う残余（evidence-sufficiency の meta）                                                                                                    |
+| -------------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 状態遷移（不正な遷移）     | （未整備。中期で軽量 detector 化を検討 — issue #1517） | 許可されない状態遷移（不正な rollback・二重遷移・ガード条件の漏れなど）を diff 内で確認した証拠（状態遷移テスト・ガード条件のレビュー記録）があるか |
+| 副作用（隠れた副作用）     | （未整備。中期で軽量 detector 化を検討 — issue #1517） | 宣言・シグネチャに現れない副作用（意図しない外部呼び出し・共有状態への書き込み・ログ／通知の発火）を洗い出した証拠があるか                          |
+
+専用 skill を切り出した場合は、上の #1470 表と同じ形式で統合し、この節は削除する。中期の detector 化は `.claude/rules/review-core.md` の #1070 責務分界（決定論領域は静的解析、意味的判断は AI レビュー）に整合させ、FP guard + canary を用意することを条件とする（issue #1517 受入条件）。
+
 ## 分界の原則
 
 - **defect（S）は委譲先、evidence-sufficiency（M）は本観点**。委譲先は「リスクが差分に顕在化した時」に指摘し、本観点は「そのリスク種別を調査した証拠が残っているか」を横断合成する。


### PR DESCRIPTION
## Summary

Issue #1517 の短期案（taxonomy 追記）を実装する。

- 出典記事「[AIコードレビューの「見逃し」を3か月ログしたら、5つの盲点タイプに全部収まった](https://zenn.dev/kenimo49/articles/ai-code-review-blind-spots-3month-5-types)」（井本 賢 / 2026-07-06）の5盲点タイプのうち、境界条件・契約違反・意味的矛盾の3類型は既存委譲先（`nullability-contract`/`coverage-gap`、`api-compatibility`/`existing-pattern-conformance`、`self-contradiction`）で対応済みと `skills/` 横断 grep で再確認した。
- 残る2類型（**状態遷移（不正な遷移）・副作用（隠れた副作用）**）は専用 defect 検出 skill が存在しないため、`skills/agent-skills/unknown-coverage-review/references/DELEGATION.md` に新節「追加 Unknown 種別（#1517 由来）」を追加し、evidence-sufficiency meta 問いとして暫定記録した。
- `SKILL.md` の6 Unknown 観点説明末尾に同節への参照を追記し、`DELEGATION.md`（詳細）と `SKILL.md`（要約 + 参照）のドリフトを避けた。

### 追加先の選定理由

issue が提示した2案（DELEGATION.md の委譲表に行を追加 / 6 Unknown 観点の説明に明示）のうち、**DELEGATION.md への新規節追加**を選んだ。理由:

- 既存の #1470 由来6カテゴリ表は列見出し（`Unknown 種別（#1470）`）が issue #1470 の taxonomy に固定されており、由来の異なる zenn 5類型の行を同じ表に混在させると出典が曖昧になる。
- 2類型には委譲先スキルが存在しないため、既存表の「委譲先（defect 検出）」列の意味（既存スキルへの委譲）と整合しない。別節・別表にして「委譲先未整備」であることを明示した。
- `SKILL.md` 側は要約と参照リンクのみに留め、詳細（表・provenance）は `DELEGATION.md` を SSoT とすることで、acceptance criteria の「片方だけの更新によるドリフトを避ける」を満たした。

### 由来明記

`DELEGATION.md` の新節冒頭に `由来 / Inspired by` として zenn 記事タイトル・著者・URL を明記した。記事本文の転載はせず、nominative fair use に留め endorsement 表現は含めていない（issue 受入条件）。

### 中期（detector 化）は未着手

2類型の専用 detector 切り出しは本 PR のスコープ外。新節末尾に「中期の detector 化は `.claude/rules/review-core.md` の #1070 責務分界（決定論領域は静的解析、意味的判断は AI レビュー）に整合させ、FP guard + canary を用意することを条件とする」旨を明記し、issue #1517 側に残した。

## Test plan

- [x] `npm run agent-skills:validate` — exit 0（既存の無関係な warning のみ）
- [x] `npm run skills:validate` — exit 0
- [x] `npm run skills:manifest:check`（`npm run skills:manifest` で再生成しコミット同梱） — exit 0
- [x] `npx textlint --no-cache` で新規追加分に新規エラーなしを確認（`SKILL.md` の既存4件のエラーは origin/main の同一行内容で pre-existing と確認済み。本 PR のスコープ外のため未修正）
- [x] `npm run lint` — exit 0
- [x] `npm test` — 2121 tests pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)