### PR TITLE
fix(ci): dist のバイト比較で untracked な ncc chunk を検出する

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -14,7 +14,7 @@
 | `Unit tests (22.x)`       | `test.yml`（`CI`） | `test`             | `node --test`（`--experimental-test-isolation=none`）とカバレッジの Codecov アップロード |
 | `Skill schema validation` | `test.yml`（`CI`） | `skill-validation` | skill / promptfoo / agent-skill / 参照 / manifest / registry の 6 検証                   |
 | `Meta consistency`        | `test.yml`（`CI`） | `meta-check`       | `npm run meta:validate` と `npm run plugin:validate`                                     |
-| `Action dist freshness`   | `test.yml`（`CI`） | `dist-check`       | `runners/github-action/dist/` を触る変更と鮮度判定で古い変更を再ビルドしてバイト比較     |
+| `Action dist freshness`   | `test.yml`（`CI`） | `dist-check`       | `dist/` を触る変更、および鮮度判定で古いと出た変更を再ビルドしてバイト比較               |
 | `Integration (CLI)`       | `test.yml`（`CI`） | `integration-test` | `tests/integration/local-review.test.mjs`                                                |
 
 間違えやすい点が 3 つあります。

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -187,7 +187,15 @@ jobs:
           # false positives that block PRs whose change is not part of the
           # shipped bundle.
           npm run build:action
-          if git diff --quiet -- runners/github-action/dist/; then
+
+          # Compare with `git status --porcelain`, not `git diff`. ncc names
+          # its lazy chunks by number (dist/<n>.index.mjs), and a dependency
+          # change can make it emit a chunk the commit does not contain. Such
+          # a file is UNTRACKED after the rebuild, and `git diff` does not
+          # report untracked files — the job would pass on a bundle that is
+          # missing a chunk it needs at runtime.
+          rebuild_diff=$(git status --porcelain -- runners/github-action/dist/)
+          if [ -z "$rebuild_diff" ]; then
             src_date=$(git log -1 --format=%ci -- 'runners/github-action/src/' 'runners/core/' 'src/' 'package-lock.json')
             dist_date=$(git log -1 --format=%ci -- 'runners/github-action/dist/')
             echo "dist/ rebuild produced no changes; bundle is genuinely fresh (dist commit: ${dist_date}, src commit: ${src_date})."
@@ -199,8 +207,8 @@ jobs:
           echo "::error::dist/ does not match a build of the current sources (src commit: ${src_date}, dist commit: ${dist_date}); the rebuild produced byte-level changes. Run 'npm run build:action' with the Node version in .nvmrc and commit the result."
           echo "Recent src changes:"
           git log -3 --oneline -- 'runners/github-action/src/' 'runners/core/' 'src/' 'package-lock.json'
-          echo "Rebuild diff (file list):"
-          git diff --name-only -- runners/github-action/dist/
+          echo "Rebuild diff (git status --porcelain; '??' = a chunk the commit is missing):"
+          printf '%s\n' "$rebuild_diff"
           exit 1
 
   integration-test:

--- a/docs/development/dist-check-rebuild-guide.md
+++ b/docs/development/dist-check-rebuild-guide.md
@@ -87,7 +87,9 @@ git commit -m "chore(action): rebuild github-action dist"
 > - 差分が `runners/github-action/dist/` を含む（手編集・ビルドし忘れ・`.nvmrc` と違う Node でのビルドを捕捉する）
 > - 差分が `dist/` を含まず、src commit timestamp が dist より新しい（リビルド忘れを捕捉する）
 >
-> `dist/` を含む差分を必ず検証するのは、timestamp 比較だけでは同一コミットが src と `dist/` を同時に変更したときに `src_ts == dist_ts` が成立し、検証がすり抜けたため（#1749）。`dist/` に差分が無い変更（docs のみなど）は従来どおり timestamp 判定だけで即 pass する。
+> `dist/` を含む差分を必ず検証するのは、timestamp 比較だけでは同一コミットが src と `dist/` を同時に変更したときに `src_ts == dist_ts` が成立し、検証がすり抜けたため（#1749）。`dist/` に差分が無い変更の判定は従来と変わらない。docs のみの変更でも、main の tip が `package-lock.json` などを触った直後は src 側 commit のほうが dist より新しく、従来どおり rebuild 検証に回る（実例: #1752 の `Action dist freshness` は 50 秒かけてフル rebuild 経路を通った）。
+>
+> byte 比較は `git status --porcelain -- runners/github-action/dist/` で行う。ncc は lazy chunk を番号（`dist/<n>.index.mjs`）で命名するため、依存の変更でコミットに存在しない新規 chunk が生成される。この新規ファイルは untracked であり、`git diff` では検出できない。
 
 ## トラブルシューティング
 


