### PR TITLE
docs(runbook): release-kick に BEHIND / 純 BLOCKED の分岐を追記する

### DIFF
--- a/.claude/commands/release-kick.md
+++ b/.claude/commands/release-kick.md
@@ -19,15 +19,40 @@ gh api user --jq .login | grep -q s977043 || gh auth switch -u s977043
 PreToolUse hook (`gh-account-guard.sh`) が defense-in-depth で効くが、セッション開始時の確認は省略しない。
 `s977043` は本リポジトリのメンテナアカウント（CLAUDE.md「Verify gh active account before write ops」ガードと同一の値で、そちらが SSoT）。フォーク運用時は自分のアカウントに読み替える。
 
-### Step 2. PR 状態の確認
+### Step 2. PR 状態の確認と BEHIND 判定
 
 ```bash
 gh pr view $ARGUMENTS --json state,mergeStateStatus,headRefOid
+releaseBranch=$(gh pr view $ARGUMENTS --json headRefName --jq .headRefName)
+gh api "repos/:owner/:repo/compare/main...$releaseBranch" --jq '{status, ahead_by, behind_by}'
 ```
 
-`mergeStateStatus: BLOCKED` は release-please PR の通常挙動。`CLEAN` なら Step 3〜4 をスキップして Step 5 へ進む。
+`mergeStateStatus: BLOCKED` は release-please PR の通常挙動。`CLEAN` なら Step 3〜5 をスキップして Step 6 へ進む。
 
-### Step 3. release-please-kick の実行
+BLOCKED の場合は `behind_by` の値で次に打つ手が変わる。`mergeable_state` は単一の値しか返さず BEHIND と BLOCKED の複合状態を見分けられないため、compare の `behind_by` で判定する。
+
+| `behind_by` | 状態             | 次に進む Step           | 空コミット kick       |
+| ----------- | ---------------- | ----------------------- | --------------------- |
+| `> 0`       | BEHIND + BLOCKED | Step 3（update-branch） | CI が実発火すれば不要 |
+| `0`         | 純 BLOCKED       | Step 4（kick）          | 必要                  |
+
+分岐の根拠と実証ケースは `docs/runbook/release-please-kick.md`（SSoT）を参照。
+
+### Step 3. BEHIND の場合: update-branch を先に実行
+
+`behind_by > 0` のときだけ実行する。
+
+```bash
+gh api "repos/:owner/:repo/pulls/$ARGUMENTS/update-branch" -X PUT
+```
+
+update-branch が作るマージコミットは自アカウントのトークンで push されるため、bot トークンの no-recursion 制約を受けない。実ユーザー push として全ワークフローが発火するので、Step 4 の空コミット kick は飛ばして Step 5 へ進む。実発火すれば空コミット1本と CI 1周を節約できる。
+
+Step 5 で `action_required` のまま止まっていた場合だけ Step 4 に戻る。`behind_by == 0` の状態で実行すると 422 が返るため、そのときは Step 4 が正。
+
+### Step 4. release-please-kick の実行
+
+`behind_by == 0`（純 BLOCKED）のとき、または Step 3 の update-branch 後も CI が発火しなかったときに実行する。
 
 ```bash
 bash scripts/release-please-kick.sh
@@ -35,7 +60,7 @@ bash scripts/release-please-kick.sh
 
 空コミットで新しい head を作り、`pull_request: synchronize` を実ユーザー相当のトークンで発火させる。ブランチ名を省略すると open な release PR を自動検出する。詳細・`RELEASE_KICK_PAT` 未設定時のエラー・`workflow_dispatch` 経由の代替は runbook 参照。
 
-### Step 4. 新 head の CI 実発火確認
+### Step 5. 新 head の CI 実発火確認
 
 ```bash
 gh run list --limit 5 --json databaseId,status,conclusion,headBranch,workflowName
@@ -43,7 +68,7 @@ gh run list --limit 5 --json databaseId,status,conclusion,headBranch,workflowNam
 
 新 head の run が `action_required` のまま止まっていないか（＝実発火しているか）を確認する。`action_required` のままなら `RELEASE_KICK_PAT` 未設定などが疑われる。runbook のトラブルシュートへ。
 
-### Step 5. CI green までポーリング
+### Step 6. CI green までポーリング
 
 Monitor ツールは使わず、1つの Bash 呼び出し内で sleep しながらポーリングする。**ポーリング用の変数名に `status` を使わない**（zsh の読み取り専用変数と衝突し代入が失敗する）。
 
