### PR TITLE
fix(skills): 実装成果物を対象とするスキルの phase を複数指定に修正する

### DIFF
--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -252,7 +252,7 @@
     {
       "id": "data-model-db-design",
       "path": "skills/upstream/data-model-db-design",
-      "checksum": "sha256:ff3101316392ca5e1cade6fe912da517a2be01d50cd51b714ccda27fd23e7de7",
+      "checksum": "sha256:f842a5e47f62b08d5ded9ef3122dcd153303bb0b81e79b065887030aeec9dfc9",
       "files": 1
     },
     {
@@ -348,7 +348,7 @@
     {
       "id": "gha-workflow-security",
       "path": "skills/downstream/gha-workflow-security",
-      "checksum": "sha256:542150693e92009527ada1134d95164eb25c0dec1127310484234d6983d84244",
+      "checksum": "sha256:129fcd3e90b5ec41cd768fa6373e135ddb26625e76837fc1146cacd20af8bf8c",
       "files": 4
     },
     {
@@ -402,7 +402,7 @@
     {
       "id": "laravel-migration-safety",
       "path": "skills/upstream/laravel-migration-safety",
-      "checksum": "sha256:daf3b298d64346396b56aca248ef15e3d007cb92b970fca8e00f1f0c0c1c445c",
+      "checksum": "sha256:1b5dbb830ff3f0a78b9cc46d238dc6027ec5ca336609ce4d2cfd7a66891d98c4",
       "files": 4
     },
     {
@@ -432,7 +432,7 @@
     {
       "id": "migration-safety",
       "path": "skills/upstream/migration-safety",
-      "checksum": "sha256:72af98b37d7d02b41e88fd3bbec2c51603d8801277b5da43ed9645f8b5d0d738",
+      "checksum": "sha256:0fbb50c17633160d155295a34388aaa84289b927e2d5a4729a1eb43ef03c9862",
       "files": 1
     },
     {

--- a/skills/downstream/gha-workflow-security/SKILL.md
+++ b/skills/downstream/gha-workflow-security/SKILL.md
@@ -4,7 +4,7 @@ name: 'GitHub Actions Workflow Security Review'
 description: 'Reviews GitHub Actions workflow diffs for script injection of untrusted input, pull_request_target with untrusted checkout, over-broad GITHUB_TOKEN permissions, and unpinned third-party actions.'
 version: 0.1.0
 category: downstream
-phase: downstream
+phase: [midstream, downstream]
 applyTo:
   - '.github/workflows/**/*.{yml,yaml}'
 tags: [github-actions, security, ci, supply-chain, downstream]

--- a/skills/registry.yaml
+++ b/skills/registry.yaml
@@ -601,7 +601,7 @@ skills:
     name: 'GitHub Actions Workflow Security Review'
     path: skills/downstream/gha-workflow-security/SKILL.md
     category: downstream
-    phase: downstream
+    phase: [midstream, downstream]
     tags: [github-actions, security, ci, supply-chain, downstream]
     severity: major
     recommended: false
@@ -734,7 +734,7 @@ skills:
     name: 'Logic Torturing 論理検証'
     path: skills/midstream/logic-torturing/SKILL.md
     category: midstream
-    phase: midstream
+    phase: [upstream, midstream]
     tags:
       [adversarial, logic-torturing, decision-quality, critical-thinking, midstream, cognitive-bias]
     severity: major
@@ -902,7 +902,7 @@ skills:
     name: 'Migration Safety Review (framework-agnostic)'
     path: skills/upstream/migration-safety/SKILL.md
     category: upstream
-    phase: upstream
+    phase: [upstream, midstream]
     tags: [migration, database, schema, safety, rollback, upstream]
     severity: major
     recommended: true
@@ -913,7 +913,7 @@ skills:
     name: 'Laravel Migration Safety Review'
     path: skills/upstream/laravel-migration-safety/SKILL.md
     category: upstream
-    phase: upstream
+    phase: [upstream, midstream]
     tags: [laravel, migration, database, postgresql, safety, upstream]
     severity: major
     recommended: false
@@ -1145,7 +1145,7 @@ skills:
     name: 'Data Model & DB Design Review'
     path: skills/upstream/data-model-db-design/SKILL.md
     category: upstream
-    phase: upstream
+    phase: [upstream, midstream]
     tags: [database, schema, migration, upstream]
     severity: major
     recommended: true

--- a/skills/upstream/data-model-db-design/SKILL.md
+++ b/skills/upstream/data-model-db-design/SKILL.md
@@ -4,7 +4,7 @@ name: 'Data Model & DB Design Review'
 description: 'Ensure data model/DB designs cover constraints, integrity, indexes, migrations, rollback, and operational impacts.'
 version: 0.1.0
 category: upstream
-phase: upstream
+phase: [upstream, midstream]
 applyTo:
   - '**/*schema*.{sql,prisma}'
   - '**/*migrate*/**/*.sql'

--- a/skills/upstream/laravel-migration-safety/SKILL.md
+++ b/skills/upstream/laravel-migration-safety/SKILL.md
@@ -4,7 +4,7 @@ name: 'Laravel Migration Safety Review'
 description: 'Reviews Laravel migrations for destructive operations, change() dropping modifiers, locking index creation on large tables (PostgreSQL), and asymmetric down().'
 version: 0.1.0
 category: upstream
-phase: upstream
+phase: [upstream, midstream]
 applyTo:
   - 'database/migrations/**/*.php'
 tags: [laravel, migration, database, postgresql, safety, upstream]

--- a/skills/upstream/migration-safety/SKILL.md
+++ b/skills/upstream/migration-safety/SKILL.md
@@ -4,7 +4,7 @@ name: 'Migration Safety Review (framework-agnostic)'
 description: 'スキーマ/データ移行の安全性を framework 非依存で審査する。破壊的スキーマ変更・ロック誘発・backfill・ロールバック可逆性・expand-contract の段階適用を、prisma / typeorm / Rails / Django / Alembic / 生 SQL などに横断適用する。'
 version: 0.1.0
 category: upstream
-phase: upstream
+phase: [upstream, midstream]
 applyTo:
   - '**/migrations/**/*'
   - '**/migrate/**/*'


### PR DESCRIPTION
## 背景

CLI（`runners/cli/src/commands/review.mjs:19`）と GitHub Action（`runners/github-action/action.yml:7`）の既定 phase は `midstream` 固定で、1 run = 1 phase である。このため、検出対象アーティファクトが実装成果物（migration ファイル・CI workflow・SQL/prisma）なのに `upstream` / `downstream` 単独に割り当てられているスキルは、既定実行で永久に不発になっていた。

## 変更内容

SKILL.md frontmatter と `skills/registry.yaml` の `phase` を両方同期して修正する（配列 phase は schema `schemas/skill.schema.json` の `oneOf` で許容済み。既存前例: `ai-agent-review-readiness`）。

| skill | before | after |
| --- | --- | --- |
| `gha-workflow-security` | `downstream` | `[midstream, downstream]` |
| `migration-safety` | `upstream` | `[upstream, midstream]` |
| `laravel-migration-safety` | `upstream` | `[upstream, midstream]` |
| `data-model-db-design` | `upstream` | `[upstream, midstream]` |
| `logic-torturing` | registry のみ `midstream`（SKILL.md は `[upstream, midstream]`） | registry を `[upstream, midstream]` に同期 |

`docs/data/skill-manifest.json` は pre-commit の `skills:manifest` により自動再生成。

## 検証

- `npm run skills:validate` pass（registry paths 119 entries / fixture drift 5 skills consistent / naming collisions 130 unique）
- ローダー実行（`runners/core/skill-cache.mjs` の `loadSkillsCached`）で対象 5 スキルがロードされ、`src/core/skill-dispatcher.mjs` と同一の phase=midstream フィルタ判定を全件 pass
- `npm test` pass（tests 2143 / pass 2143 / fail 0）
- `npm run lint` pass
- 対象スキルは `tests/fixtures/review-eval/cases.json` に含まれないため `eval:fixtures` の対象外。fixture drift は `skills:validate` 内チェックで担保

🤖 Generated with [Claude Code](https://claude.com/claude-code)