### PR TITLE
fix(skills): proto スキーマに一切マッチしない dead glob を修正する

### DIFF
--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -300,7 +300,7 @@
     {
       "id": "event-driven-semantics",
       "path": "skills/upstream/event-driven-semantics",
-      "checksum": "sha256:6b3bed9f88cad4565b76317aeda0b3073648151b8533a3a6f1c8c6b34227ab68",
+      "checksum": "sha256:edcb8b840abdbd6dcc2b443c3690317660851dc55b507ee183a73dfb07e96935",
       "files": 1
     },
     {
@@ -384,7 +384,7 @@
     {
       "id": "integration-contracts",
       "path": "skills/upstream/integration-contracts",
-      "checksum": "sha256:eaaf49ca4dd1998f2559816e5c7cf6a1e93ced44873fc86ae20a4fba1cba5a51",
+      "checksum": "sha256:508916403b5858fb8f8c133c3fccb135935f28bc8e5dcaa3b81f6a3cc2f6b462",
       "files": 1
     },
     {

--- a/skills/upstream/event-driven-semantics/SKILL.md
+++ b/skills/upstream/event-driven-semantics/SKILL.md
@@ -16,7 +16,7 @@ applyTo:
   - 'pages/**/*message*.md'
   - '**/*asyncapi*.{yml,yaml,json}'
   - '**/*schema*.{avsc,json}'
-  - '**/*proto*.proto'
+  - '**/*.proto'
 tags: [architecture, events, messaging, reliability, upstream]
 severity: major
 inputContext: [diff, adr]

--- a/skills/upstream/integration-contracts/SKILL.md
+++ b/skills/upstream/integration-contracts/SKILL.md
@@ -15,7 +15,7 @@ applyTo:
   - '**/*openapi*.{yml,yaml,json}'
   - '**/*asyncapi*.{yml,yaml,json}'
   - '**/*schema*.{avsc,json}'
-  - '**/*proto*.proto'
+  - '**/*.proto'
 tags: [integration, contract, api, events, upstream]
 severity: major
 inputContext: [diff, fullFile, adr]


### PR DESCRIPTION
## 概要

`skills/upstream/event-driven-semantics` と `skills/upstream/integration-contracts` の frontmatter `applyTo` にある `**/*proto*.proto` は dead glob だったため、`**/*.proto` に修正する。

minimatch で実証済み: `proto/service.proto` / `proto/user.proto` / `api/order.proto` のいずれにもマッチせず、ファイル名自体に "proto" を含む `order_proto.proto` にしか当たらない（`*proto*` はファイル名部分にのみ適用されるため）。実質 100% 不発だった。

## 変更内容（skill / old / new）

| skill | old pattern | new pattern |
| --- | --- | --- |
| event-driven-semantics | `**/*proto*.proto` | `**/*.proto` |
| integration-contracts | `**/*proto*.proto` | `**/*.proto` |

`docs/data/skill-manifest.json` は lint-staged による自動再生成。`skills/registry.yaml` に applyTo フィールドはないため変更なし。

## 検証

- `minimatch('proto/service.proto', '**/*.proto')` → `true`（`proto/user.proto` / `api/order.proto` も `true`）
- `npm run skills:validate` → pass（130 identifier(s) unique / registry paths 119 entry resolve）
- `npm run planner:eval:dataset`（docs/development/skill-applyto-scoping.md の手順に従い before / after 比較）

| metric | before (main) | after |
| --- | --- | --- |
| cases | 47 | 47 |
| coverage(avg) | 100.0% | 100.0% |
| top1Match(avg) | 96.7% (cases: 30) | 96.7% (cases: 30) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)