### PR TITLE
fix(skills): registry の severity を SKILL.md（実行時 SSoT）に同期する（major 3 件）

### DIFF
--- a/skills/registry.yaml
+++ b/skills/registry.yaml
@@ -163,7 +163,7 @@ skills:
     category: midstream
     phase: midstream
     tags: [typescript, type-safety, midstream]
-    severity: minor
+    severity: major
     recommended: true
     description: 'Enforces TypeScript strict mode best practices'
 
@@ -174,7 +174,7 @@ skills:
     category: midstream
     phase: midstream
     tags: [typescript, null-safety, midstream]
-    severity: minor
+    severity: major
     recommended: true
     description: 'Checks for null/undefined handling'
 
@@ -437,7 +437,7 @@ skills:
     category: midstream
     phase: midstream
     tags: [community, nextjs, app-router, ui, midstream]
-    severity: minor
+    severity: major
     recommended: true
     description: 'Surfaces Next.js App Router boundary issues (server vs client component placement, "use client" misuse).'
 


### PR DESCRIPTION
## 概要

SKILL.md frontmatter（実行時 SSoT）と `skills/registry.yaml` の severity が食い違っているスキルのうち、major 側へ揃える 3 件を同期する。

| id | SKILL.md（SSoT） | registry（変更前） | registry（変更後） |
| --- | --- | --- | --- |
| typescript-strict | major | minor | major |
| typescript-nullcheck | major | minor | major |
| nextjs-app-router-boundary | major | minor | major |

`registry.yaml` の 3 エントリの `severity:` のみを変更し、SKILL.md には触れていない。

## 根拠（severity-rubric）

`docs/development/skill-severity-rubric.md` に整合する:

- 「再分類を避けるべきケース」: 実装ガード系（`typescript-strict`, `nullability-contract`）— type-unsafety は実害につながるため major のままが妥当。frontmatter の major が正であり、registry の minor が同期漏れ。
- 「共通パターン（観察）」3: registry.yaml の同期漏れは #781 でも Copilot review が検出しており、severity を変える際は registry エントリを能動的に確認することが推奨されている。本 PR はその同期漏れの是正。

info へ下げる 2 件は別 PR で扱う。

## 検証

- `npm run skills:validate` → exit 0（registry paths: 119 entry path(s) resolve / naming collisions: 130 identifier(s) unique）
- registry と frontmatter の severity 一致を grep で確認:

```
typescript-strict: registry=major frontmatter=major MATCH
typescript-nullcheck: registry=major frontmatter=major MATCH
nextjs-app-router-boundary: registry=major frontmatter=major MATCH
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
