### PR TITLE
docs(merge-check): マージ前手順に PR 本文の closing keyword 確認を追加する

### DIFF
--- a/.claude/commands/merge-check.md
+++ b/.claude/commands/merge-check.md
@@ -1,7 +1,7 @@
 ---
 description: docs/governance.md の「マージ前チェックリスト」を PR 番号 1 つに対して実行し、MERGE_OK / BLOCKED を判定する
 argument-hint: '<PR number>'
-allowed-tools: Bash(gh pr checks:*), Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh api:*), Bash(git fetch:*), Bash(git log:*), Bash(npm run check:comment-disposition:*)
+allowed-tools: Bash(gh pr checks:*), Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh pr edit:*), Bash(gh issue view:*), Bash(gh api:*), Bash(git fetch:*), Bash(git log:*), Bash(npm run check:comment-disposition:*)
 ---
 
 マージ前チェック: PR #$ARGUMENTS が `gh pr merge` 可能な状態か、`docs/governance.md` § 「PR レビューとマージ」>「マージ前チェックリスト」(SSoT) の全項目を実コマンドで検証して判定する。
@@ -92,14 +92,55 @@ gh pr diff $ARGUMENTS --name-only | grep '^runners/github-action/src/' || echo "
 - 該当する場合、`.nvmrc` の Node バージョンで `npm run build:action` 済みであることを確認する。Step 1 で `Action dist freshness` チェックが green ならビルド済みとみなしてスキップ可
 - 失敗時のトラブルシュートは `docs/development/dist-check-rebuild-guide.md` を参照
 
-### Step 6. 複数 PR 並行時の追加確認
+### Step 6. PR 本文の closing keyword 確認
+
+squash merge では **PR 本文**の closing keyword（`closes` / `fixes` / `resolves` + issue 番号）が効き、マージと同時に該当 issue が close される。コミット本文に `refs #N` と書いてあっても、PR 本文が `closes #N` なら閉じる。
+
+```bash
+gh api "repos/:owner/:repo/pulls/$ARGUMENTS" --jq .body | grep -i 'closes\|fixes\|resolves'
+```
+
+grep はコードブロックや引用の中の言及も拾うため、ヒットしても実際に紐付いているとは限らない。ヒットした場合は、GitHub が実際に close 対象として解決した issue を確認する。
+
+```bash
+gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){closingIssuesReferences(first:20){nodes{number title state}}}}}' \
+  -F o=:owner -F r=:repo -F n=$ARGUMENTS --jq '.data.repository.pullRequest.closingIssuesReferences.nodes'
+```
+
+- `-F o=:owner` / `-F r=:repo` のプレースホルダは `gh api graphql` でも現在のリポジトリへ展開される（本 PR で #1830 に対して実行し、`[{"number":1827}]` が返ることを確認済み）
+- 空配列ならこの Step は pass。1 件以上返った場合は、下記の基準で **それぞれが「閉じてよい issue」か**を判定する
+
+#### 閉じてよい issue かの判定基準
+
+列挙するだけでは素通りする。返ってきた issue ごとに `gh issue view <issue番号>` で本文を読み、次の 3 点を確認する。**1 つでも該当すれば「閉じてはいけない issue」**である。
+
+1. **その PR のスコープが issue の全体をカバーしていない** — issue が要求する変更のうち、この PR に入っていないものがある
+2. **Epic / 追跡用 issue である** — 複数 PR にまたがる傘 issue、または他 issue を子として持つもの。この種は最後の子 PR がマージされたあとに人間が閉じる
+3. **本文に未完了のチェックボックス（`- [ ]`）または「残り」「follow-up」「後続」等の記述がある**
+
+判定が付かない場合は「閉じてはいけない」側に倒す。誤って開けたままにするのは後から閉じられるが、事故で閉じた issue は「判断して閉じた」記録との区別が付かなくなる。
+
+#### 閉じてはいけない issue がある場合
+
+マージの前に PR 本文を書き換え、closing keyword を非 closing の語（`refs`）へ変える。
+
+```bash
+gh pr edit $ARGUMENTS --body "$(gh api "repos/:owner/:repo/pulls/$ARGUMENTS" --jq .body | sed 's/closes \[#/refs [#/g')"
+```
+
+- 実際の本文の書式（`closes [#N](URL)` / `Closes #N` 等）を確認してから置換対象を決める。上の `sed` は release-please が生成する `closes [#N](...)` 形式に対する例である
+- 書き換え後、上記 GraphQL を再実行して `closingIssuesReferences` が空になったことを確認してからマージへ進む
+
+release-please が生成するリリース PR は、コミット本文が `refs #N` でも PR 本文では `closes [#N]` へ変換される。**リリース PR ではこの Step が必ず該当する**ため省略してはならない（`/release-kick` の Step 7 からも本 Step を参照している）。
+
+### Step 7. 複数 PR 並行時の追加確認
 
 複数 PR を連続マージする作業の一部としてこのコマンドを実行している場合:
 
 - `/preflight <PR numbers>` で対象 PR が obsolete / 並行作業中でないことを先に検証する
 - `/plan-merge-order <PR numbers>` でマージ順序を事前計画する（本 PR がその順序の先頭であることを確認する）
 
