### PR TITLE
docs(skills): loose/strict 二重 schema の契約を明文化する

### DIFF
--- a/docs/skills-structure.md
+++ b/docs/skills-structure.md
@@ -25,6 +25,33 @@ frontmatter の `description` は、レビュー実行時にプランナーや L
 
 両者の文言差は意図的な役割分担であり、ドリフトとして機械的に揃える対象ではありません。ただし同一言語かつ同一意図のまま字句だけがずれた場合は、要約としての簡潔さを保ちつつ frontmatter 側の最新の意図を反映するように整えます。
 
+## loose / strict 二重 schema の契約
+
+`scripts/validate-agent-skills.mjs` は agent-skill の SKILL.md frontmatter を 2 段階の JSON Schema で検証します。役割は次のとおりです。
+
+| Schema                                  | 役割                                                        | additionalProperties              |
+| --------------------------------------- | ----------------------------------------------------------- | --------------------------------- |
+| `schemas/agent-skill-loose.schema.json` | 外部 Agent Skills 仕様の受け入れフロント                    | `true`（未知フィールドを許容）    |
+| `schemas/skill.schema.json`             | ランタイムの権威。`loadAllSkillMetadata()` がこれで検証する | `false`（未定義フィールドを拒否） |
+
+- **strict schema がランタイムの権威である。** loose schema を通過しても、strict schema に定義のないフィールドは `loadAllSkillMetadata()` 読み込み時にサイレント脱落する。frontmatter 全体が失敗するのではなく、未定義フィールドだけが読み飛ばされる。
+- **loose schema は外部 Agent Skills 仕様の受け入れフロントである。** `name` / `description` の最小要件のみを課し、それ以外の未知フィールドを許容する。これは外部ツール（agentskills.io / Warp / Oz / Claude Code 等）が発行する SKILL.md を広く受け入れるための設計であり、ランタイムでの利用を保証するものではない。
+- **両者に差分が生まれ、あるフィールドが実行時にも本当に必要だと判明した場合は、strict schema（`schemas/skill.schema.json`）側に定義を追加するのが正しい対応である。** `applyToExemptions`（#1508）はこの経路で追加された実例である。loose schema だけを通り strict schema で弾かれるフィールドは設計上の意図どおりの挙動であり、loose 側を緩めて合わせる対応は誤りとする。
+
+### 脱落事故の教訓（#1559）
+
+`applyToExemptions` フィールドが strict schema に未定義のまま導入され、loose schema のみを通過する状態になっていた。そのため、当該フィールドを持つスキルが `loadAllSkillMetadata()` から**エラーなくサイレントに**脱落していた。CI の loose 検証は green のまま気づかれず、実行時にのみ影響が出る典型的な drift だった。
+
+再発防止として `scripts/validate-agent-skills.mjs` に `validateStrictSchemaDrift()` ガードを追加した。このガードは `loadSkillMetadata()` と同じローダー経路（strict schema 検証込み）を、CI で全 agent-skill に対して強制実行する。`agent` タグ付きスキルは `excludedTags` によるランタイム側の意図的な除外のため、この検証の対象外とする。
+
+### 検証コマンド
+
+```bash
+npm run agent-skills:validate
+```
+
+このスクリプトは loose 検証・`applyTo` カバレッジ検証・strict drift ガードを一括で実行します。drift ガードが失敗した場合は「loose は通るが strict で落ちる」フィールドがあることを意味するため、strict schema にフィールド定義を追加するか、フィールド自体の要否を見直してください。
+
 ## 現在の構造
 
 ### Agent Skills 形式（実装済み）

--- a/docs/skills-structure.md
+++ b/docs/skills-structure.md
@@ -34,7 +34,7 @@ frontmatter の `description` は、レビュー実行時にプランナーや L
 | `schemas/agent-skill-loose.schema.json` | 外部 Agent Skills 仕様の受け入れフロント                    | `true`（未知フィールドを許容）    |
 | `schemas/skill.schema.json`             | ランタイムの権威。`loadAllSkillMetadata()` がこれで検証する | `false`（未定義フィールドを拒否） |
 
-- **strict schema がランタイムの権威である。** loose schema を通過しても、strict schema に定義のないフィールドは `loadAllSkillMetadata()` 読み込み時にサイレント脱落する。frontmatter 全体が失敗するのではなく、未定義フィールドだけが読み飛ばされる。
+- **strict schema がランタイムの権威である。** loose schema を通過しても、strict schema に定義のないフィールドがあると `loadAllSkillMetadata()` 読み込み時にバリデーションエラーとなる。未定義フィールドだけが読み飛ばされるのではなく、そのスキル（frontmatter）全体がロード対象から脱落する点に注意する。
 - **loose schema は外部 Agent Skills 仕様の受け入れフロントである。** `name` / `description` の最小要件のみを課し、それ以外の未知フィールドを許容する。これは外部ツール（agentskills.io / Warp / Oz / Claude Code 等）が発行する SKILL.md を広く受け入れるための設計であり、ランタイムでの利用を保証するものではない。
 - **両者に差分が生まれ、あるフィールドが実行時にも本当に必要だと判明した場合は、strict schema（`schemas/skill.schema.json`）側に定義を追加するのが正しい対応である。** `applyToExemptions`（#1508）はこの経路で追加された実例である。loose schema だけを通り strict schema で弾かれるフィールドは設計上の意図どおりの挙動であり、loose 側を緩めて合わせる対応は誤りとする。
 


### PR DESCRIPTION
## Summary
- #1559 の strict loader 脱落修正で確認された設計不変条件を `docs/skills-structure.md` に明文化した。
- strict schema (`schemas/skill.schema.json`) = ランタイムの権威、loose schema (`schemas/agent-skill-loose.schema.json`) = 外部 Agent Skills 仕様の受け入れフロント、という役割分担と、差分が生じた場合は strict 側にフィールド定義を追加するのが正しい対応であることを記載。
- `applyToExemptions` (#1508) がサイレント脱落した #1559 の事故と、その再発防止として追加された `validateStrictSchemaDrift()` ガードの教訓もあわせて記述。
- 検証コマンド (`npm run agent-skills:validate`) を明記。
- docs のみの変更。src/ やスキーマファイル自体は変更していない。

Closes #1563

## Test plan
- [x] `npm run agent-skills:validate` — exit 0（既存の warning のみ、error なし）
- [x] `npx textlint --no-cache docs/skills-structure.md` — exit 0
- [x] `npm run fix:dashes` — 変更なし（"No heading/title dash normalizations needed."）

🤖 Generated with [Claude Code](https://claude.com/claude-code)