### PR TITLE
docs(runbook): release-kick に手順書の鮮度ガードと必須チェック基準のポーリングを追加する

### DIFF
--- a/.claude/commands/release-kick.md
+++ b/.claude/commands/release-kick.md
@@ -1,7 +1,7 @@
 ---
 description: release-please のリリース PR を BLOCKED 解除 → CI green 確認 → マージ → リリース公開検証まで一貫実行する（v1.44.0〜v1.53.0 の11リリースで実証済みの型）
 argument-hint: '<release PR number>'
-allowed-tools: Bash(gh api user:*), Bash(gh auth switch:*), Bash(gh pr view:*), Bash(gh pr checks:*), Bash(gh pr merge:*), Bash(gh api:*), Bash(gh run list:*), Bash(gh release view:*), Bash(git ls-remote:*), Bash(scripts/release-please-kick.sh:*), Bash(bash scripts/release-please-kick.sh:*)
+allowed-tools: Bash(gh api user:*), Bash(gh auth switch:*), Bash(gh pr view:*), Bash(gh pr checks:*), Bash(gh pr merge:*), Bash(gh api:*), Bash(gh run list:*), Bash(gh release view:*), Bash(git ls-remote:*), Bash(git fetch:*), Bash(git diff:*), Bash(scripts/release-please-kick.sh:*), Bash(bash scripts/release-please-kick.sh:*)
 ---
 
 release PR #$ARGUMENTS を、BLOCKED 解除からマージ・リリース公開の検証まで一貫して実行する。
@@ -9,6 +9,17 @@ release PR #$ARGUMENTS を、BLOCKED 解除からマージ・リリース公開�
 release-please が生成するリリース PR の head は `GITHUB_TOKEN` push であるため、通常は `mergeStateStatus: BLOCKED`（"N of N required checks are expected"）になる（CLAUDE.md「`N of N required checks are expected` = bot/GITHUB_TOKEN push」ガード参照）。この BLOCKED の原因・`RELEASE_KICK_PAT` のセットアップ・`workflow_dispatch` 経由の代替手順は `docs/runbook/release-please-kick.md` が SSoT。本コマンドはそれを前提に、実際にマージして公開を確認するまでの実行手順を1コマンド化したもの。矛盾があれば runbook を正とし、本コマンドを修正する。
 
 ## 手順
+
+### Step 0. 手順書の鮮度確認
+
+```bash
+git fetch origin
+git diff --quiet HEAD origin/main -- .claude/commands/release-kick.md docs/runbook/release-please-kick.md || echo "手順書が古い: origin/main 版を読み直すこと"
+```
+
+ローカル main が origin より遅れていると、改訂前の手順書を読んだまま実走することになる。上のメッセージが出たら `git pull` で追いついてから、本コマンドと runbook を読み直す。差分がなければ何も出力されない。
+
+v1.67.1 の実走では、ローカルが 24 コミット遅れていた。その結果、#1702 による改訂前の版を読み込んだまま実走している。#1702 のマージ時刻はキックの 16 分前だった。
 
 ### Step 1. gh アカウント確認
 
@@ -72,18 +83,29 @@ gh run list --limit 5 --json databaseId,status,conclusion,headBranch,workflowNam
 
 Monitor ツールは使わず、1つの Bash 呼び出し内で sleep しながらポーリングする。**ポーリング用の変数名に `status` を使わない**（zsh の読み取り専用変数と衝突し代入が失敗する）。
 