-### Step 7. strict mode の注意
+### Step 8. strict mode の注意
 
 branch protection が `strict: true` の場合（このリポジトリの main は該当）、PR が最新 main よりも遅れているとマージできない。
 
@@ -114,9 +155,9 @@ gh api "repos/:owner/:repo/pulls/$ARGUMENTS" --jq '{mergeable_state}'
 
 ### A. MERGE_OK
 
-条件: Step 1〜5 が全て pass（Step 5 は該当時のみ）、Step 6〜7 の該当事項なし。
+条件: Step 1〜6 が全て pass（Step 5 は該当時のみ）、Step 7〜8 の該当事項なし。
 
-対応: 各 Step の確認結果（CI チェック数 / 2 エンドポイントのコメント件数と disposition / ラベル一覧 / review state）を添えて報告し、`gh pr merge` に進んでよい。
+対応: 各 Step の確認結果（CI チェック数 / 2 エンドポイントのコメント件数と disposition / ラベル一覧 / review state / closing keyword で閉じる issue の一覧と可否判定）を添えて報告し、`gh pr merge` に進んでよい。
 
 ### B. BLOCKED
 
@@ -132,8 +173,11 @@ gh api "repos/:owner/:repo/pulls/$ARGUMENTS" --jq '{mergeable_state}'
 - review state（`reviewDecision`）のみでコメントの確認を省略してはならない
 - disposition 未確定のコメントを残したまま `gh pr merge` に進んではならない
 - 阻止ラベルが付いたまま `gh pr merge` に進んではならない。マージする側がラベルを外して進めることも禁止である
+- closing keyword が閉じる issue を確認しないまま `gh pr merge` に進んではならない。リリース PR でもこの Step を省略してはならない
 - 本コマンドの手順と governance.md が食い違う場合、governance.md を正としてこちらを修正する
 
 ## なぜこのスキルが必要か
 
 マージ前チェックリスト（CI green / コメントの全件 disposition / 阻止ラベル / preflight / dist Node 整合）は `docs/governance.md` に SSoT として整備されたが、完全手動運用のため実行漏れが起きやすい。レビュアーコメントは CI を失敗させないため見落とされ、`--paginate` 忘れによる部分列挙も観測されている。2026-08-04 には PR #1746 で `pulls/<N>/comments` のみを列挙して 0 件だったため「指摘なし」と判定し、`issues/<N>/comments` にあった指摘 3 件と `blocked` ラベルを見落としてマージ、v1.72.0 で回帰をリリースした。`/preflight` / `/verify-agent-report` と同様に、**実行可能な決定論チェックリストとして 1 コマンド化**することで、マージのたびに確実に全項目を通す。
+
+2026-08-12 には Issue #1827 が release PR #1830 のマージで自動 close された。閉じる判断は誰もしていない。コミット本文は `refs #1827` だったが、release-please が PR 本文を `closes [#1827]` としてレンダリングしていた。当時この確認手順はセッションを跨がない carry-over 台帳にしかなく、`/merge-check` にも `/release-kick` にも存在しなかった。Step 6 はこの再発防止である（`docs/development/retrospectives/2026-08-12.md` の O5 が SSoT）。

