### PR TITLE
chore: codex login artifacts を gitignore に追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,13 @@ CLAUDE.local.md
 .codex/logs_*.sqlite-*
 .codex/state_*.sqlite-*
 .codex/installation_id
+# Codex login artifacts (`codex login` with CODEX_HOME=.codex): auth.json holds
+# the OAuth token and must never be committed
+.codex/auth.json
+.codex/cache/
+.codex/log/
+.codex/models_cache.json
+.codex/plugins/
 .lycheecache
 .worktrees/
 .vale/Microsoft


### PR DESCRIPTION
## 概要

`npm run codex:exec`（ask-codex skill）利用時に `CODEX_HOME=.codex` で `codex login` すると、OAuth トークンを含む `.codex/auth.json` などのローカル生成物が untracked のまま残り、gitignore されていないため `git add -A` で誤コミット・漏洩し得る状態でした。

## 変更内容

- `.gitignore` に以下を追加: `.codex/auth.json`（OAuth トークン）/ `.codex/cache/` / `.codex/log/` / `.codex/models_cache.json` / `.codex/plugins/`

## 検証

- `git check-ignore` で 5 パスすべてが ignore 対象になることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)