### PR TITLE
feat(skills): テストのアサーション有効性（常に PASS する検証）を検出する skill を追加する

### DIFF
--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "description": "Deterministic skill manifest for drift detection by selective adopters. Compare the checksum of your copied skill against this list to notice upstream changes. Regenerate with: npm run skills:manifest",
-  "skillCount": 127,
+  "skillCount": 128,
   "skills": [
     {
       "id": "a11y-accessible-name",
@@ -654,7 +654,7 @@
     {
       "id": "river-review-testing",
       "path": "skills/agent-skills/river-review-testing",
-      "checksum": "sha256:3eef2a548e8e5e45d3989a4683097155e1c90c2f7de1cf878ca5ef602f59ae69",
+      "checksum": "sha256:7766843391660016e43071218d4c036663e7876ae3d7a7824ee8f47e8b11758d",
       "files": 2
     },
     {
@@ -698,6 +698,12 @@
       "path": "skills/midstream/tailwind-class-hygiene",
       "checksum": "sha256:fdd43409e2236b24467ce219685236cf02e18f0df405bc81f32fe63959880504",
       "files": 4
+    },
+    {
+      "id": "test-assertion-effectiveness",
+      "path": "skills/downstream/test-assertion-effectiveness",
+      "checksum": "sha256:6acf580cfade4ff661c07d166e4f5602113948785a53481c94436ac7d7f088d8",
+      "files": 7
     },
     {
       "id": "test-existence",

--- a/skills/agent-skills/river-review-testing/SKILL.md
+++ b/skills/agent-skills/river-review-testing/SKILL.md
@@ -32,17 +32,18 @@ license: MIT
 
 ## Routing / ルーティング
 
-| キーワード           | スキルID           | 説明                   |
-| -------------------- | ------------------ | ---------------------- |
-| カバレッジ, 網羅     | `coverage-gap`     | カバレッジギャップ検出 |
-| フレーキー, 不安定   | `flaky-test`       | フレーキーテストリスク |
-| テスト有無, 存在     | `test-existence`   | テスト存在確認         |
-| 命名, 構造, describe | `test-naming`      | テスト命名・構造       |
-| テスト観点, 計画     | `test-plan-review` | テスト観点レビュー     |
+| キーワード                    | スキルID                       | 説明                             |
+| ----------------------------- | ------------------------------ | -------------------------------- |
+| カバレッジ, 網羅              | `coverage-gap`                 | カバレッジギャップ検出           |
+| フレーキー, 不安定            | `flaky-test`                   | フレーキーテストリスク           |
+| テスト有無, 存在              | `test-existence`               | テスト存在確認                   |
+| 命名, 構造, describe          | `test-naming`                  | テスト命名・構造                 |
+| テスト観点, 計画              | `test-plan-review`             | テスト観点レビュー               |
+| アサーション, 常に PASS, 恒真 | `test-assertion-effectiveness` | アサーション有効性（無効な検証） |
 
 ### デフォルト動作
 
-- テストファイルの変更 → `test-naming` + `flaky-test`
+- テストファイルの変更 → `test-naming` + `flaky-test` + `test-assertion-effectiveness`
 - ソースコードの変更 → `test-existence` + `coverage-gap`
 - 大規模変更 → 全スキル実行
 
@@ -59,7 +60,8 @@ license: MIT
    ├─ coverage-gap: カバレッジギャップ検出
    ├─ test-naming: 命名・構造検証
    ├─ flaky-test: フレーキーリスク検出
-   └─ test-plan-review: テスト観点の妥当性
+   ├─ test-plan-review: テスト観点の妥当性
+   └─ test-assertion-effectiveness: アサーション有効性（常に PASS する検証）
 
 3. 統合サマリの生成
 ```

--- a/skills/agent-skills/river-review-testing/references/ROUTING.md
+++ b/skills/agent-skills/river-review-testing/references/ROUTING.md
@@ -32,9 +32,15 @@
 - 英語: test plan, test strategy, edge case, test perspective
 - → `test-plan-review`
 
+### アサーション有効性
+
+- 日本語: アサーション, 常に PASS, 恒真, 空の検証, 期待値が古い, スコープ不足
+- 英語: assertion, always passing, vacuous, tautological, stale expectation, unscoped
+- → `test-assertion-effectiveness`
+
 ## 自動判定ルール
 
-1. テストファイルのみ変更 → `test-naming` + `flaky-test`
+1. テストファイルのみ変更 → `test-naming` + `flaky-test` + `test-assertion-effectiveness`
 2. ソースファイルのみ変更 → `test-existence` + `coverage-gap`
 3. テスト + ソース両方 → 全スキル実行
 4. 10ファイル以上の変更 → `test-plan-review` を追加

--- a/skills/downstream/test-assertion-effectiveness/SKILL.md
+++ b/skills/downstream/test-assertion-effectiveness/SKILL.md
@@ -1,0 +1,225 @@
+---
+id: 'test-assertion-effectiveness'
+name: 'Test Assertion Effectiveness 常に PASS するテストの検出'
+description: 'テストは存在するがアサーションが実質何も検証しておらず、実装が壊れても落ちない（常に PASS する）構造を diff-time で検出する。Check 1 missing assertion（テスト本体にアサーションが無い）、Check 2 tautological assertion（定数同士・入力自身・mock の戻り値自身を assert し SUT に依存しない）、Check 3 nonexistent expected literal（assertDontSee / assertNotContains 等の期待文字列が対象ファイルに実在しない）、Check 4 stale expected value（同一 diff で対象の出力が変わったのに期待値が据え置き）、Check 5 unscoped expectation（汎用的な属性・クラスを応答全体に対して assert し対象要素にスコープされていない）、Check 6 swallowed failure（例外の握り潰しや到達しない位置のアサーションで判定が成立しない）、の 6 Check を対象とする report-only。テストの有無は test-existence、未テスト経路の量は coverage-gap、非決定性は flaky-test、命名は test-naming、JS/TS の un-awaited resolves / rejects は vitest-mock-isolation、tdd-ledger artifact ベースの RED/GREEN 検証は plangate-tdd-evidence、.only / .skip / xit / @ts-ignore と空の catch は heuristic-review.mjs の決定論検出器へ委譲する'
+version: 0.1.0
+category: downstream
+phase: downstream
+applyTo:
+  - '**/*.{test,spec}.{ts,tsx,js,jsx,mjs,cjs}'
+  - '**/*Test.php'
+  - '**/test_*.py'
+  - '**/*_test.{py,go,rb}'
+  - 'tests/**/*'
+  - 'test/**/*'
+  - '__tests__/**/*'
+tags:
+  [
+    tests,
+    assertion,
+    assertion-effectiveness,
+    vacuous-test,
+    always-passing,
+    test-quality,
+    downstream,
+  ]
+severity: major
+inputContext: [diff, fullFile]
+outputKind: [findings, questions]
+modelHint: high-accuracy
+dependencies: [code_search]
+---
+
+## Naming / 命名
+
+`skills/README.md` の Naming Q0–Q5 に従って決定した。Q0 では外部プロジェクトの成果物を取り込んでいないため「概念の再実装」に分類され、リネーム（新規命名）が既定となる。Q1 は衝突なし（`assertion` を含む skill id は既存に無い）、Q2・Q3 は参照元の原語が存在しないため適用外、Q4 で既存の `test-*` 命名ファミリ（`test-existence` / `test-naming` / `test-plan-review`）に整合することを確認し、Q5 で「価値（アサーションが有効であること）を名指す」名として `test-assertion-effectiveness` を採用した。機構名（tautology 検出・grep 照合）ではなく価値を名指す点が Q5 の要件である。
+
+## Pattern declaration
+
+Primary pattern: Reviewer
+Secondary patterns: Inversion
+Why: アサーションの形はパターンとして拾えるが、「そのアサーションが SUT の挙動に依存しているか」の判定は意味的であり、期待値の照合先（テンプレート・コンポーネント）が discover できない差分では実行を止めるゲートが必要である。
+
+## Goal / 目的
+
+テストの「有無」や「粒度」は既存 skill が見るが、**書かれたアサーションが実際に失敗しうるか**は誰も見ていない。アサーションが無効なテストは行を通過するためカバレッジ指標にも現れず、CI が緑であることも有効性の証明にならない（レビュー時点の CI が古い sha で緑だった実例が #1684 に記録されている）。この盲点を diff-time の静的観点として埋める。
+
+次の 6 Check のいずれかに該当し、**そのテストが実装の退行を検知できない**と読み取れる場合に指摘する。report-only（ADR-005）であり、finding / question のみを出力して自動修正はしない。
+
+## Non-goals / 扱わないこと（委譲表）
+
+| 隣接領域                                                   | 委譲先                                        | 分界                                                                                                                                          |
+| ---------------------------------------------------------- | --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| テストが存在しない                                         | `test-existence`                              | 委譲先は「変更コードに対応するテストが差分に無い」。本 skill は逆に**テストがある差分にだけ働く**（委譲先はテスト差分があると黙る前提のため） |
+| 未テスト経路・分岐・境界の量                               | `coverage-gap`                                | 委譲先は「その経路のテストが存在しない」。本 skill は「テストは存在するがアサーションが落ちない」                                             |
+| 実行ごとに結果が変わる不安定さ                             | `flaky-test`                                  | 委譲先は非決定性。本 skill は**決定論的に必ず PASS する**構造                                                                                 |
+| `describe` / `it` の命名・構造                             | `test-naming`                                 | 命名の明瞭さは対象外。名前が適切でもアサーションが無効なら本 skill が扱う                                                                     |
+| JS / TS の un-awaited `expect(...).resolves` / `.rejects`  | `vitest-mock-isolation`                       | 委譲先が「常に pass する空 assertion」として既に所有する。`async-correctness` も本番コード側からここへ委譲済みであり、三重管理にしない        |
+| `tdd-ledger` artifact による RED / GREEN 証跡の検証        | `plangate-tdd-evidence`                       | 委譲先は artifact 駆動（artifact 非供給の adopter では常に `NO_REVIEW`）。本 skill は**artifact に依存しない diff-time 観点**                 |
+| 影響・失敗系・外部依存を調査した証拠の有無                 | `impact-evidence-coverage`                    | 委譲先は同一 diff のテストを「証拠あり」として充足扱いにする。本 skill はその**テスト自体が有効か**を見る（矛盾ではなく補完関係）             |
+| 本番経路の例外握り潰し・配線切れ                           | `e2e-wiring` / `logging-observability`        | 委譲先は `src/**` 等の本番経路。本 skill が見る握り潰しは**テスト本体の中で判定を無効化するもの**に限る                                       |
+| `.only` / `.skip` / `xit` / `@ts-ignore` / 空の `catch {}` | `src/lib/heuristic-review.mjs` の決定論検出器 | 決定論で判定済みのため**重複指摘しない**（`.claude/rules/review-core.md` §「カスタム静的解析の False-positive 責務分界（#1070）」）           |
+
+さらに次はスコープ外とする。
+
+- **ミューテーションテストの導入**: 実行時にアサーション有効性を測る仕組みの導入は静的レビュー観点の責務ではない（#1684 Non-goals）。
+- **カバレッジ閾値の変更**: 閾値・ゲートの設定変更は扱わない（#1684 Non-goals）。
+- **snapshot テストであること自体**: snapshot は意図を明示しないという批判があるが、正当な用途（意図的な回帰固定・大きな出力の差分検知）が多く誤検出になりやすいため指摘しない。snapshot に加えて Check 1〜6 のいずれかに該当する場合のみ、その Check として扱う。
+- **アサーションライブラリの選定**やマッチャーの好み（`toBe` と `toEqual` の使い分け等）。
+
+## 決定論と LLM 判断の分界（#1070）
+
+`.claude/rules/review-core.md` の責務分界に従い、本 skill が扱う範囲を次の 3 層に分ける。
+
+1. **既に決定論で守られている領域（本 skill は触れない）**: `.only` / `.skip` / `xit` / `xdescribe` / `@ts-ignore` / `@ts-nocheck` / 空の `catch (...) {}` / コード変更に対するテストファイルの不在。これらは `src/lib/heuristic-review.mjs` の検出器が構文的に判定済みであり、重複指摘は禁止する。
+2. **構文的に決定論化できるが現時点は本 skill が見る領域（canary で回帰防止）**: Check 1 の「テスト本体に assert トークンが 1 つも無い」、Check 3 の「期待文字列リテラルが対象ファイルに grep でヒットしない」。将来この 2 つがカスタム linter 化された場合、本 skill は当該 Check を委譲し、`fixtures/` の canary が誤検出の回帰防止を引き継ぐ。
+3. **LLM 判断が必須の領域（本 skill の中核）**: Check 2 の「その値が SUT の出力に依存しているか」、Check 4 の「据え置きが追従漏れか意図的か」、Check 5 の「スコープが対象要素を特定できているか」、Check 6 の「その構造が失敗判定を無効化しているか」。いずれも周辺コードと変更意図の読解を要し、パターン照合では判定できない。
+
+## Pre-execution Gate / 実行前ゲート
+
+このスキルは以下の条件が**すべて**満たされない限り `NO_REVIEW` を返す。
+
+- [ ] inputContext に `diff` が含まれている。
+- [ ] 差分にテストファイルの追加・変更が含まれている（本 skill はテストが存在する差分のみを対象とする）。
+- [ ] 変更されたテストにアサーション、またはアサーションを含むテストケースの追加・変更が含まれている（セットアップ・fixture・import のみの変更では実行しない）。
+- [ ] Check 3〜5 を判定する場合、期待値の照合先（テンプレート・コンポーネント・レンダリング結果）が差分・`fullFile`・`code_search` のいずれかで到達できる。到達できない場合、その Check は finding を出さず question に留める。
+
+ゲート不成立時の出力: `NO_REVIEW: test-assertion-effectiveness — アサーションの追加・変更を含むテスト差分が無い`
+
+## False-positive guards / 抑制条件
+
+正当なテストを FP にしないため、次を厳守する。
+
+- **ヘルパー経由の assert は指摘しない**: アサーションが共通ヘルパー・カスタムマッチャー・`expect.extend`・trait / base class に切り出されている場合、テスト本体に assert トークンが無くても Check 1 に該当しない。呼び出し先を確認できないときは question に留める。
+- **パラメタライズドテストは指摘しない**: `it.each` / `test.each` / `@dataProvider` / `pytest.mark.parametrize` の入力テーブルは「入力自身を assert している」ように見えるが、実行はケースごとに SUT を通る。表側の定数を Check 2 として扱わない。
+- **正当な snapshot テストは指摘しない**: 上記 Non-goals のとおり、snapshot であることのみを理由に指摘しない。
+- **否定アサーションが常に正当な文脈を除外する**: 「削除された文言が今後も出ないこと」を回帰テストとして固定するケースでは、期待文字列が対象に存在しないことが**期待どおり**である。同一 diff またはコメント・テスト名で「削除の回帰固定」であることが読み取れる場合、Check 3 として指摘しない。指摘するのは、そのアサーションが**新機能・変更後の挙動を検証する意図で書かれている**と読み取れる場合に限る。
+- **意図的な smoke test は指摘しない**: 「例外を投げずに完走すること」自体が検証内容であると、テスト名・コメント・PR 本文で明示されている場合は Check 1 として指摘しない。
+- **照合先が discover できなければ question**: 期待値の照合先ファイルを特定できない、または動的生成（i18n キー解決・テンプレート合成）で静的に照合できない場合は、finding ではなく question とする（false-positive-first）。
+- **委譲先の領分は指摘しない**: 上記委譲表の各行、特に `.only` / `.skip` / `@ts-ignore` / 空の `catch {}` / JS・TS の un-awaited `.resolves` / `.rejects` は本 skill から出力しない。
+- **指摘上限**: Check ごとに finding と question の合算で最大 2 件、全体で最大 5 件とする。保持の優先順は findings（severity 降順）→ questions とし、上限超過分は優先度の低い側から切り捨てる。
+
+抑制時の出力: 該当する指摘を出力しない（黙る）。
+
+## Rule / ルール
+
+### Check 1 — Missing assertion / アサーション不在
+
+テスト本体が SUT を呼び出すのみで、アサーションが 1 つも存在しない。例外が投げられた場合しか落ちないため、戻り値・副作用の退行を検知できない。ヘルパー経由の assert と意図的な smoke test は抑制条件で除外する。
+
+### Check 2 — Tautological assertion / 恒真・SUT 非依存のアサーション
+
+アサーションの結果が SUT の挙動に依存しない。次を含む。
+
+- 定数同士の比較（`expect(true).toBe(true)` / `assertTrue(true)` / `assertSame(1, 1)`）。
+- テスト自身が組み立てた入力・fixture リテラルをそのまま assert している。
+- mock に設定した戻り値を、その mock 自身から取り出して assert している（SUT を通っていない）。
+
+### Check 3 — Nonexistent expected literal / 期待値が対象に実在しない
+
+否定系アサーション（`assertDontSee` / `assertNotContains` / `not.toContain` 等）の期待文字列が、照合先のテンプレート・コンポーネントに元から存在しない。存在しないものが「無いこと」を検証しているため常に PASS する。肯定系（`assertSee` 等）で期待文字列が照合先に一度も存在しない場合も同じ根拠で扱う。
+
+### Check 4 — Stale expected value / 出力変更への追従漏れ
+
+同一 diff で照合先の出力（マークアップ・レンダリング結果・シリアライズ形式）が変更されているのに、その出力を検証するアサーションの期待値が据え置かれている。連結された文字列が複数要素へ分割された場合など、変更後は一致しなくなる形が典型である。
+
+### Check 5 — Unscoped expectation / 期待値のスコープ不足
+
+汎用的すぎる属性・クラス・トークン（`rel=` / `target=` / 汎用ユーティリティクラス / 共通ヘッダーの文言等）を応答全体に対して単独で assert しており、検証対象の要素から当該属性を除去しても他の箇所が供給するため PASS してしまう。
+
+### Check 6 — Swallowed failure / 失敗の握り潰し・到達しないアサーション
+
+テスト本体の構造が失敗判定を無効化している。次を含む。
+
+- `catch` 節が再 throw も明示的な失敗（`fail()` / `expect.unreachable()` / `$this->fail()`）も行わず、例外発生時に PASS してしまう。
+- 期待していた例外が発生しなかった場合に落ちる仕組み（`expect.assertions(n)` / `expectException` / `assertThrows`）が無いまま、アサーションを `try` 節にのみ置いている。
+- 早期 `return` や到達しない分岐の後ろにアサーションが置かれている。
+
+なお空の `catch (...) {}` は決定論検出器（`silent-catch`）が既に検出するため、本 Check からは重複指摘しない。本 Check が扱うのは、**catch 節に何らかのコード（コメント・ログ出力等）があるため決定論検出器が黙る**が、失敗判定は成立していないケースである。
+
+### 検出ロジック
+
+1. **Check の特定**: 変更されたアサーションがどの Check に該当するかを判定する。該当しないアサーションは調査しない。
+2. **照合先の解決**: Check 3〜5 では期待文字列の照合先（テンプレート・コンポーネント・レンダリング経路）を `code_search` または `fullFile` で特定する。特定できなければ question に落とす。
+3. **有効性の判定**: 「実装側を意図的に壊したとき、このアサーションは落ちるか」を 1 ケースだけ具体的に述べられるかで判定する。述べられなければ無効と扱う。
+4. **正当化の棄却**: 抑制条件（ヘルパー経由・パラメタライズド・削除の回帰固定・意図的 smoke test）に該当しないことを確認する。判断できなければ question とする。
+5. **resolution の付与**: 各 finding に最小修正案を添える。「期待値を変更後の出力に合わせる」「対象要素にスコープした正規表現 / DOM 選択へ置換する」「SUT の戻り値・副作用を assert する」「`expect.assertions` / `expectException` で失敗経路を固定する」のいずれかを明示する。
+
+### severity 較正
+
+- 検証対象の挙動を壊しても落ちず、その挙動がクリティカルパス（認証・課金・データ保存・公開ページの出力契約）に属するものは `blocker`。
+- アサーションが無効で退行を検知できないが、影響範囲が限定的で merge 前に修正すれば足りるものは `warning`。
+- 有効性は保たれているがスコープが広く、将来の誤検知・見逃しの温床になる程度のものは `nit`。
+- 照合先が discover できず、無効と断定できないものは question（`info` 相当）。
+
+## Evidence / 根拠の取り方
+
+- finding の `file:line` は差分内のアサーション行にアンカーする。差分外の推測に基づく指摘は question として返す。
+- Check 3〜5 では、照合先ファイルのパスと**照合に使った検索語**を併記し、第三者が同じ grep で再現できるようにする。
+- 「このアサーションは常に PASS する」と述べる場合、**どの実装変更を加えても落ちないか**を 1 ケース具体的に示す。示せない場合は question とする。
+- テスト作者の意図（手抜き・ごまかし）を断定しない。アサーションの構造と照合結果の事実のみを述べる（`.claude/rules/review-core.md`）。
+
+## Output / 出力フォーマット
+
+すべて日本語。標準の finding フォーマットに従い、各指摘に `check`（1〜6）と `resolution` を含める。
+
+```text
+(test-assertion-effectiveness):1: [要約] 最も影響の大きい無効アサーションは〈1文〉
+
+<file>:<line>: [Ineffective assertion] <タイトル>
+  check: 1 | 2 | 3 | 4 | 5 | 6
+  Finding: どのアサーションがなぜ失敗しえないか
+  Evidence: 照合先 `<file>` と検索語 `<query>`、または差分内の該当行
+  Impact: どの退行を見逃すか（1文）
+  Fix: <最小修正案>
+  Confidence: high | medium | low
+  Severity: blocker | warning | nit（較正基準に従う）
+  resolution: <解消手順>
+```
+
+## Good / Bad Examples
+
+### Good
+
+```text
+tests/Feature/ComparisonPageTest.php:48: [Ineffective assertion] 期待文字列がテンプレートに存在せず assertDontSee が常に PASS する
+  check: 3
+  Finding: `assertDontSee('要件整理シート付き比較表をダウンロード')` の期待文字列が、照合先テンプレートに 1 件も存在しない
+  Evidence: 照合先 resources/views/comparison/show.blade.php、検索語 `要件整理シート付き比較表をダウンロード`（0 件）。分割後の文言は同ファイル 31-32 行に 2 要素で存在する
+  Impact: 対象文言が再び出力されるようになっても、このテストは落ちない
+  Fix: 分割後のマークアップに合わせ、対象要素へスコープした正規表現で検証する
+  Confidence: high
+  Severity: warning
+  resolution: 期待値を変更後の出力に合わせるか、検証意図が「削除の回帰固定」であればテスト名とコメントにその旨を明記する
+```
+
+### Bad
+
+```text
+このテストは意味がありません
+```
+
+（Check の特定なし、照合先と検索語のアンカーなし、落ちない根拠の提示なし、resolution なし、作者の意図の断定）
+
+## 評価指標（Evaluation）
+
+- 合格基準: Check が特定され、無効と判断した根拠が差分内のアンカーと照合先の検索語で再現可能に示され、抑制条件（ヘルパー経由・パラメタライズド・削除の回帰固定・snapshot・意図的 smoke test）が棄却され、resolution が示されている。委譲表の領分を重複指摘しない。
+- 不合格基準: 照合を行わずアサーションの見た目だけで指摘している、ヘルパー経由の assert を Check 1 と誤認している、パラメタライズドテストの入力テーブルを Check 2 と誤認している、決定論検出器や `vitest-mock-isolation` の領分を重複指摘している、resolution が無い。
+
+## 人間に返す条件（Human Handoff）
+
+- 期待値の照合先が動的生成（i18n・テンプレート合成・CMS 由来）で、静的に有効性を判定できない場合。
+- アサーションが弱いのが意図的な設計判断（契約の緩さを許容する統合テスト等）かどうかの判別に、チームのテスト戦略上の合意を要する場合。
+
+## References
+
+- `skills/downstream/test-existence/SKILL.md` — テストの有無（委譲先）
+- `skills/downstream/coverage-gap/SKILL.md` — 未テスト経路の量（委譲先）
+- `skills/downstream/flaky-test/SKILL.md` — 非決定性（委譲先）
+- `skills/downstream/test-naming/SKILL.md` — 命名・構造（委譲先）
+- `skills/midstream/vitest-mock-isolation/SKILL.md` — JS / TS の un-awaited `.resolves` / `.rejects`（委譲先）
+- `skills/upstream/plangate-tdd-evidence/SKILL.md` — `tdd-ledger` artifact ベースの証跡検証（委譲先）
+- `skills/midstream/impact-evidence-coverage/SKILL.md` — 証拠の充足性（補完関係）
+- `src/lib/heuristic-review.mjs` — `.only` / `.skip` / `@ts-ignore` / 空 `catch` の決定論検出器（重複指摘しない境界）
+- `.claude/rules/review-core.md` §「カスタム静的解析の False-positive 責務分界（#1070）」 — 決定論と意味的判断の分界
+- `docs/review/output-format.md` — 重要度ラベルと出力形式（SSoT）

--- a/skills/downstream/test-assertion-effectiveness/fixtures/01-nonexistent-expected-literal-should-detect.md
+++ b/skills/downstream/test-assertion-effectiveness/fixtures/01-nonexistent-expected-literal-should-detect.md
@@ -1,0 +1,56 @@
+# Test Case: 期待文字列が対象テンプレートに実在しない（Check 3 / should-detect）
+
+## Description
+
+新機能「比較表ダウンロード導線の出し分け」を追加する PR で、無料プランに導線が出ないことを `assertDontSee` で検証している。しかし期待文字列 `無料プランではご利用いただけません` はテンプレートに一度も存在せず、テンプレートが出力するのは `このプランではご利用いただけません` である。したがってこのアサーションは実装が壊れても常に PASS する。issue #1684 パターン1 に対応する。
+
+## Input Diff
+
+```diff
+diff --git a/resources/views/comparison/show.blade.php b/resources/views/comparison/show.blade.php
+index 1111111..2222222 100644
+--- a/resources/views/comparison/show.blade.php
++++ b/resources/views/comparison/show.blade.php
+@@ -28,6 +28,11 @@
+   @if ($plan->allowsDownload())
+     <a href="{{ route('comparison.download', $comparison) }}">比較表をダウンロード</a>
++  @else
++    <p class="notice">このプランではご利用いただけません</p>
+   @endif
+diff --git a/tests/Feature/ComparisonDownloadTest.php b/tests/Feature/ComparisonDownloadTest.php
+index 3333333..4444444 100644
+--- a/tests/Feature/ComparisonDownloadTest.php
++++ b/tests/Feature/ComparisonDownloadTest.php
+@@ -40,4 +40,12 @@ class ComparisonDownloadTest extends TestCase
+     }
++
++    public function test_free_plan_cannot_download(): void
++    {
++        $user = User::factory()->freePlan()->create();
++
++        $response = $this->actingAs($user)->get('/comparison/1');
++
++        $response->assertDontSee('無料プランではご利用いただけません');
++    }
+ }
+```
+
+## 照合先 / Artifacts
+
+- 照合先テンプレート: `resources/views/comparison/show.blade.php`（同一 diff に含まれる）。
+- 検索語 `無料プランではご利用いただけません` は同ファイルに 0 件。実際の出力は `このプランではご利用いただけません`。
+- PR 本文・テスト名・コメントに「削除された文言の回帰固定」を示す記述は無い。新機能の検証意図で書かれている。
+
+## Expected Behavior
+
+1. Check 3 として finding を 1 件出す。アンカーは `tests/Feature/ComparisonDownloadTest.php` の `assertDontSee` 行。
+2. Evidence に照合先ファイルパスと検索語（ヒット 0 件）を明記し、第三者が同じ grep で再現できるようにする。
+3. Fix / resolution として、期待値を実際の出力 `このプランではご利用いただけません` に合わせる最小修正を示す。
+4. 「テンプレートに `@else` 分岐を追加したこと」自体は指摘しない（本 skill の対象はアサーションの有効性であり、実装の是非ではない）。
+
+<!-- expected:
+findings:
+  - check: 3
+    severity: major
+    reason: assertDontSee の期待文字列が照合先テンプレートに 0 件で、実装が壊れても落ちない
+-->

--- a/skills/downstream/test-assertion-effectiveness/fixtures/02-stale-expected-value-should-detect.md
+++ b/skills/downstream/test-assertion-effectiveness/fixtures/02-stale-expected-value-should-detect.md
@@ -1,0 +1,63 @@
+# Test Case: マークアップ変更にアサーションが追従していない（Check 4 / should-detect）
+
+## Description
+
+同一 diff でテンプレートの文言が 2 つの `<span>` に分割されたが、その文言を検証する `assertSee` の期待値は連結文字列のまま据え置かれている。分割後の HTML には連結文字列が現れないため、このテストは次の実行で必ず失敗する。テストファイルも同一 diff で変更されている（別ケースの追加）にもかかわらず、期待値だけが追従していない点が検出条件である。issue #1684 パターン2 に対応する。
+
+レビュー時点の CI が 2 コミット前の sha で緑だったため、CI の色は有効性の証明にならない。
+
+## Input Diff
+
+```diff
+diff --git a/resources/views/comparison/show.blade.php b/resources/views/comparison/show.blade.php
+index 1111111..2222222 100644
+--- a/resources/views/comparison/show.blade.php
++++ b/resources/views/comparison/show.blade.php
+@@ -14,7 +14,10 @@
+-  <a href="{{ route('comparison.download', $comparison) }}">
+-    <span>要件整理シート付き比較表をダウンロード</span>
+-  </a>
++  <a href="{{ route('comparison.download', $comparison) }}">
++    <span class="badge">要件整理シート付き</span>
++    <span class="label">比較表をダウンロード</span>
++  </a>
+diff --git a/tests/Feature/ComparisonDownloadTest.php b/tests/Feature/ComparisonDownloadTest.php
+index 3333333..4444444 100644
+--- a/tests/Feature/ComparisonDownloadTest.php
++++ b/tests/Feature/ComparisonDownloadTest.php
+@@ -18,6 +18,14 @@ class ComparisonDownloadTest extends TestCase
+     {
+         $response = $this->actingAs($this->paidUser)->get('/comparison/1');
+
+         $response->assertSee('要件整理シート付き比較表をダウンロード');
+     }
++
++    public function test_download_link_points_to_signed_url(): void
++    {
++        $response = $this->actingAs($this->paidUser)->get('/comparison/1');
++
++        $response->assertSee(route('comparison.download', 1));
++    }
+ }
+```
+
+## 照合先 / Artifacts
+
+- 照合先テンプレート: `resources/views/comparison/show.blade.php`（同一 diff で変更済み）。
+- 変更後のマークアップに連結文字列 `要件整理シート付き比較表をダウンロード` は存在しない（2 要素に分割）。
+- PR 本文: 「比較表ダウンロード導線のラベルを 2 段組みに変更し、署名付き URL のテストを追加する」。期待値の据え置きを意図した記述は無い。
+
+## Expected Behavior
+
+1. Check 4 として finding を 1 件出す。アンカーは据え置かれた `assertSee('要件整理シート付き比較表をダウンロード')` の行。差分の `-` 行ではなく、変更されずに残っている既存アサーション行を対象とする。
+2. Evidence として、同一 diff でテンプレート側が分割された `file:line` と、分割後に連結文字列が一致しなくなる事実を併記する。
+3. Fix / resolution として、対象要素にスコープした検証（分割後の 2 要素をそれぞれ検証する、または対象 `<a>` 要素へスコープした正規表現）への置換を示す。
+4. 新規追加された `assertSee(route(...))` は SUT 由来の値を検証しており有効なため指摘しない。
+5. 「CI が緑だから問題ない」という理由で抑制しない。
+
+<!-- expected:
+findings:
+  - check: 4
+    severity: major
+    reason: 同一 diff でマークアップが分割されたのに assertSee の期待値が連結文字列のまま据え置かれている
+-->

--- a/skills/downstream/test-assertion-effectiveness/fixtures/03-unscoped-expectation-should-detect.md
+++ b/skills/downstream/test-assertion-effectiveness/fixtures/03-unscoped-expectation-should-detect.md
@@ -1,0 +1,56 @@
+# Test Case: 期待値が対象要素にスコープされていない（Check 5 / should-detect）
+
+## Description
+
+外部リンクに `rel="nofollow"` を付与する変更に対し、`assertSee('rel="nofollow"')` で検証している。しかし共通レイアウトのフッターが常時 `rel="nofollow"` を出力するため、検証対象の外部リンクから `rel` を除去してもこのアサーションは PASS する。issue #1684 パターン3 に対応する。
+
+## Input Diff
+
+```diff
+diff --git a/resources/views/articles/show.blade.php b/resources/views/articles/show.blade.php
+index 1111111..2222222 100644
+--- a/resources/views/articles/show.blade.php
++++ b/resources/views/articles/show.blade.php
+@@ -22,7 +22,7 @@
+   @foreach ($article->externalLinks as $link)
+-    <a href="{{ $link->url }}" target="_blank">{{ $link->title }}</a>
++    <a href="{{ $link->url }}" target="_blank" rel="nofollow noopener">{{ $link->title }}</a>
+   @endforeach
+diff --git a/tests/Feature/ArticleExternalLinkTest.php b/tests/Feature/ArticleExternalLinkTest.php
+index 3333333..4444444 100644
+--- a/tests/Feature/ArticleExternalLinkTest.php
++++ b/tests/Feature/ArticleExternalLinkTest.php
+@@ -12,4 +12,13 @@ class ArticleExternalLinkTest extends TestCase
+     }
++
++    public function test_external_links_are_nofollow(): void
++    {
++        $article = Article::factory()->withExternalLink('https://example.com')->create();
++
++        $response = $this->get("/articles/{$article->slug}");
++
++        $response->assertSee('rel="nofollow"', false);
++    }
+ }
+```
+
+## 照合先 / Artifacts
+
+- 照合先テンプレート: `resources/views/articles/show.blade.php`（同一 diff）と共通レイアウト `resources/views/layouts/app.blade.php`（diff 外・`code_search` で到達可能）。
+- 検索語 `rel="nofollow"` は `resources/views/layouts/app.blade.php` のフッターリンクにも 3 件ヒットする。ページ共通で常時出力される。
+- 検証対象は記事本文の外部リンクのみだが、アサーションは応答全体を対象にしている。
+
+## Expected Behavior
+
+1. Check 5 として finding を 1 件出す。アンカーは `assertSee('rel="nofollow"', false)` の行。
+2. Evidence として、共通レイアウト側で同じトークンが出力される `file:line` と、そこに到達するのに使った検索語を明記する。
+3. Impact として「検証対象の外部リンクから `rel` を除去しても PASS する」ことを述べる。
+4. Fix / resolution として、対象要素にスコープした検証（`assertSeeInOrder` での前後関係固定、対象 `href` を含む正規表現、または DOM 選択ベースの検証）への置換を示す。
+5. テンプレート側で `noopener` を併記したことは指摘しない（アサーション有効性の観点外）。
+
+<!-- expected:
+findings:
+  - check: 5
+    severity: major
+    reason: 共通レイアウトが常時出力するトークンを応答全体に対して assert しており、対象要素から除去しても PASS する
+-->

--- a/skills/downstream/test-assertion-effectiveness/fixtures/04-vacuous-and-swallowed-should-detect.md
+++ b/skills/downstream/test-assertion-effectiveness/fixtures/04-vacuous-and-swallowed-should-detect.md
@@ -1,0 +1,75 @@
+# Test Case: アサーション不在・恒真・失敗の握り潰し（Check 1 / 2 / 6 / should-detect）
+
+## Description
+
+課金計算モジュールに 3 つのテストを追加した PR。1 件目はアサーションが無く SUT を呼ぶだけ、2 件目は mock に設定した戻り値を SUT を通さず assert している恒真ケース、3 件目は `catch` 節にログ出力があるだけで再 throw も明示的な失敗もせず、例外が起きても PASS する。3 件とも実装が壊れても落ちない。
+
+## Input Diff
+
+```diff
+diff --git a/src/billing/charge.mjs b/src/billing/charge.mjs
+index 1111111..2222222 100644
+--- a/src/billing/charge.mjs
++++ b/src/billing/charge.mjs
+@@ -8,6 +8,10 @@ export function calculateCharge(order, taxRate) {
++  if (order.amount < 0) {
++    throw new RangeError('amount must be non-negative');
++  }
+   return Math.round(order.amount * (1 + taxRate));
+ }
+diff --git a/tests/billing/charge.test.mjs b/tests/billing/charge.test.mjs
+index 3333333..4444444 100644
+--- a/tests/billing/charge.test.mjs
++++ b/tests/billing/charge.test.mjs
+@@ -1,5 +1,29 @@
+ import { describe, it, expect, vi } from 'vitest';
+ import { calculateCharge } from '../../src/billing/charge.mjs';
++import { fetchTaxRate } from '../../src/billing/tax.mjs';
++
++describe('calculateCharge', () => {
++  it('handles a standard order', () => {
++    const order = { amount: 1000 };
++    calculateCharge(order, 0.1);
++  });
++
++  it('uses the configured tax rate', () => {
++    const spy = vi.spyOn({ fetchTaxRate }, 'fetchTaxRate').mockReturnValue(0.1);
++    expect(spy()).toBe(0.1);
++  });
++
++  it('rejects a negative amount', () => {
++    try {
++      calculateCharge({ amount: -1 }, 0.1);
++    } catch (err) {
++      console.log('expected error', err.message);
++    }
++  });
++});
+```
+
+## 照合先 / Artifacts
+
+- SUT: `src/billing/charge.mjs`（同一 diff）。
+- テスト名・コメント・PR 本文に「完走すること自体を検証する smoke test である」旨の記述は無い。
+- 共通ヘルパー・カスタムマッチャー・`expect.extend` はこのテストファイルおよび setup ファイルに存在しない。
+
+## Expected Behavior
+
+1. Check 1 として `it('handles a standard order')` を指摘する。SUT を呼ぶのみでアサーションが無く、例外時しか落ちない。
+2. Check 2 として `expect(spy()).toBe(0.1)` を指摘する。mock に設定した戻り値をその mock 自身から取り出しており、`calculateCharge` を通っていないため SUT の挙動に依存しない。
+3. Check 6 として `it('rejects a negative amount')` を指摘する。`catch` 節に `console.log` があるだけで再 throw も `expect.unreachable()` も無く、例外が投げられなくなっても PASS する。`expect.assertions(1)` や `expect(() => ...).toThrow(RangeError)` への置換を Fix として示す。
+4. `vi.spyOn` の未復元（`afterEach` / `restoreMocks` の不在）は `vitest-mock-isolation` の領分であり、本 skill からは指摘しない。
+5. `catch` 節が空ではない（`console.log` がある）ため、決定論検出器 `silent-catch` の重複指摘には当たらない。空の `catch {}` であれば本 skill は黙る。
+
+<!-- expected:
+findings:
+  - check: 1
+    severity: major
+    reason: SUT を呼び出すのみでアサーションが 1 つも無く、例外時しか落ちない
+  - check: 2
+    severity: major
+    reason: mock に設定した戻り値をその mock 自身から取り出して assert しており SUT を通っていない
+  - check: 6
+    severity: major
+    reason: catch 節が再 throw も明示的失敗もせず、例外が投げられなくなっても PASS する
+-->

--- a/skills/downstream/test-assertion-effectiveness/fixtures/05-helper-parameterized-deletion-pinning-canary.md
+++ b/skills/downstream/test-assertion-effectiveness/fixtures/05-helper-parameterized-deletion-pinning-canary.md
@@ -1,0 +1,79 @@
+# Test Case: ヘルパー経由 assert・パラメタライズド・削除の回帰固定（Check 1 / 2 / 3 の抑制条件 / canary）
+
+## Description
+
+一見すると「アサーションが無い」「入力自身を assert している」「存在しない文字列を検証している」ように読めるが、いずれも正当なテスト形である should-not-detect canary。Check 1・Check 2・Check 3 の抑制条件がそれぞれ成立することを固定する。
+
+## Input Diff
+
+```diff
+diff --git a/tests/support/assertions.mjs b/tests/support/assertions.mjs
+index 1111111..2222222 100644
+--- a/tests/support/assertions.mjs
++++ b/tests/support/assertions.mjs
+@@ -1,3 +1,9 @@
++export function assertChargeMatches(actual, expected) {
++  expect(actual.total).toBe(expected.total);
++  expect(actual.currency).toBe(expected.currency);
++  expect(actual.taxIncluded).toBe(true);
++}
+diff --git a/tests/billing/charge.test.mjs b/tests/billing/charge.test.mjs
+index 3333333..4444444 100644
+--- a/tests/billing/charge.test.mjs
++++ b/tests/billing/charge.test.mjs
+@@ -1,6 +1,24 @@
+ import { describe, it, expect } from 'vitest';
+ import { calculateCharge } from '../../src/billing/charge.mjs';
++import { assertChargeMatches } from '../support/assertions.mjs';
++
++describe('calculateCharge', () => {
++  it('applies tax to a standard order', () => {
++    assertChargeMatches(calculateCharge({ amount: 1000 }, 0.1), {
++      total: 1100,
++      currency: 'JPY',
++    });
++  });
++
++  it.each([
++    { amount: 0, rate: 0.1, total: 0 },
++    { amount: 1, rate: 0.1, total: 1 },
++    { amount: 999, rate: 0.08, total: 1079 },
++  ])('rounds $amount at rate $rate to $total', ({ amount, rate, total }) => {
++    expect(calculateCharge({ amount }, rate).total).toBe(total);
++  });
++});
+diff --git a/tests/Feature/LegacyBannerTest.php b/tests/Feature/LegacyBannerTest.php
+index 5555555..6666666 100644
+--- a/tests/Feature/LegacyBannerTest.php
++++ b/tests/Feature/LegacyBannerTest.php
+@@ -8,4 +8,13 @@ class LegacyBannerTest extends TestCase
+     }
++
++    /** 撤去済みキャンペーンバナーが再掲載されないことを固定する回帰テスト（#1512 で撤去） */
++    public function test_removed_campaign_banner_never_reappears(): void
++    {
++        $response = $this->get('/');
++
++        $response->assertDontSee('春の乗り換えキャンペーン実施中');
++    }
+ }
+```
+
+## 照合先 / Artifacts
+
+- 共通ヘルパー: `tests/support/assertions.mjs`（同一 diff に含まれ、`expect` を 3 件実行する）。
+- 照合先テンプレート: `resources/views/home.blade.php`。検索語 `春の乗り換えキャンペーン実施中` は 0 件（#1512 で撤去済み）。
+- テストの docblock に「撤去済み」「回帰テスト」と撤去 issue 番号が明記されている。
+
+## Expected Behavior
+
+本 skill は findings を 1 件も出さないこと。
+
+1. **Check 1 として指摘しない**: `it('applies tax to a standard order')` の本体に `expect` は現れないが、アサーションは `assertChargeMatches` ヘルパーへ切り出されており、同一 diff でその実体を確認できる（抑制条件「ヘルパー経由の assert」）。
+2. **Check 2 として指摘しない**: `it.each` の入力テーブルは定数の羅列だが、各ケースは `calculateCharge` を通った結果を assert している（抑制条件「パラメタライズドテスト」）。期待値 `total` が入力から自明に見えることを恒真と誤認しない。
+3. **Check 3 として指摘しない**: `assertDontSee('春の乗り換えキャンペーン実施中')` の期待文字列は照合先に 0 件だが、docblock が「撤去済み文言の回帰固定」であることを明示している（抑制条件「削除の回帰固定」）。この形は期待文字列が存在しないことこそが期待どおりである。
+4. 「アサーションが弱い」「テストが薄い」といった一般論の指摘や question を出さない（false-positive-first）。
+
+<!-- expected:
+findings: []
+-->

--- a/skills/downstream/test-assertion-effectiveness/fixtures/06-scoped-snapshot-delegated-territory-canary.md
+++ b/skills/downstream/test-assertion-effectiveness/fixtures/06-scoped-snapshot-delegated-territory-canary.md
@@ -1,0 +1,84 @@
+# Test Case: 追従済み期待値・スコープ済み検証・委譲先の領分（Check 4 / 5 / 6 の抑制条件 / canary）
+
+## Description
+
+マークアップ変更にアサーションが正しく追従し、期待値が対象要素へスコープされ、例外検証も明示的に固定されている should-not-detect canary。あわせて、決定論検出器および `vitest-mock-isolation` の領分（`.skip` / 空の `catch {}` / un-awaited `.resolves`）と正当な snapshot テストを差分に含め、本 skill が重複指摘しないことを固定する。
+
+## Input Diff
+
+```diff
+diff --git a/resources/views/comparison/show.blade.php b/resources/views/comparison/show.blade.php
+index 1111111..2222222 100644
+--- a/resources/views/comparison/show.blade.php
++++ b/resources/views/comparison/show.blade.php
+@@ -14,7 +14,10 @@
+-  <a href="{{ route('comparison.download', $comparison) }}">
+-    <span>要件整理シート付き比較表をダウンロード</span>
+-  </a>
++  <a href="{{ route('comparison.download', $comparison) }}" rel="nofollow">
++    <span class="badge">要件整理シート付き</span>
++    <span class="label">比較表をダウンロード</span>
++  </a>
+diff --git a/tests/Feature/ComparisonDownloadTest.php b/tests/Feature/ComparisonDownloadTest.php
+index 3333333..4444444 100644
+--- a/tests/Feature/ComparisonDownloadTest.php
++++ b/tests/Feature/ComparisonDownloadTest.php
+@@ -18,7 +18,23 @@ class ComparisonDownloadTest extends TestCase
+     {
+         $response = $this->actingAs($this->paidUser)->get('/comparison/1');
+
+-        $response->assertSee('要件整理シート付き比較表をダウンロード');
++        $response->assertSeeInOrder(['要件整理シート付き', '比較表をダウンロード'], false);
++        $response->assertMatchesRegularExpression(
++            '#<a href="[^"]*comparison/1/download"[^>]*rel="nofollow"#',
++            $response->getContent()
++        );
+     }
++
++    public function test_download_rejects_a_free_plan_user(): void
++    {
++        $this->expectException(AuthorizationException::class);
++
++        $this->actingAs($this->freeUser)->get('/comparison/1/download');
++    }
+ }
+diff --git a/tests/ui/ComparisonCard.test.tsx b/tests/ui/ComparisonCard.test.tsx
+index 5555555..6666666 100644
+--- a/tests/ui/ComparisonCard.test.tsx
++++ b/tests/ui/ComparisonCard.test.tsx
+@@ -4,6 +4,17 @@ import { ComparisonCard } from '../../src/ui/ComparisonCard';
++  it('matches the rendered markup', () => {
++    const { container } = render(<ComparisonCard comparison={fixture} />);
++    expect(container.firstChild).toMatchSnapshot();
++  });
++
++  it.skip('supports the legacy layout', () => {
++    expect(render(<ComparisonCard variant="legacy" />)).toBeTruthy();
++  });
++
++  it('loads the comparison', () => {
++    expect(loadComparison(1)).resolves.toMatchObject({ id: 1 });
++  });
+```
+
+## 照合先 / Artifacts
+
+- 照合先テンプレート: `resources/views/comparison/show.blade.php`（同一 diff で変更済み）。
+- 検索語 `要件整理シート付き` と `比較表をダウンロード` はいずれも変更後のテンプレートに存在する。
+- 検索語 `rel="nofollow"` は共通レイアウトにも出現するが、テスト側は `href` を含む正規表現で対象 `<a>` 要素へスコープしている。
+- snapshot ファイル `tests/ui/__snapshots__/ComparisonCard.test.tsx.snap` は同一 diff で更新されている。
+
+## Expected Behavior
+
+本 skill は findings を 1 件も出さないこと。
+
+1. **Check 4 として指摘しない**: マークアップの分割に対し、期待値が `assertSeeInOrder` の 2 要素へ正しく追従している。据え置きは無い。
+2. **Check 5 として指摘しない**: `rel="nofollow"` は共通レイアウトにも現れる汎用トークンだが、`href` を含む正規表現で対象要素にスコープされているため、対象 `<a>` から `rel` を除去すればテストは落ちる。
+3. **Check 6 として指摘しない**: `expectException` により、例外が投げられなかった場合にテストが落ちる仕組みが成立している。
+4. **snapshot テストを指摘しない**: `toMatchSnapshot` のみのテストは、それ自体を理由に指摘しない（Non-goals）。
+5. **委譲先の領分を指摘しない**: `it.skip` は決定論検出器（`disabled-test`）、un-awaited な `expect(...).resolves` は `vitest-mock-isolation` の責務であり、本 skill からは出力しない。
+6. 一般論の指摘や question を出さない（false-positive-first / 責務分界の遵守）。
+
+<!-- expected:
+findings: []
+-->

--- a/skills/registry.yaml
+++ b/skills/registry.yaml
@@ -667,6 +667,26 @@ skills:
     recommended: false
     description: '変更差分から重要なテスト観点と欠落を洗い出し、優先度付きでテストケース案を提示する'
 
+  - id: test-assertion-effectiveness
+    version: '0.1.0'
+    name: 'Test Assertion Effectiveness 常に PASS するテストの検出'
+    path: skills/downstream/test-assertion-effectiveness/SKILL.md
+    category: downstream
+    phase: downstream
+    tags:
+      [
+        tests,
+        assertion,
+        assertion-effectiveness,
+        vacuous-test,
+        always-passing,
+        test-quality,
+        downstream,
+      ]
+    severity: major
+    recommended: false
+    description: 'テストは存在するがアサーションが実質何も検証しておらず、実装が壊れても落ちない（常に PASS する）構造を diff-time で検出する。対象は Check 1 missing assertion アサーション不在、Check 2 tautological assertion 恒真・SUT 非依存、Check 3 nonexistent expected literal 期待文字列が対象ファイルに実在しない、Check 4 stale expected value 出力変更への追従漏れ、Check 5 unscoped expectation スコープ不足、Check 6 swallowed failure 失敗の握り潰しの 6 つ。テストの有無は test-existence、未テスト経路の量は coverage-gap、非決定性は flaky-test、命名は test-naming、JS / TS の un-awaited resolves / rejects は vitest-mock-isolation、tdd-ledger artifact ベースの証跡検証は plangate-tdd-evidence、.only / .skip / @ts-ignore と空の catch は heuristic-review.mjs の決定論検出器へ委譲する'
+
   # Adversarial Review Skills (Cognitive Bias Countermeasures)
   - id: pre-mortem
     version: '0.1.0'


### PR DESCRIPTION
## 概要

テストが「壊れても落ちない（常に PASS する）」状態になっていることを検知する観点を新設する。issue #1684 のパターン1〜3 に加え、隣接する 3 パターン（アサーション不在・恒真・失敗の握り潰し）を合わせた 6 Check の skill として実装した。

- 新設 skill: `test-assertion-effectiveness`（downstream, severity `major`, `recommended: false`）
- fixtures: should-detect 4 件（6 Check を網羅）+ canary 2 件
- `river-review-testing` ルーターへ登録（issue の「`river-review-testing` に観点を追加する」に対応）

Closes #1684

## 手順1: 既存カバレッジの突合（調査結果）

「アサーションが実質何も検証していない」を扱う skill は**存在しない**ことを確認した。repo 全体（`node_modules` / `.git` 除く）の grep 結果:

| 探索語                                                                                       | ヒット |
| -------------------------------------------------------------------------------------------- | ------ |
| `assertDontSee` / `assertSee` / `assertNotContains`                                          | 0 件   |
| `expect(true` / `assertTrue(true` / `toBeTruthy()` / `self.assertTrue`                       | 0 件   |
| `assert` / `expect` / `アサー` を **レビュー基準として** 扱う記述（`src/lib/*.mjs` 検出器側） | 0 件   |

隣接 skill との突合（file:line 付き）:

| skill                                                       | 実際のスコープ                                                                                                           | 本 issue の領域か                            |
| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------- |
| `skills/downstream/test-existence/SKILL.md:39`              | 「テスト差分がすでにある場合の追加要求（原則として黙る）」。テストの **有無** のみ                                       | ✗ テスト差分があると黙るため、本件は素通り   |
| `skills/downstream/coverage-gap/SKILL.md:40`                | 「例外処理やエラーリターンに対するアサーションが見当たらない」= **その経路のテストが無い**                               | △ 表現が最も近いが「量」の問題。重複ではない |
| `skills/downstream/flaky-test/SKILL.md:41`                  | 未 `await` の Promise を **flakiness** として扱う                                                                        | ✗ 非決定性であり「必ず PASS」ではない        |
| `skills/downstream/test-plan-review/SKILL.md:45`            | 実装前のテスト観点列挙。テストコードは書かない                                                                           | ✗                                            |
| `skills/downstream/test-naming/SKILL.md:52`                 | `describe` / `it` の命名・構造                                                                                           | ✗                                            |
| `skills/midstream/vitest-mock-isolation/SKILL.md:27,56`     | 「`expect(...).resolves` / `.rejects` の await 漏れによる**常に pass する空 assertion**」                                | ◎ **唯一の実質的な重複。Non-goals で委譲**   |
| `skills/midstream/async-correctness/SKILL.md:33`            | Non-goals に「テストコード内の un-awaited assertion（`vitest-mock-isolation` の役割）」と明記済み                        | ✗ 既に委譲済み。三重管理を避ける             |
| `skills/upstream/plangate-tdd-evidence/SKILL.md:75,87,102`  | `tdd-ledger` artifact の RED/GREEN 検証、「mock のみを検証」の指摘                                                       | △ ただし `:150` で **standalone では常に `NO_REVIEW`** |
| `skills/midstream/impact-evidence-coverage/SKILL.md:66-67`  | 同一 diff のテスト存在を「証拠あり」として **充足扱い**                                                                  | ✗ 前提が逆。補完関係として明記               |
| `skills/midstream/e2e-wiring/SKILL.md:33,60`                | 例外の握り潰しを扱うが `:33` で「テストの有無そのもの」を除外し、**本番経路の配線**に限定                                | ✗ テスト本体は未所有                         |
| `skills/downstream/review-policy-standard-downstream/SKILL.md:88` | 「テスト観点では**意味のある assertion**…を最優先する」                                                            | △ 唯一の既存宣言だが `severity: info` の posture skill で検出ルール・fixture なし |

`src/lib/heuristic-review.mjs` の決定論検出器のうちテスト関連は 3 つのみで、いずれもアサーション本体を見ていない:

- `findMissingTests`（`:588`）— コード変更があり **テストファイルが 1 つも触られていない** ときだけ発火（`:594-597`）
- `findFocusedTests`（`:743`）— `.only`
- `findDisabledTests`（`:771`）— `.skip` / `xit` / `xdescribe` / `xtest` / `xcontext`

加えて `findSilentCatch`（`:470`）は **テストファイルを除外していない**ため、空の `catch (...) {}` はテスト内でも既に決定論で検出される。本 skill の Check 6 は「catch 節にコードがあるため決定論検出器が黙るが失敗判定が成立しない」ケースに限定し、重複を避けた。

**結論**: 新設は重複にならない。唯一の重複候補である `vitest-mock-isolation` の領域（JS/TS の un-awaited `.resolves` / `.rejects`）は Non-goals で明示的に委譲した。

## 手順2: 命名ゲート（`skills/README.md` Q0–Q5）の判定過程

| ゲート | 判定                                                                                                                             |
| ------ | -------------------------------------------------------------------------------------------------------------------------------- |
| Q0     | 外部プロジェクトの成果物を取り込んでいない（issue #1684 と実運用 PR の取りこぼしが出所）→「概念の再実装」に分類し、**新規命名が既定** |
| Q1     | 衝突なし。`assertion` を含む skill id / dir / command は repo 内に存在しない。商標・出所混同のリスクもなし → 判定継続             |
| Q2     | 参照元の原語が存在しないため適用外                                                                                               |
| Q3     | 同上（認知価値のある原語なし）                                                                                                   |
| Q4     | 既存の `test-*` 命名ファミリ（`test-existence` / `test-naming` / `test-plan-review`）に整合することを確認                        |
| Q5     | **ここで確定**。価値（アサーションが有効であること）を名指す `test-assertion-effectiveness` を採用。機構名（tautology 検出・grep 照合）ではない |

共通ルールの確認: 組織名詞なし / 機構のみの名前でない / 既存名とハイフン差だけの違いでない / 名詞句 / 64 文字以内 / 予約語（`anthropic`・`claude`）なし。判定過程は SKILL.md の `## Naming / 命名` にも記載した。

phase は既存テストファミリと同じ **downstream**（Testing & Release）を選択し、ルーター `river-review-testing`（`category: downstream`）と揃えた。

## 検出対象（6 Check）

| Check | 英題                        | 内容                                                                          | 出所            |
| ----- | --------------------------- | ----------------------------------------------------------------------------- | --------------- |
| 1     | Missing assertion           | テスト本体にアサーションが無く、例外時しか落ちない                            | 追加            |
| 2     | Tautological assertion      | 定数同士・入力自身・mock の戻り値自身を assert し SUT に依存しない            | 追加            |
| 3     | Nonexistent expected literal | 期待文字列が対象テンプレートに実在しない（`assertDontSee` 等）                | issue パターン1 |
| 4     | Stale expected value        | 同一 diff で出力が変わったのに期待値が据え置き                                | issue パターン2 |
| 5     | Unscoped expectation        | 汎用属性・クラスを応答全体に assert しスコープされていない                    | issue パターン3 |
| 6     | Swallowed failure           | catch で握り潰す / 到達しない位置のアサーションで判定が成立しない             | 追加            |

**snapshot だけで意図を検証しないケースは Non-goals に置いた**。正当な用途（意図的な回帰固定・大きな出力の差分検知）が多く FP になりやすいため、snapshot であること自体は指摘せず、Check 1〜6 のいずれかに該当する場合のみその Check として扱う。

## 決定論と LLM 判断の分界（`.claude/rules/review-core.md` #1070）

SKILL.md に 3 層で明記した。

1. **既に決定論で守られている領域（触れない）**: `.only` / `.skip` / `xit` / `xdescribe` / `@ts-ignore` / `@ts-nocheck` / 空の `catch (...) {}` / コード変更に対するテストファイルの不在
2. **決定論化できるが現状 LLM が見る領域（canary で回帰防止）**: Check 1 の assert トークン不在、Check 3 の期待文字列 grep 不在。将来 linter 化されたら委譲し、canary が誤検出の回帰防止を引き継ぐ
3. **LLM 判断が必須（中核）**: Check 2 の SUT 依存性、Check 4 の追従漏れか意図か、Check 5 のスコープ十分性、Check 6 の失敗判定の成否

## Non-goals 委譲表

`test-existence`（テストの有無）/ `coverage-gap`（未テスト経路の量）/ `flaky-test`（非決定性）/ `test-naming`（命名）/ `vitest-mock-isolation`（JS・TS の un-awaited `.resolves` / `.rejects`）/ `plangate-tdd-evidence`（artifact ベースの証跡）/ `impact-evidence-coverage`（証拠の充足性・補完関係）/ `e2e-wiring`・`logging-observability`（本番経路の握り潰し）/ `heuristic-review.mjs` の決定論検出器、との分界を SKILL.md の表に記載した。あわせて issue の Non-goals（ミューテーションテスト導入・カバレッジ閾値変更）とアサーションライブラリの選定もスコープ外とした。

## fixtures

| ファイル                                                | 種別          | 対象 Check |
| ------------------------------------------------------- | ------------- | ---------- |
| `01-nonexistent-expected-literal-should-detect.md`      | should-detect | 3          |
| `02-stale-expected-value-should-detect.md`              | should-detect | 4          |
| `03-unscoped-expectation-should-detect.md`              | should-detect | 5          |
| `04-vacuous-and-swallowed-should-detect.md`             | should-detect | 1 / 2 / 6  |
| `05-helper-parameterized-deletion-pinning-canary.md`    | **canary**    | 1 / 2 / 3 の抑制条件 |
| `06-scoped-snapshot-delegated-territory-canary.md`      | **canary**    | 4 / 5 / 6 の抑制条件 |

canary が固定する「指摘してはいけない形」: ヘルパー経由の assert・パラメタライズドテスト（`it.each`）・削除文言の回帰固定としての `assertDontSee`・追従済みの期待値・対象要素にスコープ済みの検証・正当な snapshot テスト・委譲先の領分（`.skip` / un-awaited `.resolves`）。

`<!-- expected: -->` ブロックで Check 番号を宣言しているため、`scripts/validate-skills.mjs` の `validateFixtureDrift` が **frontmatter description が全 Check を列挙していること** を機械的に強制する（CLAUDE.md「Skill-check fixture/description drift」ガードの機械化版）。

## 検証

すべて Node 22.22.2（`.nvmrc` 準拠）で実行。

| コマンド                       | 結果                                                                     |
| ------------------------------ | ------------------------------------------------------------------------ |
| `npm run skills:validate`      | EXIT=0 — `fixture drift: 8 skill(s) with expected blocks consistent` ほか |
| `npm run skills:validate:refs` | EXIT=0 — `✅ dangling skill-ID 参照なし`                                 |
| `npm run agent-skills:validate` | EXIT=0 — `river-review-testing` に新規 warning なし                     |
| `npm run skills:manifest:check` | `skill manifest is up to date (128 skills).`                            |
| `npm run lint`                 | EXIT=0（format:check / check:dashes / lint:code / lint:md / lint:text）  |
| `npm test`                     | `# tests 2577 / # pass 2577 / # fail 0`                                  |

> textlint の対象は `pages/**/*.md` のみ（`package.json:32`）のため `skills/**` は対象外。markdownlint と prettier は `**/*.md` を対象としており、いずれも通過している。

<details>
<summary>npm test 実測出力</summary>

```text
1..1305
# tests 2577
# suites 299
# pass 2577
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 20089.049208
```

</details>

## 並行 PR への注記

#1685 も skill を新設中で、`skills/registry.yaml` と `docs/data/skill-manifest.json` が衝突しうる。本 PR は **自分の skill エントリ追加のみ**（`registry.yaml` の downstream ブロック末尾に 1 エントリ追記）に限定している。マージ時に rebase が必要になった場合、`docs/data/skill-manifest.json` は手で解決せず **`npm run skills:manifest` で機械再生成**すること（checksum ベースの決定論生成物のため、再生成すれば必ず正しい状態になる）。`registry.yaml` は追記位置が異なれば衝突しないが、衝突した場合は両エントリを残す。

## レビューしてほしい点

- `recommended: false` とした判断。downstream のテスト系で `recommended: true` なのは `test-existence` / `coverage-gap` の 2 つ（いずれも grandfathered）のみで、専門系（`flaky-test` / `test-naming` / `test-plan-review`）は全て `false` という既存の family 慣行に揃えた。ルーター `river-review-testing` からは `recommended` に関わらず routing される。実運用での FP 率を見てから昇格を検討する想定。
- Check 6 と決定論検出器 `silent-catch`（`heuristic-review.mjs:470`、テストファイルを除外しない）の境界。「catch 節が空でない場合のみ本 skill が扱う」という切り分けで妥当か。
- `src/` は一切変更していない（決定論検出器の追加は行わず、レビュー観点として実装）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