--- a/.claude/commands/release-kick.md
+++ b/.claude/commands/release-kick.md
@@ -1,7 +1,7 @@
 ---
 description: release-please のリリース PR を BLOCKED 解除 → CI green 確認 → マージ → リリース公開検証まで一貫実行する（v1.44.0〜v1.53.0 の11リリースで実証済みの型）
 argument-hint: '<release PR number>'
-allowed-tools: Bash(gh api user:*), Bash(gh auth switch:*), Bash(gh pr view:*), Bash(gh pr checks:*), Bash(gh pr merge:*), Bash(gh api:*), Bash(gh run list:*), Bash(gh release view:*), Bash(git ls-remote:*), Bash(git fetch:*), Bash(git diff:*), Bash(scripts/release-please-kick.sh:*), Bash(bash scripts/release-please-kick.sh:*)
+allowed-tools: Bash(gh api user:*), Bash(gh auth switch:*), Bash(gh pr view:*), Bash(gh pr checks:*), Bash(gh pr merge:*), Bash(gh pr edit:*), Bash(gh issue view:*), Bash(gh api:*), Bash(gh run list:*), Bash(gh release view:*), Bash(git ls-remote:*), Bash(git fetch:*), Bash(git diff:*), Bash(scripts/release-please-kick.sh:*), Bash(bash scripts/release-please-kick.sh:*)
 ---
 
 release PR #$ARGUMENTS を、BLOCKED 解除からマージ・リリース公開の検証まで一貫して実行する。
@@ -109,7 +109,17 @@ gh pr checks $ARGUMENTS --json name,bucket --jq '.[] | select(.bucket != "skippi
 
 ### Step 7. マージ
 
