### PR TITLE
docs: /release-kick コマンドとワーカー規律テンプレートを追加する

### DIFF
--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -10,6 +10,7 @@ Repo-development slash commands (NOT part of the distributed plugin surface).
 | `/verify-agent-report`   | `verify-agent-report.md`   | Verify agent completion reports against real branches, PRs, and commits                     |
 | `/merge-check`           | `merge-check.md`           | Run the pre-merge checklist (docs/governance.md) against a PR number                        |
 | `/register-plugin-asset` | `register-plugin-asset.md` | Register a new distributed command/agent/agent-skill into the plugin manifests and validate |
+| `/release-kick`          | `release-kick.md`          | Drive a release-please PR from BLOCKED unblock through merge and release verification       |
 
 > **配布対象のコマンド** (`/check` `/pr` `/skill` `/review-local` `/challenge`) は #996 で top-level [`commands/`](../../commands/) へ分離し、`.claude-plugin/plugin.json` がそこを参照します。本ディレクトリには repo-dev 専用コマンドのみが残ります。
 >

--- a/.claude/commands/release-kick.md
+++ b/.claude/commands/release-kick.md
@@ -17,6 +17,7 @@ gh api user --jq .login | grep -q s977043 || gh auth switch -u s977043
 ```
 
 PreToolUse hook (`gh-account-guard.sh`) が defense-in-depth で効くが、セッション開始時の確認は省略しない。
+`s977043` は本リポジトリのメンテナアカウント（CLAUDE.md「Verify gh active account before write ops」ガードと同一の値で、そちらが SSoT）。フォーク運用時は自分のアカウントに読み替える。
 
 ### Step 2. PR 状態の確認
 

--- a/.claude/commands/release-kick.md
+++ b/.claude/commands/release-kick.md
@@ -1,0 +1,100 @@
+---
+description: release-please のリリース PR を BLOCKED 解除 → CI green 確認 → マージ → リリース公開検証まで一貫実行する（v1.44.0〜v1.53.0 の11リリースで実証済みの型）
+argument-hint: '<release PR number>'
+allowed-tools: Bash(gh api user:*), Bash(gh auth switch:*), Bash(gh pr view:*), Bash(gh pr checks:*), Bash(gh pr merge:*), Bash(gh api:*), Bash(gh run list:*), Bash(gh release view:*), Bash(git ls-remote:*), Bash(scripts/release-please-kick.sh:*), Bash(bash scripts/release-please-kick.sh:*)
+---
+
+release PR #$ARGUMENTS を、BLOCKED 解除からマージ・リリース公開の検証まで一貫して実行する。
+
+release-please が生成するリリース PR の head は `GITHUB_TOKEN` push であるため、通常は `mergeStateStatus: BLOCKED`（"N of N required checks are expected"）になる（CLAUDE.md「`N of N required checks are expected` = bot/GITHUB_TOKEN push」ガード参照）。この BLOCKED の原因・`RELEASE_KICK_PAT` のセットアップ・`workflow_dispatch` 経由の代替手順は `docs/runbook/release-please-kick.md` が SSoT。本コマンドはそれを前提に、実際にマージして公開を確認するまでの実行手順を1コマンド化したもの。矛盾があれば runbook を正とし、本コマンドを修正する。
+
+## 手順
+
+### Step 1. gh アカウント確認
+
+```bash
+gh api user --jq .login | grep -q s977043 || gh auth switch -u s977043
+```
+
+PreToolUse hook (`gh-account-guard.sh`) が defense-in-depth で効くが、セッション開始時の確認は省略しない。
+
+### Step 2. PR 状態の確認
+
+```bash
+gh pr view $ARGUMENTS --json state,mergeStateStatus,headRefOid
+```
+
+`mergeStateStatus: BLOCKED` は release-please PR の通常挙動。`CLEAN` なら Step 3〜4 をスキップして Step 5 へ進む。
+
+### Step 3. release-please-kick の実行
+
+```bash
+bash scripts/release-please-kick.sh
+```
+
+空コミットで新しい head を作り、`pull_request: synchronize` を実ユーザー相当のトークンで発火させる。ブランチ名を省略すると open な release PR を自動検出する。詳細・`RELEASE_KICK_PAT` 未設定時のエラー・`workflow_dispatch` 経由の代替は runbook 参照。
+
+### Step 4. 新 head の CI 実発火確認
+
+```bash
+gh run list --limit 5 --json databaseId,status,conclusion,headBranch,workflowName
+```
+
+新 head の run が `action_required` のまま止まっていないか（＝実発火しているか）を確認する。`action_required` のままなら `RELEASE_KICK_PAT` 未設定などが疑われる。runbook のトラブルシュートへ。
+
+### Step 5. CI green までポーリング
+
+Monitor ツールは使わず、1つの Bash 呼び出し内で sleep しながらポーリングする。**ポーリング用の変数名に `status` を使わない**（zsh の読み取り専用変数と衝突し代入が失敗する）。
+
+```bash
+for i in $(seq 1 8); do
+  pendingCount=$(gh pr checks $ARGUMENTS --json name,bucket --jq '[.[] | select(.bucket=="pending")] | length')
+  echo "iteration $i: pending=$pendingCount"
+  [ "$pendingCount" = "0" ] && break
+  sleep 14
+done
+gh pr checks $ARGUMENTS --json name,bucket --jq '.[] | select(.bucket != "skipping")'
+```
+
+- 8 回（約 2 分弱）で `pending` が解消しない場合はループを打ち切り、実出力を提示したうえで待機を継続するか判断を仰ぐ
+- `fail` バケットが出た場合は直ちに報告し、原因調査へ切り替える（本コマンドはマージ前提の手順であり、CI 失敗の修正は別タスク）
+
+### Step 6. BEHIND の場合
+
+```bash
+gh api "repos/:owner/:repo/pulls/$ARGUMENTS" --jq '{mergeable_state}'
+```
+
+`behind` なら:
+
+```bash
+gh api "repos/:owner/:repo/pulls/$ARGUMENTS/update-branch" -X PUT
+```
+
+update-branch で CI が再実行されるため Step 5 のポーリングをやり直す。
+
+### Step 7. マージ
+
+`mergeStateStatus: CLEAN` かつ Step 5 の CI が green になったら:
+
+```bash
+gh pr merge $ARGUMENTS --squash --delete-branch
+```
+
+### Step 8. 検証
+
+- Release Please workflow の run が success で終わっていることを `gh run list` で確認する
+- tag が merge commit と一致することを確認する。`repos/:owner/:repo/git/ref/tags/<tag>` が単発 404 を返す場合は `git ls-remote --tags origin` でも照合する
+- `gh release view <tag>` で release が published になっていることを確認する
+
+## 禁止事項
+
+- `git push --force`
+- `git reset --hard`
+- `gh pr merge --admin`（`enforce_admins: true` の場合はそもそも BLOCKED を回避できない）
+- release PR の内容（CHANGELOG / バージョン番号等）へのファイル編集。本コマンドは release-please が生成した内容をそのままマージする手順であり、内容修正が必要な場合は release-please の設定側を直す
+
+## 参照
+
+- `docs/runbook/release-please-kick.md`（SSoT: BLOCKED の原因、`RELEASE_KICK_PAT` セットアップ、`workflow_dispatch` 代替手順）
+- CLAUDE.md「`N of N required checks are expected` = bot/GITHUB_TOKEN push」ガード

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,12 +62,13 @@ When a retrospective identifies a recurring mistake or missing guardrail, follow
 
 ## Tooling
 
-| Component   | Location                  | Behavior                                                              |
-| ----------- | ------------------------- | --------------------------------------------------------------------- |
-| Permissions | `.claude/settings.json`   | Defines allow/ask/deny command lists                                  |
-| Rules       | `.claude/rules/`          | Auto-loaded by glob pattern in frontmatter (e.g., `**/*`)             |
-| Hooks       | `.claude/hooks/format.sh` | PostToolUse: auto-runs prettier on all changed files (vs HEAD)        |
-| Sub-agent   | `agents/river-review.md`  | Distributed plugin agent (top-level per #996); Read, Grep, Glob, Bash |
+| Component         | Location                                         | Behavior                                                              |
+| ----------------- | ------------------------------------------------ | --------------------------------------------------------------------- |
+| Permissions       | `.claude/settings.json`                          | Defines allow/ask/deny command lists                                  |
+| Rules             | `.claude/rules/`                                 | Auto-loaded by glob pattern in frontmatter (e.g., `**/*`)             |
+| Hooks             | `.claude/hooks/format.sh`                        | PostToolUse: auto-runs prettier on all changed files (vs HEAD)        |
+| Sub-agent         | `agents/river-review.md`                         | Distributed plugin agent (top-level per #996); Read, Grep, Glob, Bash |
+| Worker discipline | `docs/development/worker-discipline-template.md` | Copy-paste discipline block for delegated worker prompts              |
 
 ## Custom Commands
 
@@ -86,7 +87,8 @@ When a retrospective identifies a recurring mistake or missing guardrail, follow
 | `/verify-agent-report`   | Verify agent completion reports against real branches, PRs, and commits                     |
 | `/merge-check`           | Run the pre-merge checklist (docs/governance.md) against a PR number                        |
 | `/register-plugin-asset` | Register a new distributed command/agent/agent-skill into the plugin manifests and validate |
+| `/release-kick`          | Drive a release-please PR from BLOCKED unblock through merge and release verification       |
 
-Details: distributed commands (`/check` `/pr` `/skill` `/review-local` `/challenge` `/review-team` `/setup-team`) live in top-level `commands/` (plugin surface, per #996); repo-dev commands (`/propose-issue` `/plan-merge-order` `/preflight` `/verify-agent-report` `/merge-check` `/register-plugin-asset`) stay in `.claude/commands/`.
+Details: distributed commands (`/check` `/pr` `/skill` `/review-local` `/challenge` `/review-team` `/setup-team`) live in top-level `commands/` (plugin surface, per #996); repo-dev commands (`/propose-issue` `/plan-merge-order` `/preflight` `/verify-agent-report` `/merge-check` `/register-plugin-asset` `/release-kick`) stay in `.claude/commands/`.
 
 > Note: the distributed commands resolve only when river-review is **installed as a plugin**. When working inside this repo directly, Claude Code auto-discovers project commands from `.claude/commands/` only — so the seven distributed commands are not available as in-repo slash commands (the repo-dev commands are).

--- a/docs/development/worker-discipline-template.md
+++ b/docs/development/worker-discipline-template.md
@@ -1,0 +1,87 @@
+# ワーカー規律テンプレート
+
+委託ワーカー（`Agent` ツールで起動する background 実装エージェント）のプロンプトに毎回複製している規律定型の SSoT。オーガナイザーはワーカーを起動する際、下記「コピペ用テンプレート」をプロンプトへ含める。
+
+## 背景
+
+複数 PR を並行委託する運用では、同じ規律（gh アカウント guard、Node バージョン、`--no-verify` 禁止など）を毎回プロンプトに手で書き起こしており、書き漏れが個別インシデントの原因になってきた。CLAUDE.md の AI Misoperation Guards はオーガナイザー自身のセッションには自動適用される。しかし `Agent` ツールで起動したワーカーは新規セッションであり、CLAUDE.md を読まない場合がある（サブエージェント定義次第）ため、規律をプロンプト本文に明示的に含める必要がある。
+
+## コピペ用テンプレート
+
+以下をワーカー委託プロンプトの末尾にそのまま含める。
+
+```text
+## 作業規律（厳守）
+
+- gh の書き込み系操作（pr create/merge/edit, issue create, api の POST/PATCH/PUT/DELETE 等）の前に毎回:
+  `gh api user --jq .login | grep -q s977043 || gh auth switch -u s977043`
+  404 や permission エラーが出たら、まずこのアカウント切り替わりを疑うこと。
+- シェルの PATH 先頭に `/opt/homebrew/opt/node@22/bin` を通してから作業すること。既定の `node`（v26 系）を使わない。
+  worktree で作業する場合は最初に `npm ci` を実行すること（lockfile 由来の依存不整合を防ぐ）。
+- `git commit` / `git push` で `--no-verify` を使わないこと。lint-staged が manifest 再生成・textlint を担っており、
+  スキップすると CI で初めて失敗が露見する。
+- commit subject は小文字または日本語で始めること（commitlint の subject-case ルールに抵触するため大文字始まりは reject される）。
+  例: `fix: ...` / `feat: ...` / `docs: ...`（日本語 subject も可）。
+- Monitor ツールは使用しないこと。CI やポーリング待ちが必要な場合は、1つの Bash 呼び出し内で
+  `for i in $(seq 1 N); do ...; sleep <秒>; done` の形で自力ポーリングすること。
+  ポーリング用の変数名に `status` を使わないこと（zsh の読み取り専用変数と衝突し代入が失敗する）。
+- 検証は実際のコマンド出力と exit code で判定すること。テスト件数・lint 結果などの報告数値は、
+  自分の記憶や推測ではなく実行したツール出力から転記すること。
+- 作業は PR 作成 → CI green の確認までとし、マージは行わないこと（マージはオーガナイザー側が実施する）。
+- 完了報告には以下を必須項目として含めること: PR 番号、head の commit SHA、CI 結果（実出力を添える）、
+  変更したファイル一覧。
+- セッション上限（時間・ターン数）に達しそうな場合は、未完了のまま放置せず、その時点の成果を
+  commit + push してから状態を報告すること。
+- 日本語ドキュメントを編集した場合は `npx textlint --no-cache <files>` が pass することを確認し、
+  同じパスで `npm run fix:dashes` も実行すること。
+```
+
+## 各項目の詳細・根拠
+
+### gh アカウント guard
+
+`gh` の keyring には `s977043`（本リポジトリ用）と `kominem-unilabo`（別業務用）の2アカウントを登録している。アクティブアカウントはセッション中に無言で切り替わることがある（複数回観測済み）。PreToolUse hook（`.claude/hooks/gh-account-guard.sh`）は defense-in-depth として効く。ただし hook が効かない環境（ワーカーの worktree で `.claude/settings.json` の hook 設定が引き継がれない場合等）もあり得るため、プロンプト側にも明示する。詳細: CLAUDE.md「Verify gh active account before write ops」。
+
+### Node バージョン / worktree の `npm ci`
+
+既定シェルの `node` は v26 系だが、本リポジトリは `.nvmrc` で Node 22（`22.22.2`）に固定されている。lockfile 操作は Node 22 で行うことが安全側。worktree は独立した `node_modules` を持たないため、作業開始時に `npm ci` を実行しないと依存解決が壊れた状態で作業することになる。詳細: `docs/runbook/dev.md`、memory `local-node-version-mismatch`。
+
+### `--no-verify` 禁止
+
+lint-staged が pre-commit で manifest 再生成・`textlint --no-cache` を担っており、`--no-verify` でスキップすると CI の Lint job で初めて失敗が露見し、修正コストがワーカー委託後まで持ち越される。CLAUDE.md の repo rules 全般でも `--no-verify` は明示的な合意なしに使わない方針。
+
+### commit subject の大小文字
+
+commitlint の subject-case ルールにより、大文字始まりの subject（例: `Fix AGENTS.md typo`）は commit-msg フックで reject される。小文字始まり（`fix: ...`）または日本語始まりの subject を使う。詳細: memory `commitlint-subject-case`。
+
+### Monitor 禁止・sleep 自力ポーリング
+
+ワーカーセッションでの Monitor ツール利用は停止・ハングの原因になることが観測されている。CI やマージ待ちなど時間のかかる確認は、1つの Bash 呼び出し内で `sleep` を挟んだ for ループとして自力ポーリングする。ポーリング変数名に `status` を使うと zsh の読み取り専用変数と衝突し代入が失敗するため、別名（例: `pendingCount` / `ciState`）を使う。詳細: `.claude/commands/release-kick.md` の Step 5 に実装例がある。
+
+### 検証は実出力 + exit code
+
+報告の具体性（もっともらしい PR 番号・テスト件数・コマンド出力ブロック）は実行の証拠にならない。ワーカー自身も、検証結果を記憶や推測ではなく実行したコマンドの実出力・exit code から転記すること。オーガナイザー側の裏取り手順は `/verify-agent-report` を参照。
+
+### PR 作成までで停止・マージ禁止
+
+複数ワーカーが並行してマージまで行うと、マージ順序やコンフリクトの管理が破綻する。マージ判断（`/merge-check` の実行含む）はオーガナイザー側に一元化する。
+
+### 完了報告の必須項目
+
+PR 番号 / head SHA / CI 結果（実出力）/ 変更ファイル一覧が揃っていないと、オーガナイザー側の `/verify-agent-report` による裏取りができない。
+
+### セッション上限時の扱い
+
+作業途中でセッション上限に達した場合、未commitの成果を残したまま終了すると引き継ぎ時に失われるリスクがある。成果を commit + push し、状態（完了した Step / 残タスク）を報告する。
+
+### 日本語 docs の textlint
+
+`npm run lint:text` はキャッシュを再利用するため、新規追加した違反を見逃すことがある。`npx textlint --no-cache <files>` で直接検証し、`npm run fix:dashes` も同じパスで実行する。詳細: CLAUDE.md「Doc-edit textlint」ガード。
+
+## 関連
+
+- CLAUDE.md—AI Misoperation Guards（本テンプレートの各項目の一次情報）
+- `.claude/hooks/gh-account-guard.sh`—gh アカウント guard の実装
+- `.claude/commands/verify-agent-report.md`—オーガナイザー側の完了報告裏取り手順
+- `.claude/commands/release-kick.md`—sleep ポーリングの実装例
+- `docs/runbook/dev.md`—Node バージョン / worktree セットアップ

--- a/docs/development/worker-discipline-template.md
+++ b/docs/development/worker-discipline-template.md
@@ -45,6 +45,7 @@
 ### Node バージョン / worktree の `npm ci`
 
 既定シェルの `node` は v26 系だが、本リポジトリは `.nvmrc` で Node 22（`22.22.2`）に固定されている。lockfile 操作は Node 22 で行うことが安全側。worktree は独立した `node_modules` を持たないため、作業開始時に `npm ci` を実行しないと依存解決が壊れた状態で作業することになる。詳細: `docs/runbook/dev.md`、memory `local-node-version-mismatch`。
+なお `/opt/homebrew/opt/node@22/bin` というパスは、本リポジトリのメンテナ開発機（Apple Silicon + Homebrew）を前提とした値。他環境の場合、各自の Node 22 系の入手先に読み替える（バージョン要件の SSoT は `.nvmrc` / `engines.node`）。
 
 ### `--no-verify` 禁止
 


### PR DESCRIPTION
## Summary

- `.claude/commands/release-kick.md`: release-please のリリース PR を BLOCKED 解除 → CI green 確認 → マージ → リリース公開検証まで一貫実行する repo-dev コマンド。v1.44.0〜v1.53.0 の11リリースで実証済みの手順型を定型化した。`docs/runbook/release-please-kick.md` を SSoT として参照し、重複記述を最小化している。
- `docs/development/worker-discipline-template.md`: 委託ワーカープロンプトに毎回複製している規律定型（gh account guard / Node 22 PATH・worktree の `npm ci` / `--no-verify` 禁止 / commit subject 大小文字 / Monitor 禁止・sleep 自力ポーリング(`status` 変数禁止込み) / 検証は実出力+exit code / PR作成までで停止・マージ禁止 / 完了報告必須項目 / セッション上限時の扱い / textlint）の SSoT。コピペ用テンプレートブロックを含む。
- `CLAUDE.md`: Custom Commands 表に `/release-kick` を1行追加、Tooling 表に worker-discipline-template への参照を1行追加。
- `.claude/commands/README.md`: repo-dev コマンド一覧に `/release-kick` を1行追加（このファイル自身の「整合性」注記に従う）。

ユーザー承認済みタスク（CLAUDE.md のコマンド表1行追記を含む）。

## Test plan

- [x] `npx textlint --no-cache docs/development/worker-discipline-template.md` — pass
- [x] `npm run fix:dashes` — 実行済み（`関連` セクションのダッシュ表記を正規化）
- [x] `npx markdownlint` (対象4ファイル) — pass
- [x] `npx prettier --check` (対象4ファイル) — pass
- [x] `npm run lint`（format:check / check:dashes / lint:code / lint:md / lint:text）— 全て pass
- [x] `npm run skills:validate` — pass（既存の無関係な警告のみ）
- [ ] `npm run agents:validate` — 未関連の環境エラー（`node_modules/ajv` の draft-07 スキーマファイル欠落によるもので、`agents/` 配下のファイルはこの PR で変更していない。事前に main でも再現するローカル環境固有の問題と判断）

🤖 Generated with [Claude Code](https://claude.com/claude-code)