@@ -60,27 +85,15 @@ gh pr checks $ARGUMENTS --json name,bucket --jq '.[] | select(.bucket != "skippi
 - 8 回（約 2 分弱）で `pending` が解消しない場合はループを打ち切り、実出力を提示したうえで待機を継続するか判断を仰ぐ
 - `fail` バケットが出た場合は直ちに報告し、原因調査へ切り替える（本コマンドはマージ前提の手順であり、CI 失敗の修正は別タスク）
 
-### Step 6. BEHIND の場合
-
-```bash
-gh api "repos/:owner/:repo/pulls/$ARGUMENTS" --jq '{mergeable_state}'
-```
-
-`behind` なら:
-
-```bash
-gh api "repos/:owner/:repo/pulls/$ARGUMENTS/update-branch" -X PUT
-```
-
-update-branch で CI が再実行されるため Step 5 のポーリングをやり直す。
-
 ### Step 7. マージ
 
-`mergeStateStatus: CLEAN` かつ Step 5 の CI が green になったら:
+`mergeStateStatus: CLEAN` かつ Step 6 の CI が green になったら:
 
 ```bash
 gh pr merge $ARGUMENTS --squash --delete-branch
 ```
+
+ポーリング中に main が進んで再び BEHIND になった場合は、Step 3 の update-branch を実行してから Step 6 のポーリングをやり直す。
 
 ### Step 8. 検証
 
@@ -97,5 +110,5 @@ gh pr merge $ARGUMENTS --squash --delete-branch
 
 ## 参照
 
-- `docs/runbook/release-please-kick.md`（SSoT: BLOCKED の原因、`RELEASE_KICK_PAT` セットアップ、`workflow_dispatch` 代替手順）
+- `docs/runbook/release-please-kick.md`（SSoT: BLOCKED の原因、BEHIND と純 BLOCKED の判定、`RELEASE_KICK_PAT` セットアップ、`workflow_dispatch` 代替手順）
 - CLAUDE.md「`N of N required checks are expected` = bot/GITHUB_TOKEN push」ガード

--- a/docs/development/worker-discipline-template.md
+++ b/docs/development/worker-discipline-template.md
@@ -57,7 +57,7 @@ commitlint の subject-case ルールにより、大文字始まりの subject�
 
 ### Monitor 禁止・sleep 自力ポーリング
 
-ワーカーセッションでの Monitor ツール利用は停止・ハングの原因になることが観測されている。CI やマージ待ちなど時間のかかる確認は、1つの Bash 呼び出し内で `sleep` を挟んだ for ループとして自力ポーリングする。ポーリング変数名に `status` を使うと zsh の読み取り専用変数と衝突し代入が失敗するため、別名（例: `pendingCount` / `ciState`）を使う。詳細: `.claude/commands/release-kick.md` の Step 5 に実装例がある。
+ワーカーセッションでの Monitor ツール利用は停止・ハングの原因になることが観測されている。CI やマージ待ちなど時間のかかる確認は、1つの Bash 呼び出し内で `sleep` を挟んだ for ループとして自力ポーリングする。ポーリング変数名に `status` を使うと zsh の読み取り専用変数と衝突し代入が失敗するため、別名（例: `pendingCount` / `ciState`）を使う。詳細: `.claude/commands/release-kick.md` の Step 6 に実装例がある。
 
 ### 検証は実出力 + exit code
 

--- a/docs/runbook/release-please-kick.md
+++ b/docs/runbook/release-please-kick.md
@@ -6,6 +6,46 @@ The release-please PR is BLOCKED because required status checks were not
 registered on the auto-generated branch (a common consequence of strict
 branch protection on freshly created refs).
 