-`mergeStateStatus: CLEAN` かつ Step 6 の CI が green になったら:
+`mergeStateStatus: CLEAN` かつ Step 6 の CI が green になったら、**マージの前に `/merge-check` の Step 6「PR 本文の closing keyword 確認」を実施する**。
+
+release-please は、コミット本文が `refs #N` であっても release PR の本文では `closes [#N](...)` としてレンダリングする。squash merge では PR 本文の closing keyword が効くため、リリース PR のマージは該当 issue を閉じる。**リリース PR ではこの確認が必ず該当する。**
+
+```bash
+gh api "repos/:owner/:repo/pulls/$ARGUMENTS" --jq .body | grep -i 'closes\|fixes\|resolves'
+```
+
+ヒットした場合の判定基準（スコープの全体カバー / Epic・追跡用 issue でないか / 未完了チェックボックスの有無）と、閉じてはいけない issue があった場合の `gh pr edit` による `closes` → `refs` 書き換え手順は `.claude/commands/merge-check.md` の Step 6 が SSoT である。
+
+確認が済んだらマージする。
 
 ```bash
 gh pr merge $ARGUMENTS --squash --delete-branch
@@ -132,5 +142,6 @@ gh pr merge $ARGUMENTS --squash --delete-branch
 
 ## 参照
 
+- `.claude/commands/merge-check.md` Step 6（SSoT: PR 本文の closing keyword 確認、閉じてよい issue かの判定基準、`closes` → `refs` の書き換え手順）
 - `docs/runbook/release-please-kick.md`（SSoT: BLOCKED の原因、BEHIND と純 BLOCKED の判定、`RELEASE_KICK_PAT` セットアップ、`workflow_dispatch` 版が deprecated である理由）
 - CLAUDE.md「`N of N required checks are expected` = bot/GITHUB_TOKEN push」ガード

--- a/docs/development/guard-ledger.yaml
+++ b/docs/development/guard-ledger.yaml
@@ -163,6 +163,10 @@ guards:
       呼ばれるだけであるため、実行しないという選択が依然として可能なこと。必須チェック化は
       「人間コメントが 1 件付いた瞬間に恒久的にマージ不能になる」誤停止を生み、improvement-flow.md の
       「止めるべきでないものを止めない」を満たせないため採らなかった。/preflight の実施も散文のまま残る。
+      2026-08-12 の再発として、release PR #1830 のマージで Issue #1827 が事故で close された
+      （retrospectives/2026-08-12.md の O5）。PR 本文の closing keyword 確認を /merge-check の Step 6 と
+      governance.md のチェックリスト 6 番へ追加し、/release-kick の Step 7 から参照させた。
+      これは手順の追加であって機械検証ではないため mechanized は partial のまま据え置く。
 
   - id: strict-mode-batch-merge
     title: Strict-mode batch merge

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -102,6 +102,21 @@ gh pr view <N> --json labels --jq '[.labels[].name]'
 
 `git commit` / `git push` / `git switch` / `gh pr merge` の直後は、出力されたブランチ名・コミットハッシュ・status 行を読み、意図したターゲットに作用したことを確認してから次のコマンドへ進んでください。曖昧な場合は `git status -sb` または `git rev-parse --abbrev-ref HEAD` で再確認します。
 
+#### 6. PR 本文の closing keyword 確認
+
+squash merge では **PR 本文**の closing keyword（`closes` / `fixes` / `resolves` + issue 番号）が効き、マージと同時に該当 issue が close されます。コミット本文が `refs #N` であっても、PR 本文が `closes #N` なら閉じます。
+
+```bash
+gh api "repos/:owner/:repo/pulls/<N>" --jq .body | grep -i 'closes\|fixes\|resolves'
+```
+
+- grep はコードブロックや引用の中の言及も拾うため、ヒットしても実際に紐付いているとは限りません。GraphQL の `closingIssuesReferences` で、GitHub が close 対象として解決した issue を確定させてください。
+- 該当する issue が「閉じてよいもの」かは、PR のスコープが issue 全体をカバーしているか / Epic・追跡用 issue でないか / 本文に未完了のチェックボックスや残作業の記述がないか、の 3 点で判定します。
+- 閉じてはいけない issue がある場合は、マージ前に `gh pr edit <N> --body` で `closes` を `refs` へ書き換えます。
+- 実行手順・判定基準・書き換えコマンドの詳細は `/merge-check` の Step 6（`.claude/commands/merge-check.md`）を参照してください。**リリース PR では必ず該当します。**
+
+> **経緯**: 2026-08-12、Issue #1827 が release PR #1830 のマージで自動 close されました。閉じる判断は誰もしていません。コミット本文は `refs #1827` でしたが、release-please は release PR の本文を `closes [#1827]` としてレンダリングします。当時この確認手順は `/merge-check` にも `/release-kick` にも存在せず、セッションを跨がない carry-over 台帳にしかありませんでした（`docs/development/retrospectives/2026-08-12.md` の O5）。
+
 ### レビュアーコメントの扱い
 
 CI の成否はレビュアーコメント（`Copilot` / `sentry[bot]` などの AI レビュアー、および人間レビュアー）をカバーしません。これらは CI を失敗させないため見落としやすい一方、実バグを指摘していることがあります。マージ前には本セクションの手順で必ず列挙・評価してください。


### PR DESCRIPTION
## 背景（実事故）

2026-08-12、Issue #1827 が release PR #1830 のマージによって**自動 close されました**。閉じる判断は誰もしていません。

経路: 実装 3 本のコミット本文には `refs #1827` と正しく書いていましたが、**release-please は release PR の本文で `closes [#1827]` としてレンダリングします**。squash merge では PR 本文の closing keyword が効くため、release PR のマージが issue を閉じました。

`docs/development/retrospectives/2026-08-12.md` の O5 が SSoT です。同節が記録しているとおり、**この確認手順は repo 側のどのコマンドにも存在せず**、セッションを跨がない carry-over 台帳にしかありませんでした。

## 変更内容

