### PR TITLE
docs(skills): coverage-gap / test-existence の既定 CI 非発火理由を明記

### DIFF
--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -204,7 +204,7 @@
     {
       "id": "coverage-gap",
       "path": "skills/downstream/coverage-gap",
-      "checksum": "sha256:549f0d7729fb199e85be1ea1d500e16ffe528aa4201d78738a17b610d5bceea6",
+      "checksum": "sha256:187bf4e78b2355dfa2ba617a87e5864417e54f40f126d2513e0d4dcade8baf8c",
       "files": 1
     },
     {
@@ -690,7 +690,7 @@
     {
       "id": "test-existence",
       "path": "skills/downstream/test-existence",
-      "checksum": "sha256:05a61e8ffb58effbf4c5c831101418b776d1da7710b09dab0e5a644a0db31808",
+      "checksum": "sha256:5faa5866c0af701bdbba5decb13d2eb4889bb0f651f3b2f18902c7ebf0908e3e",
       "files": 1
     },
     {

--- a/skills/downstream/coverage-gap/SKILL.md
+++ b/skills/downstream/coverage-gap/SKILL.md
@@ -18,6 +18,10 @@ modelHint: balanced
 dependencies: [test_runner, coverage_report]
 ---
 
+## 既定 CI レビューでは発火しない / Not triggered on the default CI review path
+
+このスキルは repo 全体の既存テスト木（変更されていないファイルを含む）を要するため、既定 runner の供給コンテキスト（`RUNNER_SUPPLIED_CONTEXTS = ['diff', 'prDescription', 'fullFile']`、`scripts/validate-skills.mjs`）では発火しない。`RIVER_AVAILABLE_CONTEXTS` を拡張して `tests`（repo-wide test tree）を供給する構成でのみ有効になる（`GRANDFATHERED_UNSUPPLIED_CONTEXT` に登録済み、#1606）。
+
 ## Pattern declaration
 
 Primary pattern: Reviewer

--- a/skills/downstream/test-existence/SKILL.md
+++ b/skills/downstream/test-existence/SKILL.md
@@ -18,6 +18,10 @@ modelHint: balanced
 dependencies: [test_runner, coverage_report]
 ---
 
+## 既定 CI レビューでは発火しない / Not triggered on the default CI review path
+
+このスキルは repo 全体の既存テスト木（変更されていないファイルを含む）を要するため、既定 runner の供給コンテキスト（`RUNNER_SUPPLIED_CONTEXTS = ['diff', 'prDescription', 'fullFile']`、`scripts/validate-skills.mjs`）では発火しない。`RIVER_AVAILABLE_CONTEXTS` を拡張して `tests`（repo-wide test tree）を供給する構成でのみ有効になる（`GRANDFATHERED_UNSUPPLIED_CONTEXT` に登録済み、#1606）。
+
 ## Pattern declaration
 
 Primary pattern: Reviewer


### PR DESCRIPTION
## Summary
- `coverage-gap` / `test-existence` は #1606 の grandfathered 縮小後も残る (b) tier の2スキル。repo 全体の既存テスト木（変更されていないファイルを含む）を要するため、既定 runner の供給コンテキスト（`RUNNER_SUPPLIED_CONTEXTS = ['diff', 'prDescription', 'fullFile']`、`scripts/validate-skills.mjs`）では発火しない。
- 利用者・保守者が「なぜこのスキルが既定 CI レビューで出ないか」を SKILL.md 本文だけで理解できるよう、両スキルの frontmatter 直後に注記セクションを追加した。
- スキル判定ロジック（`GRANDFATHERED_UNSUPPLIED_CONTEXT` / gate 条件 / inputContext）は変更していない。docs のみの変更。

## Test plan
- [x] `npm run skills:validate` — exit 0（`GRANDFATHERED_UNSUPPLIED_CONTEXT` 2件は変更なしのまま維持されていることを確認）
- [x] `npm test` — 2221 tests pass / 0 fail
- [x] `npm run lint` — exit 0（format:check / check:dashes / lint:code / lint:md / lint:text 全て green）
- [x] pre-commit lint-staged が `skills:manifest` / `skills:registry` を自動再生成（drift ガード通過）

Refs #1606

🤖 Generated with [Claude Code](https://claude.com/claude-code)