### PR TITLE
feat(hooks): force 系の破壊的 git コマンドを PreToolUse フックで阻止する

### DIFF
--- a/.claude/commands/plan-merge-order.md
+++ b/.claude/commands/plan-merge-order.md
@@ -141,4 +141,5 @@ done
 - 「順序は適当で大丈夫」と断定してはならない
 - `gh pr list` / `gh pr view` の GraphQL 結果のみで state を信頼してはならない (必ず `gh api repos/.../pulls/{N}` で裏取り)
 - strict mode 環境で N 本 PR を「1 本ずつ更新して CI を待つ」ことで済ませない（N 倍の CI 待ちが発生する）
-- push 済みブランチを rebase して force push（`--force-with-lease` / `--force-if-includes` を含む）で上書きしてはならない（AGENTS.md Safety。取り込みは update-branch か `git merge`）
+- push 済みブランチを rebase して force push（`--force` / `-f` / `--force-with-lease`）で上書きしてはならない（AGENTS.md Safety。取り込みは update-branch か `git merge`）
+  - `--force-if-includes` は force フラグではない。`--force-with-lease` の検査を強める安全側の修飾子である。単体では push の挙動を変えない。`git help push` に「If the option is passed without specifying `--force-with-lease` ... it is a "no-op".」とある。AGENTS.md Safety の禁止列挙にも含まれない

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -29,6 +29,19 @@ Argument order does not matter: `git push --force origin x` and
 `git push origin x --force` are both blocked, as are `git -C /repo push --force`
 and compound commands (`… && git push --force …`).
 
+### Scope
+
+This hook only sees an agent's `Bash` tool calls. It never runs on GitHub
+Actions, so it does not touch `.github/workflows/release-please.yml`'s
+force-update of the moving major tag — AGENTS.md § Safety scopes that
+exemption to the workflow, and the same command typed by an agent stays
+blocked. That is the SSoT's intent, not a gap.
+
+`--force-if-includes` is not blocked. Per `git help push`, "If the option is
+passed without specifying `--force-with-lease` … it is a 'no-op'." It tightens
+`--force-with-lease` rather than forcing on its own, and the combination that
+does force is caught by the `--force-with-lease` rule.
+
 ### How it works
 
 1. Reads the PreToolUse stdin JSON and extracts `.tool_input.command`.

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -1,5 +1,72 @@
 # Claude Hooks
 
