### PR TITLE
test(memory): legacy 形の expiresAt 2 値を REJECTED に追加する

### DIFF
--- a/tests/expires-at-ssot.test.mjs
+++ b/tests/expires-at-ssot.test.mjs
@@ -29,7 +29,21 @@ const validateSuppressionContext = compileSuppressionContextValidator();
 
 // `Date.parse` が「読めてしまう」ために分裂が生じていた値と、RFC 3339 の正常値。
 // `2027-02-30` は存在しない日で、`Date` は 2027-03-02 に繰り上げる。
-const REJECTED = ['0', '2026', '2026-08-04 10:00', 'notadate', '2027-02-30'];
+//
+// 末尾 2 つ（offset 省略・秒省略）は、v1.72.0–v1.72.1 の `--expires` ゲート
+// （`if (Number.isNaN(Date.parse(value)))` のみ、値は verbatim 保存）が通した
+// legacy 形のうち最も現実的なもの。`toISOString().slice(0, 19)` の切り出しや
+// 多くのツールの既定表記がこの形になるため、`2027` や `March 5, 2027` より
+// 実データに現れやすい。
+const REJECTED = [
+  '0',
+  '2026',
+  '2026-08-04 10:00',
+  'notadate',
+  '2027-02-30',
+  '2027-01-01T00:00:00', // offset 省略
+  '2027-01-01T00:00Z', // 秒省略
+];
 const ACCEPTED = ['2027-01-01', '2027-01-01T00:00:00Z', '2027-01-01T00:00:00+09:00'];
 
 /** CLI の実経路で `--expires <value>` が受理されるか。 */


### PR DESCRIPTION
#1777 のフォローアップ（テストデータのみ、コード変更なし）。Refs #1768

## 経緯

#1777 への敵対的レビューで、PR 本文の「新定義で unparseable になる既存値」の列挙が不正確だと指摘されました。テストへの 2 値追加を push した時点で #1777 は既にマージ済みだったため、フォローアップ PR として切り出します。#1777 の本文側の訂正は反映済みです。

## 何が抜けていたか

v1.72.0–v1.72.1 の `--expires` ゲートは `Date.parse` が NaN でないかだけを見て、値は verbatim 保存していました。

```console
$ git show v1.72.1:src/cli.mjs | sed -n '659p'
        if (Number.isNaN(Date.parse(value))) {
```

したがって RFC 3339 外でも `Date.parse` が読める形は既存 index に入りえます。#1777 が追加したテストの `REJECTED` 配列は `2027` / `March 5, 2027` / `2027-02-30` に相当する形しか持たず、**より現実的な legacy 形を検査していませんでした**。

```console
$ node -e "for (const v of ['2027-01-01T00:00:00','2027-01-01T00:00Z','2027/01/01','2027-01-01T09:00:00+0900']) console.log(v.padEnd(28), !Number.isNaN(Date.parse(v)) ? 'Date.parse:受理' : 'Date.parse:拒否')"
2027-01-01T00:00:00          Date.parse:受理     ← offset 省略
2027-01-01T00:00Z            Date.parse:受理     ← 秒省略
2027/01/01                   Date.parse:受理     ← スラッシュ区切り
2027-01-01T09:00:00+0900     Date.parse:受理     ← basic format offset
```

これらは `toISOString().slice(0, 19)` の切り出し、`date -Iseconds` の出力、多くのツールの既定表記に対応するため、`2027` や `March 5, 2027` より実データに現れやすい形です。

## 変更内容

`tests/expires-at-ssot.test.mjs` の `REJECTED` に、上記のうち最も現実的な 2 形を追加します。

- `2027-01-01T00:00:00`（offset 省略）
- `2027-01-01T00:00Z`（秒省略）

配列を参照している 4 つの test（CLI との一致・unparseable 判定・`onUnparseable` の振り分け・呼び出し元 3 箇所の実挙動）が自動的にこの 2 値も検査します。`expireEntries` の警告件数の assert は `REJECTED.length` を参照しているため、そのまま追随します。

**コード変更はありません。** `src/` は 1 行も触っていません。

## 旧実装での分類（実測）

追加した 2 値が、#1777 以前のライブラリ実装で「有効な期限」として扱われていたことを確認しました。

```console
# hasUnparseableExpiresAt を旧実装（new Date(...).getTime()）へ戻した状態で評価
2027-01-01T00:00:00      hasUnparseable(OLD impl)= false
2027-01-01T00:00Z        hasUnparseable(OLD impl)= false
```

旧実装へ戻したときのテスト失敗件数の実測です。

```
1) hasUnparseableExpiresAt だけを旧実装へ戻す    … tests 11 / pass 7 / fail 4
2) hasUnparseableExpiresAt と isExpired の両方   … tests 11 / pass 5 / fail 6
3) 現行実装                                      … tests 11 / pass 11 / fail 0
```

失敗する **test の件数**は 2 値の追加では増えません（追加した値が既に失敗していた test の内側に入るため）。増えるのは検査される値の方であり、上記の値ごとの実測がその実効性の根拠です。

## 検証（実出力）

```
npm test              tests 3092 / pass 3092 / fail 0
npm run lint          exit 0（format:check / check:dashes / lint:code / lint:md / lint:text）
npm run meta:validate exit 0（Meta consistency: OK / Doc enumerations: OK / Sidebar reachability: OK）
```

## 非目標

- コード変更なし。`--expires` の受理範囲も `hasUnparseableExpiresAt` の判定も #1777 のまま
- `2027/01/01` と `2027-01-01T09:00:00+0900` は配列に追加していません（同一クラスの検査として上記 2 値で足りるため）
- suppression の `context.expiresAt` が `expireEntries` の警告経路に構造的に載らない件（`expireEntries` はトップレベルの `entry.expiresAt` を読む）は別途起票予定であり、本 PR では扱いません