+終了条件は「必須チェックが全件 `pass`」かつ「`fail` バケットが 0 件」の 2 つとする。`pending` の総数を終了条件にしてはならない（理由は下記）。
+
 ```bash
-for i in $(seq 1 8); do
-  pendingCount=$(gh pr checks $ARGUMENTS --json name,bucket --jq '[.[] | select(.bucket=="pending")] | length')
-  echo "iteration $i: pending=$pendingCount"
-  [ "$pendingCount" = "0" ] && break
-  sleep 14
+requiredTotal=$(gh api "repos/:owner/:repo/branches/main/protection/required_status_checks" --jq '.checks | length')
+[ "$requiredTotal" -gt 0 ] 2>/dev/null || { echo "必須チェック数を取得できない。Step 1 の gh アカウント確認へ戻る"; exit 1; }
+for i in $(seq 1 15); do
+  requiredPass=$(gh pr checks $ARGUMENTS --required --json bucket --jq '[.[] | select(.bucket=="pass")] | length')
+  failCount=$(gh pr checks $ARGUMENTS --json bucket --jq '[.[] | select(.bucket=="fail")] | length')
+  echo "iteration $i: requiredPass=$requiredPass/$requiredTotal fail=$failCount"
+  [ "$failCount" != "0" ] && break
+  [ "$requiredPass" = "$requiredTotal" ] && break
+  sleep 15
 done
 gh pr checks $ARGUMENTS --json name,bucket --jq '.[] | select(.bucket != "skipping")'
 ```
 
-- 8 回（約 2 分弱）で `pending` が解消しない場合はループを打ち切り、実出力を提示したうえで待機を継続するか判断を仰ぐ
-- `fail` バケットが出た場合は直ちに報告し、原因調査へ切り替える（本コマンドはマージ前提の手順であり、CI 失敗の修正は別タスク）
+- 母数の `requiredTotal` は branch protection から取る。`gh pr checks --required` の件数を母数にすると、まだ報告されていない必須チェックが母数から抜け落ちるため、早期に green と誤判定する
+- `requiredTotal` の数値ガードは省略しない。branch protection の参照には admin 権限が要るので、gh アカウントが無言で切り替わると 404 になり、`requiredTotal` にエラー JSON が入ってループが空回りする（本手順の検証中に実際に発生した）
+- `pending` の総数は単調減少しない。キック直後はワークフローが順次キューされるので、いったん減ってから増える。v1.67.1 実走の推移は 7→5→4→**9**→8→6→3→2 であり、旧条件（`pending == 0`）は一度も成立せず 8 周の上限に達した
+- `pending` の総数には必須外のコンテキストが多数含まれる。v1.67.1 実走時点の release PR には 24 コンテキストが付き、必須はうち 6 件のみだった（残りは Vercel / Link Check / CodeQL / PlanGate Review など）。必須外の完了はマージ条件ではない
+- 早期 break しない場合、ループは最長で約 4 分半（15 周 × sleep 15 秒 + API 応答）を要する。Bash ツールの timeout に 360000（ミリ秒）以上を指定して実行し、既定の 120000 のまま走らせない
+- 15 回で終了条件を満たさない場合はループを打ち切り、実出力を提示したうえで待機を継続するか判断を仰ぐ。v1.67.1 実走では run 作成 05:36:45Z から最終必須チェック完了 05:39:40Z まで約 3 分を要しており、旧設定の 8 回（約 2 分弱）では足りない
+- `fail` バケットが出たらループを抜け、直ちに報告して原因調査へ切り替える（本コマンドはマージ前提の手順であり、CI 失敗の修正は別タスク）。必須外の `fail` でも一度ループを抜けて報告し、マージ可否は人間が判断する
 
 ### Step 7. マージ
 

--- a/docs/runbook/release-please-kick.md
+++ b/docs/runbook/release-please-kick.md
@@ -6,6 +6,18 @@ The release-please PR is BLOCKED because required status checks were not
 registered on the auto-generated branch (a common consequence of strict
 branch protection on freshly created refs).
 
+## Before you start: confirm the procedure is current
+
+This runbook and `.claude/commands/release-kick.md` are revised often. A local
+`main` that trails `origin` silently hands you a pre-revision copy. Check the
+freshness of the procedure itself before any diagnosis below. Fetch `origin`,
+diff both files against `origin/main`, and re-read them if either differs.
+Step 0 of `.claude/commands/release-kick.md` holds the executable form.
+
+Observed in the v1.67.1 run: the local checkout was 24 commits behind. The
+pre-#1702 revision of the procedure was therefore the one actually read, even
+though #1702 had merged 16 minutes before the kick.
+
 ## First: diagnose BEHIND vs pure BLOCKED
 
 A release PR can be behind `main` and BLOCKED at the same time, and which one it


