### PR TITLE
chore(ci): setup-node の v6 コメント残存と composite action の未 pin を v7 に統一する

### DIFF
--- a/.github/actions/setup-node-deps/action.yml
+++ b/.github/actions/setup-node-deps/action.yml
@@ -13,7 +13,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
       with:
         node-version: ${{ inputs.node-version }}
         cache: ${{ inputs.cache }}

--- a/.github/workflows/auto-rebuild-action-dist.yml
+++ b/.github/workflows/auto-rebuild-action-dist.yml
@@ -69,7 +69,7 @@ jobs:
           # GITHUB_TOKEN fallback pushes fine but cannot re-fire CI.
           token: ${{ secrets.RELEASE_KICK_PAT || secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           # .nvmrc is the SSoT for the Node version; ncc output differs across
           # Node majors (see docs/development/dist-check-rebuild-guide.md).

--- a/.github/workflows/promptfoo-eval.yml
+++ b/.github/workflows/promptfoo-eval.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,7 +134,7 @@ jobs:
 
           echo "Timestamp suggests dist is stale; will rebuild to verify."
           echo "needs_rebuild=true" >> "$GITHUB_OUTPUT"
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         if: steps.judge.outputs.needs_rebuild == 'true'
         with:
           node-version-file: '.nvmrc'
@@ -196,7 +196,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'


### PR DESCRIPTION
## Summary
- dependabot #1617 の setup-node v7.0.0 SHA pin（`820762786026740c76f36085b0efc47a31fe5020`）バンプ後、直接参照の行末コメントに `# v6` が残存していたため `# v7` に修正（`.github/workflows/promptfoo-eval.yml` / `auto-rebuild-action-dist.yml` / `test.yml` の計4箇所、SHA自体は変更なし）
- composite action `.github/actions/setup-node-deps/action.yml` がタグ参照 `actions/setup-node@v6`（未 pin）のまま二重管理になっていたため、直接参照と同じ v7 SHA pin に統一
- v7 の breaking changes は #1617 の検証で「利用側インターフェース影響なし・cache: npm / node-version-file 挙動不変」と確認済み。composite action も同じ利用パターン（node-version 入力 + cache: npm）のため挙動不変

## Test plan
- [x] `grep -rn 'setup-node@' .github/` で `# v6` 表記・タグ参照が残っていないことを確認
- [x] `actionlint` を実行（既存の shellcheck warning のみで、変更箇所への新規指摘なし）
- [x] CI green を確認（PR作成後に確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)