### PR TITLE
fix(ci): blocked-label-guard の concurrency を外し cancelled な check-run の残留を止める

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,16 +6,17 @@
 
 ## 必須チェック（branch protection）
 
-`main` の branch protection が要求する必須チェックは 6 件で、**すべて `test.yml`（ワークフロー名 `CI`）のジョブ**です。ほかのワークフローは 1 本も必須チェックになっていません。
+`main` の branch protection が要求する必須チェックは 7 件です。うち 6 件は `test.yml`（ワークフロー名 `CI`）のジョブで、残る 1 件が `blocked-label-guard.yml` の `Blocked label guard` です。
 
-| 必須チェック名 (context)  | ワークフロー       | ジョブキー         | 実行内容                                                                                 |
-| ------------------------- | ------------------ | ------------------ | ---------------------------------------------------------------------------------------- |
-| `Lint`                    | `test.yml`（`CI`） | `lint`             | `npm run lint`                                                                           |
-| `Unit tests (22.x)`       | `test.yml`（`CI`） | `test`             | `node --test`（`--experimental-test-isolation=none`）とカバレッジの Codecov アップロード |
-| `Skill schema validation` | `test.yml`（`CI`） | `skill-validation` | skill / promptfoo / agent-skill / 参照 / manifest / registry の 6 検証                   |
-| `Meta consistency`        | `test.yml`（`CI`） | `meta-check`       | `npm run meta:validate` と `npm run plugin:validate`                                     |
-| `Action dist freshness`   | `test.yml`（`CI`） | `dist-check`       | `dist/` を触る変更、および鮮度判定で古いと出た変更を再ビルドしてバイト比較               |
-| `Integration (CLI)`       | `test.yml`（`CI`） | `integration-test` | `tests/integration/local-review.test.mjs`                                                |
+| 必須チェック名 (context)  | ワークフロー                                       | ジョブキー            | 実行内容                                                                                 |
+| ------------------------- | -------------------------------------------------- | --------------------- | ---------------------------------------------------------------------------------------- |
+| `Lint`                    | `test.yml`（`CI`）                                 | `lint`                | `npm run lint`                                                                           |
+| `Unit tests (22.x)`       | `test.yml`（`CI`）                                 | `test`                | `node --test`（`--experimental-test-isolation=none`）とカバレッジの Codecov アップロード |
+| `Skill schema validation` | `test.yml`（`CI`）                                 | `skill-validation`    | skill / promptfoo / agent-skill / 参照 / manifest / registry の 6 検証                   |
+| `Meta consistency`        | `test.yml`（`CI`）                                 | `meta-check`          | `npm run meta:validate` と `npm run plugin:validate`                                     |
+| `Action dist freshness`   | `test.yml`（`CI`）                                 | `dist-check`          | `dist/` を触る変更、および鮮度判定で古いと出た変更を再ビルドしてバイト比較               |
+| `Integration (CLI)`       | `test.yml`（`CI`）                                 | `integration-test`    | `tests/integration/local-review.test.mjs`                                                |
+| `Blocked label guard`     | `blocked-label-guard.yml`（`Blocked Label Guard`） | `blocked-label-guard` | `blocked` などマージ阻止ラベルの有無を event payload から判定する                        |
 
 間違えやすい点が 3 つあります。
 
@@ -54,7 +55,7 @@ gh api repos/s977043/river-review/rulesets/<id> --jq '[.rules[].type]'
 | `auto-fix-dashes.yml`          | Auto Fix Dashes                   | `schedule`（`0 3 * * 6` = 毎週土 03:00 UTC）                                                                                         | `npm run fix:dashes` でダッシュ前後の空白を正規化し、差分があれば PR を自動作成する                    | -          |
 | `auto-milestone.yml`           | Auto-assign milestone from labels | `issues`（opened / labeled / reopened）                                                                                              | `m1-public` などのラベルから対応するマイルストーンを Issue に自動設定する                              | -          |
 | `auto-rebuild-action-dist.yml` | Auto Rebuild Action Dist          | `pull_request`（`runners/github-action/src/**` / `runners/core/**` / `src/**` / `package-lock.json`）                                | 同一リポジトリの PR で `dist/` が古ければ再ビルドし、PR ブランチへ push する                           | -          |
