### PR TITLE
feat(scripts): .github/workflows/README.md のワークフロー一覧を doc-enum spec に登録する

### DIFF
--- a/docs/development/doc-enumeration-checks.md
+++ b/docs/development/doc-enumeration-checks.md
@@ -64,14 +64,17 @@ grep -cxF -f /tmp/rr-undef.txt /tmp/rr-refs.txt # 分子: 6
 
 ## 何を検証しているか
 
-登録内容は `scripts/check-doc-enumerations.mjs` の `DOC_ENUMERATION_SPECS` が SSoT です。初期スコープは、誤検出でメイン開発を止めないことを優先し、決定論で判定できる 4 件に絞ってあります。
+登録内容は `scripts/check-doc-enumerations.mjs` の `DOC_ENUMERATION_SPECS` が SSoT です。初期スコープ（#1726）は、誤検出でメイン開発を止めないことを優先し、決定論で判定できる 4 件に絞ってあります。#1728 で `.github/workflows/README.md` のワークフロー一覧（`workflows-readme-table`）を追加しました。
 
-| spec id                      | 対象ドキュメント             | 宣言側                              | 実体                                    |
-| ---------------------------- | ---------------------------- | ----------------------------------- | --------------------------------------- |
-| `skills-stream-counts`       | `docs/skills-structure.md`   | ツリー図の `# <n> スキル` コメント  | `skills/<stream>/` の実ディレクトリ数   |
-| `distributed-commands-table` | `commands/README.md`         | コマンド表の `File` 列              | `commands/*.md`（`README.md` を除く）   |
-| `repo-dev-commands-table`    | `.claude/commands/README.md` | コマンド表の `File` 列              | `.claude/commands/*.md`（同上）         |
-| `claude-md-command-table`    | `CLAUDE.md`                  | `Custom Commands` 表の `Command` 列 | 上記 2 ディレクトリのコマンド名の和集合 |
+| spec id                      | 対象ドキュメント              | 宣言側                              | 実体                                           |
+| ---------------------------- | ----------------------------- | ----------------------------------- | ---------------------------------------------- |
+| `skills-stream-counts`       | `docs/skills-structure.md`    | ツリー図の `# <n> スキル` コメント  | `skills/<stream>/` の実ディレクトリ数          |
+| `distributed-commands-table` | `commands/README.md`          | コマンド表の `File` 列              | `commands/*.md`（`README.md` を除く）          |
+| `repo-dev-commands-table`    | `.claude/commands/README.md`  | コマンド表の `File` 列              | `.claude/commands/*.md`（同上）                |
+| `claude-md-command-table`    | `CLAUDE.md`                   | `Custom Commands` 表の `Command` 列 | 上記 2 ディレクトリのコマンド名の和集合        |
+| `workflows-readme-table`     | `.github/workflows/README.md` | ワークフロー一覧表の `ファイル` 列  | `.github/workflows/` 直下の `*.yml` / `*.yaml` |
+
+`workflows-readme-table` は `kind: 'names'` だけを登録しています。README には「27 本」という本数の記述もありますが、names 比較は過不足の両方向を検出して件数の主張を包含するため、`kind: 'counts'` の spec は重ねて登録しません（「1 本消して 1 本足す」は counts では素通りします）。ワークフロー名・トリガー・目的・必須チェック該否の列は機械検証の対象外で、人手のままです（必須チェックの SSoT は branch protection API であり、CI からネットワークを叩かないため対象外とします）。
 
 既存チェックとの重複は避けています。`CLAUDE.md` の「Details: distributed commands (...)」という散文は、すでに機械検証の対象です。担当は `scripts/validate-plugin-manifest.mjs` の `checkClaudeMdCommandParity` であり、`.claude-plugin/plugin.json` の `commands[]` と突き合わせます。本 script が受け持つのは `Custom Commands` の**表**であって、散文ではありません。
 

--- a/scripts/check-doc-enumerations.mjs
+++ b/scripts/check-doc-enumerations.mjs
@@ -143,6 +143,14 @@ async function listCommandFiles(relDir) {
   return files.filter((file) => file !== 'README.md');
 }
 