### PR DESCRIPTION
## 概要

v1.67.1 リリース（PR #1707）の `/release-kick` 実走で顕在化した 3 件の手順不備を、手順書側に反映する。#1702 で追加した BEHIND / 純 BLOCKED 分岐の初回実走から得たフィードバック。

## 実走フィードバックとの対応表

| #   | 実走で起きたこと                                                                                                | 反映内容                                                                                 | 変更ファイル                                                     |
| --- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| 1   | ローカル main が 24 コミット遅れており、#1702 で改訂される前の手順書を読んだまま実走した                        | Step 0「手順書の鮮度確認」を Step 1 の前に追加。`git fetch` + `git diff --quiet` のガード | `.claude/commands/release-kick.md` / `docs/runbook/release-please-kick.md` |
| 2   | Step 6 の終了条件 `pending == 0` が一度も成立せず、既定 8 周の上限に達して打ち切り扱いになった                  | 終了条件を「必須チェック全件 `pass` かつ `fail` 0 件」へ変更。周回数も 15 周へ            | `.claude/commands/release-kick.md`                                 |
| 3   | ループが `pending` しか数えないため、`fail` が出ても 8 周回りきるまで気づけない（直後の記述と不整合）           | ループ内に `fail` 件数の出力と break を追加                                              | `.claude/commands/release-kick.md`                                 |

## Evidence（v1.67.1 実走・PR #1707 の実測）

**1. 手順書の鮮度**

- ローカル main が origin より 24 コミット遅れ、#1702 改訂前の版が Read された
- #1702（`.claude/commands/release-kick.md` ほかを改訂）のマージは `2026-07-31T05:20:04Z`、キックによる新 head の run 作成は `05:36:45Z`。改訂の 16 分後に、改訂前の版で実走していた

**2. `pending` 総数は単調減少しない**

- 実走時の推移: 7 → 5 → 4 → **9** → 8 → 6 → 3 → 2（増加を挟む）
- キック直後にワークフローが順次キューされるため。旧条件 `pending == 0` は一度も成立せず 8 周の上限に到達した
- `pending` 総数には必須外が多数含まれる。PR #1707 のコンテキストは全 24 件、うち branch protection の必須は 6 件のみ

```console
$ gh api "repos/s977043/river-review/branches/main/protection/required_status_checks" --jq '{strict, checks: [.checks[].context]}'
{"checks":["Lint","Unit tests (22.x)","Skill schema validation","Meta consistency","Action dist freshness","Integration (CLI)"],"strict":true}
```

必須外の例: `Vercel` / `Vercel Preview Comments` / `lychee` / `CodeQL` / `vale` / `plugin-scanner` / `river review exec` / `river review plan` / `verify & comment`（PlanGate Review）ほか。

**3. 周回数が足りない**

必須チェックの所要は run 作成 `05:36:45Z` → 最終必須完了 `05:39:40Z` で約 3 分。旧設定の 8 周 × sleep 14 秒（約 2 分弱）では終了条件を満たす前に必ず打ち切られる。

```console
$ gh pr checks 1707 --required --json name,startedAt,completedAt --jq '.[] | "\(.name)\t\(.startedAt)\t\(.completedAt)"'
Skill schema validation	2026-07-31T05:38:10Z	2026-07-31T05:38:52Z
Integration (CLI)	2026-07-31T05:38:10Z	2026-07-31T05:38:51Z
Action dist freshness	2026-07-31T05:38:10Z	2026-07-31T05:38:58Z
Unit tests (22.x)	2026-07-31T05:38:05Z	2026-07-31T05:39:40Z
Meta consistency	2026-07-31T05:38:04Z	2026-07-31T05:38:39Z
Lint	2026-07-31T05:36:48Z	2026-07-31T05:38:02Z
```

## スニペットのドライラン

両スニペットをファイルから逐語抽出し、bash / zsh の両方で実行して確認した。

**Step 0（鮮度ガード）**

