### PR TITLE
docs(skills): ask-codex の macOS 非互換 timeout 指示を修正する

### DIFF
--- a/.claude/skills/ask-codex/SKILL.md
+++ b/.claude/skills/ask-codex/SKILL.md
@@ -36,10 +36,13 @@ files itself — reference paths in the prompt instead of pasting large files.
      `runners/core/review-runner.mjs`),
    - the specific questions to answer, numbered,
    - a request to be concise and to state a clear conclusion.
-2. **Run Codex** with a generous timeout (design reviews can take minutes):
+2. **Run Codex** with a generous timeout (design reviews can take minutes).
+   Set the timeout on the Bash tool call itself (e.g. `timeout: 600000` ms) —
+   do **not** prefix the command with `timeout 600`: macOS ships no GNU
+   `timeout` binary, so that prefix fails with `command not found`.
 
    ```bash
-   timeout 600 npm run codex:exec -- "<prompt>"
+   npm run codex:exec -- "<prompt>"
    ```
 
 3. **Handle authentication failure.** If the output contains
@@ -47,7 +50,9 @@ files itself — reference paths in the prompt instead of pasting large files.
    authenticated. Do **not** retry blindly. Tell the user to authenticate
    themselves in this session (these are interactive / secret-bearing and you
    cannot run them for them):
-   - `! codex login`, or
+   - `! CODEX_HOME="$(git rev-parse --show-toplevel)/.codex" codex login`
+     (the `CODEX_HOME` prefix is required — a bare `codex login` writes
+     credentials to `~/.codex` and the project-local config keeps failing), or
    - set `OPENAI_API_KEY` in the environment (warn that pasting a key into chat
      leaves it in history; prefer env/keychain).
      Then offer to re-run once authenticated.


### PR DESCRIPTION
## Summary

2026-07-25 セッションの振り返り（軽量モード）から、`ask-codex` skill の手順書 2 点を修正:

### A. ドキュメント追記（2件）

- Step 2 の `timeout 600 npm run codex:exec` を廃止し、Bash ツール側の timeout 指定へ変更。macOS には GNU `timeout` が無く `command not found` で失敗する（本セッションで実際に発生）
- Step 3 の認証手順を `CODEX_HOME=$(git rev-parse --show-toplevel)/.codex` 付きの `codex login` へ修正。素の `codex login` は `~/.codex` に書くため project-local 設定では 401 が解消しない（本セッションで実際に発生し、CODEX_HOME 付きで解消を確認）

## Test plan

- [x] 修正後の手順（Bash timeout 指定 + CODEX_HOME 付き login）は本セッションで実際に成功した手順の転記

## 関連セッション

- 対象セッションのマージ済み PR: #1645, #1646

🤖 Generated with [Claude Code](https://claude.com/claude-code)