### PR TITLE
docs(skills): review-automation-boundary に強制ゲート回避の実測データを参照追記する

### DIFF
--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -570,7 +570,7 @@
     {
       "id": "review-automation-boundary",
       "path": "skills/midstream/review-automation-boundary",
-      "checksum": "sha256:1212dd046c5ad799e8dc17cd1a7f575f2519ed92b9b6f0de7235fd0c292b4d4e",
+      "checksum": "sha256:77a5481406bec5d555db614fa44c13cf2ac32aab54be16dd37b2b7e3a0447200",
       "files": 1
     },
     {

--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -570,7 +570,7 @@
     {
       "id": "review-automation-boundary",
       "path": "skills/midstream/review-automation-boundary",
-      "checksum": "sha256:77a5481406bec5d555db614fa44c13cf2ac32aab54be16dd37b2b7e3a0447200",
+      "checksum": "sha256:11afcde93ef42ab3acdb2c27800c729f97eb886f2e4369a90ffcfb36288eedff",
       "files": 1
     },
     {

--- a/skills/midstream/review-automation-boundary/SKILL.md
+++ b/skills/midstream/review-automation-boundary/SKILL.md
@@ -36,6 +36,8 @@ Why: 自動化可能なレビュー指摘を検出しCI/lint委譲を提案す�
 
 外部実証: [「コードレビュー指摘300件を3ヶ月分類したら効いていたのは2種類だけだった」](https://zenn.dev/kenimo49/articles/code-review-300-comments-2-effective-categories)（井本 賢, 2026-07-04）は、実際に効果があった指摘は Bug/Spec 系のみだったと報告する。Style/Naming/Refactor/Arch 系は効果が低く自動化・前倒しに適するという結果は、本スキルの方針を裏付ける一次データとして参照できる。
 
+外部実証（続報）: [「AIレビューのブロックを100PRで測ったら、70PRはno-verifyで通り抜けていた」](https://zenn.dev/kenimo49/articles/ai-review-block-100pr-70-noverify-3month)（井本 賢, 2026-07-23）は、100 PR の実測で pre-commit hook のブロックのうち 70% が `--no-verify` で回避されていたと報告します。強制ゲートの守備範囲を「壊れて動かないコード」（構文エラー・smoke test 失敗）へ絞り、lint / 型 / スタイルの判定を AI レビュー側へ移した結果、実修正率は 30% から 61% へ改善したという結果も、同じ方針を裏付けます。
+
 ## Non-goals / 扱わないこと
 
 - 自動化できない判断（設計方針、セキュリティ上のトレードオフ、仕様の解釈）への言及。

--- a/skills/midstream/review-automation-boundary/SKILL.md
+++ b/skills/midstream/review-automation-boundary/SKILL.md
@@ -36,7 +36,7 @@ Why: 自動化可能なレビュー指摘を検出しCI/lint委譲を提案す�
 
 外部実証: [「コードレビュー指摘300件を3ヶ月分類したら効いていたのは2種類だけだった」](https://zenn.dev/kenimo49/articles/code-review-300-comments-2-effective-categories)（井本 賢, 2026-07-04）は、実際に効果があった指摘は Bug/Spec 系のみだったと報告する。Style/Naming/Refactor/Arch 系は効果が低く自動化・前倒しに適するという結果は、本スキルの方針を裏付ける一次データとして参照できる。
 
-外部実証（続報）: [「AIレビューのブロックを100PRで測ったら、70PRはno-verifyで通り抜けていた」](https://zenn.dev/kenimo49/articles/ai-review-block-100pr-70-noverify-3month)（井本 賢, 2026-07-23）は、100 PR の実測で pre-commit hook のブロックのうち 70% が `--no-verify` で回避されていたと報告します。強制ゲートの守備範囲を「壊れて動かないコード」（構文エラー・smoke test 失敗）へ絞り、lint / 型 / スタイルの判定を AI レビュー側へ移した結果、実修正率は 30% から 61% へ改善したという結果も、同じ方針を裏付けます。
+外部実証（続報）: [「AIレビューのブロックを100PRで測ったら、70PRはno-verifyで通り抜けていた」](https://zenn.dev/kenimo49/articles/ai-review-block-100pr-70-noverify-3month)（井本 賢, 2026-07-23）は、100 PR の実測で pre-commit hook のブロックのうち 70% が `--no-verify` で回避されていたと報告します。強制ゲートの守備範囲を「壊れて動かないコード」（構文エラー・smoke test 失敗）へ絞り、lint / 型 / スタイルの判定を AI レビュー側へ移したところ、ブロック後の修正率は 30% から 83% へ改善しました。この前後比較も、本スキルの方針を裏付ける一次データとして参照できます。
 
 ## Non-goals / 扱わないこと
 


### PR DESCRIPTION
Closes #1670

## 概要

`skills/midstream/review-automation-boundary/SKILL.md` の Goal 節（外部実証）に、同一著者の後続記事による一次実測データを 1 段落追記した。#1518 で追加済みの前作の引用行と同じ書式（通常の出典リンク + 著者・日付）に揃えている。

## 追記内容

- 出典: [「AIレビューのブロックを100PRで測ったら、70PRはno-verifyで通り抜けていた」](https://zenn.dev/kenimo49/articles/ai-review-block-100pr-70-noverify-3month)（井本 賢, 2026-07-23）
- 100 PR の実測で pre-commit hook のブロックの 70% が `--no-verify` で回避されていた
- 守備範囲を「壊れて動かないコード」（構文エラー・smoke test 失敗）へ絞り、lint / 型 / スタイルの判定を AI レビュー側へ移したところ、ブロック後の修正率が 30% → 83% へ改善した

> 注: issue #1670 本文の「実修正率 30% → 61%」は、一次ソースの 2 つの指標（前後比較である「ブロック後の修正率 30% → 83%」と、改善後の別指標である「AI 指摘の実修正率 61%」）を混同したものでした。本 PR では前後比較として正しい 30% → 83% を採用しています（記事の該当箇所を WebFetch で再確認済み。hook ブロック件数 100 → 18 / `--no-verify` 通過 70 → 3 / ブロック後の修正率 30% → 83%）。

## Non-goals

- hook 設計そのもの（pre-commit の構成）は River Review のスコープ外。追記は「自動化可能な指摘を CI / lint へ委譲する」基準の裏付けに留め、hook 構成の推奨は書いていない
- 新規 skill は作らない（概念の再実装ではなく一次データの引用のため、命名ゲートの対象外）
- `pages/explanation/security-model.md` と `docs/development/review-gates-design.md` への参照追記は本 PR のスコープ外（issue 本文では任意とされているが、並行 PR とのコンフリクト回避のため見送り）

## 変更ファイル

- `skills/midstream/review-automation-boundary/SKILL.md`（本文追記）
- `docs/data/skill-manifest.json`（pre-commit の `skills:manifest` による checksum 自動再生成）

## 検証

- `npx textlint --no-cache skills/midstream/review-automation-boundary/SKILL.md` → exit 1。ただし検出は既存行（L30 `Why:` 行の `ja-no-mixed-period`）1 件のみで、本 PR の追記行に指摘はなし
- `npm run fix:dashes` → exit 0（`No heading/title dash normalizations needed.`）
- `npm run lint` → exit 0（format:check / check:dashes / lint:code / lint:md / lint:text すべて pass）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