+## no-force-push.sh
+
+PreToolUse hook (matcher: `Bash`) that blocks destructive git commands.
+
+### Purpose
+
+AGENTS.md § Safety bans commands that rewrite already-pushed branch history
+(`git push --force` / `-f` / `--force-with-lease`) or discard work
+(`git reset --hard`, `git stash drop`). That ban is prose in four places
+(AGENTS.md Safety, CLAUDE.md, `docs/development/worker-discipline-template.md`,
+and the commands) and still slipped through once each in #1656 and #1720.
+This hook makes it deterministic.
+
+`permissions.deny` was not used: its prefix matching lets
+`git push origin branch --force` through, while a hook sees the whole command
+string and is argument-order independent.
+
+### What it blocks
+
+| Blocked                                                         | Not blocked                                                                                 |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `git push` with `--force` / `-f` / `--force-with-lease[=<ref>]` | `git fetch --tags --force`, `git fetch -f` (used by `.github/workflows/release-please.yml`) |
+| `git reset --hard`                                              | `git tag -f` (tag retarget; out of the AGENTS.md scope)                                     |
+| `git stash drop`, `git stash clear`                             | `git clean`, `git checkout -- <path>`, `git restore` (prose discipline only, per #1730)     |
+
+Argument order does not matter: `git push --force origin x` and
+`git push origin x --force` are both blocked, as are `git -C /repo push --force`
+and compound commands (`… && git push --force …`).
+
+### How it works
+
+1. Reads the PreToolUse stdin JSON and extracts `.tool_input.command`.
+2. Fast-path exit 0 for anything that cannot be a destructive git command.
+3. Sanitizes the command string before matching: heredoc bodies are dropped,
+   line continuations are joined, and quoted segments are replaced by a space.
+   So `grep -rn -- "--force-with-lease" .` and
+   `echo "do not use git push --force"` stay allowed — a false positive would
+   stall documentation work on this repo. A quoted segment that is itself only
+   a force flag (`git push "--force"`) is kept.
+4. Matches POSIX ERE patterns scoped to a single command segment
+   (`[^;&|]*`), so `git push origin x && git fetch --tags --force` passes.
+5. On a match, exits 2 with a stderr message naming the blocked command, the
+   non-destructive alternative (`git merge` / `git merge --ff-only` then a
+   fast-forward push), the source (AGENTS.md Safety), and the instruction to
+   escalate rather than work around the hook.
+
+Ambiguous input is allowed: a false positive stalls all development, a miss
+costs one incident.
+
+### Known limitation
+
+Quoted text is treated as data, so an interpreter form such as
+`bash -c "git push --force"` is not detected. The hook is defense-in-depth;
+AGENTS.md § Safety remains the SSoT for the ban.
+
+### Setup
+
+```bash
+chmod +x .claude/hooks/no-force-push.sh
+```
+
+### Tests
+
+`tests/no-force-push-hook.test.mjs` spawns the script with real PreToolUse JSON
+payloads on stdin and asserts the exit code for every blocked and allowed
+command: `node --test tests/no-force-push-hook.test.mjs`
+
 ## gh-account-guard.sh
 
 PreToolUse hook (matcher: `Bash`) that verifies the active `gh` CLI account

--- a/.claude/hooks/no-force-push.sh
+++ b/.claude/hooks/no-force-push.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# PreToolUse hook (matcher: Bash): block destructive git commands deterministically.
+#
+# Background: AGENTS.md Safety bans commands that rewrite already-pushed branch
+# history (`git push --force` / `-f` / `--force-with-lease`) or discard work
+# (`git reset --hard`, `git stash drop`). That ban is stated in prose in four
+# places (AGENTS.md Safety, CLAUDE.md, docs/development/worker-discipline-template.md,
+# and the commands) yet still slipped through once each in #1656 and #1720.
+# This hook makes the prose deterministic. `permissions.deny` was not used
+# because its prefix matching lets `git push origin branch --force` through —
+# a hook sees the whole command string and is argument-order independent.
+#
+# Contract (PreToolUse):
+#   stdin  : JSON payload; the Bash tool command is .tool_input.command
+#   exit 0 : allow the tool call to proceed
+#   exit 2 : block the tool call; stderr is fed back to Claude
+#
+# Behavior:
+#   - Commands that cannot contain a git invocation: exit 0 immediately.
+#   - The command string is sanitized before matching: heredoc bodies are
+#     dropped, line continuations are joined, and quoted segments are replaced
+#     by a space (so `grep -rn -- "--force-with-lease" .` and
+#     `echo "do not use git push --force"` stay allowed). A quoted segment that
+#     is itself only a force flag (`git push "--force"`) is kept.
+#   - Blocked: `git push` with --force / -f / --force-with-lease (any argument
+#     order, `--force-with-lease=<ref>` included), `git reset --hard`,
+#     `git stash drop`, `git stash clear`.
+#   - Explicitly NOT blocked (non-destructive or out of the AGENTS.md scope):
+#     `git fetch --tags --force` / `git fetch -f` (used by
+#     .github/workflows/release-please.yml), `git tag -f`, `git clean`,
+#     `git checkout -- <path>`, `git restore`. Ambiguous input is allowed:
+#     a false positive stalls all development, a miss costs one incident.
+#
+# Known limitation: quoted text is treated as data, so an interpreter form such
+# as `bash -c "git push --force"` is not detected. The hook is defense-in-depth;
+# AGENTS.md Safety remains the SSoT for the ban.
+set -u
+
+# --- Extract the Bash command from the stdin JSON payload -------------------
+if [ -t 0 ]; then
+  # No hook payload (manual invocation without stdin): nothing to check.
+  exit 0
+fi
+HOOK_INPUT="$(cat 2>/dev/null || true)"
+if [ -z "$HOOK_INPUT" ] || ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+COMMAND="$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)"
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# --- Fast path: skip anything that cannot be a destructive git command ------
+case "$COMMAND" in
+  *git*) ;;
+  *) exit 0 ;;
+esac
+case "$COMMAND" in
+  *force* | *--hard* | *stash* | *-f*) ;;
+  *) exit 0 ;;
+esac
+if ! command -v awk >/dev/null 2>&1; then
+  # No sanitizer available: allow rather than risk blocking on a raw match.
+  exit 0
+fi
+
+# --- Sanitize: drop heredoc bodies, join line continuations -----------------
+SQ="'"
+# shellcheck disable=SC2016  # awk program: $0 must not be expanded by the shell
+STRIP_HEREDOC='
+BEGIN { delim = ""; buf = "" }
+{
+  if (delim != "") {
+    t = $0
+    sub(/^[[:space:]]+/, "", t)
+    sub(/[[:space:]]+$/, "", t)
+    if (t == delim) { delim = "" }
+    next
+  }
+  line = $0
+  if (match(line, /(^|[^<])<<-?[[:space:]]*[^[:space:];&|<>]+/)) {
+    d = substr(line, RSTART, RLENGTH)
+    sub(/^[^<]?<<-?[[:space:]]*/, "", d)
+    gsub(/"/, "", d)
+    gsub(Q, "", d)
+    if (d != "") { delim = d }
+  }
+  buf = buf line
+  if (buf ~ /\\$/) { sub(/\\$/, " ", buf); next }
+  print buf
+  buf = ""
+}
+END { if (buf != "") { print buf } }
+'
+
+# --- Sanitize: replace quoted segments with a space -------------------------
+# A segment whose content is itself a force flag is kept, so that
+# `git push "--force"` is still caught while `echo "... --force"` is not.
+# shellcheck disable=SC2016  # awk program: $0 must not be expanded by the shell
+STRIP_QUOTES='
+function flagish(s,   t) {
+  t = s
+  sub(/^[[:space:]]+/, "", t)
+  if (t ~ /^(-f|--force|--force-with-lease)([[:space:]=]|$)/) { return " " t " " }
+  return " "
+}
+BEGIN { st = 0; seg = "" }
+{
+  line = $0
+  out = ""
+  i = 1
+  n = length(line)
+  while (i <= n) {
+    c = substr(line, i, 1)
+    if (st == 0) {
+      if (c == "\\") { out = out " "; i += 2; continue }
+      if (c == Q) { st = 1; seg = ""; i++; continue }
+      if (c == "\"") { st = 2; seg = ""; i++; continue }
+      out = out c
+      i++
+      continue
+    }
+    if (st == 1) {
+      if (c == Q) { st = 0; out = out flagish(seg); i++; continue }
+      seg = seg c
+      i++
+      continue
+    }
+    if (c == "\\") { seg = seg substr(line, i + 1, 1); i += 2; continue }
+    if (c == "\"") { st = 0; out = out flagish(seg); i++; continue }
+    seg = seg c
+    i++
+  }
+  if (st != 0) { seg = seg " " }
+  print out
+}
+'
+
+SANITIZED="$(
+  printf '%s\n' "$COMMAND" |
+    awk -v Q="$SQ" "$STRIP_HEREDOC" |
+    awk -v Q="$SQ" "$STRIP_QUOTES"
+)"
+
+# --- Destructive-command detection ------------------------------------------
+# G = a `git` word start: beginning of string or a shell separator, then `git`
+# followed by whitespace and any number of global options — with an inline
+# value (`--git-dir=x`) or a separate value token (`-C /repo`) — before the
+# subcommand. `[^;&|]*` keeps each match inside one command segment, so
+# `git push origin x && git fetch --tags --force` does not match.
+# Uses POSIX ERE only (portable across BSD/GNU grep).
+GIT_OPT='(-[^[:space:]]+([[:space:]]+[^-[:space:]][^[:space:]]*)?[[:space:]]+)*'
+G="(^|[;&|([:space:]])git[[:space:]]+${GIT_OPT}"
+FORCE_FLAG='(--force|--force-with-lease|-[[:alnum:]]*f[[:alnum:]]*)([[:space:]=]|$)'
+BLOCK_RE="${G}push([[:space:]]+[^;&|]*)?[[:space:]]+${FORCE_FLAG}"
+BLOCK_RE="${BLOCK_RE}|${G}reset([[:space:]]+[^;&|]*)?[[:space:]]+--hard([[:space:]=]|\$)"
+BLOCK_RE="${BLOCK_RE}|${G}stash[[:space:]]+(drop|clear)([[:space:]]|\$)"
+
+if ! printf '%s' "$SANITIZED" | grep -qE "$BLOCK_RE"; then
+  exit 0
+fi
+
+EXCERPT="$(printf '%s' "$COMMAND" | tr '\n' ' ' | cut -c1-200)"
+cat >&2 <<EOF
+[no-force-push] BLOCKED: destructive git command.
+  command: ${EXCERPT}
+  AGENTS.md Safety bans rewriting already-pushed branch history
+  (git push --force / -f / --force-with-lease) and discarding work
+  (git reset --hard, git stash drop). --force-with-lease is not an exception.
+  Instead: take the remote in with 'git merge origin/<branch>' or
+  'git merge --ff-only origin/<branch>', then push a fast-forward.
+  If history still looks like it must be rewritten, do not work around this
+  hook — stop and escalate to the organizer / human.
+EOF
+exit 2

