### PR TITLE
docs(security-model): レビュー基準の出所と rules の信頼境界を明記する

### DIFF
--- a/pages/explanation/security-model.en.md
+++ b/pages/explanation/security-model.en.md
@@ -42,6 +42,17 @@ The diff is untrusted input placed into the prompt. That is the prompt-injection
 - Secret redaction runs on both the input and the output.
 - No dynamic code execution or deserialization happens, so an RCE-style "malicious payload" does not apply.
 
+## Where the review criteria come from
+
+The review criteria themselves live in the same repository as the diff. [`loadProjectRules`](https://github.com/s977043/river-review/blob/main/src/lib/rules.mjs) reads `.river/rules.md` and `.river/rules.d/*.md` straight from the working tree.
+
+- **Rules trust boundary**: `.river/rules.md` and `.river/rules.d/*.md` sit inside the reviewed agent's write authority. The loaded text is passed into the prompt as trusted policy.
+- **No provenance mechanism**: there is no pin to a base ref, no blob SHA record of the loaded rules, no schema validation, and no floor of criteria that a PR cannot weaken.
+- **Consequence on the Action path**: the GitHub Action uses the rules in the working tree it checked out, so a change that weakens `.river/rules.md` inside a PR takes effect on that same PR's review criteria immediately.
+- **The worst case stays bounded**: the Action defaults to `dry_run: true` (report-only) and has no approve or auto-merge path. The impact stays at "a human reads a lenient comment produced under weakened criteria".
+
+Rules are an input with no tamper evidence; pinning their provenance (a base pin, recording the blob SHA) is the caller / CI's responsibility. The immediate harm is small, but leaving this trust boundary undocumented is itself the risk. The same kind of statement is written for the runs store in the [loop convergence contract](../reference/loop-convergence-contract.en.md).
+
 ## Common misconceptions
 
 - **"Large change → run all skills" is not code execution.** It means applying all review lenses (test coverage, naming, flakiness, and so on); no privileged operation or shell is involved.

--- a/pages/explanation/security-model.md
+++ b/pages/explanation/security-model.md
@@ -42,6 +42,17 @@ River Review のスキルは、フロントマターとプロンプト本文か�
 - 入力と出力の両方でシークレットを秘匿化（redaction）する。
 - 動的なコード実行・デシリアライズを行わないため、RCE 型の「悪意あるペイロード」は成立しない。
 
+## レビュー基準の出所
+
+レビュー基準そのものも、差分と同じリポジトリに置かれます。[`loadProjectRules`](https://github.com/s977043/river-review/blob/main/src/lib/rules.mjs) が `.river/rules.md` と `.river/rules.d/*.md` を working tree からそのまま読み込みます。
+
+- **rules の信頼境界**: `.river/rules.md` および `.river/rules.d/*.md` は被レビューエージェントの書込権限内にある。読み込んだテキストは信頼された policy としてプロンプトへ渡される。
+- **出所を固定する機構は無い**: base ref への pin・読み込んだ rules の blob SHA 記録・schema 検証・PR 側から削減できない最低基準は、いずれも存在しない。
+- **Action 経路での帰結**: GitHub Action はチェックアウトした working tree の rules を使うため、PR 内で `.river/rules.md` を弱めた変更は、その PR 自身のレビュー基準に即時反映される。
+- **最悪ケースの限定**: Action は既定で `dry_run: true`（report-only）であり、承認や自動マージの経路を持たない。影響は「弱い基準で出た甘いコメントを人間が読む」までに留まる。
+
+rules は改竄検知性のない入力です。出所の固定（base への pin・blob SHA の記録）は caller / CI の責務となります。即時の実害は小さいものの、この信頼境界が明文化されていないこと自体がリスクです。同種の記述は [ループ収束契約](../reference/loop-convergence-contract.md) の runs store についても置かれています。
+
 ## よくある誤解
 
 - **「大規模変更 → 全スキル実行」はコード実行ではない**。これは全レビュー観点（テスト網羅性・命名・フレーキー等）を適用する、という意味である。特権操作やシェル実行を伴わない。


### PR DESCRIPTION
## 概要

`pages/explanation/security-model.md` と `pages/explanation/security-model.en.md` に「レビュー基準の出所 / Where the review criteria come from」節を追加し、`.river/rules.md` の信頼境界を明文化しました。

Refs #1669（スライス1: docs のみ。スライス2 の skill 新設とスライス3 の provenance / base pin はスコープ外）

## 変更内容

ja / en それぞれに 1 節（本文 2 段落 + 箇条書き 4 点）を追加しました。

- rules の信頼境界（被レビュー側の書込権限内にあり、信頼された policy としてプロンプトへ渡される）
- 出所を固定する機構が無いこと（base pin / blob SHA 記録 / schema 検証 / 削減不可な最低基準のいずれも無し）
- Action 経路での帰結（PR 内で rules を弱めると当該 PR のレビュー基準に即時反映される）
- report-only 既定による最悪ケースの限定

語彙は `pages/reference/loop-convergence-contract.md`（ja / en それぞれ L91）の runs store 記述に揃え、新語彙は作っていません（「被レビューエージェントの書込権限内」「改竄検知性のない」「caller / CI の責務」/ "sits inside the reviewed agent's write authority", "no tamper evidence", "the caller / CI's responsibility"）。記事由来の "Review Definition" / "Protected Policy" は既存語彙と衝突するため使用していません（#1669 の命名ゲート判定に従う）。

## 記述の根拠（確認した file:line）

| 記述 | 根拠 |
| --- | --- |
| `loadProjectRules` が working tree からルールを読む | `src/lib/rules.mjs:44`（`fs.readFile` で `.river/rules.md` と `.river/rules.d/*.md` を読み、返すのは `rulesText` / `path` / `extraPaths` のみ。ref pin・blob SHA・schema 検証は無し） |
| src 側の呼び出し元は 1 箇所 | `src/lib/local-runner.mjs:145`（`const { rulesText: projectRules } = await loadProjectRules(repoRoot);`）。import は `src/lib/local-runner.mjs:13` |
| Action 側に rules を扱うコードが無い | `grep -rn "rules" runners/github-action/src/ runners/github-action/action.yml` → 該当なし（dist の bundle を除く） |
| Action 既定が report-only | `runners/github-action/action.yml:24-27`（`dry_run` の `default: 'true'`）、同 `:147-149`（true のとき `--dry-run` を付与） |
| runs store の語彙 | `pages/reference/loop-convergence-contract.md:91` / `pages/reference/loop-convergence-contract.en.md:91` |

`src/` と `schemas/` は一切変更していません。

## 検証

| コマンド | 結果 |
| --- | --- |
| `npx textlint --no-cache pages/explanation/security-model.md pages/explanation/security-model.en.md` | exit 0 |
| `npm run fix:dashes` | exit 0（`No heading/title dash normalizations needed.`） |
| `npm run lint` | exit 0（format:check / check:dashes / lint:code / lint:md / lint:text すべて pass） |

pre-commit の lint-staged（`check:dashes` / `prettier --write` / `markdownlint --fix` / `check:bilingual` / `textlint --no-cache`）も pass しています。

## レビュー観点

- ja / en の内容一致（片方だけ更新すると SSoT がずれるため両方更新済み）
- `loop-convergence-contract` への相対 `.md` リンク（lychee 対応）
- 脅威の記述レベル（report-only という緩和要因を併記し、「即時の実害は小さいが明文化されていないこと自体がリスク」という位置づけを維持）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