+## First: diagnose BEHIND vs pure BLOCKED
+
+A release PR can be behind `main` and BLOCKED at the same time, and which one it
+is decides whether the kick is needed at all. `mergeable_state` holds a single
+value, so it cannot tell the two apart. Compare the branches instead:
+
+```bash
+releaseBranch=$(gh pr view <N> --json headRefName --jq .headRefName)
+gh api "repos/:owner/:repo/compare/main...$releaseBranch" --jq '{status, ahead_by, behind_by}'
+```
+
+| `behind_by` | State            | First action                                      | Kick still needed                     |
+| ----------- | ---------------- | ------------------------------------------------- | ------------------------------------- |
+| `> 0`       | BEHIND + BLOCKED | `PUT /repos/:owner/:repo/pulls/<N>/update-branch` | No, once the new head's workflows run |
+| `0`         | pure BLOCKED     | kick (`workflow_dispatch` or the local script)    | Yes                                   |
+
+When `behind_by > 0`, run `update-branch` first. The merge commit it creates is
+pushed with your own account's token, not the bot token. The no-recursion safety
+therefore does not apply, and the workflows fire as a real user push. That makes
+the empty-commit kick unnecessary, saving one commit and one CI round.
+
+When `behind_by == 0`, `update-branch` has nothing to merge and returns HTTP 422.
+The kick is then the only way forward.
+
+Either way, confirm the new head before moving on:
+
+```bash
+gh run list --limit 5 --json databaseId,status,conclusion,headBranch,workflowName
+```
+
+If the runs sit at `action_required`, the push did not count as a real user push.
+Fall back to the kick below.
+
+### Evidence
+
+- **v1.66.1** (PR #1693): BEHIND + BLOCKED. `update-branch` alone fired every
+  workflow, so the empty-commit kick was skipped.
+- **v1.67.0** (PR #1699): `ahead_by: 1, behind_by: 0` right after release-please
+  opened the PR. `update-branch` did not apply, and the kick was the correct move.
+
 ## Setup (one-time): `RELEASE_KICK_PAT` secret
 
 The workflow requires a Personal Access Token to actually unblock downstream CI.
@@ -42,3 +82,10 @@ local checkout, which is useful during `fs-loss` incidents.
 
 See `docs/development/retrospectives/2026-05-21-25.md` (W1+W5). The empty-commit
 pattern is recorded in `AGENT_LEARNINGS.md` (2026-05-24 entry).
+
+## Related
+
+`.claude/commands/release-kick.md` turns this runbook into an end-to-end
+procedure (unblock, merge, verify the release). This runbook stays the SSoT for
+the BLOCKED cause, the BEHIND decision, `RELEASE_KICK_PAT` setup, and the
+`workflow_dispatch` alternative. Fix the command when the two disagree.


### PR DESCRIPTION
# 🌊 River Review Docs Update

## Summary

`/release-kick` の手順に **BEHIND 分岐**を追記します。本日の 2 リリース（v1.66.1 / v1.67.0）で、リリース PR の状態によって「空コミット kick が必要かどうか」が変わることが実証されたため、その判定基準を恒久化します。

分岐条件は `behind_by > 0` かどうかです。現行手順は Step 3（kick）→ Step 6（BEHIND 処理）の順で、実態と逆になっていました。

- Primary phase focus: Midstream（リリース運用手順）

## 実証された 2 ケース

| リリース    | PR                                                          | compare の結果              | 打った手                             | 結果                                                                                                                                            |
| ----------- | ----------------------------------------------------------- | --------------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
| **v1.66.1** | [#1693](https://github.com/s977043/river-review/pull/1693) | BEHIND + BLOCKED の複合状態 | kick より先に `update-branch` を実行 | 自アカウントのトークンによる実ユーザー push として全ワークフローが発火し、**Step 3 の空コミット kick が不要**（空コミット 1 本 + CI 1 周を節約） |
| **v1.67.0** | [#1699](https://github.com/s977043/river-review/pull/1699) | `ahead_by: 1, behind_by: 0` | 従来どおり kick                      | PR 作成直後で main が動いていない純 BLOCKED。`update-branch` は 422 になるため kick が正                                                         |

## 追記する分岐

`mergeable_state` は単一の値しか返さず BEHIND と BLOCKED の複合状態を見分けられないため、compare API の `behind_by` で判定します。

```bash
releaseBranch=$(gh pr view <N> --json headRefName --jq .headRefName)
gh api "repos/:owner/:repo/compare/main...$releaseBranch" --jq '{status, ahead_by, behind_by}'
```

| `behind_by` | 状態             | 最初に打つ手    | 空コミット kick       |
| ----------- | ---------------- | --------------- | --------------------- |
| `> 0`       | BEHIND + BLOCKED | `update-branch` | CI が実発火すれば不要 |
| `0`         | 純 BLOCKED       | kick            | 必要                  |

## Changes

- **`.claude/commands/release-kick.md`**
  - Step 2 を「PR 状態の確認と BEHIND 判定」に拡張し、compare による `behind_by` 確認と分岐表を追加
  - Step 順を実態に合わせて整理: 新 Step 3 = BEHIND の場合の `update-branch`、新 Step 4 = kick（旧 Step 3）。以降 1 つずつ繰り下げ（旧 Step 4/5 → 新 Step 5/6）
  - 旧 Step 6「BEHIND の場合」は新 Step 3 に統合し、重複を解消
  - 旧 Step 6 が担っていた「CI 待ち中に main が進んで BEHIND 化した場合」のケースは Step 7（マージ）の注記として保持
  - 参照セクションの SSoT スコープに「BEHIND と純 BLOCKED の判定」を追加
- **`docs/runbook/release-please-kick.md`**（SSoT）
  - `## First: diagnose BEHIND vs pure BLOCKED` を追加し、判定コマンド・分岐表・根拠・実証 2 ケースを記載
  - `## Related` を追加し、コマンド側との相互参照と「矛盾時は runbook が正」を明示
- **`docs/development/worker-discipline-template.md`**
  - sleep ポーリング実装例への参照を Step 5 → Step 6 に追従（Step 繰り下げによるリンク切れ防止）

### SSoT の扱い

`release-kick.md` は既に「BLOCKED の原因・`RELEASE_KICK_PAT` セットアップ・`workflow_dispatch` 代替手順は runbook が SSoT。矛盾があれば runbook を正とし、本コマンドを修正する」と宣言しています。この既存宣言に従い、**判定基準の本文（根拠・実証ケース）は runbook 側**に置き、コマンド側は実行手順と分岐表 + runbook への参照に留めています。

## Flow Consistency

- [x] Upstream: concepts/architecture remain accurate（概念変更なし）
- [x] Midstream: examples and commands match current runner/skills（compare API のフィールド名 `status` / `ahead_by` / `behind_by` を実コールで確認済み）
- [x] Downstream: validation steps and QA guidance are current
- [ ] Schema Validation passed? (`schemas/skill.schema.json`) — 対象外（skills / schemas 無変更）
- [ ] Skill file structure validated? — 対象外

Language / 言語:

- [x] Japanese（日本語・標準）— `.claude/commands/release-kick.md`
- [x] English（英語）— `docs/runbook/release-please-kick.md`（既存が英語のため踏襲）

## Validation & Evidence

```bash
$ npm run lint
> npm run format:check && npm run check:dashes && npm run lint:code && npm run lint:md && npm run lint:text
All matched files use Prettier code style!
No heading/title dash normalizations needed.
✅ code hygiene OK（duplicate-import / tmp-literal / mkdtemp-cleanup / phantom-dep）
LINT_EXIT=0

$ npm run fix:dashes
No heading/title dash normalizations needed.
```

textlint（`docs/**` と `.claude/**` は `npm run lint:text` のスコープ外のため個別実行）:

```bash
$ npx textlint --no-cache .claude/commands/release-kick.md docs/runbook/release-please-kick.md docs/development/worker-discipline-template.md
✖ 5 problems (5 errors, 0 warnings, 0 infos)
```

この 5 件は**すべて編集前から存在する既存違反**で、本 PR による新規違反は 0 件です（編集前に同じコマンドで baseline を取得し、件数と箇所を照合済み）。内訳:

- `.claude/commands/release-kick.md` 3 件 — prh `GITHUB => GitHub` × 2（`GITHUB_TOKEN` という識別子への誤検出）、冒頭パラグラフの sentence-length 210 字
- `docs/runbook/release-please-kick.md` 2 件 — 既存の英文パラグラフ 2 箇所の sentence-length（188 字 / 165 字）

新規追記分では sentence-length / `no-exclamation-question-mark` の違反が出ないよう文を分割済みです。

compare API のフィールド名は実コールで確認しました:

```bash
$ gh api "repos/s977043/river-review/compare/main...v1.66.1" --jq '{status, ahead_by, behind_by}'
{"ahead_by":0,"behind_by":5,"status":"behind"}
```

## 不変であることを確認した箇所

- 禁止事項リスト（`git push --force` / `git reset --hard` / `gh pr merge --admin` / release PR 内容の編集）— diff に含まれず無変更
- Step 1（gh アカウント確認）/ Step 8（検証）の内容
- Step 6（ポーリング）・Step 7（マージ）のコマンド本体（番号参照のみ更新）
- `src/**` / `schemas/**` — 無変更

## Related Issues

- Related: v1.66.1 (#1693) / v1.67.0 (#1699)

## Follow-ups

- 次回リリース時に新しい Step 順で運用し、Step 2 の compare 判定で実際に kick をスキップできるか再確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)