--- a/.claude/hooks/no-force-push.sh
+++ b/.claude/hooks/no-force-push.sh
@@ -166,7 +166,8 @@ cat >&2 <<EOF
   command: ${EXCERPT}
   AGENTS.md Safety bans rewriting already-pushed branch history
   (git push --force / -f / --force-with-lease) and discarding work
-  (git reset --hard, git stash drop). --force-with-lease is not an exception.
+  (git reset --hard, git stash drop, git stash clear).
+  --force-with-lease is not an exception.
   Instead: take the remote in with 'git merge origin/<branch>' or
   'git merge --ff-only origin/<branch>', then push a fast-forward.
   If history still looks like it must be rewritten, do not work around this

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -54,6 +54,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": ".claude/hooks/no-force-push.sh"
+          },
+          {
+            "type": "command",
             "command": ".claude/hooks/gh-account-guard.sh"
           }
         ]

--- a/tests/no-force-push-hook.test.mjs
+++ b/tests/no-force-push-hook.test.mjs
@@ -41,6 +41,9 @@ const BLOCKED = [
   'git push origin feat/x --force-with-lease',
   'git push --force-with-lease=refs/heads/feat/x origin feat/x',
   'git push -fu origin feat/x',
+  // --force-if-includes が実際に force を成立させるのは --force-with-lease と
+  // 併用したときだけで、その組み合わせは lease 側で捕捉される。
+  'git push --force-with-lease --force-if-includes origin feat/x',
   // git のグローバルオプション経由
   'git -C /repo push --force origin feat/x',
   'git --git-dir=/repo/.git push origin feat/x --force',
@@ -71,6 +74,11 @@ const ALLOWED = [
   'git push --set-upstream origin feat/x',
   'git push --follow-tags origin main',
   'git push origin HEAD',
+  // 単体の --force-if-includes は force ではない。git help push:
+  // 「If the option is passed without specifying --force-with-lease, ... it is a "no-op".」
+  // force が成立する --force-with-lease との併用は BLOCKED 側で捕捉している。
+  'git push --force-if-includes origin feat/x',
+  'git push --no-force-with-lease origin feat/x',
   // fetch の --force は破壊操作ではない（release-please.yml が実際に使う）
   'git fetch --tags --force',
   'git fetch -f',
@@ -139,6 +147,19 @@ test('block message names the command, the alternative, and the source', () => {
   assert.match(r.stderr, /AGENTS\.md Safety/);
   assert.match(r.stderr, /merge --ff-only/);
   assert.match(r.stderr, /escalate/);
+});
+
+test('block message enumerates every blocked family', () => {
+  const stderr = runHook('git push --force origin feat/x').stderr;
+  for (const family of [
+    'git push --force',
+    '--force-with-lease',
+    'git reset --hard',
+    'git stash drop',
+    'git stash clear',
+  ]) {
+    assert.ok(stderr.includes(family), `message should name ${family}`);
+  }
 });
 
 test('passing commands produce no stderr noise', () => {

--- a/tests/no-force-push-hook.test.mjs
+++ b/tests/no-force-push-hook.test.mjs
@@ -51,9 +51,11 @@ const BLOCKED = [
   'git stash drop',
   'git stash drop stash@{0}',
   'git stash clear',
-  // 複合コマンドの後段に紛れているケース
+  // 複合コマンドの後段や制御構文の中に紛れているケース
   'git add -A && git commit -m "wip" && git push --force origin feat/x',
   'npm test; git reset --hard origin/main',
+  'if [ -n "$CI" ]; then git push --force origin feat/x; fi',
+  'git   push   origin   feat/x   --force',
   // 引用符で囲まれた force フラグ単体は「データ」ではなく引数
   'git push "--force" origin feat/x',
   // 行継続・複数行
@@ -81,6 +83,12 @@ const ALLOWED = [
   'git checkout -- src/foo.mjs',
   'git restore src/foo.mjs',
   'git restore --staged src/foo.mjs',
+  // 禁止対象の「隣」にあるが AGENTS.md Safety の対象外のもの。
+  // 将来パターンを広げすぎたときの回帰検知として固定する。
+  'git checkout -f main',
+  'git branch -f tmp origin/main',
+  'git rebase origin/main',
+  'git commit --amend --no-edit',
   // reset の非 --hard 形
   'git reset HEAD~1',
   'git reset --soft HEAD~1',

--- a/tests/no-force-push-hook.test.mjs
+++ b/tests/no-force-push-hook.test.mjs
@@ -1,0 +1,147 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// .claude/hooks/no-force-push.sh (PreToolUse hook) を実プロセス実行で検証する。
+// 本物の PreToolUse ペイロードを stdin に流し、exit code だけで判定する
+// （内部ロジックのモック呼び出しはしない）。
+// exit 0 = 通過 / exit 2 = ブロック。
+const HOOK = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '.claude',
+  'hooks',
+  'no-force-push.sh'
+);
+
+function runHook(command) {
+  const res = spawnSync('bash', [HOOK], {
+    input: JSON.stringify({
+      session_id: 'test',
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_input: { command },
+    }),
+    encoding: 'utf8',
+  });
+  return { status: res.status, stderr: res.stderr };
+}
+
+// --- ブロックすべきコマンド ------------------------------------------------
+const BLOCKED = [
+  // force push: 引数順に依存しないこと
+  'git push --force',
+  'git push --force origin feat/x',
+  'git push origin feat/x --force',
+  'git push -f origin feat/x',
+  'git push origin feat/x -f',
+  'git push --force-with-lease origin feat/x',
+  'git push origin feat/x --force-with-lease',
+  'git push --force-with-lease=refs/heads/feat/x origin feat/x',
+  'git push -fu origin feat/x',
+  // git のグローバルオプション経由
+  'git -C /repo push --force origin feat/x',
+  'git --git-dir=/repo/.git push origin feat/x --force',
+  // 作業破棄系
+  'git reset --hard',
+  'git reset --hard origin/main',
+  'git reset --hard HEAD~1',
+  'git stash drop',
+  'git stash drop stash@{0}',
+  'git stash clear',
+  // 複合コマンドの後段に紛れているケース
+  'git add -A && git commit -m "wip" && git push --force origin feat/x',
+  'npm test; git reset --hard origin/main',
+  // 引用符で囲まれた force フラグ単体は「データ」ではなく引数
+  'git push "--force" origin feat/x',
+  // 行継続・複数行
+  'git push \\\n  --force origin feat/x',
+  'npm run lint\ngit push origin feat/x --force-with-lease',
+];
+
+// --- 通すべきコマンド ------------------------------------------------------
+const ALLOWED = [
+  // 通常の push（このフックが自分自身の作業を妨げないこと）
+  'git push origin feat/x',
+  'git push -u origin feat/x',
+  'git push --set-upstream origin feat/x',
+  'git push --follow-tags origin main',
+  'git push origin HEAD',
+  // fetch の --force は破壊操作ではない（release-please.yml が実際に使う）
+  'git fetch --tags --force',
+  'git fetch -f',
+  'git fetch origin --tags --force && git push origin feat/x',
+  // タグ張り替えは AGENTS.md Safety の対象外
+  'git tag -f v1.0.0',
+  'git tag -f -a v1 -m msg',
+  // ローカル操作（散文の規律に留める / #1730）
+  'git clean -fd',
+  'git checkout -- src/foo.mjs',
+  'git restore src/foo.mjs',
+  'git restore --staged src/foo.mjs',
+  // reset の非 --hard 形
+  'git reset HEAD~1',
+  'git reset --soft HEAD~1',
+  'git reset --mixed HEAD',
+  // stash の非破壊サブコマンド
+  'git stash push -m wip',
+  'git stash pop',
+  'git stash list',
+  // 引用符やヒアドキュメントの「中身」として --force を含むだけのケース
+  'grep -rn -- "--force-with-lease" .',
+  "grep -rn -- '--force-with-lease' docs/",
+  'echo "do not use git push --force"',
+  "echo 'git push --force is banned'",
+  'rg "git push --force" docs/ AGENTS.md',
+  'git commit -m "docs: ban git push --force in worker prompts"',
+  'git commit -m "chore: allow git fetch --tags --force"',
+  "cat > /tmp/note.md <<'EOF'\ngit push --force origin main\ngit reset --hard\nEOF",
+  // git を含むが破壊操作ではないもの
+  'git log --oneline -5 | grep -f /tmp/patterns.txt',
+  'git status -sb',
+  'git merge --ff-only origin/feat/x && git push origin feat/x',
+  'npm test',
+];
+
+// サブテスト名にコマンド文字列を出すことで、
+// テスト出力そのものが「どのコマンドがどちらに分類されたか」の一覧になる。
+test('destructive git commands are blocked with exit 2', async (t) => {
+  for (const cmd of BLOCKED) {
+    await t.test(`BLOCK ${JSON.stringify(cmd)}`, () => {
+      assert.equal(runHook(cmd).status, 2);
+    });
+  }
+});
+
+test('non-destructive commands pass with exit 0', async (t) => {
+  for (const cmd of ALLOWED) {
+    await t.test(`PASS ${JSON.stringify(cmd)}`, () => {
+      assert.equal(runHook(cmd).status, 0);
+    });
+  }
+});
+
+test('block message names the command, the alternative, and the source', () => {
+  const r = runHook('git push --force origin feat/x');
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /BLOCKED/);
+  assert.match(r.stderr, /git push --force origin feat\/x/);
+  assert.match(r.stderr, /AGENTS\.md Safety/);
+  assert.match(r.stderr, /merge --ff-only/);
+  assert.match(r.stderr, /escalate/);
+});
+
+test('passing commands produce no stderr noise', () => {
+  const r = runHook('git push origin feat/x');
+  assert.equal(r.status, 0);
+  assert.equal(r.stderr, '');
+});
+
+test('empty or malformed stdin payload passes', () => {
+  for (const input of ['', '{not json', '{}', '{"tool_input":{}}']) {
+    const res = spawnSync('bash', [HOOK], { input, encoding: 'utf8' });
+    assert.equal(res.status, 0, JSON.stringify(input));
+  }
+});


### PR DESCRIPTION
# 🌊 River Review Pull Request

## Overview / 説明

- [x] force 系の破壊的 git コマンドを `.claude/hooks/no-force-push.sh`（PreToolUse フック）で決定論的に阻止します。2026-08-02 の振り返りで確定した学び C「mechanical に検証できるなら、手順ではなく検証を書く」（`docs/development/improvement-flow.md` Step 2）を、force 禁止に適用したものです。
- Primary phase focus: Midstream

## なぜフックか（散文 4 箇所ではすり抜けた）

`AGENTS.md` § Safety が禁じる force 系の操作は、現在 4 箇所の散文に書かれています。

| 位置                                             | 記述                                                         |
| ------------------------------------------------ | ------------------------------------------------------------ |
| `AGENTS.md` § Safety                             | destructive commands 禁止（`--force-with-lease` 含む・SSoT） |
| `CLAUDE.md`                                      | Commit before branch switches ほか複数の guard               |
| `docs/development/worker-discipline-template.md` | 委託ワーカー向けの force 禁止ブロック                        |
| `.claude/commands/*.md`                          | `/release-kick` `/plan-merge-order` `/merge-check`           |

それでも **#1656 と #1720 で各 1 回すり抜けました**。本 PR 作成時に timeline API で再確認しています。

```bash
$ gh api --paginate "repos/s977043/river-review/issues/1656/timeline?per_page=100" \
    --jq '[.[] | select(.event=="head_ref_force_pushed")] | length'
1
$ gh api --paginate "repos/s977043/river-review/issues/1720/timeline?per_page=100" \
    --jq '[.[] | select(.event=="head_ref_force_pushed")] | length'
1
```

散文の規律は「守られない前提で設計する」ものであり、決定論で止める機構がありませんでした。

### `permissions.deny` ではなくフックを選んだ理由

`.claude/settings.json` の `permissions.deny` は前方一致で判定するため、**引数順が変わると素通りします**。

| コマンド                             | `Bash(git push --force:*)` の deny |
| ------------------------------------ | ---------------------------------- |
| `git push --force origin feat/x`     | 阻止できる                         |
| `git push origin feat/x --force`     | **素通り**                         |
| `git -C /repo push --force origin x` | **素通り**                         |

フックはコマンド文字列全体を受け取るため、正規表現で引数順に依存せず判定できます。既存の `gh-account-guard.sh` と同じ契約（stdin に JSON / `.tool_input.command` / exit 0 で許可 / exit 2 でブロックし stderr が Claude へ返る）に揃えました。

## 何をブロックし、何を通すか

`AGENTS.md` § Safety の定義（push 済みブランチ履歴を書き換えるもの、作業を破棄するもの）に一致させています。

| ブロック                                                      | 通す                                                                                        |
| ------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| `git push` の `--force` / `-f` / `--force-with-lease[=<ref>]` | `git fetch --tags --force`、`git fetch -f`（`.github/workflows/release-please.yml` が使用） |
| `git reset --hard`                                            | `git tag -f`（タグ張り替えは AGENTS.md の対象外）                                           |
| `git stash drop`、`git stash clear`                           | `git clean`、`git checkout -- <path>`、`git restore`（散文の規律に留める / #1730）          |

引数順に依存しません。`git push --force origin x` と `git push origin x --force` の両方、`git -C /repo push --force`、複合コマンド（`... && git push --force ...`）も阻止します。

### 誤検出を避ける設計

このフックは**全 Bash 呼び出しに割り込む**ため、誤検出はメイン開発を止めます。判定前にコマンド文字列を次の順で正規化しています。

1. ヒアドキュメント本文の除去（`cat > note.md <<'EOF' ... EOF` の中身）
2. 行継続（バックスラッシュ + 改行）の結合
3. 引用符内の除去（空白へ置換）

これにより、本リポジトリのドキュメント作業で日常的に実行するコマンドが通ります。

```bash
grep -rn -- "--force-with-lease" .           # 通る
echo "do not use git push --force"           # 通る
git commit -m "docs: ban git push --force"   # 通る
```

ただし引用符の中身が force フラグそのものである場合（`git push "--force"`）は引数として扱い、ブロックします。判定対象は単一コマンドセグメント（`[^;&|]*`）に限定しているため、`git push origin x && git fetch --tags --force` も通ります。

判断に迷う入力は「通す」側に倒しています。誤検出は全開発を止め、すり抜けは 1 件のインシデントで済むためです。

### `--force-if-includes` を対象にしない理由

`git help push` の `--force-if-includes` の項に次の記載があります。

> If the option is passed without specifying `--force-with-lease`, or specified along with `--force-with-lease=<refname>:<expect>`, it is a "no-op".

単体では push の挙動を変えないため、ブロック対象に入れていません。force が成立するのは `--force-with-lease` と併用したときだけで、その場合は lease 側で阻止されます。両方をテストで固定しています。

- BLOCKED: `git push --force-with-lease --force-if-includes origin feat/x`
- PASS: `git push --force-if-includes origin feat/x`

あわせて `.claude/commands/plan-merge-order.md:144` の SSoT 食い違いを本 PR で直しました。同行は `--force-if-includes` を force フラグとして列挙し、出典に `AGENTS.md` Safety を挙げていましたが、`grep -c "force-if-includes" AGENTS.md` は **0** です。禁止の趣旨（rebase して force push で上書きするな）は保ったまま、force フラグの列挙を `--force` / `-f` / `--force-with-lease` に揃え、`--force-if-includes` が no-op であることを根拠付きで補足しました。

### 適用範囲（ワークフローは対象外）

このフックが見るのはエージェントの `Bash` ツール呼び出しだけで、GitHub Actions 上では動きません。したがって `.github/workflows/release-please.yml` の可動メジャータグ force 更新には影響しません。`AGENTS.md` § Safety はその免除を**ワークフロー限定**と定義しており（`That exemption belongs to the workflow and is never a licence for an agent to force-push.`）、同じコマンドをエージェントが打った場合はブロックされます。これは SSoT の意図どおりで、抜けではありません。`.claude/hooks/README.md` にも Scope 節として明記しました。

### 既知の制限

引用符の中身はデータとして扱うため、`bash -c "git push --force"` のようなインタプリタ経由の形は検出しません。フックは defense-in-depth であり、禁止の SSoT は `AGENTS.md` § Safety のままです。この制限は `.claude/hooks/README.md` にも明記しました。

## ブロック時の出力

```
[no-force-push] BLOCKED: destructive git command.
  command: git push --force origin feat/x
  AGENTS.md Safety bans rewriting already-pushed branch history
  (git push --force / -f / --force-with-lease) and discarding work
  (git reset --hard, git stash drop, git stash clear).
  --force-with-lease is not an exception.
  Instead: take the remote in with 'git merge origin/<branch>' or
  'git merge --ff-only origin/<branch>', then push a fast-forward.
  If history still looks like it must be rewritten, do not work around this
  hook — stop and escalate to the organizer / human.
```

回避手段（環境変数によるバイパス等）は意図的に設けていません。履歴の書き換えが必要に見える場合はエスカレーションさせます。

## Validation & Evidence

テストはフックを `child_process` で実プロセス起動し、**本物の PreToolUse JSON ペイロードを stdin に流して exit code を検証**します（内部ロジックのモックではありません）。サブテスト名にコマンド文字列を出しているため、テスト出力そのものが分類の一覧になります。

```bash
bash -n .claude/hooks/no-force-push.sh          # exit 0
shellcheck .claude/hooks/no-force-push.sh       # exit 0 (v0.11.0)
node --test tests/no-force-push-hook.test.mjs   # exit 0 / tests 69 pass 69 fail 0
npm test                                        # exit 0 / tests 2918 pass 2918 fail 0
npm run lint                                    # exit 0
npm run meta:validate                           # exit 0 / Doc enumerations: OK (5 spec(s) checked)
```

`origin/main`（#1732 まで）を `git merge origin/main --no-edit` で取り込み済みです（force 不使用・コンフリクトなし）。#1732 が増やした doc-enum spec が 5 件になっていることを取り込み後の `npm run meta:validate` で確認しています。

ブロック 25 件 / 通過 38 件の実測結果（抜粋）:

```
▶ destructive git commands are blocked with exit 2
  ✔ BLOCK "git push --force"
  ✔ BLOCK "git push origin feat/x --force"
  ✔ BLOCK "git push -f origin feat/x"
  ✔ BLOCK "git push origin feat/x -f"
  ✔ BLOCK "git push --force-with-lease=refs/heads/feat/x origin feat/x"
  ✔ BLOCK "git -C /repo push --force origin feat/x"
  ✔ BLOCK "git reset --hard origin/main"
  ✔ BLOCK "git stash drop stash@{0}"
  ✔ BLOCK "git stash clear"
  ✔ BLOCK "git add -A && git commit -m \"wip\" && git push --force origin feat/x"
  ✔ BLOCK "if [ -n \"$CI\" ]; then git push --force origin feat/x; fi"
  ✔ BLOCK "git   push   origin   feat/x   --force"
  ✔ BLOCK "git push \"--force\" origin feat/x"
▶ non-destructive commands pass with exit 0
  ✔ PASS "git push origin feat/x"
  ✔ PASS "git push -u origin feat/x"
  ✔ PASS "git fetch --tags --force"
  ✔ PASS "git fetch -f"
  ✔ PASS "git tag -f v1.0.0"
  ✔ PASS "git clean -fd"
  ✔ PASS "git checkout -- src/foo.mjs"
  ✔ PASS "git restore src/foo.mjs"
  ✔ PASS "git checkout -f main"
  ✔ PASS "git branch -f tmp origin/main"
  ✔ PASS "git rebase origin/main"
  ✔ PASS "git reset --soft HEAD~1"
  ✔ PASS "git stash pop"
  ✔ PASS "grep -rn -- \"--force-with-lease\" ."
  ✔ PASS "echo \"do not use git push --force\""
  ✔ PASS "git commit -m \"docs: ban git push --force in worker prompts\""
  ✔ PASS "cat > /tmp/note.md <<'EOF'\ngit push --force origin main\ngit reset --hard\nEOF"
  ✔ PASS "git merge --ff-only origin/feat/x && git push origin feat/x"
```

このフックが自分自身の作業を妨げないことも確認しました。フック追加後の `git push -u origin feat/no-force-push-hook` は exit 0 で通っています（本 PR のブランチはそれで push されています）。

## Documentation / ドキュメント

- [x] Yes, docs are changed/added（`.claude/hooks/README.md` に新規フックを追記）
- [x] Reference（リファレンス / 仕様や事実の一覧）
- [x] English（既存の `.claude/hooks/README.md` に合わせる）

## Checklist / チェックリスト

- [x] Added or updated tests related to the changes.
- [x] Verified that tests pass.
- [x] Updated documentation or notes if necessary.

## Related Issues

- Related #1656 / #1720（force push がすり抜けた PR）
- Related #1730 / #1731（force 禁止の SSoT 整理と 2026-08-02 の振り返り）

## Reviewer Notes

- `.claude/settings.json` の `hooks.PreToolUse` は既存の `gh-account-guard.sh` エントリを壊さず、同じ matcher `Bash` の配列へ追加しています。
- `AGENTS.md` と `CLAUDE.md` は変更していません。フックは散文の置き換えではなく、決定論の追加です。散文 4 箇所のうち `.claude/commands/plan-merge-order.md` だけは、SSoT と食い違っていた force フラグの列挙を修正しています（上記参照）。
- awk による正規化は BSD awk（macOS）と GNU/mawk（CI）の双方で動くよう POSIX 機能のみを使い、シングルクォートは `-v Q="'"` で渡しています。
- 通過側には、禁止対象の「隣」にあるが対象外のコマンド（`git checkout -f` / `git branch -f` / `git rebase`）を回帰ケースとして入れています。将来パターンを広げすぎたときに気づけるようにするためです。

## Deviations / 計画からの逸脱（#1412）

- [x] 計画からの逸脱なし / No deviations from the original plan
