### PR TITLE
fix(ci): lychee 0.24 の include_fragments 型変更に .lychee.toml を追随させる

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -93,8 +93,12 @@ accept = [
 # Exclude all private IPs from checking
 exclude_all_private = true
 
-# Include fragments in link checking (important for internal anchor links in documentation)
-include_fragments = true
+# Include fragments in link checking (important for internal anchor links in documentation).
+# lychee >= 0.24 (lychee-action >= 2.9.0, #1538) changed this option from a boolean to an
+# enum: "none" | "anchor-only" | "text-only" | "full". The pre-0.24 `true` checked anchor
+# fragments only, so "anchor-only" preserves the previous behavior. Requires lychee >= 0.24
+# for local runs (`npm run check:links*`); older lychee (<= 0.23) rejects the string value.
+include_fragments = "anchor-only"
 
 # Cache results for faster subsequent runs
 cache = true


### PR DESCRIPTION
## 概要

#1538（lycheeverse/lychee-action 2.8.0 → 2.9.0）マージ以降、**main を含む全ブランチで Link Check job が落ちている**問題の修正。config 更新で対応する（action の pin 戻しはしない）。

## 根本原因（実地調査）

- lychee-action の既定バンドル lychee は **2.8.0 = v0.23.0 → 2.9.0 = v0.24.2**（両タグの `action.yml` の `lycheeVersion.default` を実確認）
- lychee 0.24.x で `include_fragments` が **boolean → enum へ型変更**。`lychee-bin/src/config/mod.rs`（tag `lychee-v0.24.2`）の `FragmentMode` enum（serde kebab-case）は `none | anchor-only | text-only | full` の4値で、CLI ヘルプの `value_name = "none|anchor-only|text-only|full"` とも一致
- 既存 `.lychee.toml:97` の `include_fragments = true` が `TOML parse error at line 97, column 21`（column 21 = 値 `true` の開始位置）で reject され、Link Check が config ロード段階で exit 3
- リリースノート（lychee-v0.24.0）はこの config 型変更を breaking change として明記していない（アーカイブ構造・API 変更のみ記載）— 公式 `lychee.example.toml`（tag `lychee-v0.24.2`）は `include_fragments = "full"` 形式に更新済み

## 変更内容

- `.lychee.toml`: `include_fragments = true` → `include_fragments = "anchor-only"` + 経緯コメント
- **値の選定根拠**: 0.23 の `true` は anchor fragment のみ検査（text fragment 検査は 0.24 の新機能）。`"anchor-only"` が**旧挙動の完全保存**。`"full"` にすると text fragment 検査が加わり挙動変化（新規 FP リスク）のため採らない

## 検証

- `python3 tomllib` で TOML parse OK（`include_fragments = anchor-only` を確認）
- ローカル lychee 0.23.0 は新 enum 値を reject する（後方非互換・config コメントに明記。ローカル `npm run check:links*` 実行者は lychee >= 0.24 へ更新が必要）
- macOS 用 0.24.2 バイナリのローカル取得は sandbox 制約で不可のため、**本 PR の lychee チェック（CI = v0.24.2 実機）green が実証**

## レビュー要点

- `"anchor-only"` vs `"full"` の選定は「最小差分・挙動保存」優先の判断。fragment 検査を text fragment まで広げたい場合は別 PR で `"full"` 化を検討

Refs #1538

🤖 Generated with [Claude Code](https://claude.com/claude-code)