-| `blocked-label-guard.yml`      | Blocked Label Guard               | `pull_request`（opened / reopened / synchronize / labeled / unlabeled）                                                              | `blocked` などマージ阻止ラベルが付いた PR でジョブを落とし、マージを機械的に止める                     | -          |
+| `blocked-label-guard.yml`      | Blocked Label Guard               | `pull_request`（opened / reopened / synchronize / labeled / unlabeled）                                                              | `blocked` などマージ阻止ラベルが付いた PR でジョブを落とし、マージを機械的に止める                     | 1 件       |
 | `build.yml`                    | Build Docusaurus Site             | `pull_request`（`pages/**` / `docs/**` / `docusaurus.config.js` / `sidebars.js` / `package.json` / `package-lock.json`）             | ドキュメントサイトが `npm run build` でビルドできることを確認する                                      | -          |
 | `codeql.yml`                   | CodeQL                            | `push`（main）/ `pull_request`（main）/ `schedule`（`30 2 * * 1` = 毎週月 02:30 UTC）                                                | JavaScript の静的セキュリティ解析を実行する                                                            | -          |
 | `deploy.yml`                   | Deploy to GitHub Pages            | `push`（main）/ `workflow_dispatch`                                                                                                  | Docusaurus をビルドして GitHub Pages へデプロイする                                                    | -          |
@@ -99,7 +100,7 @@ gh api repos/s977043/river-review/rulesets/<id> --jq '[.rules[].type]'
 - advisory な指摘のみを目的とし、失敗させる意図がない（例: `river-review.yml`）
 - fork からの PR で権限不足により動作しない
 
-いま必須チェックが `test.yml` の 6 ジョブに集中しているのは、この基準を満たすのが `test.yml` のジョブだけだからです。
+必須チェック 7 件のうち 6 件が `test.yml` に集中しているのは、この基準を満たすジョブが `test.yml` に固まっているからです。例外の `Blocked label guard` は `paths:` フィルタを持たず、event payload だけで決定論的に判定するため基準を満たします。
 
 ### 2. 必須チェックにしない場合
 