| ファイル | 変更 |
| --- | --- |
| `.claude/commands/merge-check.md` | **Step 6「PR 本文の closing keyword 確認」を新設**（旧 Step 6/7 を 7/8 へ繰り下げ、判定条件・禁止事項・背景節も更新）。`allowed-tools` に `gh pr edit` / `gh issue view` を追加 |
| `docs/governance.md` | マージ前チェックリストへ「6. PR 本文の closing keyword 確認」を追加（このチェックリストが SSoT） |
| `.claude/commands/release-kick.md` | Step 7 のマージ直前に merge-check Step 6 の実施を要求。release PR では必ず該当する旨と参照を追加 |
| `docs/development/guard-ledger.yaml` | `merge-time-checks` の `notes` へ本追加を追記。手順追加であり機械検証ではないため `mechanized: partial` は据え置き |

### 判定基準

単に列挙するだけでは前回と同じく素通りするため、「閉じてはいけない issue」の判定基準を明記しました。1 つでも該当すれば閉じてはいけません。

1. PR のスコープが issue 全体をカバーしていない
2. Epic / 追跡用 issue（複数 PR にまたがる傘 issue）である
3. 本文に未完了のチェックボックスまたは残作業の記述がある

判定が付かない場合は「閉じてはいけない」側へ倒す、としています。誤って開けたままにするのは後から閉じられますが、事故 close は「判断して閉じた」記録と区別が付かなくなるためです。

## 実行検証（Execute what you document）

本 PR 自身が「Execute what you document」の対象です。追加した手順を実 PR に対して実行しました。

**検出できること（#1830 = `closes [#1827]` が実在）:**

```console
$ gh api repos/:owner/:repo/pulls/1830 --jq .body | grep -i 'closes\|fixes\|resolves'
* **meta:** pipeline call site チェックリストを機械照合する ([#1831](...)), closes [#1827](https://github.com/s977043/river-review/issues/1827)
```

**grep だけでは足りないこと（#1836 = 振り返り PR。本文が O5 の記述を引用しているため grep はヒットするが、実際には何も閉じない）:**

```console
$ gh api graphql -f query='...closingIssuesReferences...' -F o=:owner -F r=:repo -F n=1830 --jq '...'
[{"number":1827,"state":"CLOSED","title":"[Chore] 再発実績のある 3 ガード..."}]

$ gh api graphql -f query='...closingIssuesReferences...' -F o=:owner -F r=:repo -F n=1836 --jq '...'
[]
```

この差から、grep をヒット判定、GraphQL `closingIssuesReferences` を確定判定とする 2 段構成にしました。

**書き換え手順の dry-run（#1830 の実本文に対して）:**

```console
$ gh api repos/:owner/:repo/pulls/1830 --jq .body | sed 's/closes \[#/refs [#/g' | grep 'refs \[#'
* **meta:** ... , refs [#1827](https://github.com/s977043/river-review/issues/1827)
```

### 執筆中に自己訂正した誤り

初稿では「`-F o=:owner` の `:owner` は GraphQL では展開されない」と書きましたが、実行して**誤りと判明**しました。`gh api graphql` でも展開され、#1830 に対して `[{"number":1827}]` が返ります。該当記述は実測に合わせて訂正済みです。

## 検証

| コマンド | exit code |
| --- | --- |
| `npx textlint --no-cache -c tools/textlint/docs.textlintrc.json docs/governance.md` | 0 |
| `npm run fix:dashes` | 0 |
| `npm run lint` | 0 |
| `npm run meta:validate` | 0（Meta consistency: OK / Doc enumerations: OK / Sidebar reachability: OK） |
| guard-ledger.yaml の js-yaml パース + `notes` 全文の可視性確認 | 0 |

`.claude/commands/**` は textlint のスコープ外です（`lint:text` は `pages/**` と `docs/**` のみ）。

## スコープ外

- **script 化はしていません。** 今回は「手順追加」の判断です。将来、`closingIssuesReferences` の取得と「Epic か / 未完了チェックボックスがあるか」の機械判定を `scripts/` へ倒す余地はあります（`check-comment-disposition.mjs` と同じ形）。ただし「PR のスコープが issue 全体をカバーしているか」は決定論では判定できないため、機械化しても partial 止まりになります
- CLAUDE.md「Merge-time checks」ガード本文は変更していません（詳細手順は governance.md を正とする現行の分担どおり）
- `guard-ledger.yaml` の `mechanized` は `partial` のまま据え置いています

🤖 Generated with [Claude Code](https://claude.com/claude-code)