### PR DESCRIPTION
#1773 の敵対的レビューで出た **major-1**（docs の過大表明）と **m2**（byte 比較が untracked を見ない）への対応です。修正コミットを push した時点で #1773 は既にマージされていたため、フォローアップ PR として切り出しました。

Refs #1749、follow-up of #1773

## m2: バイト比較が untracked ファイルを見ていなかった

`Rebuild and verify dist bytes` の判定 `git diff --quiet -- runners/github-action/dist/` は untracked ファイルを検出しません。ncc は lazy chunk を番号（`dist/<n>.index.mjs`）で命名するため、依存の変更でコミットに存在しない chunk が生成されると、検証を素通りします（この repo の `dist/` には `528.index.mjs` などのチャンクが実在します）。

これは #1773 が作った問題ではありません。ただし #1773 の Gate 1 がこの検証へ流す PR を増やしたため、ここが主要防御線になりました。

判定を `git status --porcelain -- runners/github-action/dist/` に置き換え、失敗時のファイル一覧も同じ出力を使います（`??` = コミットに欠けている chunk であることをメッセージで明示）。

### before / after の実測（3 状態）

```
=== state 0: clean (dist matches HEAD) ===
    BEFORE git diff --quiet     exit=0 -> PASS
    AFTER  git status --porcelain -> '' -> PASS

=== state 1: an untracked NEW ncc chunk in dist/ ===
?? runners/github-action/dist/6437.index.mjs
    BEFORE git diff --quiet     exit=0 -> PASS
    AFTER  git status --porcelain -> '?? runners/github-action/dist/6437.index.mjs' -> FAIL

=== state 2: an existing tracked dist file modified ===
    BEFORE git diff --quiet     exit=1 -> FAIL
    AFTER  git status --porcelain -> ' M runners/github-action/dist/index.mjs' -> FAIL
```

挙動が変わるのは state 1 だけです（盲点を塞いだ）。state 0（差分なし = false-positive を出してはいけないケース）と state 2（既存ファイルの書き換え）は変わりません。

## major-1: docs の「即 pass する」が偽だったので修正

#1773 で `docs/development/dist-check-rebuild-guide.md` に「`dist/` に差分が無い変更（docs のみなど）は従来どおり timestamp 判定だけで即 pass する」と書きましたが、反例があります。#1752 は docs のみ（dist 差分ゼロ）ですが、`Action dist freshness` はフル rebuild 経路を 50 秒かけて通っています。

```console
$ gh api repos/s977043/river-review/pulls/1752/files --paginate --jq '[.[].filename] | map(select(test("dist/"))) | length'
0
$ gh api repos/s977043/river-review/pulls/1752/files --paginate --jq 'length'
6
$ gh api repos/s977043/river-review/actions/runs/30897768404/jobs --jq '.jobs[] | select(.name=="Action dist freshness") | [.id,.conclusion,.started_at,.completed_at] | @tsv'
91954876453	success	2026-08-04T09:47:16Z	2026-08-04T09:48:06Z      # = 50 秒
```

ジョブログにも rebuild 経路が出ています。

```
09:47:25 Timestamp suggests dist is stale; will rebuild to verify.
09:47:33 npm ci
09:47:58 dist/ rebuild produced no changes; bundle is genuinely fresh
```

main の tip が release-please 等で `package-lock.json` を触った直後は、docs のみの PR でも Gate 2 が stale 判定を出します。断定を外し、「`dist/` に差分が無い変更の判定は従来と変わらない」＋この反例、という記述に直しました。Gate 2 の挙動自体は変えていないので、修正は文言のみです。

`.github/workflows/README.md` の `Action dist freshness` セルは、同種の断定が無いことを確認したうえで係り受けだけ直しました（「`dist/` を触る変更、および鮮度判定で古いと出た変更を再ビルドしてバイト比較」）。

## 変更ファイル

- `.github/workflows/test.yml` — `Rebuild and verify dist bytes` の判定を `git status --porcelain` に変更
- `docs/development/dist-check-rebuild-guide.md` — major-1 の断定を除去し、byte 比較の手段と理由を追記
- `.github/workflows/README.md` — セル文の係り受け修正

## 含めないもの

**m1**（`pull_request` の checkout は `refs/pull/N/merge` の実行時再計算だが、`BASE_SHA` はイベント payload に凍結された `base.sha` なので `gh run rerun` でずれる）は follow-up。ブロックはせず、誤ったメッセージと余分な実行時間のみが影響します。修正案は `git rev-parse HEAD^1`（merge ref の第 1 親）。

## 検証

```
actionlint .github/workflows/test.yml     exit=0
npx textlint --no-cache <edited docs>     exit=0
npm run fix:dashes                        No heading/title dash normalizations needed.
npm run meta:validate                     exit=0
npm run lint                              exit=0
```

ジョブ名 `Action dist freshness` は変更していません（必須チェックの context のため）。branch protection / ruleset も変更していません。
