### PR TITLE
feat(skills): fix-scope-integrity 観点で指摘対応ループのスコープ逸脱・前提破壊を検出する (#1516)

### DIFF
--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -330,7 +330,7 @@
     {
       "id": "fix-scope-integrity",
       "path": "skills/midstream/fix-scope-integrity",
-      "checksum": "sha256:a0b85299a44f3e4698188c350eabc43fa2ed9aeebb9405e9c988c6147fbae523",
+      "checksum": "sha256:071f7875a24fbe7d7b5280e5c28b0b1c5c00d1efb9ccab019165d04668b526d6",
       "files": 4
     },
     {

--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "description": "Deterministic skill manifest for drift detection by selective adopters. Compare the checksum of your copied skill against this list to notice upstream changes. Regenerate with: npm run skills:manifest",
-  "skillCount": 129,
+  "skillCount": 130,
   "skills": [
     {
       "id": "a11y-accessible-name",
@@ -325,6 +325,12 @@
       "id": "firebase-security-rules",
       "path": "skills/midstream/firebase-security-rules",
       "checksum": "sha256:dd8f260481e1ab77b45d5842f26a1cf21ca23e678b363955d2a6369001af2d76",
+      "files": 4
+    },
+    {
+      "id": "fix-scope-integrity",
+      "path": "skills/midstream/fix-scope-integrity",
+      "checksum": "sha256:a0b85299a44f3e4698188c350eabc43fa2ed9aeebb9405e9c988c6147fbae523",
       "files": 4
     },
     {

--- a/skills/midstream/fix-scope-integrity/SKILL.md
+++ b/skills/midstream/fix-scope-integrity/SKILL.md
@@ -1,0 +1,165 @@
+---
+id: 'fix-scope-integrity'
+name: 'Fix Scope Integrity 指摘対応ループのスコープ逸脱・前提破壊検出'
+description: '指摘対応の反復（レビューコメント→修正→再レビュー）で、個別には正しい修正の蓄積が当初スコープを逸脱した（scope creep）、または成立済みの前提（"動いていた"状態）を破壊した（premise break）連鎖を diff-time で検出する。技術的正しさとスコープ整合性を別軸で評価し、report-only で finding/question のみ出力する。1コメント単位のトリアージ・構造変更後の caller 残骸・plan 前提解消は隣接 skill へ委譲する'
+version: 0.1.0
+category: midstream
+phase: midstream
+applyTo:
+  - 'src/**/*.{ts,tsx,js,jsx,mjs}'
+  - 'runners/**/*.{ts,js,mjs}'
+  - 'scripts/**/*.mjs'
+  - 'app/**/*.{ts,tsx,js,jsx,php}'
+tags:
+  [
+    fix-scope-integrity,
+    scope-creep,
+    premise-break,
+    fix-scope-guard,
+    review-response-loop,
+    scope-consistency,
+    midstream,
+  ]
+severity: major
+inputContext: [diff, fullFile]
+outputKind: [findings, questions]
+modelHint: high-accuracy
+dependencies: [code_search]
+---
+
+## Origin / 由来
+
+inspired by:
+
+- <https://zenn.dev/fixu/articles/copilot-review-scope-creep-revert> — Copilot の指摘に5往復従った結果、個別に正しい修正の蓄積が当初スコープを逸脱した事例（scope creep）。
+- <https://zenn.dev/urario/articles/ai-review-rally> — AI 設計レビューへの修正が成立済みの前提を壊し、次の欠陥を4往復連鎖させた事例と、「修正が依存する前提を列挙させる」対処（premise break）。
+
+上記は観測された現象と対処法の紹介であり、本文の転載・著者による endorsement を含まない（nominative fair use）。命名は `skills/README.md` Naming Q0–Q5 に従い value を表す新規名として付与した。
+
+## Pattern declaration
+
+Primary pattern: Reviewer
+Secondary patterns: Inversion
+Why: スコープ整合性・前提破壊は意味的判断が主だが、指摘対応ループの文脈（元スコープ/前提の discover）が成立しない差分では実行を止めるゲートが必要。
+
+## Goal / 目的
+
+指摘対応の反復（レビューコメント→修正→再レビュー）という時間軸上で、**個別には正しい修正の蓄積**が次のいずれかを起こしていないかを diff-time で検出する。技術的正しさとは独立した軸で評価する。
+
+1. **Scope creep（スコープ逸脱の蓄積）**: 当初スコープ・移植元・受入基準に無い制約/挙動を、指摘対応を通じて追加している。
+2. **Premise break（成立済み前提の破壊）**: ある修正が、先に受理された変更 or 既存システムが依存していた前提（"動いていた"状態）を無効化し、次の欠陥の起点になっている。
+
+report-only（ADR-005）。finding/question のみを出力し、自動修正・自動マージはしない。
+
+## Non-goals / 扱わないこと（委譲表）
+
+- **1コメント単位のトリアージ**: コメントの重要度づけ・対応方針（自然言語）・返信案は `review-comment-triage` が担う。本 skill は複数往復にまたがる**蓄積**のスコープ/前提整合のみを見る。
+- **構造変更後の caller 残骸**: 記号再採番・シグネチャ変更・ファイル分割/移動に伴う caller 側の旧参照残骸 defect は `cross-file-leakage` が担う。本 skill は**構造変更を伴わない挙動レベルの前提破壊**を見る。
+- **plan 前提の解消トレース**: `plan` artifact 保有時の plan assumption / open question の解消証拠突合は `assumption-resolution-trace` が担う。本 skill は **plan を伴わない指摘対応ループ**の前提を都度追跡する。
+- **完了主張の監査**: 「全部置換した」「-N%削減」等の完了主張 vs 残骸/試算の突合は `refactor-claim-audit` が担う。本 skill は完了主張ではなくスコープ/前提の逸脱を見る。
+- **evidence-sufficiency の横断合成**: 6観点全体の証拠充足合成は agent-skill `unknown-coverage-review` が担う。本 skill は defect 寄り（scope/premise 破壊という意味的欠陥）に集中し、合成は委譲する。
+- **技術的正しさそのものの検証**: 指摘対応が技術的に正しいか（バグ有無・実測妥当性）は defect 系観点の責務。本 skill は正しくても**スコープ整合性が別軸**である点だけを扱う。
+
+## Pre-execution Gate / 実行前ゲート
+
+このスキルは以下の条件がすべて満たされない限り `NO_REVIEW` を返す。
+
+- [ ] inputContext に `diff` が含まれている。
+- [ ] 差分が**リポジトリ内で実行されるコード**に触れる（docs・コメントのみの差分は対象外）。
+- [ ] **指摘対応ループの文脈**が discover できる。具体的には次のいずれかの signal がある: PR 本文・コミットメッセージ・レビュースレッドが「レビュー指摘への対応/再対応」を示す（例: `review 対応`・`指摘 反映`・`fix per review`・複数の fix/対応コミットの連鎖）、または既存の "動いていた" ベースラインに対する逐次修正であることが読み取れる。
+- [ ] **比較基準**が discover できる。すなわち当初スコープ/意図（タスク説明・移植元・受入基準）または既存システムが依存する前提のいずれかが差分・PR 本文・参照コードから特定できる。特定できない場合は finding を出さず、必要なら question に留める。
+- [ ] ビルド成果物・生成物（`dist/**`・`*.map`・lockfile・自動生成 manifest）は Gate 判定からもレビュー対象からも除外する。
+
+ゲート不成立時の出力: `NO_REVIEW: fix-scope-integrity — 指摘対応ループの文脈または比較基準が discover できない`
+
+## False-positive guards / 抑制条件
+
+正当なスコープ拡大・前提変更を FP にしないため、次を厳守する。
+
+- **スコープ内の関連修正は指摘しない**: レビュー指摘対応で必要になった、当初スコープ内の関連修正（バグ修正に不可欠な近接変更）は scope creep ではない。
+- **事前宣言/事前承認済みは指摘しない**: PR 本文・issue・コメントで事前に宣言/承認されたリファクタ同梱や制約追加は指摘しない。
+- **受入基準の更新で正当化された拡大は指摘しない**: タスク説明・受入基準が更新され、その範囲に収まる変更は逸脱ではない。
+- **前提変更が意図された目的なら指摘しない**: 前提を変えること自体がタスクの目的（例: 状態の持ち方を意図的に再設計する）である場合、premise break として指摘しない。
+- **前提列挙が済んでいれば充足**: 修正が依存する前提の列挙と影響確認が PR 本文・コメント・差分内に残っている場合、premise 軸は充足とみなし指摘しない。
+- **discover できなければ question**: 当初スコープ・前提を差分・PR 本文・参照コードから特定できない、または別在の可能性を Grep / Glob / artifact 参照で棄却できない場合は、finding ではなく question とする（false-positive-first）。
+- **指摘上限**: 観点（Scope creep / Premise break）ごとに finding と question の合算で最大 3 件、severity 降順で切り捨てる。切り捨ては findings（severity 降順）→ questions の順とする。
+- 決定論的に判定できる領域（構文・パターン）はカスタム静的解析側の責務（`.claude/rules/review-core.md` #1070）。本 skill はスコープ整合性・前提破壊という意味的判断に集中し、canary が守る領域を重複指摘しない。
+
+## Rule / ルール
+
+### 検出ロジック
+
+1. **軸の特定**: 差分が Scope creep / Premise break のどちらに該当するかを判定する。該当軸のみ調査する。
+2. **比較基準の特定**: 当初スコープ/意図（タスク説明・移植元・受入基準）または成立済み前提を、PR 本文・参照コード・Grep で特定する。
+   - Scope creep: 移植元・当初スコープに無い制約/挙動（値域制限・バリデーション厳格化・新規分岐）が指摘対応の差分で追加されていないか、移植元を Grep して確認する。
+   - Premise break: 修正が触れた挙動が、先に受理された変更 or 既存 caller が依存していた前提（例「呼び出し側は状態を持たない」）を無効化していないか、依存箇所を Grep して確認する。
+3. **別軸判定**: 指摘対応が技術的に正しくても、比較基準に対して逸脱/前提破壊があれば `妥当だが対象外`（scope-inconsistent）として finding 化する。技術的正しさを理由に不問にしない。
+4. **別在の棄却**: 逸脱/前提破壊を「事前承認・スコープ更新・前提列挙で正当化されている可能性」を PR 本文・artifact 参照で棄却できたときのみ finding 化する。棄却できなければ question とする。
+5. **resolution の付与**: 各 finding に解消手順を添える。scope creep は「当初基準点まで戻す（git revert 相当の切り出し）／別 PR へ分離／受入基準を更新して正当化」、premise break は「依存する前提を列挙し影響範囲を確認してから再提出」を明示する。
+
+### severity 較正
+
+- premise break が**回帰・データ損失・互換破壊**を招く（"動いていた"経路を壊す）なら `blocker`。
+- scope creep が現在系の挙動を変える out-of-scope 制約を追加し、merge 前に分離/正当化すべきものは `warning`。
+- 逸脱が軽微（挙動不変の out-of-scope な体裁変更等）で、merge 後の follow-up で足りるものは `nit`。
+- 比較基準が弱く確証が持てないものは question（`info` 相当）。
+
+## Evidence / 根拠の取り方
+
+- finding の `file:line` は差分内にアンカーする。差分外の推測に基づく逸脱は question として返す。
+- 逸脱/前提破壊の判断に使った比較基準（移植元の `file:line`・当初スコープの記述・依存 caller の `file:line`）と Grep の検索語を明示し、再現可能にする。
+- 「技術的には正しいが対象外」である旨を明記し、批判的口調を避ける（`.claude/rules/review-core.md`）。
+
+## Output / 出力フォーマット
+
+すべて日本語。標準の finding フォーマットに従い、各指摘に `axis`（scope_creep / premise_break）と `resolution` を含める。
+
+```text
+(fix-scope-integrity):1: [要約] 最も逸脱している軸は〈1文〉
+
+<file>:<line>: [Scope creep|Premise break] <タイトル>
+  axis: scope_creep | premise_break
+  当初基準: <当初スコープ/移植元/依存前提のアンカー>(検索語: `<grep pattern>`)
+  逸脱内容: <個別に正しくても基準からどう逸脱/前提破壊したか>
+  Severity: blocker | warning | nit（較正基準に従う）
+  resolution: <解消手順>（分離 / revert / 前提列挙して再提出 / 受入基準更新のいずれか）
+```
+
+## Good / Bad Examples
+
+### Good
+
+```text
+src/forms/signup.mjs:42: [Scope creep] 移植元に無い値域制限を指摘対応で追加
+  axis: scope_creep
+  当初基準: 「既存フォームをそのまま移植」。移植元 src/forms/legacy-signup.mjs:30 に range 制限は無い(検索語: `git grep -n "min:\|max:" src/forms/legacy-signup.mjs` がヒット0)
+  逸脱内容: 指摘対応3往復目で min/max バリデーションを新規側にだけ追加。個別には妥当だが移植スコープ外
+  Severity: warning
+  resolution: 当該制限を別 PR へ分離するか、受入基準を「移植＋バリデーション強化」に更新して正当化する
+```
+
+### Bad
+
+```text
+スコープが広がっている気がします
+```
+
+（軸の特定なし、当初基準のアンカーなし、検索語なし、resolution なし、技術的正しさとの分離なし）
+
+## 評価指標（Evaluation）
+
+- 合格基準: 軸が特定され、当初基準/依存前提が grep 再現可能なアンカーで示され、正当化（事前承認・スコープ更新・前提列挙）の可能性が棄却され、resolution が示されている。正当なスコープ拡大・前提列挙済みのケースでは指摘しない。
+- 不合格基準: 技術的正しさを理由に逸脱を不問にしている、比較基準を示さず「広がった気がする」で指摘している、事前承認/前提列挙済みなのに指摘している、隣接 skill の領分（1コメント triage・caller 残骸・plan 前提解消・完了主張）を重複指摘している、resolution が無い。
+
+## 人間に返す条件（Human Handoff）
+
+- premise break が "動いていた" 経路の回帰・データ損失に及び、merge 可否や revert 範囲の判断を要する場合。
+- scope creep の正当化可否（受入基準を更新するか、別 PR へ分離するか）がチーム/PO 判断を要する場合。
+
+## References
+
+- `skills/midstream/review-comment-triage/SKILL.md` — 1コメント単位トリアージ（委譲先）
+- `skills/midstream/cross-file-leakage/SKILL.md` — 構造変更後の caller 残骸（委譲先）
+- `skills/midstream/assumption-resolution-trace/SKILL.md` — plan 前提の解消トレース（委譲先）
+- `.claude/rules/review-core.md` §「カスタム静的解析の False-positive 責務分界（#1070）」 — 意味的判断と静的解析の分界
+- `docs/review/output-format.md` — 重要度ラベルと出力形式（SSoT）

--- a/skills/midstream/fix-scope-integrity/SKILL.md
+++ b/skills/midstream/fix-scope-integrity/SKILL.md
@@ -82,7 +82,7 @@ report-only（ADR-005）。finding/question のみを出力し、自動修正・
 - **前提変更が意図された目的なら指摘しない**: 前提を変えること自体がタスクの目的（例: 状態の持ち方を意図的に再設計する）である場合、premise break として指摘しない。
 - **前提列挙が済んでいれば充足**: 修正が依存する前提の列挙と影響確認が PR 本文・コメント・差分内に残っている場合、premise 軸は充足とみなし指摘しない。
 - **discover できなければ question**: 当初スコープ・前提を差分・PR 本文・参照コードから特定できない、または別在の可能性を Grep / Glob / artifact 参照で棄却できない場合は、finding ではなく question とする（false-positive-first）。
-- **指摘上限**: 観点（Scope creep / Premise break）ごとに finding と question の合算で最大 3 件、severity 降順で切り捨てる。切り捨ては findings（severity 降順）→ questions の順とする。
+- **指摘上限**: 観点（Scope creep / Premise break）ごとに finding と question の合算で最大 3 件とする。保持の優先順は findings（severity 降順）→ questions（info 相当）とし、上限超過分は優先度の低い側（questions → 低 severity findings）から切り捨てる。
 - 決定論的に判定できる領域（構文・パターン）はカスタム静的解析側の責務（`.claude/rules/review-core.md` #1070）。本 skill はスコープ整合性・前提破壊という意味的判断に集中し、canary が守る領域を重複指摘しない。
 
 ## Rule / ルール

--- a/skills/midstream/fix-scope-integrity/fixtures/01-scope-creep-detect.md
+++ b/skills/midstream/fix-scope-integrity/fixtures/01-scope-creep-detect.md
@@ -11,7 +11,7 @@ diff --git a/src/forms/signup.mjs b/src/forms/signup.mjs
 index 1111111..2222222 100644
 --- a/src/forms/signup.mjs
 +++ b/src/forms/signup.mjs
-@@ -38,7 +38,11 @@ export function buildSignupSchema() {
+@@ -38,5 +38,5 @@ export function buildSignupSchema() {
    return {
      name: { type: 'string', required: true },
 -    age: { type: 'number', required: true },

--- a/skills/midstream/fix-scope-integrity/fixtures/01-scope-creep-detect.md
+++ b/skills/midstream/fix-scope-integrity/fixtures/01-scope-creep-detect.md
@@ -1,0 +1,49 @@
+# Test Case: Scope Creep Accumulated Across Review-Response Loop (should detect)
+
+## Description
+
+「既存フォームをそのまま移植する」限定スコープで始めた新規登録フォームの修正が、レビュー指摘対応の3往復目で移植元に無い値域制限（min/max バリデーション）を新規側にだけ追加した。個別の指摘（値域を絞れ）は技術的に妥当だが、移植スコープからは逸脱している。fix-scope-integrity は Scope creep 軸で 1 件検出する。
+
+## Input Diff
+
+```diff
+diff --git a/src/forms/signup.mjs b/src/forms/signup.mjs
+index 1111111..2222222 100644
+--- a/src/forms/signup.mjs
++++ b/src/forms/signup.mjs
+@@ -38,7 +38,11 @@ export function buildSignupSchema() {
+   return {
+     name: { type: 'string', required: true },
+-    age: { type: 'number', required: true },
++    age: { type: 'number', required: true, min: 18, max: 120 },
+   };
+ }
+```
+
+## 参照コード / 移植元
+
+```js
+// src/forms/legacy-signup.mjs（移植元 / 変更なし）
+export function buildLegacySignupSchema() {
+  return {
+    name: { type: 'string', required: true },
+    age: { type: 'number', required: true }, // 値域制限なし
+  };
+}
+```
+
+## PR 本文 / Artifacts
+
+- PR 本文: 「既存フォーム（legacy-signup）をそのまま移植する」とスコープを宣言。
+- コミット連鎖: `feat: 移植` → `fix: レビュー指摘対応(1)` → `fix: レビュー指摘対応(2)` → `fix: 値域制限を追加(レビュー指摘対応3)`。指摘対応ループの signal あり。
+- 受入基準の更新なし。値域制限の事前承認・前提列挙なし。
+
+## Expected Behavior
+
+本 skill は以下を満たすこと。
+
+1. Scope creep 軸を 1 件検出する（移植元 `src/forms/legacy-signup.mjs` に無い `min: 18, max: 120` を指摘対応で新規側にだけ追加している）。
+2. 当初基準を grep 再現可能なアンカーで示す（例: 移植元に range 制限が無いことを `git grep -n "min:\|max:" src/forms/legacy-signup.mjs` がヒット0で確認）。
+3. 技術的正しさ（値域を絞るのは妥当）とスコープ整合性を分離し、`妥当だが対象外` として指摘する。
+4. `Severity: warning`（現在系の挙動を変える out-of-scope 制約・merge 前に分離/正当化すべき）とし、resolution（別 PR へ分離するか受入基準を更新して正当化）を添える。
+5. 隣接 skill の領分（1コメント triage・caller 残骸・plan 前提解消・完了主張）としては指摘しない。

--- a/skills/midstream/fix-scope-integrity/fixtures/02-premise-break-detect.md
+++ b/skills/midstream/fix-scope-integrity/fixtures/02-premise-break-detect.md
@@ -1,0 +1,47 @@
+# Test Case: Fix Breaks a Previously-Holding Premise (should detect)
+
+## Description
+
+「エラー処理の責務が重複している」という設計レビュー指摘に対し、責務を `Widget` 側へ統合した。しかしこの統合は、既存の caller が依存していた「`renderWidget` は状態を持たず呼び出し側が error state を保持する」という成立済みの前提（"動いていた"状態）を壊し、caller 側の error 表示が動かなくなる連鎖の起点になっている。構造変更（シグネチャ変更）は伴わず、挙動レベルで前提が破壊されている。fix-scope-integrity は Premise break 軸で 1 件検出する。
+
+## Input Diff
+
+```diff
+diff --git a/src/ui/widget.mjs b/src/ui/widget.mjs
+index 1111111..2222222 100644
+--- a/src/ui/widget.mjs
++++ b/src/ui/widget.mjs
+@@ -10,9 +10,13 @@ export function renderWidget(props) {
+-  // 呼び出し側が error state を保持する前提（caller が props.error を渡す）
+-  return { view: draw(props), error: props.error };
++  // 責務統合: error state を Widget 内部で保持する
++  const error = detectError(props);
++  internalState.lastError = error;
++  return { view: draw(props) };
+ }
+```
+
+## 参照コード / 依存 caller（変更なし）
+
+```js
+// src/ui/dashboard.mjs（変更なし・依存 caller）
+const result = renderWidget({ ...props, error: this.errorState });
+// 呼び出し側は result.error を読んで error バナーを描画する前提
+if (result.error) showBanner(result.error); // ← result.error が undefined になり動かなくなる
+```
+
+## PR 本文 / Artifacts
+
+- PR 本文: 「レビュー指摘（責務重複）への対応」。指摘対応ループの signal あり。
+- 「この修正が依存する前提」の列挙なし・影響範囲確認の記録なし。
+- 前提を変えること自体はタスクの目的として宣言されていない（責務重複の解消が目的で、caller 契約の変更は意図外）。
+
+## Expected Behavior
+
+本 skill は以下を満たすこと。
+
+1. Premise break 軸を 1 件検出する（`renderWidget` が返す `error` を撤去したことで、`src/ui/dashboard.mjs` が依存していた「caller が result.error を読む」前提を破壊している）。
+2. 依存 caller を grep 再現可能なアンカーで示す（例: `git grep -n "renderWidget(" src/` で caller を特定し、`result.error` 依存を確認）。
+3. 構造変更（シグネチャ変更）を伴わない挙動レベルの前提破壊として記録し、`cross-file-leakage`（構造変更後の caller 残骸）の領分としては重複指摘しない。
+4. `Severity: blocker`（"動いていた" error 表示経路の回帰を招く）とし、resolution（この修正が依存する前提を列挙し影響範囲を確認してから再提出）を添える。
+5. 前提列挙が無いことを理由に指摘する（前提列挙・影響確認が残っていれば充足とみなす FP guard の裏返し）。

--- a/skills/midstream/fix-scope-integrity/fixtures/02-premise-break-detect.md
+++ b/skills/midstream/fix-scope-integrity/fixtures/02-premise-break-detect.md
@@ -11,7 +11,7 @@ diff --git a/src/ui/widget.mjs b/src/ui/widget.mjs
 index 1111111..2222222 100644
 --- a/src/ui/widget.mjs
 +++ b/src/ui/widget.mjs
-@@ -10,9 +10,13 @@ export function renderWidget(props) {
+@@ -10,3 +10,5 @@ export function renderWidget(props) {
 -  // 呼び出し側が error state を保持する前提（caller が props.error を渡す）
 -  return { view: draw(props), error: props.error };
 +  // 責務統合: error state を Widget 内部で保持する

--- a/skills/midstream/fix-scope-integrity/fixtures/03-approved-related-fix-canary.md
+++ b/skills/midstream/fix-scope-integrity/fixtures/03-approved-related-fix-canary.md
@@ -1,0 +1,49 @@
+# Test Case: Pre-Approved In-Scope Related Fix (False Positive Guard)
+
+## Description
+
+レビュー指摘対応で、当初スコープ内のバグ修正に不可欠な関連修正を追加した差分。さらに PR 本文で「バリデーション共通化のリファクタを同梱する」と事前宣言しており、受入基準も更新されている。指摘対応ループの文脈はあるが、スコープ拡大は正当（スコープ内の関連修正 + 事前承認済みリファクタ）で、前提破壊も無い。fix-scope-integrity はこの差分に対して findings を出してはならない should-not-detect canary。
+
+## Input Diff
+
+```diff
+diff --git a/src/forms/signup.mjs b/src/forms/signup.mjs
+index 1111111..2222222 100644
+--- a/src/forms/signup.mjs
++++ b/src/forms/signup.mjs
+@@ -38,8 +38,8 @@ export function buildSignupSchema() {
+   return {
+     name: { type: 'string', required: true },
+-    age: { type: 'number', required: true },
++    // バグ修正: age 未入力時に required が効かない不具合を修正（当初スコープ内）
++    age: { type: 'number', required: true, nullable: false },
+   };
+ }
+diff --git a/src/forms/validate.mjs b/src/forms/validate.mjs
+new file mode 100644
+index 0000000..3333333
+--- /dev/null
++++ b/src/forms/validate.mjs
+@@ -0,0 +1,6 @@
++// PR 本文で事前宣言済みのバリデーション共通化リファクタ
++export function assertRequired(schema, value) {
++  if (schema.required && (value == null || value === '')) {
++    throw new Error('required field is missing');
++  }
++}
+```
+
+## PR 本文 / Artifacts
+
+- PR 本文: 「新規登録フォームの required バグ修正。**あわせてバリデーション共通化のリファクタを同梱する**（事前承認済み）」とスコープを宣言。
+- 受入基準: 「required バグの修正」に加え「バリデーション共通化」が追記済み（更新で正当化）。
+- コミット連鎖に `fix: レビュー指摘対応` あり（指摘対応ループの signal はある）。
+- caller が依存する前提（`renderWidget` の error 契約等）は変更していない。
+
+## Expected Behavior
+
+本 skill は以下を満たすこと。
+
+1. **findings を出さない**。`nullable: false` の追加は当初スコープ内のバグ修正に不可欠な関連修正であり scope creep ではない。`validate.mjs` の追加は PR 本文で事前宣言/事前承認され受入基準も更新済みのため正当なスコープ拡大。
+2. 前提破壊が無いことを確認する（依存 caller の契約は不変）。Premise break 軸でも指摘しない。
+3. 「スコープが広がっている気がする」等の一般論や、正当化済み拡大への question を出さない（false-positive-first / 低リスク PR での過剰出力の抑制）。

--- a/skills/midstream/fix-scope-integrity/fixtures/03-approved-related-fix-canary.md
+++ b/skills/midstream/fix-scope-integrity/fixtures/03-approved-related-fix-canary.md
@@ -11,7 +11,7 @@ diff --git a/src/forms/signup.mjs b/src/forms/signup.mjs
 index 1111111..2222222 100644
 --- a/src/forms/signup.mjs
 +++ b/src/forms/signup.mjs
-@@ -38,8 +38,8 @@ export function buildSignupSchema() {
+@@ -38,5 +38,6 @@ export function buildSignupSchema() {
    return {
      name: { type: 'string', required: true },
 -    age: { type: 'number', required: true },

--- a/skills/registry.yaml
+++ b/skills/registry.yaml
@@ -813,6 +813,26 @@ skills:
     recommended: true
     description: 'plan artifact がある時のみ、plan の assumption / open question が実装で解消された証拠を diff・PR 本文と突合する evidence-sufficiency 観点。plan 欠損時は発火せず、PR 本文に前提が inline 列挙されていれば列挙分のみ部分評価する。unknown-coverage-review 合成層の観点6 を registry として単独実行する'
 
+  - id: fix-scope-integrity
+    version: '0.1.0'
+    name: 'Fix Scope Integrity 指摘対応ループのスコープ逸脱・前提破壊検出'
+    path: skills/midstream/fix-scope-integrity/SKILL.md
+    category: midstream
+    phase: midstream
+    tags:
+      [
+        fix-scope-integrity,
+        scope-creep,
+        premise-break,
+        fix-scope-guard,
+        review-response-loop,
+        scope-consistency,
+        midstream,
+      ]
+    severity: major
+    recommended: true
+    description: '指摘対応の反復（レビューコメント→修正→再レビュー）で、個別には正しい修正の蓄積が当初スコープを逸脱した（scope creep）、または成立済みの前提を破壊した（premise break）連鎖を diff-time で検出する。技術的正しさとスコープ整合性を別軸で評価し report-only。1コメント triage は review-comment-triage、構造変更後の caller 残骸は cross-file-leakage、plan 前提解消は assumption-resolution-trace へ委譲する'
+
   - id: cross-file-leakage
     version: '0.1.0'
     name: 'Cross-File Leakage リファクタ後の caller 側残骸検出'


### PR DESCRIPTION
## What / 概要

指摘対応の反復（レビューコメント→修正→再レビュー）という時間軸上で、**個別には正しい修正の蓄積**が当初スコープを逸脱（scope creep）、または成立済みの前提（"動いていた"状態）を破壊（premise break）する連鎖を diff-time で検出する新規 midstream registry skill `fix-scope-integrity` を追加します。

Closes #1516

設計判断（命名 Q0–Q5・検出観点・隣接 skill 分界）は実装前に issue へコメント済み: https://github.com/s977043/river-review/issues/1516#issuecomment-4950329517

## Why / 動機

Zenn ウォッチ digest #1515（テーマA）で同一ギャップを指す2記事が取り込み候補に:

- https://zenn.dev/fixu/articles/copilot-review-scope-creep-revert （scope creep）
- https://zenn.dev/urario/articles/ai-review-rally （premise break）

隣接3 skill（`review-comment-triage` / `cross-file-leakage` / `assumption-resolution-trace`）は隣接観点を持つが、「指摘対応の反復という時間軸上の蓄積」を主対象にしていないため真のギャップと判断（詳細は #1516）。要約は主張の紹介であり本文の転載はしていません（nominative fair use）。

## 命名の確定 — `fix-scope-integrity`

`skills/README.md` Naming Q0–Q5 を通し value を表す新規名を付与。`fix-scope-guard`（暫定案）は `-guard` が mechanism 名かつ "False-positive guards" 節と語彙衝突するため却下、`premise-integrity` は scope creep を undersell するため却下。検索性のため `tags` に `scope-creep` / `premise-break` / `fix-scope-guard` を残置。

## 検出観点（report-only / ADR-005）

1. **Scope creep**: 当初スコープ・移植元・受入基準に無い制約/挙動を指摘対応で追加。技術的正しさとスコープ整合性を別軸で判定し `妥当だが対象外` を指摘。
2. **Premise break**: 修正が成立済みの前提（既存 caller が依存する挙動）を無効化し次の欠陥の起点になっている（構造変更を伴わない挙動レベル）。
3. **前提列挙の不在（question）**: 前提に触れる修正なのに依存前提の列挙・影響確認の証拠が無い場合は finding ではなく question。

## False-positive guards + canary

スコープ内の関連修正・事前承認済みリファクタ・受入基準更新・意図された前提変更・前提列挙済みは指摘しない。当初スコープ/前提が discover 不能なら question に留める（false-positive-first / #1070 分界に整合）。should-not-detect canary fixture で回帰防止。

## 変更ファイル

- `skills/midstream/fix-scope-integrity/SKILL.md` — 由来明記・Pre-execution Gate・検出観点・FP guards・Non-goals 委譲表・severity 較正・出力例・評価指標。
- `skills/midstream/fix-scope-integrity/fixtures/` — scope-creep 検出・premise-break 検出の should-detect 各1、正当な追随修正の should-not-detect canary 1。
- `skills/registry.yaml` — エントリ追加（version/tags/severity を SKILL.md と同期）。
- `docs/data/skill-manifest.json` — 再生成（130 skills）。

## 受入条件チェック（#1516）

- [x] report-only（自動修正・自動マージなし）
- [x] FP guard + canary（should-not-detect fixture）
- [x] 由来（`inspired by <URL>`）を SKILL.md 冒頭に明記
- [x] 隣接3 skill との重複回避（委譲表を明記）
- [x] improvement-flow に沿って codify

## 検証

- `npm run skills:validate` — recommended eval 56/56・registry paths 119・naming collisions unique
- `npm run skills:manifest:check` — up to date (130 skills)
- `npm run eval:fixtures` — All review fixtures passed
- `npm run plugin:validate` — Plugin manifest: OK
- `npm test` — tests 2121 / fail 0
- `npm run lint` — format/dashes/code/md/text all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
