### PR TITLE
feat(ci): river-review LLM レビューを GitHub Models へ切替える

### DIFF
--- a/.github/workflows/river-review.yml
+++ b/.github/workflows/river-review.yml
@@ -10,6 +10,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  models: read # GitHub Models 推論を組み込み GITHUB_TOKEN に許可（キーレス化）
 
 concurrency:
   group: river-review-${{ github.ref }}
@@ -37,5 +38,8 @@ jobs:
           gate: false # advisory only — never fail the job
           max_cost: '0.50' # safety cap (OPENAI_MODEL とセットで有効)
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_MODEL: gpt-4o-mini # max_cost の見積単価を実モデルに一致させる（見積器既定 gpt-4-turbo のままだと大型PRを誤abortするため必須の結合）
+          # GitHub Models 切替（キーレス化。設計書参照。ロールバックはこの env ブロックを戻す）
+          OPENAI_API_KEY: ${{ secrets.GITHUB_TOKEN }} # Bearer として GitHub Models に渡る
+          RIVER_OPENAI_BASE_URL: https://models.github.ai/inference/chat/completions # CI レビュー経路が読む endpoint（review-engine.mjs）
+          RIVER_OPENAI_MODEL: openai/gpt-4o-mini # 実 API 呼び出しモデル ID（GitHub Models カタログ形式）
+          OPENAI_MODEL: gpt-4o-mini # max_cost の見積単価を実モデルに一致させる（見積器既定 gpt-4-turbo のままだと大型PRを誤abortするため必須の結合。prefix無しで併設）


### PR DESCRIPTION
## 概要

river-review CI の Stage1 LLM レビューを、`OPENAI_API_KEY` secret 不要の **GitHub Models（`models.github.ai` + 組み込み `GITHUB_TOKEN`）** へ切替える。`.github/workflows/river-review.yml` の env / permissions のみを変更し、`src/` は無変更。

設計 SSoT: 事前調査エージェントによる `keyless-llm-design-v1.md`（案1採用・ユーザー承認済み）。

## 変更内容

- `permissions` に `models: read` を追加（既存 permissions は保持）
- `OPENAI_API_KEY` を `secrets.GITHUB_TOKEN` に差し替え（`callChatCompletion` が `Bearer` として送信）
- `RIVER_OPENAI_BASE_URL: https://models.github.ai/inference/chat/completions` を追加（CI レビュー経路 `review-engine.mjs` の `resolveOpenAIConfig` が読む env）
- `RIVER_OPENAI_MODEL: openai/gpt-4o-mini` を追加（実 API 呼び出しモデル ID。`ENV_DEFAULT_MODEL` で `OPENAI_MODEL` より優先される）
- `OPENAI_MODEL: gpt-4o-mini` は prefix 無しで維持（CostEstimator の単価キー用。`openai/` prefix 付きだと未知モデル扱いで既定単価に落ち、大型 PR を誤 abort するリスクがあるため必須の結合）
- Stage1 のラベル opt-in 構造（`if:` 条件・`gate: false`・`dry_run: false`）は無変更

## なぜコード変更ゼロで成立するか

CI レビュー経路（`generateReview` → `callChatCompletion`）は OpenAI 互換の生 fetch で、`provider` は `openai` 固定のまま `endpoint` だけ `RIVER_OPENAI_BASE_URL` で完全に上書きできる（`src/lib/review-engine.mjs:72-86`）。GitHub Models は OpenAI 互換のチャット補完形式のため、base URL とモデル ID の差し替えのみで動作する想定。

## ロールバック手順

この env ブロックを元の内容に戻すだけ（数行）:

\`\`\`yaml
env:
  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
  OPENAI_MODEL: gpt-4o-mini
\`\`\`

`permissions.models: read` の削除も合わせて行う。

## 検証計画（本 PR 上で実施・マージ前）

1. 通常 CI green を確認
2. 本 PR に `river-review` ラベルを付与し、GitHub Models 経由で Stage1 LLM レビューが実行されるか実地確認
3. run ログから LLM 呼び出し成否・未確認3点（生 fetch のヘッダ互換 / モデル ID の在庫 / 組織の models 権限）を判定
4. 検証結果は本 PR にコメントで追記

検証が完了するまでこの PR はマージしない。