### PR TITLE
fix(schema): zod InputContextEnum を JSON Schema の inputContext enum と一致させる

### DIFF
--- a/src/lib/skillYamlSchema.mjs
+++ b/src/lib/skillYamlSchema.mjs
@@ -9,6 +9,8 @@ import { z } from 'zod';
 export const PhaseEnum = z.enum(['upstream', 'midstream', 'downstream']);
 export const StreamCategoryEnum = z.enum(['core', 'upstream', 'midstream', 'downstream']);
 export const SeverityEnum = z.enum(['info', 'minor', 'major', 'critical']);
+// Keep in sync with schemas/skill.schema.json $defs.inputContext.enum.
+// The enum-parity canary in tests/skill-schema-parity.test.mjs asserts they match.
 export const InputContextEnum = z.enum([
   'diff',
   'fullFile',
@@ -16,6 +18,10 @@ export const InputContextEnum = z.enum([
   'adr',
   'commitMessage',
   'repoConfig',
+  'reviewSelf',
+  'reviewExternal',
+  'findingsPool',
+  'prDescription',
 ]);
 export const OutputKindEnum = z.enum([
   'findings',

--- a/tests/skill-schema-parity.test.mjs
+++ b/tests/skill-schema-parity.test.mjs
@@ -24,7 +24,7 @@ import { fileURLToPath } from 'node:url';
 import Ajv2020 from 'ajv/dist/2020.js';
 import addFormats from 'ajv-formats';
 
-import { SkillYamlSchema } from '../src/lib/skillYamlSchema.mjs';
+import { SkillYamlSchema, InputContextEnum } from '../src/lib/skillYamlSchema.mjs';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const schema = JSON.parse(
@@ -189,6 +189,42 @@ describe('skill schema parity (ajv vs zod)', () => {
     assert.equal(zodParsed.success, true);
     assert.equal(ajvCopy.deterministicGate.failSeverity, 'strict_block');
     assert.equal(zodParsed.data.deterministicGate.failSeverity, 'strict_block');
+  });
+});
+
+/**
+ * inputContext enum parity canary (#1564).
+ *
+ * The set of allowed inputContext values is declared TWICE — as
+ * schemas/skill.schema.json $defs.inputContext.enum (ajv, the runtime authority)
+ * and as InputContextEnum in src/lib/skillYamlSchema.mjs (zod). #1559 uncovered a
+ * drift where the zod side was missing reviewSelf / reviewExternal / findingsPool
+ * / prDescription. This canary compares the two enum lists directly (not just via
+ * accept/reject cases) so any future add/remove on one side without the other
+ * fails loudly instead of drifting.
+ */
+describe('inputContext enum parity (zod vs JSON Schema $defs)', () => {
+  const schemaEnum = schema.$defs?.inputContext?.enum;
+  const zodEnum = InputContextEnum.options;
+
+  test('JSON Schema exposes $defs.inputContext.enum as an array', () => {
+    assert.ok(Array.isArray(schemaEnum), 'schema.$defs.inputContext.enum must be an array');
+    assert.ok(Array.isArray(zodEnum), 'InputContextEnum.options must be an array');
+  });
+
+  test('zod enum and JSON Schema enum contain the same values (order-insensitive)', () => {
+    const sortedSchema = [...schemaEnum].sort();
+    const sortedZod = [...zodEnum].sort();
+    assert.deepEqual(
+      sortedZod,
+      sortedSchema,
+      `inputContext enum drift: zod=${JSON.stringify(sortedZod)} vs schema=${JSON.stringify(sortedSchema)}`
+    );
+  });
+
+  test('no duplicate values in either enum', () => {
+    assert.equal(new Set(schemaEnum).size, schemaEnum.length, 'JSON Schema enum has duplicates');
+    assert.equal(new Set(zodEnum).size, zodEnum.length, 'zod enum has duplicates');
   });
 });
 


### PR DESCRIPTION
## 背景

#1559 の作業中に発見された既存乖離。zod 側の `InputContextEnum`（`src/lib/skillYamlSchema.mjs`）に、権威である JSON Schema（`schemas/skill.schema.json` の `$defs.inputContext.enum`）が持つ次の4値が未収載だった。

- `reviewSelf`
- `reviewExternal`
- `findingsPool`
- `prDescription`

zod 側は top-level 非 strict のため現時点で実害はないが、この enum 経由で上記4値を持つスキルを検証すると不当に reject される可能性がある。strict schema=権威の原則に従い JSON Schema 側へ寄せた。

## 変更

- `src/lib/skillYamlSchema.mjs`: `InputContextEnum` に4値を追加し、JSON Schema と同一の10値に揃える。SSoT コメントを併記。
- `tests/skill-schema-parity.test.mjs`: 両 enum を直接突合する parity canary を追加（順序非依存の集合一致・重複なしを検証）。片側だけの add/remove が発生すると loud に fail する。

## 検証

- `node --test tests/skill-schema-parity.test.mjs tests/skill-yaml-schema.test.mjs` → 41 pass / 0 fail
- `npm run lint` → 全 job green

Closes #1564