@@ -130,7 +131,7 @@ gh api -X PATCH repos/s977043/river-review/branches/main/protection/required_sta
 JSON
 ```
 
-`app_id` は GitHub Actions のアプリ ID（現状 `15368`）です。この配列は全置換なので、既存の 6 件を省略すると必須チェックから外れてしまいます。手順 2 で取得した配列へ追記する形が安全です。
+`app_id` は GitHub Actions のアプリ ID（現状 `15368`）です。この配列は全置換なので、既存の 7 件を省略すると必須チェックから外れてしまいます。手順 2 で取得した配列へ追記する形が安全です。
 
 一方、**既存の必須チェックの名前を変える場合（matrix leg の増減・改名・ジョブ名の変更）は逆で、branch protection を先に更新します**。この順序と背景は [CLAUDE.md](../../CLAUDE.md) の AI Misoperation Guards「CI matrix leg ↔ branch-protection required-check sync」が SSoT です。ここでは重複させないので、必ずそちらを読んでください。
 
@@ -144,7 +145,8 @@ JSON
 - ただし composite の既定は `.nvmrc` ではなくリテラル `22.x` である（`.nvmrc` は `22.22.2`）。ncc の出力が Node メジャーで変わるため、dist を再ビルドする `auto-rebuild-action-dist.yml` と `test.yml`（`dist-check` / `engine-install`）だけは `node-version-file: '.nvmrc'` を厳密に指定する。composite を使わない `promptfoo-eval.yml` も同じ指定である
 - サードパーティ action は commit SHA でピン留めする。現状 `scorecard.yml` の `ossf/scorecard-action@v2.4.4` だけがタグ参照である
 - `permissions:` は 28 本すべてが top-level で宣言している。読み取りだけで済むものには `read-all` か `contents: read` を置き、書き込みが要るジョブにだけスコープを足す。`auto-milestone.yml` は `issues: write` のみを与える最小例である
-- 共有状態（ref・デプロイ・Issue・外部リソース）に触れるワークフローには `concurrency:` グループを設定する。読み取り専用のジョブでは省略してよい。現状 28 本中 27 本が設定済みで、例外は `hol-plugin-scanner.yml` の 1 本である
+- 共有状態（ref・デプロイ・Issue・外部リソース）に触れるワークフローには `concurrency:` グループを設定する。読み取り専用のジョブでは省略してよい。現状 28 本中 26 本が設定済みで、例外は `hol-plugin-scanner.yml` と `blocked-label-guard.yml` の 2 本である
+- **必須チェックのワークフローには `concurrency:` を設定しない。** グループ内で cancel された run は `cancelled` の check-run を残し、pass でも fail でもない結論として必須チェックの判定を止める。`cancel-in-progress: false` にしても避けられない。グループ内に pending の run がある状態で新しい run が queue に入ると、既存の pending が cancel されて新しい run が置き換わる仕様のためである（[workflow-syntax#concurrency](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency)）。`blocked-label-guard.yml` はこの事故（#1778）を受けて `concurrency:` を外している
 - `GITHUB_TOKEN` による push は下流の `pull_request` ワークフローを再発火させない（GitHub の再帰防止仕様）。dist 再ビルドや release-please のキックでこの制約に当たった場合の脱出手順は [CLAUDE.md](../../CLAUDE.md) の「`N of N required checks are expected` = bot/`GITHUB_TOKEN` push」を参照する
 - ワークフローや CI 自動化をマージする前のレビュー観点（並行実行・既定値の結合・部分失敗）は [AGENTS.md](../../AGENTS.md) の「Code-gen review」に従う
 

--- a/.github/workflows/blocked-label-guard.yml
+++ b/.github/workflows/blocked-label-guard.yml
@@ -21,9 +21,19 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: blocked-label-guard-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+# concurrency は意図的に設定しない。
+# このジョブは event payload の labels を読んで終了するだけで、API 呼び出しも
+# 共有状態への書き込みも無いため、同一 PR で並行実行しても害が無い。実行時間も
+# 実測で 5〜15 秒（成功 30 件、中央値 7 秒）と短く、重複コストは無視できる。
+#
+# 逆に concurrency を設定すると `cancelled` の check-run が残り、必須チェックとして
+# マージを止める（#1778）。これは `cancel-in-progress: false` でも避けられない。
+# GitHub の仕様では、グループ内に pending の run がある状態で新しい run が queue に
+# 入ると「既存の pending は cancel され、新しい run が置き換わる」ためである
+# （https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency）。
+# つまり cancel されるタイミングが in-progress から pending へ移るだけで、
+# `cancelled` の check-run が残る事象そのものは消えない。
+# 必須チェックである以上、pass / fail 以外の結論を一切生じさせないことが要件になる。
 
 jobs:
   blocked-label-guard:


### PR DESCRIPTION
Closes #1778

## 何を変えたか

`.github/workflows/blocked-label-guard.yml` から `concurrency:` ブロックを削除しました（Issue の対応案 2）。ジョブ名 `Blocked label guard` と判定ロジックは変更していません。

あわせて `.github/workflows/README.md` の「共通の約束事」に、必須チェックのワークフローへ `concurrency:` を設定しない旨の項目を足しています。

## 発生率（自分で測り直した実測値）

測定時刻は **2026-08-06T00:36:57Z** です。

```console
$ gh api --paginate 'repos/s977043/river-review/actions/workflows/blocked-label-guard.yml/runs?per_page=100' \
    --jq '.workflow_runs[] | "\(.conclusion) \(.head_sha)"' > runs.txt
$ wc -l < runs.txt
      99
$ awk '{print $1}' runs.txt | sort | uniq -c
   4 action_required
  11 cancelled
   4 failure
  80 success
$ awk '{print $2}' runs.txt | sort -u | wc -l
      82
$ awk '$1=="cancelled"{print $2}' runs.txt | sort -u | wc -l
       7
