### PR TITLE
test(cli): usage error の exit code 78 ケースを canary テーブルで固定する

### DIFF
--- a/tests/cli-usage-error-exit-codes.test.mjs
+++ b/tests/cli-usage-error-exit-codes.test.mjs
@@ -1,0 +1,664 @@
+// tests/cli-usage-error-exit-codes.test.mjs
+//
+// #1709 Slice 1 — オプションエラーの exit code を「現状のまま」機械固定する canary。
+//
+// ============================================================================
+// ★ この表は「望ましい姿」ではない。2026-08-02 時点の実態の pin である。
+// ============================================================================
+//
+// #1709 は「オプションエラーの exit code がコマンドごとにバラバラで、多くが
+// exit 0 のまま成功扱いになる」という問題を扱う。実測すると、現状は「exit 0 か
+// 1 か」ではなく 4 つの契約に分裂している（11 コマンド面 × 5 エラー種別 = 78
+// ケース、うち 57 件 = 73% が exit 0）。本ファイルはその 78 ケースをそのまま
+// 期待値として固定する。
+//
+// したがって **ここに書かれた期待値の大半は、修正されるべき挙動である**。
+// #1709 の後続スライスで期待値は意図的に書き換わる:
+//
+//   - Slice 2: C2（34 件）を exit 1 + stderr 要約へ
+//   - Slice 3: C1（23 件）を exit 1 へ
+//
+// canary の役割は「正しさの主張」ではなく「変更の全量可視化」にある。
+// 後続スライスでは *この表の差分 = 挙動変更の全量* という不変条件を保つこと。
+// 期待値を書き換えるときは、必ず EXPECTED_CONTRACT_COUNTS も併せて更新する。
+//
+// ---------------------------------------------------------------------------
+// #1721 直後の一時的な後退を pin していることに注意
+// ---------------------------------------------------------------------------
+// #1721（feedback add のオプション値を parse 時に検証する）が本 canary の作成中に
+// main へ入り、下の 3 セルが動いた。いずれも「entry を書かない・stderr にエラーを
+// 出す」方向では改善だが、**exit code の観点では C2（exit 0 + help）に寄った**:
+//
+//   - `feedback add --type`（値欠落）              C3 exit 1 -> C2 exit 0
+//   - `feedback add ... --pr`（値欠落）            C1 exit 0 -> C2 exit 0
+//   - `feedback add ... --pr abc`（不正値）        C1 exit 0 -> C2 exit 0
+//
+// つまり 1 件は exit 1 -> exit 0 の後退である。#1709 Slice 2 で C2 を一括 exit 1 に
+// する際、この 3 セルもまとめて exit 1 に戻る想定。ここで pin しているのは
+// 「#1721 直後の過渡状態」であって、到達点ではない。
+//
+// なお #1721 が塞いだ入力パターンのうち、この 78 ケースに現れるのは上記 3 件で、
+// 残り（`--skill` 欠落 / `--trigger --pr` / `--fingerprint --pr` / `--fingerprint ""`）は
+// 本マトリクスの 5 エラー種別の組み合わせ外なので tests/cli-parse-args.test.mjs 側で
+// 担保されている。
+//
+// 観測された 4 契約（`contract` フィールドの値）:
+//
+//   | クラス | exit | help 全文が stdout | 内容                                       |
+//   | ------ | ---- | ------------------ | ------------------------------------------ |
+//   | C1     | 0    | no                 | メッセージすら出ず黙って無視。処理は続行   |
+//   | C2     | 0    | yes                | help 全文を stdout、エラーを stderr へ     |
+//   | C3     | 1    | no                 | stderr にエラー（#1652/#1682/#1696 の規約）|
+//   | C4     | 3    | no                 | stderr にエラー（review 系のハンドラ検出） |
+//
+// 判定は (exit code, help 全文が stdout に出たか) の 2 軸だけで機械的に行う。
+// stderr の文言は S2 で全面的に書き換わる前提なので、あえて固定しない。
+//
+// 実行環境（決定論のための前提）:
+//   隔離した一時 git repo を cwd にする。`skills/` と
+//   `tests/fixtures/review-eval/cases.json` を置くのは、それらが無いと
+//   `skills list` / `eval` が ENOENT で偶発的に exit 1 になり、usage error の
+//   契約ではなく環境の欠落を pin してしまうため（実測で 5 セルが動いた）。
+//   この 2 つを用意した状態が、実 repo で観測される契約と一致する。
+//
+// 実装コスト: 81 回の CLI 起動を before フックで 1 回だけ掃引し、各 test は
+// その結果を参照するだけにしてある（in-process 実行で全掃引 ~2.5 秒）。
+
+import assert from 'node:assert/strict';
+import { join } from 'node:path';
+import test, { after, before, describe } from 'node:test';
+
+import { runCliInProcess } from './helpers/cli.mjs';
+import { createTempGitRepo } from './helpers/temp-repo.mjs';
+
+const HELP_MARKER = 'Usage: river <command> <path> [options]';
+
+/** 観測された 4 契約。canary はこの 2 軸だけを判定する。 */
+const CONTRACTS = {
+  C1: { exit: 0, helpOnStdout: false, label: 'exit 0 / silently ignored' },
+  C2: { exit: 0, helpOnStdout: true, label: 'exit 0 / full help on stdout' },
+  C3: { exit: 1, helpOnStdout: false, label: 'exit 1 / error on stderr' },
+  C4: { exit: 3, helpOnStdout: false, label: 'exit 3 / error on stderr' },
+};
+
+/**
+ * 契約ごとの件数。表を編集したら必ずここも更新する
+ * （= 挙動変更の総量をレビューで一目で見えるようにするための第 2 の錠）。
+ */
+const EXPECTED_CONTRACT_COUNTS = { C1: 23, C2: 34, C3: 19, C4: 2 };
+
+/** 一時 repo 配下の「存在しないパス」に実行時に差し替えるプレースホルダ。 */
+const NONEXISTENT_PATH = '<nonexistent-path>';
+
+/**
+ * 78 ケースの canary テーブル。
+ * kind は #1709 のエラー種別 5 分類:
+ *   value-missing / invalid-value / unknown-option / unknown-subcommand / surplus-positional
+ */
+const CASES = [
+  // ---- river run ----
+  { surface: 'run', kind: 'value-missing', argv: ['run', '.', '--base'], contract: 'C2' },
+  { surface: 'run', kind: 'value-missing', argv: ['run', '.', '--max-cost'], contract: 'C2' },
+  { surface: 'run', kind: 'value-missing', argv: ['run', '.', '--from'], contract: 'C1' },
+  { surface: 'run', kind: 'invalid-value', argv: ['run', '.', '--depth', 'bogus'], contract: 'C2' },
+  {
+    surface: 'run',
+    kind: 'invalid-value',
+    argv: ['run', '.', '--output', 'bogus'],
+    contract: 'C2',
+  },
+  { surface: 'run', kind: 'invalid-value', argv: ['run', '.', '--max-cost', '-1'], contract: 'C2' },
+  { surface: 'run', kind: 'unknown-option', argv: ['run', '.', '--nope'], contract: 'C1' },
+  { surface: 'run', kind: 'unknown-option', argv: ['run', '.', '--dry-runn'], contract: 'C1' },
+  { surface: 'run', kind: 'surplus-positional', argv: ['run', '.', 'extra'], contract: 'C1' },
+
+  // ---- river review plan ----
+  {
+    surface: 'review plan',
+    kind: 'value-missing',
+    argv: ['review', 'plan', '--plan-only', '--output-file'],
+    contract: 'C2',
+  },
+  {
+    surface: 'review plan',
+    kind: 'value-missing',
+    argv: ['review', 'plan', '--plan-only', '--artifacts-dir'],
+    contract: 'C2',
+  },
+  {
+    surface: 'review plan',
+    kind: 'invalid-value',
+    argv: ['review', 'plan', '--plan-only', '--output', 'bogus'],
+    contract: 'C2',
+  },
+  {
+    // 共有パーサではなくハンドラ層（review-plan.mjs）が検出する唯一の C4 値。
+    surface: 'review plan',
+    kind: 'invalid-value',
+    argv: ['review', 'plan', '--plan-only', '--output', 'html'],
+    contract: 'C4',
+  },
+  {
+    surface: 'review plan',
+    kind: 'unknown-option',
+    argv: ['review', 'plan', '--plan-only', '--nope'],
+    contract: 'C1',
+  },
+  {
+    surface: 'review plan',
+    kind: 'surplus-positional',
+    argv: ['review', 'plan', '.', 'extra', '--plan-only'],
+    contract: 'C1',
+  },
+
+  // ---- river review exec ----
+  {
+    surface: 'review exec',
+    kind: 'value-missing',
+    argv: ['review', 'exec', '--dry-run', '--output-file'],
+    contract: 'C2',
+  },
+  {
+    surface: 'review exec',
+    kind: 'invalid-value',
+    argv: ['review', 'exec', '--dry-run', '--output', 'bogus'],
+    contract: 'C2',
+  },
+  {
+    surface: 'review exec',
+    kind: 'unknown-option',
+    argv: ['review', 'exec', '--dry-run', '--nope'],
+    contract: 'C1',
+  },
+  {
+    surface: 'review exec',
+    kind: 'surplus-positional',
+    argv: ['review', 'exec', '.', 'extra', '--dry-run'],
+    contract: 'C1',
+  },
+
+  // ---- river review route ----
+  {
+    surface: 'review route',
+    kind: 'value-missing',
+    argv: ['review', 'route', '--format'],
+    contract: 'C2',
+  },
+  {
+    surface: 'review route',
+    kind: 'invalid-value',
+    argv: ['review', 'route', '--format', 'bogus'],
+    contract: 'C2',
+  },
+  {
+    surface: 'review route',
+    kind: 'unknown-option',
+    argv: ['review', 'route', '--nope'],
+    contract: 'C1',
+  },
+  {
+    surface: 'review route',
+    kind: 'unknown-subcommand',
+    argv: ['review', 'bogus'],
+    contract: 'C4',
+  },
+  {
+    surface: 'review route',
+    kind: 'surplus-positional',
+    argv: ['review', 'route', '.', 'extra'],
+    contract: 'C1',
+  },
+
+  // ---- river skills ----
+  {
+    surface: 'skills',
+    kind: 'value-missing',
+    argv: ['skills', 'list', '--source'],
+    contract: 'C2',
+  },
+  {
+    surface: 'skills',
+    kind: 'value-missing',
+    argv: ['skills', 'import', '--from'],
+    contract: 'C1',
+  },
+  {
+    surface: 'skills',
+    kind: 'value-missing',
+    argv: ['skills', 'resolve', '--path'],
+    contract: 'C3',
+  },
+  {
+    surface: 'skills',
+    kind: 'invalid-value',
+    argv: ['skills', 'list', '--source', 'bogus'],
+    contract: 'C2',
+  },
+  { surface: 'skills', kind: 'unknown-option', argv: ['skills', 'list', '--nope'], contract: 'C1' },
+  {
+    // `bogus` はサブコマンドではなく対象 path として飲まれ、"Not a git repository"
+    // で exit 1 になる。usage error として返しているわけではない（#1709 未決 7）。
+    surface: 'skills',
+    kind: 'unknown-subcommand',
+    argv: ['skills', 'bogus'],
+    contract: 'C3',
+  },
+  {
+    surface: 'skills',
+    kind: 'surplus-positional',
+    argv: ['skills', 'list', 'extra'],
+    contract: 'C1',
+  },
+
+  // ---- river runs ----
+  { surface: 'runs', kind: 'value-missing', argv: ['runs', 'list', '--output'], contract: 'C2' },
+  {
+    surface: 'runs',
+    kind: 'invalid-value',
+    argv: ['runs', 'list', '--output', 'bogus'],
+    contract: 'C2',
+  },
+  { surface: 'runs', kind: 'unknown-option', argv: ['runs', 'list', '--nope'], contract: 'C1' },
+  { surface: 'runs', kind: 'unknown-subcommand', argv: ['runs', 'bogus'], contract: 'C3' },
+  { surface: 'runs', kind: 'surplus-positional', argv: ['runs', 'list', 'extra'], contract: 'C1' },
+
+  // ---- river feedback ----
+  // 同一コマンド・同一エラー種別の中で 2 契約に割れている面。#1709 が「世代間の
+  // 非対称」として書いた問題が、実際にはコマンド内部の非対称でもあることの実例。
+  {
+    // #1721 で exit 1 -> exit 0 に後退したセル（検証が parse 層に前倒しされ、
+    // 下流 buildFeedbackEntry の exit 1 ではなく help フォールバックに乗った）。
+    // Slice 2 で exit 1 に戻す対象。
+    surface: 'feedback',
+    kind: 'value-missing',
+    argv: ['feedback', 'add', '--type'],
+    contract: 'C2',
+  },
+  {
+    surface: 'feedback',
+    kind: 'value-missing',
+    argv: ['feedback', 'add', '--type', 'false_positive', '--skill', 's', '--run-id'],
+    contract: 'C2',
+  },
+  {
+    surface: 'feedback',
+    kind: 'value-missing',
+    argv: ['feedback', 'add', '--type', 'false_positive', '--skill', 's', '--reviewer'],
+    contract: 'C2',
+  },
+  {
+    // #1709 調査時点では C1（無言 + entry 書き込み、--pr が null に落ちる = B2）。
+    // #1721 が parse 層で弾くようになり、entry は書かれず C2 に移動した。
+    // exit code は依然 0 のままなので Slice 2 の対象。
+    surface: 'feedback',
+    kind: 'value-missing',
+    argv: ['feedback', 'add', '--type', 'false_positive', '--skill', 's', '--pr'],
+    contract: 'C2',
+  },
+  {
+    surface: 'feedback',
+    kind: 'invalid-value',
+    argv: ['feedback', 'add', '--type', 'bogus', '--skill', 's'],
+    contract: 'C3',
+  },
+  {
+    surface: 'feedback',
+    kind: 'invalid-value',
+    argv: ['feedback', 'add', '--type', 'false_positive', '--skill', 's', '--run-id', '   '],
+    contract: 'C2',
+  },
+  {
+    // 同じく B2。#1721 前は --pr abc が黙って捨てられ entry が書き込まれていた。
+    // #1721 で entry 書き込みは止まったが exit code は 0 のまま（C1 -> C2）。
+    surface: 'feedback',
+    kind: 'invalid-value',
+    argv: ['feedback', 'add', '--type', 'false_positive', '--skill', 's', '--pr', 'abc'],
+    contract: 'C2',
+  },
+  {
+    surface: 'feedback',
+    kind: 'unknown-option',
+    argv: ['feedback', 'add', '--type', 'false_positive', '--skill', 's', '--nope'],
+    contract: 'C1',
+  },
+  {
+    surface: 'feedback',
+    kind: 'unknown-subcommand',
+    argv: ['feedback', 'bogus'],
+    contract: 'C3',
+  },
+  {
+    surface: 'feedback',
+    kind: 'surplus-positional',
+    argv: ['feedback', 'add', 'extra', '--type', 'false_positive', '--skill', 's'],
+    contract: 'C1',
+  },
+
+  // ---- river promote ----
+  {
+    surface: 'promote',
+    kind: 'value-missing',
+    argv: ['promote', 'propose', '--input'],
+    contract: 'C2',
+  },
+  {
+    surface: 'promote',
+    kind: 'value-missing',
+    argv: ['promote', 'propose', '--cluster-key'],
+    contract: 'C2',
+  },
+  {
+    surface: 'promote',
+    kind: 'value-missing',
+    argv: ['promote', 'approve', 'id1', '--approver'],
+    contract: 'C2',
+  },
+  {
+    surface: 'promote',
+    kind: 'invalid-value',
+    argv: ['promote', 'retire', '--threshold', '0'],
+    contract: 'C2',
+  },
+  {
+    surface: 'promote',
+    kind: 'invalid-value',
+    argv: ['promote', 'list', '--output', 'bogus'],
+    contract: 'C2',
+  },
+  {
+    // #1709 Slice 1 で明示的に追加が求められていた promoteUnknownOption のケース。
+    surface: 'promote',
+    kind: 'unknown-option',
+    argv: ['promote', 'list', '--nope'],
+    contract: 'C3',
+  },
+  { surface: 'promote', kind: 'unknown-subcommand', argv: ['promote', 'bogus'], contract: 'C3' },
+  {
+    surface: 'promote',
+    kind: 'surplus-positional',
+    argv: ['promote', 'list', 'extra'],
+    contract: 'C1',
+  },
+
+  // ---- river evolve ----
+  {
+    surface: 'evolve',
+    kind: 'value-missing',
+    argv: ['evolve', 'aggregate', '--min'],
+    contract: 'C2',
+  },
+  {
+    surface: 'evolve',
+    kind: 'value-missing',
+    argv: ['evolve', 'replay', '--spec'],
+    contract: 'C2',
+  },
+  {
+    surface: 'evolve',
+    kind: 'value-missing',
+    argv: ['evolve', 'aggregate', '--month'],
+    contract: 'C2',
+  },
+  {
+    surface: 'evolve',
+    kind: 'invalid-value',
+    argv: ['evolve', 'aggregate', '--min', '0'],
+    contract: 'C2',
+  },
+  {
+    surface: 'evolve',
+    kind: 'invalid-value',
+    argv: ['evolve', 'aggregate', '--month', '2026-13-01'],
+    contract: 'C2',
+  },
+  {
+    surface: 'evolve',
+    kind: 'invalid-value',
+    argv: ['evolve', 'aggregate', '--output', 'yaml'],
+    contract: 'C3',
+  },
+  {
+    surface: 'evolve',
+    kind: 'unknown-option',
+    argv: ['evolve', 'aggregate', '--nope'],
+    contract: 'C3',
+  },
+  { surface: 'evolve', kind: 'unknown-subcommand', argv: ['evolve', 'agregate'], contract: 'C3' },
+  {
+    surface: 'evolve',
+    kind: 'surplus-positional',
+    argv: ['evolve', 'aggregate', '.', 'extra'],
+    contract: 'C3',
+  },
+
+  // ---- river suppression ----
+  // 5 種別すべてが C3 になる唯一の面。ただし必須オプション検証がハンドラ層に
+  // 寄っている副産物であって、未知オプション自体を検出しているわけではない
+  // （`suppression add --nope` の stderr は "--fingerprint is required"）。
+  {
+    surface: 'suppression',
+    kind: 'value-missing',
+    argv: ['suppression', 'add', '--fingerprint'],
+    contract: 'C3',
+  },
+  {
+    surface: 'suppression',
+    kind: 'value-missing',
+    argv: ['suppression', 'add', '--feedback'],
+    contract: 'C3',
+  },
+  {
+    surface: 'suppression',
+    kind: 'invalid-value',
+    argv: ['suppression', 'add', '--fingerprint', 'fp', '--feedback', 'bogus', '--rationale', 'r'],
+    contract: 'C3',
+  },
+  {
+    surface: 'suppression',
+    kind: 'invalid-value',
+    argv: [
+      'suppression',
+      'add',
+      '--fingerprint',
+      'fp',
+      '--feedback',
+      'false_positive',
+      '--rationale',
+      'r',
+      '--scope',
+      'bogus',
+    ],
+    contract: 'C3',
+  },
+  {
+    surface: 'suppression',
+    kind: 'unknown-option',
+    argv: ['suppression', 'add', '--nope'],
+    contract: 'C3',
+  },
+  {
+    surface: 'suppression',
+    kind: 'unknown-subcommand',
+    argv: ['suppression', 'bogus'],
+    contract: 'C3',
+  },
+  {
+    surface: 'suppression',
+    kind: 'surplus-positional',
+    argv: ['suppression', 'add', 'extra'],
+    contract: 'C3',
+  },
+
+  // ---- river doctor ----
+  { surface: 'doctor', kind: 'value-missing', argv: ['doctor', '.', '--output'], contract: 'C2' },
+  {
+    surface: 'doctor',
+    kind: 'invalid-value',
+    argv: ['doctor', '.', '--output', 'bogus'],
+    contract: 'C2',
+  },
+  { surface: 'doctor', kind: 'unknown-option', argv: ['doctor', '.', '--nope'], contract: 'C1' },
+  { surface: 'doctor', kind: 'surplus-positional', argv: ['doctor', '.', 'extra'], contract: 'C1' },
+
+  // ---- river eval ----
+  {
+    // 値欠落が既定 fixture への黙ったフォールバックになり PASS を出す。調査の B3。
+    surface: 'eval',
+    kind: 'value-missing',
+    argv: ['eval', '--cases'],
+    contract: 'C1',
+  },
+  {
+    surface: 'eval',
+    kind: 'invalid-value',
+    argv: ['eval', '--cases', NONEXISTENT_PATH],
+    contract: 'C3',
+  },
+  { surface: 'eval', kind: 'unknown-option', argv: ['eval', '--nope'], contract: 'C1' },
+  { surface: 'eval', kind: 'surplus-positional', argv: ['eval', 'extra'], contract: 'C1' },
+];
+
+/**
+ * 対照群。usage error ではないが、同じ 2 軸で挙動が決まるため一緒に固定する。
+ * `--help` の exit 0 + stdout は .github/workflows/test.yml の `--help > /dev/null`
+ * ガードが依存する不変条件で、S2/S3 でも変えてはならない。
+ * 一方 `river bogus` の C2 は、`Unknown command:` 分岐（src/cli.mjs）が到達不能な
+ * dead code であることの症状（調査の B1）で、S2 で是正される想定。
+ */
+const CONTROL_CASES = [
+  { surface: '(control)', kind: 'help-flag', argv: ['--help'], contract: 'C2', invariant: true },
+  { surface: '(control)', kind: 'no-args', argv: [], contract: 'C2', invariant: true },
+  {
+    surface: '(control)',
+    kind: 'unknown-command',
+    argv: ['bogus'],
+    contract: 'C2',
+    invariant: false,
+  },
+];
+
+const caseKey = (c) => `${c.surface}|${c.kind}|${c.argv.join(' ')}`;
+const caseTitle = (c) =>
+  `${c.surface} / ${c.kind} / \`river ${c.argv.join(' ')}\` -> ${c.contract} (${CONTRACTS[c.contract].label})`;
+
+describe('#1709 canary: CLI usage-error exit codes (pinned to CURRENT behavior)', () => {
+  /** @type {Map<string, { code: number, helpOnStdout: boolean }>} */
+  const observed = new Map();
+  /** @type {(() => Promise<void>) | null} */
+  let cleanupRepo = null;
+
+  before(async () => {
+    const { dir, cleanup } = await createTempGitRepo({
+      prefix: 'river-usage-exit-',
+      initialFiles: {
+        'a.txt': 'a\n',
+        // `skills list` が ENOENT にならないための最小構成（上のヘッダー参照）。
+        'skills/.gitkeep': '',
+        // `eval` の既定 cases パス。空配列なら評価対象 0 件で正常終了する。
+        'tests/fixtures/review-eval/cases.json': '[]\n',
+      },
+      changedFiles: { 'a.txt': 'a\nb\n' },
+    });
+    cleanupRepo = cleanup;
+
+    const nonexistent = join(dir, 'no-such-cases.json');
+    for (const testCase of [...CASES, ...CONTROL_CASES]) {
+      const argv = testCase.argv.map((arg) => (arg === NONEXISTENT_PATH ? nonexistent : arg));
+      // runCliInProcess は process.env / process.cwd をプロセス全体で差し替えるため、
+      // Promise.all で並行実行してはならない（tests/helpers/README.md 参照）。
+      const result = await runCliInProcess(argv, {
+        cwd: dir,
+        env: {
+          RIVER_OFFLINE: '1',
+          ANTHROPIC_API_KEY: '',
+          OPENAI_API_KEY: '',
+          NO_COLOR: '1',
+          RIVER_PHASE: undefined,
+          RIVER_PLANNER_MODE: undefined,
+        },
+      });
+      observed.set(caseKey(testCase), {
+        code: result.code,
+        helpOnStdout: result.stdout.includes(HELP_MARKER),
+      });
+    }
+  });
+
+  after(async () => {
+    if (cleanupRepo) await cleanupRepo();
+  });
+
+  // ---------------------------------------------------------------------------
+  // テーブルそのものの健全性（転記ミス・重複の検出）
+  // ---------------------------------------------------------------------------
+
+  test('the matrix pins 78 usage-error cases and every row is unique', () => {
+    assert.equal(CASES.length, 78, '#1709 の実測マトリクスは 78 ケース');
+    const keys = new Set(CASES.map(caseKey));
+    assert.equal(keys.size, CASES.length, '同一 (surface, kind, argv) の行が重複している');
+    for (const testCase of CASES) {
+      assert.ok(
+        CONTRACTS[testCase.contract],
+        `unknown contract class: ${testCase.contract} (${testCase.argv.join(' ')})`
+      );
+      assert.ok(
+        [
+          'value-missing',
+          'invalid-value',
+          'unknown-option',
+          'unknown-subcommand',
+          'surplus-positional',
+        ].includes(testCase.kind),
+        `unknown error kind: ${testCase.kind}`
+      );
+    }
+  });
+
+  test('the contract distribution is C1:23 / C2:34 / C3:19 / C4:2 (57 of 78 exit 0)', () => {
+    const counts = { C1: 0, C2: 0, C3: 0, C4: 0 };
+    for (const testCase of CASES) counts[testCase.contract] += 1;
+    assert.deepEqual(
+      counts,
+      EXPECTED_CONTRACT_COUNTS,
+      '契約ごとの件数が変わった。挙動変更の総量として意図したものか確認し、この期待値も更新すること'
+    );
+    const exitZero = counts.C1 + counts.C2;
+    assert.equal(exitZero, 57, 'usage error のうち exit 0 で成功扱いになる件数');
+  });
+
+  // ---------------------------------------------------------------------------
+  // 78 ケースの本体
+  // ---------------------------------------------------------------------------
+
+  for (const testCase of CASES) {
+    test(caseTitle(testCase), () => {
+      const got = observed.get(caseKey(testCase));
+      assert.ok(got, `before フックが結果を記録していない: ${caseKey(testCase)}`);
+      const want = CONTRACTS[testCase.contract];
+      assert.equal(
+        got.code,
+        want.exit,
+        `exit code が ${testCase.contract} の期待 (${want.exit}) と違う`
+      );
+      assert.equal(
+        got.helpOnStdout,
+        want.helpOnStdout,
+        `help 全文が stdout に出たか（${testCase.contract} の期待: ${want.helpOnStdout}）`
+      );
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // 対照群
+  // ---------------------------------------------------------------------------
+
+  for (const testCase of CONTROL_CASES) {
+    test(caseTitle(testCase), () => {
+      const got = observed.get(caseKey(testCase));
+      assert.ok(got, `before フックが結果を記録していない: ${caseKey(testCase)}`);
+      const want = CONTRACTS[testCase.contract];
+      assert.equal(got.code, want.exit);
+      assert.equal(got.helpOnStdout, want.helpOnStdout);
+    });
+  }
+});

--- a/tests/cli-usage-error-exit-codes.test.mjs
+++ b/tests/cli-usage-error-exit-codes.test.mjs
@@ -132,7 +132,11 @@ const CASES = [
     contract: 'C2',
   },
   {
-    // 共有パーサではなくハンドラ層（review-plan.mjs）が検出する唯一の C4 値。
+    // C4 は本表に 2 件ある。こちらは共有パーサではなくハンドラ層
+    // （src/lib/review-plan.mjs の resolveReviewOutputFormat）が検出するもの。
+    // もう 1 件は下の `review route` / unknown-subcommand（`river review bogus`）で、
+    // そちらは src/cli/commands/review.mjs のサブコマンド dispatch が検出しており、
+    // 検出箇所が異なる。
     surface: 'review plan',
     kind: 'invalid-value',
     argv: ['review', 'plan', '--plan-only', '--output', 'html'],
@@ -197,6 +201,9 @@ const CASES = [
     contract: 'C1',
   },
   {
+    // C4 の 2 件目。src/cli/commands/review.mjs のサブコマンド dispatch が返す。
+    // 1 件目は上の `review plan` / invalid-value（`--output html`）で、そちらは
+    // src/lib/review-plan.mjs が検出する。
     surface: 'review route',
     kind: 'unknown-subcommand',
     argv: ['review', 'bogus'],
@@ -537,7 +544,9 @@ const CONTROL_CASES = [
   },
 ];
 
-const caseKey = (c) => `${c.surface}|${c.kind}|${c.argv.join(' ')}`;
+// argv 要素には空白のみの値（`--run-id "   "`）が含まれるため、区切り文字連結だと
+// 別ケースと衝突しうる。JSON 表現なら文字列配列に対して単射なので一意性が保たれる。
+const caseKey = (c) => `${c.surface}|${c.kind}|${JSON.stringify(c.argv)}`;
 const caseTitle = (c) =>
   `${c.surface} / ${c.kind} / \`river ${c.argv.join(' ')}\` -> ${c.contract} (${CONTRACTS[c.contract].label})`;
 


### PR DESCRIPTION
Refs #1709（Slice 1: 現状固定の canary テーブル。挙動変更なし）

## 何をしたか

`tests/cli-usage-error-exit-codes.test.mjs` を新設し、**11 コマンド面 × 5 エラー種別 = 78 ケース**の現行 exit code を table-driven canary で機械固定しました。

- **`src/**` は無変更**（テストのみの PR）
- exit code / help の出力先 / エラーメッセージは**一切変えていません**
- 目的は「正しさの主張」ではなく、Slice 2 / Slice 3 で**期待値の差分＝挙動変更の全量**という不変条件を成立させること

## 現行契約の分布（実測・head 397c19d0 / base 26ad58c9）

現状は「exit 0 か 1 か」ではなく **4 契約に分裂**しており、**78 件中 57 件（73%）が exit 0** で成功扱いになります。

| クラス | exit | help 全文が stdout | 件数   | 内容                                     |
| ------ | ---- | ------------------ | ------ | ---------------------------------------- |
| C1     | 0    | no                 | **23** | メッセージすら出ず黙って無視。処理は続行 |
| C2     | 0    | yes                | **34** | help 全文を stdout、エラーを stderr へ   |
| C3     | 1    | no                 | **19** | stderr にエラー                          |
| C4     | 3    | no                 | **2**  | stderr にエラー（review 系ハンドラ検出） |

コマンド面別（`0h` = exit 0 + help 全文 stdout / `0` = exit 0 + 無言 / `-` = 該当なし）:

| コマンド       | 値欠落           | 不正値      | 未知オプション | 未知サブコマンド | 余剰 positional |
| -------------- | ---------------- | ----------- | -------------- | ---------------- | --------------- |
| `run`          | `0h` / `0`       | `0h`        | `0`            | -                | `0`             |
| `review plan`  | `0h`             | `0h` / `3`  | `0`            | -                | `0`             |
| `review exec`  | `0h`             | `0h`        | `0`            | -                | `0`             |
| `review route` | `0h`             | `0h`        | `0`            | `3`              | `0`             |
| `skills`       | `0h` / `0` / `1` | `0h`        | `0`            | `1`              | `0`             |
| `runs`         | `0h`             | `0h`        | `0`            | `1`              | `0`             |
| `feedback`     | `0h`             | `1` / `0h`  | `0`            | `1`              | `0`             |
| `promote`      | `0h`             | `0h`        | `1`            | `1`              | `0`             |
| `evolve`       | `0h`             | `0h` / `1`  | `1`            | `1`              | `1`             |
| `suppression`  | `1`              | `1`         | `1`            | `1`              | `1`             |
| `doctor`       | `0h`             | `0h`        | `0`            | -                | `0`             |
| `eval`         | `0`              | `1`         | `0`            | -                | `0`             |

## 調査時点 → 現在の変化（必ず読んでください）

#1709 の設計調査は **v1.67.1（`e8150b4c`）** 時点の実測でした。本 PR は **base `26ad58c9`（#1721 マージ直後）で 78 ケースを全数実測し直して**います。

### 変化したセル: 3 件（すべて #1721 由来）

**#1721（`fix(cli): feedback add のオプション値を parse 時に検証する`）** が本 canary の作成中に main へ入り、次の 3 セルが動きました。

| コマンド面 | エラー種別    | argv                                                    | 調査時点 (v1.67.1) | 現在 (26ad58c9) | 評価                             |
| ---------- | ------------- | ------------------------------------------------------- | ------------------ | --------------- | -------------------------------- |
| `feedback` | value-missing | `feedback add --type`                                   | **C3 / exit 1**    | **C2 / exit 0** | **exit code は後退**（1 → 0）    |
| `feedback` | value-missing | `feedback add --type false_positive --skill s --pr`     | C1 / exit 0        | **C2 / exit 0** | 改善（entry 非書き込み・stderr） |
| `feedback` | invalid-value | `feedback add --type false_positive --skill s --pr abc` | C1 / exit 0        | **C2 / exit 0** | 改善（entry 非書き込み・stderr） |

- 3 件とも **`$?` は 0**。1 件目は検証が parse 層に前倒しされた結果、下流 `buildFeedbackEntry` の exit 1 ではなく help フォールバック（C2）に乗ったため **exit 1 → exit 0 の後退**です。Slice 2 で C2 を一括 exit 1 にする際に戻ります。
- 2 件目・3 件目は設計調査で **B2（`--pr` の値落ち書き込み＝データ完全性バグ）** として挙げていたものです。実測で確認: #1721 前は 1 掃引あたり 4 件の entry が `"pr":null` で書き込まれていたのが、**#1721 後は 2 件に減少**しました（残る 2 件は `--nope` と余剰 positional で、Slice 3 の対象）。
- #1721 が塞いだ入力パターンのうち本マトリクスの 5 エラー種別に現れるのは上記 3 件のみです。残り（`--skill` 欠落 / `--trigger --pr` / `--fingerprint --pr` / `--fingerprint ""`）は組み合わせ外で、`tests/cli-parse-args.test.mjs` 側（#1721 で追加）が担保しています。

### 契約分布の変化

| クラス | 調査時点 (v1.67.1) | 現在 (26ad58c9) | 差分   |
| ------ | ------------------ | --------------- | ------ |
| C1     | 25                 | **23**          | **-2** |
| C2     | 31                 | **34**          | **+3** |
| C3     | 20                 | **19**          | **-1** |
| C4     | 2                  | 2               | 0      |
| exit 0 | 56 / 78 (72%)      | **57 / 78 (73%)** | **+1** |

### 変化しなかったセル: 75 件

`run` / `review plan|exec|route` / `skills` / `runs` / `promote` / `evolve` / `suppression` / `doctor` / `eval` の全セルは調査時点と同一でした。設計調査が言及していた #1710 / #1711 / #1716 / #1718 は、いずれもこの 78 ケースの exit code を動かしていません（#1711 が `skills` に追加した `--output` 検証は、本マトリクスが `--source` セルを測っているため非該当）。

> **これが canary の存在価値です。** 設計調査からわずか 2 日で 3 セルが動き、うち 1 件は exit code の後退でした。以後は同種の移動が必ず差分として見えます。

## 設計上の判断

### 判定軸は 2 つだけ

`(exit code, help 全文が stdout に出たか)` のみで機械判定します。stderr の文言は Slice 2 で全面的に書き換わる前提なので**あえて固定しません**（固定すると Slice 2 の diff が本質と無関係な文言差で埋まる）。

### 契約クラスをコメントではなく data で持つ

各ケースは `contract: 'C1'|'C2'|'C3'|'C4'` を持ち、`CONTRACTS` テーブルが契約 → `(exit, helpOnStdout)` を定義します。期待値はそこから導出されるため、**契約分類が機械検証されます**（コメント併記だと実態とずれても誰も気づかない）。加えて `EXPECTED_CONTRACT_COUNTS` で件数分布も固定してあり、行を書き換えたのに件数を更新しないと落ちます。

### 実行環境を hermetic にしつつ、契約を歪めない

隔離した一時 git repo を cwd にしますが、そこに `skills/` と `tests/fixtures/review-eval/cases.json`（空配列）を置いています。

理由: これらが無いと `skills list --nope` / `skills list extra` / `eval --cases` / `eval --nope` / `eval extra` の **5 セルが ENOENT で偶発的に exit 1** になり、**usage error の契約ではなく環境の欠落を pin** してしまいます。実測で確認済み（素の一時 repo と fixture 入り一時 repo で、この 5 セルだけが `1` ↔ `0` に動く）。fixture を置いた状態が実 repo で観測される契約と一致します。

`eval --cases <存在しないパス>` は POSIX 絶対パスのハードコードを避け、一時 repo 配下のパスに実行時差し替えしています。

### 対照群 3 件

`--help` / 引数なし / `river bogus` を別枠で固定しています。

- `--help` の exit 0 + stdout は `.github/workflows/test.yml` の `--help > /dev/null` ガードが依存する不変条件で、Slice 2/3 でも変えてはならないもの
- `river bogus` が exit 0 + help になるのは、`Unknown command:` 分岐が到達不能な dead code であることの症状（設計調査の B1）。Slice 2 で是正される想定

## 実行時間の増分

**CI と同じ単一プロセス実行**（`node --experimental-test-isolation=none --test`、`.github/workflows/test.yml` の Unit tests job と同一）で測定:

| 条件            | 実行時間   | テスト数 |
| --------------- | ---------- | -------- |
| base（canary 無し） | **59.31s** | 2722     |
| 本 PR（canary 有り） | **60.71s** | 2805     |
| **増分**        | **+1.40s（+2.4%）** | +83      |

canary ファイル単体: **2.61s**（`node --test tests/cli-usage-error-exit-codes.test.mjs`）。

CI は単一プロセス実行なのでファイル並列化の恩恵が無く、増分はそのまま加算されます。それでも +1.4s に収まっているのは、**81 回の CLI 起動を `before` フックで 1 回だけ掃引し、各 test は結果を参照するだけ**にしているためです（`runCliInProcess` による in-process 実行。子プロセス起動だと同じ掃引が 27 秒かかることを実測済み）。

## 検証

すべて Node v22.22.2（`.nvmrc` 準拠）で実行。

| コマンド                                            | 結果                             |
| --------------------------------------------------- | -------------------------------- |
| `npm ci`                                            | exit 0                           |
| `node --test tests/cli-usage-error-exit-codes.test.mjs` | exit 0 — **83 pass / 0 fail**    |
| `node --experimental-test-isolation=none --test`（CI 同等） | exit 0 — **2805 pass / 0 fail**  |
| `npm run lint`                                      | exit 0（prettier / dashes / code-hygiene / markdownlint / textlint すべて green） |

決定論の確認: 同一の一時 repo に対して掃引を 2 回連続実行し、81 ケースすべてで exit code / help 出力先が一致することを確認しました（`feedback add` が entry を書き足した後でも結果が変わらない）。

## Slice 1 の境界（やっていないこと）

- exit code の変更・help 出力先の変更・エラーメッセージの変更は**一切していません**
- `src/**` は読むだけで**未編集**
- `src/cli/usage.mjs`（設計調査の S1 に含まれていた `usageError()` ヘルパ）は**本 PR に含めていません**。挙動を変えないヘルパを先に置いても Slice 2 まで未使用のままになるため、Slice 2 で実際に使う PR に寄せる方が差分が読みやすいと判断しました
- `src/cli.mjs` / `src/lib/paired-replay.mjs` は並行作業中のため触れていません

## レビューで見てほしい点

1. **期待値が「現状の pin」であって「あるべき姿」ではない**ことが、ファイル冒頭のコメントで十分伝わるか
2. 一時 repo に `skills/` と `cases.json` を置く判断（環境依存の 5 セルを契約どおりに測るため）が妥当か
3. `feedback add --type` の **exit 1 → exit 0 後退**を、Slice 2 まで pin したまま置く判断でよいか（先に単独修正する選択肢もある）
4. CI 実行時間 +1.40s を許容できるか

🤖 Generated with [Claude Code](https://claude.com/claude-code)
