### PR TITLE
docs: 英語版 index と README.en の日英リンク整合を取る

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -5,7 +5,7 @@
 **Codify your team's review judgment as repo-owned skills and run them as automated PR gates.**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Documentation](https://img.shields.io/badge/docs-available-blue)](https://river-review.the3396.com/explanation/intro/)
+[![Documentation](https://img.shields.io/badge/docs-available-blue)](https://river-review.the3396.com/explanation/intro-en/)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13339/badge)](https://www.bestpractices.dev/projects/13339)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/s977043/river-review/badge)](https://securityscorecards.dev/viewer/?uri=github.com/s977043/river-review)
 [![Listed on awesome-codex-plugins](https://img.shields.io/badge/awesome--codex--plugins-listed-brightgreen)](https://github.com/hashgraph-online/awesome-codex-plugins/tree/main/plugins/s977043/river-review)
@@ -26,7 +26,7 @@ River Review helps you answer questions like:
 - Does this PR violate the team's migration, security, accessibility, or dependency policy?
 - Did the implementation agent ignore feedback from a previous review?
 
-> River Review does not replace human review with AI. By executing your team's review criteria as versioned skills, it lets human reviewers focus on the high-risk judgment that truly needs them ([Human Judgment Focus](https://river-review.the3396.com/explanation/human-judgment-focus/)).
+> River Review does not replace human review with AI. By executing your team's review criteria as versioned skills, it lets human reviewers focus on the high-risk judgment that truly needs them ([Human Judgment Focus](https://river-review.the3396.com/explanation/human-judgment-focus-en/)).
 
 ⭐ If this helps your team's review workflow in AI-assisted development, please [Star the repo](https://github.com/s977043/river-review). It keeps you posted on updates and helps other teams with the same problem find River Review.
 
@@ -83,19 +83,19 @@ The shortest no-install path is the bundled plugin: add the marketplace and ask 
 
 > **Two distribution channels: the bundled plugin (Claude Code / Codex) and GitHub Actions.** River Review is not published to npm (project policy). Contributors can run the CLI inside the repo with `npm run river -- ...` (to try it locally: `npm run river -- run . --dry-run`). The CLI is kept because it is also the GitHub Action's execution engine.
 
-| Goal                                    | Destination                                                                             |
-| --------------------------------------- | --------------------------------------------------------------------------------------- |
-| Try it in 5 minutes                     | [Quick start (GitHub Actions)](#quick-start-github-actions)                             |
-| Install as a Claude Code / Codex plugin | [Installing the plugin](#installing-the-river-review-plugin)                            |
-| Add to an existing repo                 | [Setup guide](https://river-review.the3396.com/guides/github-actions/)                  |
-| Start with a bundled Skill Pack         | [Using Skill Packs](pages/guides/use-skill-packs.en.md)                                 |
-| Create your first skill                 | [Skill tutorial](https://river-review.the3396.com/tutorials/creating-your-first-skill/) |
-| Estimate run cost                       | [Cost estimation guide](pages/guides/cost-estimation.en.md)                             |
-| Use W-check (double review)             | [W-check guide](pages/guides/w-check.en.md)                                             |
-| Use from an AI agent                    | [Agent workflow guide](pages/guides/agent-workflow.en.md)                               |
-| Repo-wide aware review                  | [Repo-wide review guide](pages/guides/repo-wide-review.en.md)                           |
-| Understand the concept                  | [Concept page](https://river-review.the3396.com/explanation/concept-en/)                |
-| Understand the design                   | [Architecture docs](https://river-review.the3396.com/explanation/river-architecture/)   |
+| Goal                                    | Destination                                                                                |
+| --------------------------------------- | ------------------------------------------------------------------------------------------ |
+| Try it in 5 minutes                     | [Quick start (GitHub Actions)](#quick-start-github-actions)                                |
+| Install as a Claude Code / Codex plugin | [Installing the plugin](#installing-the-river-review-plugin)                               |
+| Add to an existing repo                 | [Setup guide](https://river-review.the3396.com/guides/github-actions.en/)                  |
+| Start with a bundled Skill Pack         | [Using Skill Packs](pages/guides/use-skill-packs.en.md)                                    |
+| Create your first skill                 | [Skill tutorial](https://river-review.the3396.com/tutorials/creating-your-first-skill.en/) |
+| Estimate run cost                       | [Cost estimation guide](pages/guides/cost-estimation.en.md)                                |
+| Use W-check (double review)             | [W-check guide](pages/guides/w-check.en.md)                                                |
+| Use from an AI agent                    | [Agent workflow guide](pages/guides/agent-workflow.en.md)                                  |
+| Repo-wide aware review                  | [Repo-wide review guide](pages/guides/repo-wide-review.en.md)                              |
+| Understand the concept                  | [Concept page](https://river-review.the3396.com/explanation/concept-en/)                   |
+| Understand the design                   | [Architecture docs](https://river-review.the3396.com/explanation/river-architecture.en/)   |
 
 See [docs/runbook/dev.md](docs/runbook/dev.md) for the development runbook. License details are at the [bottom of this file](#license).
 

--- a/pages/index.en.md
+++ b/pages/index.en.md
@@ -26,3 +26,16 @@ Docs live under `pages/` and are served at `/docs`. Diátaxis is expressed via d
 - [Concept: turning review into an organizational judgment asset](./explanation/concept.en.md) — the problems, the core model, the review targets, the responsibility boundary, and the non-goals.
 - [Welcome to River Review](./explanation/intro.en.md) — a short introduction for first-time readers.
 - [What is River Review](./explanation/what-is-river-review.en.md) — a product overview covering features, usage, and the execution model.
+
+## Get started
+
+- [Getting started with River Review](/tutorials/getting-started.en)
+- [Quickstart](/guides/quickstart.en)
+
+## Advanced usage
+
+- [W-check (double review)](/guides/w-check.en) — feed review results from other AI or human reviewers back in for re-verification, and check whether each finding is real.
+- [Repo-wide review](/guides/repo-wide-review.en) — how to adopt and tune a review that reads repository context around the changed files, not just the PR diff.
+- [Cost estimation and optimization](/guides/cost-estimation.en) — estimating monthly cost with `--estimate` and `--max-cost`, then validating the estimate against measured usage.
+- [Agent workflow (`--reviewers auto`)](/guides/agent-workflow.en) — choosing between the entry points that call River Review from an AI agent (CLI, sub-agent, `/review-local`).
+- [Independent review synthesis](/guides/use-independent-review-synthesis.en) — the synthesis pattern that merges several AI and human review results to support a merge decision.


### PR DESCRIPTION
コンセプト改訂 follow-up（en 整合）。#1677 / #1678 の申し送り分。

## 変更内容

### 1. `pages/index.en.md` の日英整合（#1677 follow-up）

`pages/index.md`（ja）にある「はじめる」「高度な使い方」の 2 節・計 7 リンクが en 側に元から欠けていた。ja の現行構成を正として、同じ節構成・同じリンク集合を en に追加する。

| ja 節           | en 節              | リンク数 |
| --------------- | ------------------ | -------- |
| はじめる        | Get started        | 2        |
| 高度な使い方    | Advanced usage     | 5        |

リンク形式は ja 側と同じルート相対形式にそろえ、リンク先だけ各ページの英語版ルート（`.en`）へ向けている。ja 側（`pages/index.md`）は変更していない。

### 2. `README.en.md` の site リンク非対称の解消（#1678 判断メモ 3）

`README.en.md` の docs site リンクの多くが ja URL（`/explanation/...`）を指し、concept だけ en URL（`/explanation/concept-en/`）という非対称があった。**en README のリンクは en ページへ**の方針で 5 件を差し替える。

| 差し替え前                              | 差し替え後                                 | 箇所                     |
| --------------------------------------- | ------------------------------------------ | ------------------------ |
| `/explanation/intro/`                   | `/explanation/intro-en/`                   | Documentation バッジ     |
| `/explanation/human-judgment-focus/`    | `/explanation/human-judgment-focus-en/`    | 本文の引用ブロック       |
| `/guides/github-actions/`               | `/guides/github-actions.en/`               | Getting Started の表     |
| `/tutorials/creating-your-first-skill/` | `/tutorials/creating-your-first-skill.en/` | Getting Started の表     |
| `/explanation/river-architecture/`      | `/explanation/river-architecture.en/`      | Getting Started の表     |

`README.md`（ja）は変更していない。すでに en を指していた concept の 2 件はそのまま。

## 検証

差し替え先 URL は本番サイトで HTTP 200 を確認済み（現状維持にした URL はなし）。

```text
200  /explanation/intro-en/
200  /explanation/human-judgment-focus-en/
200  /guides/github-actions.en/
200  /tutorials/creating-your-first-skill.en/
200  /explanation/river-architecture.en/
200  /tutorials/getting-started.en/
200  /guides/quickstart.en/
200  /guides/w-check.en/
200  /guides/repo-wide-review.en/
200  /guides/cost-estimation.en/
200  /guides/agent-workflow.en/
200  /guides/use-independent-review-synthesis.en/
```

ローカル検証（Node 22.22.2）:

| コマンド                                             | exit code |
| ---------------------------------------------------- | --------- |
| `npx textlint --no-cache README.en.md pages/index.en.md` | 0     |
| `npm run lint`                                       | 0         |
| `npm run check:bilingual`                            | 0         |
| `npm run build`                                      | 0         |

`npm run build` は `onBrokenLinks: 'throw'` / `onBrokenMarkdownLinks: 'throw'` 設定下で成功しており、追加した 7 リンクは生成 HTML 側でも英語版ルートに解決している。

```text
href="/river-review/tutorials/getting-started.en/"
href="/river-review/guides/quickstart.en/"
href="/river-review/guides/w-check.en/"
href="/river-review/guides/repo-wide-review.en/"
href="/river-review/guides/cost-estimation.en/"
href="/river-review/guides/agent-workflow.en/"
href="/river-review/guides/use-independent-review-synthesis.en/"
```

## レビュー観点

- `pages/index.en.md` の新規 2 節はルート相対リンクを使っている。`.lychee.toml` は `pages/index.md` / `pages/index.en.md` を `exclude_path` に登録済みなので Link Check の対象外で、代わりに Docusaurus build がリンク解決を担保する。同ファイルの "Understand the concept" 節は相対 `.md` リンクなので、形式をそちらへそろえる判断もあり得る。
- `README.en.md` は `scripts/fix-dashes.mjs` の対象外（対象は `README.md` / `AGENTS.md` / `docs/`）のため、既存の ` — ` 表記に合わせている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