```

全 99 run 中 `cancelled` が 11 件、head SHA 82 件のうち 7 件で発生しています。SHA 単位で 8.5% です。

## 選んだ案と理由

Issue は案 1（`cancel-in-progress: false`）か案 2（concurrency を外す）が素直だとしていました。しかし案 1 では問題が解消しません。GitHub の仕様上、`cancel-in-progress` の値にかかわらず、グループ内に pending の run がある状態で新しい run が queue へ入ると既存の pending が cancel されるためです。

> By default, any existing `pending` job or workflow in the same concurrency group will be canceled and the new queued job or workflow will take its place.
>
> — [workflow-syntax#concurrency](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency)

案 1 は cancel されるタイミングを in-progress から pending へ移すだけで、`cancelled` の check-run が残る事象そのものを消せません。この workflow は `opened` / `reopened` / `synchronize` / `labeled` / `unlabeled` の 5 種で発火するため、ラベル操作や push が続くと 3 件以上が同一グループへ入る状況は現実に起こります。

必須チェックである以上、要件は「pass / fail 以外の結論を一切生じさせないこと」です。これを満たすのは案 2 だけなので、案 2 を採りました。

並行実行して害が無いことは実装から確認しています。`permissions` は `contents: read` のみで、checkout も API 呼び出しもありません。`github.event.pull_request.labels.*.name` を `jq` で判定して `GITHUB_STEP_SUMMARY` へ書くだけです。共有状態への書き込みが無いため、同一 PR で何本並行しても互いに干渉しません。

## 実行時間（並行実行のコスト）

直近の成功 30 run について、`run_started_at` から `updated_at` までの秒数を測りました。

```console
$ gh api 'repos/s977043/river-review/actions/workflows/blocked-label-guard.yml/runs?per_page=30&status=success' \
    --jq '.workflow_runs[] | ((.updated_at|fromdate) - (.run_started_at|fromdate))' \
  | sort -n | awk '{a[NR]=$1; s+=$1} END{print "n="NR, "min="a[1], "max="a[NR], "median="a[int((NR+1)/2)], "mean="s/NR}'
n=30 min=5 max=15 median=7 mean=8.66667
```

中央値 7 秒・最大 15 秒です。重複実行が数本増えても課金・待ち時間ともに無視できる範囲で、cancelled による手動 `gh run rerun` を強いられるコストより明確に小さいと判断しました。

## 検証

並行実行で cancelled が出ないこと、および `blocked` ラベルの阻止機能が維持されていることは、本 PR 上で実測してコメントに転記します。

ローカル検証の結果は次のとおりです。

```console
$ actionlint .github/workflows/blocked-label-guard.yml
$ echo $?
0
$ npm run meta:validate
Meta consistency: OK
Doc enumerations: OK (5 spec(s) checked, 0 ignored)
Sidebar reachability: OK (90 page(s) in sidebar, 11 allowlisted)
$ npm run lint > /dev/null 2>&1; echo "exit=$?"
exit=0
```

## 委託前提の訂正（レビュー時に確認してほしい点）

`.github/workflows/README.md` が必須チェックを 6 件と記載しており、`Blocked label guard` を反映していませんでした。実測は 7 件です。

```console
$ gh api repos/s977043/river-review/branches/main/protection/required_status_checks \
    --jq '{strict:.strict, checks:[.checks[].context]}'
{"checks":["Lint","Unit tests (22.x)","Skill schema validation","Meta consistency","Action dist freshness","Integration (CLI)","Blocked label guard"],"strict":true}
```

この drift は `docs/development/retrospectives/2026-08-04-05.md:202` に未解消として記録されていますが、追跡 Issue はありません。本 PR で足した「必須チェックのワークフローには `concurrency:` を設定しない」という規約は、どのワークフローが必須チェックなのか README から読めないと運用できません。同じファイル内へ自己矛盾を残さないため、必須チェック一覧・件数と一覧表の「必須」列を実測値へ揃えています。concurrency の修正とは別の論点なので、分割が望ましければ指示してください。