+/** repo-relative なディレクトリ直下の workflow ファイル名（*.yml / *.yaml）を返す。 */
+async function listWorkflowFiles(relDir) {
+  const entries = await fs.readdir(path.join(ROOT, relDir), { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && /\.ya?ml$/.test(entry.name))
+    .map((entry) => entry.name);
+}
+
 /**
  * 宣言的な spec テーブル。ドキュメントの列挙・件数と実体の対応をここに 1 行で登録する。
  *
@@ -215,6 +223,21 @@ export const DOC_ENUMERATION_SPECS = [
       const repoDev = await listCommandFiles('.claude/commands');
       return new Set([...distributed, ...repoDev].map((file) => `/${file.replace(/\.md$/, '')}`));
     },
+  },
+  {
+    // #1725 で新設した workflow 入口 README（#1728 で登録）。README は本数（27 本）も
+    // 書いているが、counts は「1 本消して 1 本足す」を素通りさせるため names だけを
+    // 登録する。counts の spec を重ねて足さないこと。
+    id: 'workflows-readme-table',
+    doc: '.github/workflows/README.md',
+    summary: 'ワークフロー一覧表のファイル列',
+    marker: '`ファイル | ワークフロー名 | ...` 表',
+    kind: 'names',
+    declare: (text) => {
+      const column = parseMarkdownTableColumn(text, 'ファイル');
+      return column && new Set(column.map(unwrapCodeSpan));
+    },
+    measure: async () => new Set(await listWorkflowFiles('.github/workflows')),
   },
 ];
 

--- a/tests/check-doc-enumerations.test.mjs
+++ b/tests/check-doc-enumerations.test.mjs
@@ -497,6 +497,40 @@ test('claude-md-command-table spec fails when a real row is removed from CLAUDE.
   assert.match(errors[0], /実体に "\/merge-check" があるが .* に載っていない/);
 });
 
+test('workflows-readme-table spec fails when a real row is removed from .github/workflows/README.md', async () => {
+  const spec = realSpec('workflows-readme-table');
+  const realText = await readRepoFile('.github/workflows/README.md');
+  const mutated = realText.replace(/^\|\s*`test\.yml`.*\r?\n/m, '');
+  assert.notEqual(mutated, realText, 'fixture precondition: the `test.yml` row must exist');
+
+  const { errors, checked } = await checkDocEnumerations({
+    specs: [spec],
+    readDoc: async () => mutated,
+  });
+  assert.equal(checked, 1);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /実体に "test\.yml" があるが .* に載っていない/);
+});
+
+test('workflows-readme-table spec fails when a phantom row is added to .github/workflows/README.md', async () => {
+  const spec = realSpec('workflows-readme-table');
+  const realText = await readRepoFile('.github/workflows/README.md');
+  // 「1 本消して 1 本足す」の「足す」側。実体の無い行が表に残ると落ちることを確かめる。
+  const mutated = realText.replace(
+    /^(\|\s*`test\.yml`.*\r?\n)/m,
+    '| `phantom-workflow.yml` | Phantom | - | - | - |\n$1'
+  );
+  assert.notEqual(mutated, realText, 'fixture precondition: the `test.yml` row must exist');
+
+  const { errors, checked } = await checkDocEnumerations({
+    specs: [spec],
+    readDoc: async () => mutated,
+  });
+  assert.equal(checked, 1);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /"phantom-workflow\.yml" を挙げているが実体に存在しない/);
+});
+
 test('skills-stream-counts spec fails when a real count is altered in docs/skills-structure.md', async () => {
   const spec = realSpec('skills-stream-counts');
   const realText = await readRepoFile('docs/skills-structure.md');


### PR DESCRIPTION
## 概要

Closes #1728

`.github/workflows/README.md` のワークフロー一覧表（`ファイル` 列）を `scripts/check-doc-enumerations.mjs` の `DOC_ENUMERATION_SPECS` に `workflows-readme-table`（`kind: 'names'`）として登録し、実在する `.github/workflows/` 直下の workflow ファイル名集合と双方向で突合するようにした。

## Before / After

| 観点 | Before | After |
| --- | --- | --- |
| README の一覧の検証 | 人手のみ（#1725 新設時点で正しいが、追加・削除で静かに陳腐化する） | `Meta consistency`（必須チェック）で機械検証。README に無い workflow・実体の無い README 行の両方向を検出 |
| 宣言側マーカー消失 | - | `ファイル` 列ヘッダの表が見つからなければ fail（silent skip なし。既存エンジンの `declared === null` エラー経路） |
| spec 一覧ドキュメント | 4 spec | `docs/development/doc-enumeration-checks.md` の表に 5 件目として追記 |

## 実装内容

- `scripts/check-doc-enumerations.mjs`
  - `listWorkflowFiles()` を追加（`.github/workflows/` 直下の `*.yml` / `*.yaml` ファイルを列挙。既存の `listDirectories` / `listCommandFiles` と同じ `fs.readdir` パターン）
  - `workflows-readme-table` spec を追加。`declare` は既存 SSoT の `parseMarkdownTableColumn` + `unwrapCodeSpan` を再利用（再実装なし）
- `docs/development/doc-enumeration-checks.md`
  - 「何を検証しているか」表に `workflows-readme-table` の行を追記
  - counts spec を重ねて登録しない理由（names が件数の主張を包含し、「1 本消して 1 本足す」も検出する）を明記
- `tests/check-doc-enumerations.test.mjs`
  - 実 README から `test.yml` の行を消すと落ちるテスト（欠落方向）
  - 実 README に実体の無い行を足すと落ちるテスト（幽霊行方向）
  - 既存の「登録済み spec を実 doc の改変版に当てる」パターンに準拠（自己整合テスト回避）

## 非目標

- `kind: 'counts'` spec の追加（Issue #1728 の指示どおり、names 比較を採用したため重複登録しない。散文の「27 本」表記は引き続き人手）
- ワークフロー名（`name:` 行）・トリガー・目的列の突合
- 必須チェック 6 件と branch protection API の突合（ネットワークが要るため CI では叩かない。Issue でスコープ外と明記済み）
- `.github/workflows/**` 自体の変更

## 検証結果（実出力）

- `npm run check:doc-enum` → `Doc enumerations: OK (5 spec(s) checked, 0 ignored)`（exit 0）
- `node --test tests/check-doc-enumerations.test.mjs` → `# tests 32 / # pass 32 / # fail 0`（新規 2 テスト含む）
- `npm run meta:validate` → `Meta consistency: OK` / `Doc enumerations: OK (5 spec(s) checked, 0 ignored)`（exit 0）
- `npm run lint` → exit 0（format:check / check:dashes / lint:code / lint:md / lint:text すべて pass）
- `npx textlint --no-cache docs/development/doc-enumeration-checks.md` → 違反なし
- `npm run fix:dashes` → `No heading/title dash normalizations needed.`
- Node 22.22.2（`.nvmrc` 準拠）で `npm ci` 後に実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)
