### PR TITLE
fix(skills): プロセス補助スキル 2 件の severity を info に再分類する

### DIFF
--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -342,7 +342,7 @@
     {
       "id": "gh-address-comments",
       "path": "skills/midstream/gh-address-comments",
-      "checksum": "sha256:337fc02c8a222e55c548b839c73f959d67bbfc357b45942e57a2427405a8171a",
+      "checksum": "sha256:2061e80ea8d0e44fea1a520b478075e7dbdbbcbd9c8f002316dbaf69c8783569",
       "files": 1
     },
     {
@@ -594,7 +594,7 @@
     {
       "id": "review-comment-triage",
       "path": "skills/midstream/review-comment-triage",
-      "checksum": "sha256:ee89a73323153d9aa33004a70483af50682fb142e9644a609887ef519eeba612",
+      "checksum": "sha256:073a1e292ce102946a98ebf3509b64815a691315fdfa0f8950dbe8f3e9eaff2c",
       "files": 1
     },
     {

--- a/skills/midstream/gh-address-comments/SKILL.md
+++ b/skills/midstream/gh-address-comments/SKILL.md
@@ -17,7 +17,7 @@ tags:
   - review
   - github
   - midstream
-severity: major
+severity: info
 inputContext:
   - diff
 outputKind:

--- a/skills/midstream/review-comment-triage/SKILL.md
+++ b/skills/midstream/review-comment-triage/SKILL.md
@@ -18,7 +18,7 @@ tags:
   - review
   - process
   - midstream
-severity: 'minor'
+severity: 'info'
 ---
 
 ## Pattern declaration


### PR DESCRIPTION
## 概要

SKILL.md frontmatter と \`skills/registry.yaml\` の severity 不一致 2 件を、registry 側の \`info\` に揃える再分類です。

| id | SKILL.md（変更前） | registry | 変更後 |
| --- | --- | --- | --- |
| review-comment-triage | minor | info | info |
| gh-address-comments | major | info | info |

## rubric 根拠

\`docs/development/skill-severity-rubric.md\` の「severity = そのスキルが出しうる最悪 finding の重さ」に照らした判断です。

- **review-comment-triage**: レビューコメントの重要度ラベリングと返信案整理のみを行う No-Code-Fix モード。outputKind は findings / summary / questions で、コード修正提案を出さないプロセス補助スキル。
- **gh-address-comments**: レビューコメントの対応方針・返信案の整理。outputKind は actions / questions / summary のみで、コード欠陥そのものを検出するスキルではない。

どちらも修正提案を伴う欠陥検出を行わないため、出しうる最悪 finding は \`info\` 相当です（実質的な引き下げ再分類・ユーザー承認済み）。

## 変更内容

- \`skills/midstream/review-comment-triage/SKILL.md\`: frontmatter \`severity: 'minor'\` → \`'info'\`
- \`skills/midstream/gh-address-comments/SKILL.md\`: frontmatter \`severity: major\` → \`info\`
- \`docs/data/skill-manifest.json\`: 上記 2 スキルの checksum 再生成

本文中の severity 記述は finding 単位の語彙（critical/major/minor/info、must/want/nit）の説明であり、スキル自身の severity ではないため変更なし（grep で確認済み）。

## 検証

- \`npm run skills:validate\`: pass（exit 0、registry paths 119 / naming collisions 130 unique）
- \`npm run skills:manifest\`: 再生成し checksum 変化 2 件を commit に含めた

🤖 Generated with [Claude Code](https://claude.com/claude-code)