### PR TITLE
fix(agent-skills): cache-strategy-consistency を performance から exemption 化する

### DIFF
--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -654,7 +654,7 @@
     {
       "id": "river-review-performance",
       "path": "skills/agent-skills/river-review-performance",
-      "checksum": "sha256:4d0f512eda080d85cfe28c184dd0d85b41aaf6692a865d1f65631c4dd34f4023",
+      "checksum": "sha256:912a78d22a7ad309e2a3ca1bbd1da26f9dbd902c9dd2611d8e783f953cb64396",
       "files": 2
     },
     {

--- a/skills/agent-skills/river-review-performance/SKILL.md
+++ b/skills/agent-skills/river-review-performance/SKILL.md
@@ -10,6 +10,11 @@ severity: major
 applyTo:
   - 'src/**/*.{ts,tsx,js,jsx,mjs}'
   - '**/*.sql'
+# applyTo 包含検査（#1508）の意図的除外。ルーティング表に載るが本エントリの
+# applyTo には含めないルーティング先を、理由付きで宣言する。
+applyToExemptions:
+  - skill: cache-strategy-consistency
+    reason: 参照のみ。cache-strategy-consistency は docs 向け設計文書レビュー（phase upstream、applyTo が docs/**/*.md 等のみ）で、code/sql 実行観点の本エントリ（phase midstream）とはドメインが異なる。実行は river-review-architecture に据置く（本 SKILL.md「cache-strategy-consistency の帰属について」）。本エントリの applyTo には含めない。
 inputContext: [diff, fullFile]
 outputKind: [findings, actions]
 tags: [performance, optimization, entry, routing]
@@ -30,12 +35,16 @@ license: MIT
 
 ## Routing / ルーティング
 
-| キーワード             | スキルID                      | 説明                   |
-| ---------------------- | ----------------------------- | ---------------------- |
-| キャッシュ, TTL        | `cache-strategy-consistency`  | キャッシュ戦略の一貫性 |
-| 障害, 監視, メトリクス | `failure-modes-observability` | 障害モードと可観測性   |
-| ログ, トレース         | `logging-observability`       | ロギング・可観測性     |
-| SLO, レイテンシ        | `operability-slo`             | 運用性・SLO            |
+| キーワード             | スキルID                      | 説明                                                                                               |
+| ---------------------- | ----------------------------- | -------------------------------------------------------------------------------------------------- |
+| キャッシュ, TTL        | `cache-strategy-consistency`  | 参照のみ。実行は `river-review-architecture`（[理由](#cache-strategy-consistency-の帰属について)） |
+| 障害, 監視, メトリクス | `failure-modes-observability` | 障害モードと可観測性                                                                               |
+| ログ, トレース         | `logging-observability`       | ロギング・可観測性                                                                                 |
+| SLO, レイテンシ        | `operability-slo`             | 運用性・SLO                                                                                        |
+
+### `cache-strategy-consistency` の帰属について
+
+`cache-strategy-consistency` はキャッシュ戦略という語感から performance の懸念に見えるが、実体は設計ドキュメント（docs/spec/RFC 等）のキャッシュ戦略記述をレビューする upstream スキル（`applyTo` が `docs/**/*.md` 等の docs 系のみ、Pre-execution Gate も「差分に設計ドキュメントの変更がある」ことを要求）である。本エントリ（phase midstream、`applyTo` が code/sql）とはドメインが異なるため、ドメイン一貫性を優先し実行は `river-review-architecture`（phase upstream、docs 系 applyTo を保有）に据え置く。本表には**到達性のための参照行**として掲載するのみで、performance 側に重複するアクティブなキーワードルートは追加しない。
 
 ### デフォルト動作
 


### PR DESCRIPTION
## 概要

Closes #1508（follow-up）。applyTo 包含検査（#1509）が出す既存 warning 21件のうち、`river-review-performance → cache-strategy-consistency`（docs 向けスキルが code/sql 系エントリから到達不能。architecture エントリ経由では到達可）について exemption 化か実修正かの設計判断を確定し実装する。

## 判断: exemption 化（実修正は見送り）

判断基準（要件適合性 → 安全性 → 保守性 → 実装コスト → 拡張性）で検討した結果、以下の理由から **exemption が妥当**と判断した。

- `cache-strategy-consistency` は `phase: upstream` / `applyTo` が `docs/**/*.md` 等の docs 系のみで構成され、Pre-execution Gate も「差分に設計ドキュメント（設計書/spec/RFC）の変更がある」ことを要求する **docs 中心の設計レビュースキル**。
- `river-review-performance` は `phase: midstream` / `applyTo` が `src/**/*.{ts,tsx,js,jsx,mjs}` と `**/*.sql` のみの **code/sql 実行観点のエントリ**。両者はドメインが異なる。
- `river-review-architecture` は `phase: upstream` で `docs/**/*design*.md` 等の docs 系 `applyTo` を保有しており、`cache-strategy-consistency` の本来の実行先として整合する。
- 実修正案（performance の applyTo に docs 系を足す／cache-strategy-consistency の applyTo に code 系を足す）は、過剰発火リスクまたは skill の設計意図変更を伴い、影響範囲が大きい割にリターンが薄い。
- 過去の類似判断（`river-review-frontend` の `modern-web-performance` 参照のみ行 → exemption で沈黙化）と構造的に対称（今回は逆方向: docs 系スキルが code 系エントリから参照されているだけのケース）であり、既存パターンとの一貫性が高い。

## 実装

`skills/agent-skills/river-review-performance/SKILL.md`:

- frontmatter に `applyToExemptions: [{ skill: cache-strategy-consistency, reason: ... }]` を追加（#1509 で導入された構文）。
- Routing 表の `cache-strategy-consistency` 行を「参照のみ。実行は `river-review-architecture`」に更新。
- `### cache-strategy-consistency の帰属について` セクションを追加し、判断根拠（phase/applyTo のドメイン差）を明文化。
- `docs/data/skill-manifest.json` のチェックサムを再生成（lint-staged 経由で自動反映）。

architecture 側に残る別の warning（`cache-strategy-consistency` の `design/**/*.md` 等 partial coverage）は本 follow-up のスコープ外のため変更していない。

## 検証

- `npm run agent-skills:validate` → 対象 warning が消滅（21件 → 20件）、exit 0。他の警告に変化なし。
- `npm run skills:manifest:check` → up to date。
- `npm test` → 2121 pass / 0 fail。
- `npm run lint`（format:check / check:dashes / lint:code / lint:md / lint:text）→ すべて pass。

## Before/After（validator出力差分）

Before:
```
⚠️  skills/agent-skills/river-review-performance/SKILL.md: routing target "cache-strategy-consistency" is not reachable via this entry's applyTo, but is reachable via another entry (referenced here, executed elsewhere). Add an applyToExemptions entry to document the deferral if intentional.
```

After: 該当行なし（exemption により沈黙化）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)