```console
$ git diff --quiet HEAD origin/main -- .claude/commands/release-kick.md docs/runbook/release-please-kick.md || echo "手順書が古い: origin/main 版を読み直すこと"
（出力なし・EXIT=0）

$ git diff --quiet HEAD~30 origin/main -- .claude/commands/release-kick.md docs/runbook/release-please-kick.md || echo "手順書が古い: origin/main 版を読み直すこと"
手順書が古い: origin/main 版を読み直すこと
```

**Step 6（ポーリング）** — PR #1707（全 green）に対して実行:

```console
--- bash run ---
iteration 1: requiredPass=6/6 fail=0
...
bash EXIT=0
--- zsh run ---
iteration 1: requiredPass=6/6 fail=0
...
zsh EXIT=0
```

## ドライランで追加で見つかった不具合と対処

検証中に gh のアクティブアカウントが `kominem-unilabo` へ無言で切り替わり（CLAUDE.md の既知ハザード。本作業中に 2 回発生）、branch protection の参照が 404 になった。このとき `requiredTotal` にエラー JSON が入り、ループが終了条件を満たさないまま 15 周空回りした。

```console
gh: Not Found (HTTP 404)
iteration 1: requiredPass=6/{"message":"Not Found",...,"status":"404"} fail=0
（… iteration 15 まで継続）
```

そのため数値ガードを 1 行追加した。bash / zsh 双方で `6` は通過、空文字 / 非数値 / エラー JSON / `0` は発火することを確認済み。

```bash
[ "$requiredTotal" -gt 0 ] 2>/dev/null || { echo "必須チェック数を取得できない。Step 1 の gh アカウント確認へ戻る"; exit 1; }
```

```console
--- bash run（アカウント切替中） ---
gh: Not Found (HTTP 404)
必須チェック数を取得できない。Step 1 の gh アカウント確認へ戻る
bash EXIT=1
--- zsh run（アカウント切替中） ---
必須チェック数を取得できない。Step 1 の gh アカウント確認へ戻る
zsh EXIT=1
```

## 設計上の判断

- **母数は branch protection から取る**: `gh pr checks --required` の件数を母数にすると、まだ報告されていない必須チェックが母数から抜け落ちて早期に green と誤判定する。branch protection 側は常に 6 を返すため fail-safe
- **`fail` は必須外でも break**: 一度ループを抜けて報告し、マージ可否は人間が判断する。「`fail` が出たら直ちに報告」という既存記述との整合を優先した
- **Bash timeout の明記**: 15 周 × sleep 15 秒で最長約 4 分半。Bash ツールの既定 timeout（120000ms）のままでは途中で切れるため、360000 以上を指定するよう注記した
- **runbook 側は「言及」にとどめた**: runbook の SSoT 宣言は BLOCKED の原因 / BEHIND 判定 / `RELEASE_KICK_PAT` / `workflow_dispatch` の 4 点。鮮度ガードはそこに含まれないため、実行形は Step 0 に置き、runbook からは趣旨と実測を記載して Step 0 を参照させる形にした（スニペット二重管理を回避）

## 変更していないもの

- Step 1〜5・Step 7・Step 8 の意味
- 「禁止事項」リスト
- runbook の BEHIND / 純 BLOCKED 判定表と Evidence セクション

## 検証

| コマンド                                                                          | 結果                                                             |
| --------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| `npm run lint`                                                                    | EXIT=0（format:check / check:dashes / lint:code / lint:md / lint:text すべて pass） |
| `npm run fix:dashes`                                                              | EXIT=0（`No heading/title dash normalizations needed.`）         |
| `npx textlint --no-cache .claude/commands/release-kick.md docs/runbook/release-please-kick.md` | 5 errors — HEAD 時点のベースラインと同一。新規違反 0 件           |

textlint の 5 件は変更前から存在する既存違反（`.claude/commands/**` と `docs/**` は `lint:text` の対象外。対象は `pages/**/*.md`）。HEAD 版を別ディレクトリに展開して同じ設定で実行し、件数・ルール・該当行が一致することを確認した。

Node は `.nvmrc` の 22.22.2（`/opt/homebrew/opt/node@22/bin`）で実行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
