### PR TITLE
docs(skills): 指摘上限の切り捨て順の文言を保持優先の形へ明確化する

### DIFF
--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -120,7 +120,7 @@
     {
       "id": "assumption-resolution-trace",
       "path": "skills/midstream/assumption-resolution-trace",
-      "checksum": "sha256:e4c53f59bbc6ddbacde1a787a07b670c4ba3c95a68c8a6ec93c5ab17cfd3ba39",
+      "checksum": "sha256:63b016a4d68691f1401667fdc3a741208bc9f344ace8cc2cb8cf60351b2cc703",
       "files": 3
     },
     {
@@ -366,7 +366,7 @@
     {
       "id": "impact-evidence-coverage",
       "path": "skills/midstream/impact-evidence-coverage",
-      "checksum": "sha256:116dafbe8a19b9f86330d6ba56ad5dde4007d0762eb6f452268063ea0ee914c4",
+      "checksum": "sha256:5572826fca5ec1a1f3ab7303fb3d5e0689eea07efd37be21e5404d2c00343f5e",
       "files": 3
     },
     {
@@ -762,7 +762,7 @@
     {
       "id": "unknown-coverage-review",
       "path": "skills/agent-skills/unknown-coverage-review",
-      "checksum": "sha256:cea34cbb9f3bc332517f79d44477e63663f17365f8147b2673a4519082940d94",
+      "checksum": "sha256:37cd303a0e0f4da4948283f2dfd430b4bf928be141862b60eb53dfdd65e83cb6",
       "files": 5
     },
     {

--- a/skills/agent-skills/unknown-coverage-review/SKILL.md
+++ b/skills/agent-skills/unknown-coverage-review/SKILL.md
@@ -119,7 +119,7 @@ report-only 契約に従う。**本観点はマージを止めない**。判定�
 - 指摘の `file:line` は差分内にあること（VERIFICATION の evidence 規則）。差分外の推測に基づく Unknown は finding にせず question として返す。
 - 委譲表に該当する defect は出さない（委譲先 skill の実行に委ねる）。
 - 「証拠が repo 内・別ファイル・PR 本文に存在する可能性」を Grep / artifact 参照で棄却できない場合は、finding ではなく question にする。
-- 低リスク PR（小さな明確なバグ修正・既存パターン踏襲）では過剰な Unknown を出さない。観点ごとに **finding と question の合算で** 最大 5 件、severity 降順で切り捨てる。question は severity を持たないため **`info` 相当として扱い、切り捨ては findings（severity 降順）→ questions の順**とする。
+- 低リスク PR（小さな明確なバグ修正・既存パターン踏襲）では過剰な Unknown を出さない。観点ごとに **finding と question の合算で** 最大 5 件とする。question は severity を持たないため **`info` 相当として扱い、保持の優先順は findings（severity 降順）→ questions とし、上限超過分は優先度の低い側（questions → 低 severity findings）から切り捨てる**。
 - correctness bug・セキュリティ欠陥そのものは対象外（defect 系観点の責務）。
 
 ## References

--- a/skills/midstream/assumption-resolution-trace/SKILL.md
+++ b/skills/midstream/assumption-resolution-trace/SKILL.md
@@ -73,7 +73,7 @@ Why: plan の assumption と diff の突合は artifact 参照による決定論
 - 「assumption が解消された証拠が別ファイル・既存テスト・PR 本文に存在する可能性」を Grep / Glob / artifact 参照で棄却できた場合のみ finding 化する。棄却できなければ question とする。
 - plan / plan 整合の検証（`plangate-plan-integrity` / `plangate-verification-audit` の領分）は出さない。本 skill の finding は「解消の証拠不在」に限る。
 - bare な計画 issue 参照から外部 issue 本文を取得・推測して assumption を捏造しない（部分評価は PR 本文に inline された項目に限る）。
-- 指摘上限: finding と question の合算で最大 5 件、severity 降順で切り捨てる。question は `info` 相当として扱い、切り捨ては findings（severity 降順）→ questions の順とする。
+- 指摘上限: finding と question の合算で最大 5 件とする。question は `info` 相当として扱い、保持の優先順は findings（severity 降順）→ questions とし、上限超過分は優先度の低い側（questions → 低 severity findings）から切り捨てる。
 
 ## Rule / ルール
 

--- a/skills/midstream/impact-evidence-coverage/SKILL.md
+++ b/skills/midstream/impact-evidence-coverage/SKILL.md
@@ -69,7 +69,7 @@ Why: 証拠の有無は grep / artifact 参照による決定論的突合が主�
   - タイムアウト・リトライ・レート制限・キャッシュ TTL の設定値が差分内に明示されている。
 - **証拠の別在の棄却が前提**: 「証拠が repo 内・別ファイル・既存テスト・PR 本文に存在する可能性」を Grep / Glob / artifact 参照で棄却できた場合のみ finding 化する。棄却できなければ finding ではなく question とする。
 - **委譲先の領分を侵さない**: 委譲表（`unknown-coverage-review` の DELEGATION.md）で defect 検出に割り当てられた指摘（caller 残骸・契約破壊・テスト欠落そのもの）は出さない。本 skill の finding は「証拠の不在（evidence_missing）」に限る。
-- **指摘上限**: 観点（Impact / Failure / External）ごとに finding と question の合算で最大 3 件、severity 降順で切り捨てる。question は `info` 相当として扱い、切り捨ては findings（severity 降順）→ questions の順とする。
+- **指摘上限**: 観点（Impact / Failure / External）ごとに finding と question の合算で最大 3 件とする。question は `info` 相当として扱い、保持の優先順は findings（severity 降順）→ questions とし、上限超過分は優先度の低い側（questions → 低 severity findings）から切り捨てる。
 - correctness bug・セキュリティ欠陥そのものは対象外（defect 系観点の責務）。
 
 ## Rule / ルール


### PR DESCRIPTION
## What / 概要

PR #1520 への gemini レビュー指摘（[discussion_r3565859406](https://github.com/s977043/river-review/pull/1520#discussion_r3565859406)）からの**波及修正**です。

「切り捨ては findings（severity 降順）→ questions の順とする」という指摘上限の文言は、「最も重要度の高い findings から優先的に破棄する」と読める論理的曖昧さがあります。この文言は `skills/agent-skills/unknown-coverage-review/SKILL.md` の False-positive guards 節（#1501 で導入）が本家で、踏襲先2ファイルにも同じ曖昧さが存在するため、PR #1520 での修正と同一の書き換えを行います。

## 書き換え内容

保持の優先順と切り捨て方向を分離して明記:

> 保持の優先順は findings（severity 降順）→ questions とし、上限超過分は優先度の低い側（questions → 低 severity findings）から切り捨てる

## 変更ファイル

- `skills/agent-skills/unknown-coverage-review/SKILL.md` — 本家（#1501 で導入）
- `skills/midstream/impact-evidence-coverage/SKILL.md` — 踏襲先
- `skills/midstream/assumption-resolution-trace/SKILL.md` — 踏襲先
- `docs/data/skill-manifest.json` — 再生成同梱

意味・上限件数・severity 扱いの変更はなく、文言の明確化のみです。踏襲先2ファイルは本家と同一文言を継承していたため、同一 PR で揃えて修正しています（片側のみ修正すると文言が再ドリフトするため）。

## 検証

- `npm run agent-skills:validate` — pass（警告は river-review-performance の既存分で本 PR と無関係）
- `npm run skills:validate` — pass（recommended eval 55/55・registry paths 118・naming collisions unique）
- `npm run skills:manifest:check` — 再生成同梱で pass
- pre-commit lint-staged（prettier / markdownlint / skills:validate / agent-skills:validate）pass

## 関連

- PR #1520（fix-scope-integrity — 同指摘の一次修正）
- #1501（本家文言の導入元）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
