### PR TITLE
test(skills): upstream skill 8 件に S1 fixtures を追加し免除を外す

### DIFF
--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -72,8 +72,8 @@
     {
       "id": "architecture-risk-register",
       "path": "skills/upstream/architecture-risk-register",
-      "checksum": "sha256:5dc77301b0c232722ec946bc44435d9b5a13b214a7e98cb1b892bc162f6a7140",
-      "files": 1
+      "checksum": "sha256:83d790949e808bfe4f7f1319e5a6efe1828fcc5a7bb59520d78de50a8da4fac6",
+      "files": 3
     },
     {
       "id": "architecture-traceability",
@@ -102,8 +102,8 @@
     {
       "id": "availability-architecture",
       "path": "skills/upstream/availability-architecture",
-      "checksum": "sha256:979eea3581bbcb7d1c59da6f11f83aec1a84d92d447155fc8b14976c699ef73f",
-      "files": 1
+      "checksum": "sha256:bfd91b96e51b7e51949fbbeb1357e8581fa2f4d2f43eb47a24f71162a4de5ffb",
+      "files": 3
     },
     {
       "id": "behavior-structure-separation",
@@ -126,8 +126,8 @@
     {
       "id": "capacity-cost-design",
       "path": "skills/upstream/capacity-cost-design",
-      "checksum": "sha256:3c2183bec2eaeb92152a87732eeb4f9e40c528b88a1f8943d057e598a8b46a65",
-      "files": 1
+      "checksum": "sha256:e09c13e14bde6ae2edca06de7f4e3f4f987a92a5ff3489da1bae6b52b994dd3d",
+      "files": 3
     },
     {
       "id": "change-communication",
@@ -216,8 +216,8 @@
     {
       "id": "data-flow-state-ownership",
       "path": "skills/upstream/data-flow-state-ownership",
-      "checksum": "sha256:fb99298f3f66e0e64613a01ca2e862d608a3280cfeaa5daa317edbcd643a9cf0",
-      "files": 1
+      "checksum": "sha256:ee73c1feb55c104f2274996e5ede3234afb0c1bc4a68d11f9505a0f8efe74ca8",
+      "files": 3
     },
     {
       "id": "data-model-db-design",
@@ -408,8 +408,8 @@
     {
       "id": "migration-rollout-rollback",
       "path": "skills/upstream/migration-rollout-rollback",
-      "checksum": "sha256:6d65c11517c542d053f79f050815a8a1ad796637857f79b0470f75646f964715",
-      "files": 1
+      "checksum": "sha256:82b7872451b0c45a35590fe5c025b6616bd1c3664d9599d3023755f715026e02",
+      "files": 3
     },
     {
       "id": "migration-safety",
@@ -480,8 +480,8 @@
     {
       "id": "operability-slo",
       "path": "skills/upstream/operability-slo",
-      "checksum": "sha256:b20d7548aed38362a111584a3300647fda4ddc404ca49d978d7f243b2f34d91e",
-      "files": 1
+      "checksum": "sha256:fc83f6fbc993346e6771aabb89bb2c58f99b6a555b827ff57f564996b823ebc4",
+      "files": 3
     },
     {
       "id": "plan-review-gate",
@@ -564,8 +564,8 @@
     {
       "id": "requirements-acceptance",
       "path": "skills/upstream/requirements-acceptance",
-      "checksum": "sha256:be6e1c281b93e7df2cd5757f4401931ac4e2a3720094204371c7b96ee527129c",
-      "files": 1
+      "checksum": "sha256:1d4f8e41421e8de123944b8a1e30244463e8acdcf11dc6073fac148db0323b47",
+      "files": 3
     },
     {
       "id": "review-automation-boundary",
@@ -726,8 +726,8 @@
     {
       "id": "trust-boundaries-authz",
       "path": "skills/upstream/trust-boundaries-authz",
-      "checksum": "sha256:3278b1bbad2636faedbf349b751d1b4f657ec3fb8b73052d7e635fb702c2ec81",
-      "files": 1
+      "checksum": "sha256:09ecab5132883b228f1d93879cb96703db77335f5c05d3b18ab1ac64a6bb826e",
+      "files": 3
     },
     {
       "id": "type-driven-design",

--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -33,14 +33,6 @@ const GRANDFATHERED_WITHOUT_EVAL = new Set([
   'refactor-claim-audit',
   'cross-file-leakage',
   'e2e-wiring',
-  'architecture-risk-register',
-  'availability-architecture',
-  'capacity-cost-design',
-  'data-flow-state-ownership',
-  'migration-rollout-rollback',
-  'operability-slo',
-  'requirements-acceptance',
-  'trust-boundaries-authz',
 ]);
 
 // #1598: contexts the default runner path (`river run` → src/lib/local-runner.mjs

--- a/skills/upstream/architecture-risk-register/fixtures/01-unowned-assumptions-and-open-questions-should-detect.md
+++ b/skills/upstream/architecture-risk-register/fixtures/01-unowned-assumptions-and-open-questions-should-detect.md
@@ -1,0 +1,76 @@
+# Fixture 01 — Assumptions, risks, and open questions left unowned (Happy Path)
+
+## Description
+
+A design document adds a section that states assumptions, risks, and open
+questions, but none of them are managed. Four Checklist items of this skill fail
+deterministically from the text alone:
+
+1. **Assumptions（前提）** — the assumption「レガシー側の会員データは重複が無い」は
+   明示されているが、崩れたときに何が壊れるかが書かれていない。
+2. **Risks（リスク）** — 移行リスクが「あるかもしれない」と列挙されるだけで、緩和策
+   （mitigation）も検証計画（spike/PoC）も無い。
+3. **Open Questions（未決事項）** — 未決が 2 件挙がっているが、Owner も期限も判断材料
+   も無い。
+4. **Follow-up（追跡）** — TODO が消し込み条件（完了定義）なしで置かれている。
+
+The Pre-execution Gate is satisfied: the path matches `docs/**/*design*.md`, and
+the diff adds statements about assumptions, risks, and open decisions.
+
+## Input Diff
+
+```diff
+diff --git a/docs/design/member-unification.md b/docs/design/member-unification.md
+--- a/docs/design/member-unification.md
++++ b/docs/design/member-unification.md
+@@ -10,6 +10,16 @@
+ 会員基盤を新サービスへ統合する。
+
++## 前提とリスク
++
++レガシー側の会員データは重複が無い前提で移行する。
++
++移行にはリスクがあるかもしれない。旧IDでの参照が残っている可能性がある。
++
++未決: 退会済み会員を移行対象に含めるか。
++未決: 旧システムの停止時期。
++
++TODO: 権限マッピングをあとで詰める。
+```
+
+## Expected Behavior
+
+- A summary line first (`(summary):1: ...`), naming the newly added assumptions,
+  risks, and open questions.
+- A finding that the「重複が無い」前提 has no stated blast radius: 崩れた場合に何が
+  壊れるか（統合先での ID 衝突なのか、二重請求なのか）が無いため、監視すべき兆候も
+  導出できない。Severity major, with the `前提: <内容> / 崩れた場合: <影響> / 監視: <兆候>`
+  template.
+- A finding that the migration risk is stated without mitigation or a validation
+  plan, so it cannot be tracked or closed. Severity major, with the
+  `リスク: <内容> / 影響: <大> / 緩和: <案> / Owner: <役割> / 期限: <>` template.
+- A finding that both open questions lack Owner, deadline, and the information
+  needed to decide — they are recorded but not managed. Severity major, with the
+  `未決: <問い> / 判断材料: <必要情報> / Owner: <役割> / 期限: <>` template.
+- A finding that the TODO has no completion condition, so it cannot be closed out.
+  Severity minor.
+- At most 8 findings total, per the Rule.
+- No finding demanding that the open questions be resolved now — the Non-goals
+  state that unresolved items are to be managed as unresolved, not treated as
+  defects.
+
+<!-- expected:
+findings:
+  - severity: major
+    reason: 前提「重複が無い」が崩れた場合の影響（何が壊れるか）と監視すべき兆候が書かれていない
+    anchor: docs/design/member-unification.md:14
+  - severity: major
+    reason: 移行リスクが列挙されるだけで緩和策も検証計画（spike/PoC）も無く、追跡・消し込みができない
+    anchor: docs/design/member-unification.md:16
+  - severity: major
+    reason: 未決事項 2 件に Owner・期限・判断材料が無く、記録されているだけで管理されていない
+    anchor: docs/design/member-unification.md:18
+  - severity: minor
+    reason: TODO に消し込み条件（完了定義）が無く、いつ完了したと言えるかが決まらない
+    anchor: docs/design/member-unification.md:21
+-->

--- a/skills/upstream/architecture-risk-register/fixtures/02-risks-tracked-in-referenced-register-should-not-detect.md
+++ b/skills/upstream/architecture-risk-register/fixtures/02-risks-tracked-in-referenced-register-should-not-detect.md
@@ -1,0 +1,62 @@
+# Fixture 02 — Risks and open questions tracked in a referenced register (False-Positive Guard)
+
+## Description
+
+The diff changes a document under `docs/**/*design*.md` and it does touch
+assumptions, risks, and open questions, so both content conditions of the
+Pre-execution Gate are satisfied. But every Checklist item this skill would raise
+is already answered: the assumption and its blast radius, the risk with its
+mitigation and Owner, and the open question with its decision material, deadline,
+and Owner all live in an existing risk register that this document links to and
+does not change. This is the skill's guard「既にリスク/前提/未決が別ドキュメントで
+管理され、参照が明確な場合は重複指摘しない」.
+
+Repository context (not part of the diff):
+
+```text
+docs/architecture/risk-register.md (existing, unchanged) records for this design:
+  - 前提 A-3「レガシー会員データに重複が無い」/ 崩れた場合: 統合先で会員IDが衝突し
+    請求が二重に走る / 監視: 移行バッチの duplicate_key カウンタ
+  - リスク R-7「旧IDでの参照が残存」/ 影響: 大 / 緩和: 旧ID→新ID の変換テーブルを
+    6か月併存 / 検証: ステージングでの全件リプレイ PoC / Owner: 会員基盤チーム /
+    期限: 2026-09-30
+  - 未決 Q-2「退会済み会員を移行対象に含めるか」/ 判断材料: 法務の保持期間見解と
+    退会済み件数 / Owner: PM / 期限: 設計凍結レビュー（2026-09-05）
+```
+
+## Input Diff
+
+```diff
+diff --git a/docs/design/member-unification.md b/docs/design/member-unification.md
+--- a/docs/design/member-unification.md
++++ b/docs/design/member-unification.md
+@@ -10,6 +10,14 @@
+ 会員基盤を新サービスへ統合する。
+
++## 前提・リスク・未決
++
++本設計の前提（A-3）、リスク（R-7）、未決事項（Q-2）は
++[リスク登録簿](../architecture/risk-register.md) で Owner・期限・緩和策・判断材料
++付きで管理しており、本ドキュメントでは再掲しない。本変更でこれらの内容は変わらない。
++
++移行完了の定義: 変換テーブル経由の参照が 30 日連続で 0 件になった時点で R-7 を
++クローズし、変換テーブルを削除する。
+```
+
+## Expected Behavior
+
+- `findings: []` (a summary line may still be emitted; it is not a finding).
+- The assumption's blast radius and monitoring signal, the risk's mitigation,
+  validation plan, Owner and deadline, and the open question's decision material,
+  Owner and deadline are all delegated to the linked register, which the guard
+  treats as clear. Re-raising them would be a duplicate finding.
+- The one thing this diff does add — the Follow-up tracking item — carries an
+  explicit close-out condition (30 consecutive days of zero references), so the
+  Follow-up checklist item is satisfied rather than open.
+- No finding is raised for the open question being unresolved: the Non-goals
+  exclude treating uncertainty itself as a defect once it is managed.
+
+<!-- expected:
+findings: []
+reason: 前提・リスク・未決は Owner / 期限 / 緩和策 / 判断材料付きでリスク登録簿に管理され参照が明確（重複指摘の抑制条件に該当）、追加された追跡項目にも消し込み条件が明記されている
+-->

--- a/skills/upstream/availability-architecture/fixtures/01-no-slo-no-failover-should-detect.md
+++ b/skills/upstream/availability-architecture/fixtures/01-no-slo-no-failover-should-detect.md
@@ -1,0 +1,81 @@
+# Fixture 01 — Critical path made single-region with no SLO or failover (Happy Path)
+
+## Description
+
+An architecture document moves a request-critical service to a single region and
+adds a cache in front of it. Four Checklist items of this skill fail
+deterministically from the text alone:
+
+1. **可用性目標と測定** — 重要パスの SLI/SLO（p99、エラー率）も、その計測方法・
+   除外条件も定義されていない。「速くする」としか書かれていない。
+2. **フェイルオーバーと復旧** — 障害時の切り替え手順（自動/手動）、判定メトリクス、
+   RTO/RPO のいずれも無い。「手で戻す」とだけ書かれている。
+3. **容量と冗長** — ピーク前提もスケール戦略も無く、リージョン冗長を明示的に捨てた
+   のに段階的スケール案が無い。
+4. **劣化モードと観測性** — キャッシュ不通時の挙動（バックプレッシャー、graceful
+   degradation）が説明されておらず、異常時に見るべきメトリクス/ダッシュボード/
+   アラートも列挙されていない。
+
+The Pre-execution Gate is satisfied: the path is under `docs/architecture/**`,
+and the diff adds statements about availability, redundancy, and recovery.
+
+## Input Diff
+
+```diff
+diff --git a/docs/architecture/session-store.md b/docs/architecture/session-store.md
+new file mode 100644
+--- /dev/null
++++ b/docs/architecture/session-store.md
+@@ -0,0 +1,12 @@
++# Session store
++
++## Decision
++
++セッション参照を高速化するため、セッションストアを単一リージョンに集約し、
++その手前にインメモリキャッシュを置く。速くすることが目的。
++
++## 冗長構成
++
++マルチリージョンはコストが見合わないため採用しない。
++
++障害が起きたら手で戻す。
+```
+
+## Expected Behavior
+
+- A summary line first (`(summary):1: ...`), naming the availability, failover,
+  and capacity impact of collapsing to a single region.
+- A finding that no failover procedure exists: neither the trigger metric, nor
+  whether the switch is automatic or manual, nor RTO/RPO are stated, while every
+  request on the critical path now depends on one region. Severity critical, with
+  the `Failover: trigger=<>, action=<>, verification=<logs>` template.
+- A finding that no SLI/SLO is defined for the critical path, and no measurement
+  method or exclusion condition exists, so the change cannot be evaluated as an
+  improvement or a regression. Severity major, with the
+  `SLO: service=<>, metric=p99 latency, target=<>, measurement=<dash>` template.
+- A finding that region redundancy is dropped on a cost argument with no peak
+  traffic assumption, headroom, or staged scaling alternative behind it.
+  Severity major, with the `Capacity: peak=<>, headroom=<>, scaling=<policy>`
+  template.
+- A finding that the degraded behaviour when the cache is unavailable is
+  unspecified, and the metrics, dashboards, and alerts to watch during an
+  incident are not listed. Severity major.
+- At most 8 findings total, per the Rule.
+- No finding recommending a particular cloud provider or managed cache product —
+  the Non-goals exclude infrastructure product selection.
+
+<!-- expected:
+findings:
+  - severity: critical
+    reason: 単一リージョン集約にもかかわらず切り替え手順・判定メトリクス・RTO/RPO が無く、障害時に復旧手段を選べない
+    anchor: docs/architecture/session-store.md:12
+  - severity: major
+    reason: 重要パスの SLI/SLO と計測方法・除外条件が定義されておらず、改善か劣化かを評価できない
+    anchor: docs/architecture/session-store.md:5
+  - severity: major
+    reason: ピークトラフィック前提・余裕・段階的スケール案が無いままコストのみを根拠にリージョン冗長を捨てている
+    anchor: docs/architecture/session-store.md:10
+  - severity: major
+    reason: キャッシュ不通時の劣化挙動が未定義で、異常時に見るべきメトリクス・ダッシュボード・アラートも列挙されていない
+    anchor: docs/architecture/session-store.md:6
+-->

--- a/skills/upstream/availability-architecture/fixtures/02-poc-scope-declared-should-not-detect.md
+++ b/skills/upstream/availability-architecture/fixtures/02-poc-scope-declared-should-not-detect.md
@@ -1,0 +1,69 @@
+# Fixture 02 — Availability terms in a referenced runbook, PoC scope declared (False-Positive Guard)
+
+## Description
+
+The diff changes a document under `docs/architecture/**` and it does touch
+availability, redundancy, and recovery wording, so both content conditions of the
+Pre-execution Gate are satisfied. Two suppression paths apply at once and neither
+depends on the gate failing:
+
+- The document declares itself PoC scope with no production availability
+  responsibility, which is the skill's guard「ドキュメントが PoC/実験系で、本番可用性
+  を担保する責務が無いと明記されている場合は強度を下げる」.
+- The production availability terms it does reference — SLO, failover trigger,
+  RTO/RPO, capacity headroom, degraded mode — are maintained in an existing
+  runbook that this diff links to and does not change.
+
+Repository context (not part of the diff):
+
+```text
+docs/architecture/session-store-runbook.md (existing, unchanged) defines:
+  SLO (99.95%/30d, p99 40ms, measured at the gateway, excluding client aborts),
+  failover (trigger: 5xx rate > 2% for 3 min → automatic switch to the standby
+  region; verification: gateway error-rate panel), RTO 5 min / RPO 60 s,
+  capacity (peak 12k rps, 40% headroom, staged scale-out policy), and the
+  degraded mode (cache miss falls through to the store; store unavailable →
+  read-only sessions with a visible banner).
+```
+
+## Input Diff
+
+```diff
+diff --git a/docs/architecture/session-store-experiment.md b/docs/architecture/session-store-experiment.md
+new file mode 100644
+--- /dev/null
++++ b/docs/architecture/session-store-experiment.md
+@@ -0,0 +1,13 @@
++# Session store: cache shape experiment (PoC)
++
++> スコープ: 本 PoC は社内検証環境のみで実施し、本番トラフィックは一切流さない。
++> 本番可用性を担保する責務は本ドキュメントに無い。
++
++## 目的
++
++キャッシュのキー形状 2 案について、検証環境でヒット率のみを比較する。
++
++## 本番の可用性要件
++
++SLO・フェイルオーバー条件・RTO/RPO・容量余裕・劣化モードは
++[運用 Runbook](./session-store-runbook.md) が正であり、本 PoC では変更しない。
+```
+
+## Expected Behavior
+
+- `findings: []` (a summary line may still be emitted; it is not a finding).
+- SLO, measurement definition, failover trigger and verification, RTO/RPO,
+  capacity headroom, and degraded mode are not restated here — they are delegated
+  to the linked runbook, which this diff leaves unchanged. Re-raising them would
+  be a duplicate finding.
+- The PoC scope is declared explicitly and bounded (internal verification
+  environment, no production traffic), so the skill lowers its strength rather
+  than demanding production availability artifacts, per the guard.
+- No finding is raised about the missing SLO for the experiment itself: an
+  experiment with no production traffic has no user-facing availability target
+  to define.
+
+<!-- expected:
+findings: []
+reason: 本番可用性の責務が無い PoC と明記されており（抑制条件に該当）、SLO・フェイルオーバー・RTO/RPO・容量・劣化モードは不変の運用 Runbook で管理され参照が明確
+-->

--- a/skills/upstream/capacity-cost-design/fixtures/01-no-traffic-assumption-retry-amplification-should-detect.md
+++ b/skills/upstream/capacity-cost-design/fixtures/01-no-traffic-assumption-retry-amplification-should-detect.md
@@ -1,0 +1,83 @@
+# Fixture 01 — No traffic assumption, retry amplification, unbounded cost (Happy Path)
+
+## Description
+
+A design document adds a fan-out enrichment step to a critical path. Four
+Checklist items of this skill fail deterministically from the text alone:
+
+1. **トラフィック前提** — 想定 QPS・ピーク・データ量・同時接続の前提が無く、成長率と
+   その期間の前提も無い。「今と同じくらい」としか書かれていない。
+2. **性能予算（Budget）** — 重要フローの p95/p99 目標も内訳も無い。さらに 1 リクエスト
+   につき 5 並列呼び出し × 各 3 回リトライを規定しており、依存先が劣化した瞬間に
+   負荷が 15 倍へ増幅する前提になっている。
+3. **ボトルネックと限界** — 依存先（検索インデックス）の上限と劣化時のふるまいが無く、
+   キュー溢れやレート制限時の落としどころ（backpressure）も無い。
+4. **コスト** — コストドライバー（外部 API 課金、データ転送、ログ量）が列挙されず、
+   コスト上限も監視もアラートも無い。
+
+The Pre-execution Gate is satisfied: the path matches `docs/**/*design*.md`, and
+the diff adds statements about performance, capacity, and cost assumptions.
+
+## Input Diff
+
+```diff
+diff --git a/docs/design/search-enrichment.md b/docs/design/search-enrichment.md
+new file mode 100644
+--- /dev/null
++++ b/docs/design/search-enrichment.md
+@@ -0,0 +1,14 @@
++# Search enrichment
++
++## 方式
++
++検索結果 1 件ごとに、外部の在庫 API を呼んで在庫数を付与する。1 リクエストあたり
++5 件を並列で呼び、失敗したら各 3 回までリトライする。
++
++## 前提
++
++トラフィックは今と同じくらいを想定する。
++
++## コスト
++
++外部 API は従量課金だが、多くはならないと見込む。
+```
+
+## Expected Behavior
+
+- A summary line first (`(summary):1: ...`), naming the critical path and the
+  assumptions the change introduces.
+- A finding on retry amplification: 5 parallel calls × 3 retries per request means
+  a dependency slowdown multiplies load by up to 15× exactly when the dependency
+  is already failing, and no timeout or retry budget bounds it. Severity critical,
+  with the `性能: p95=<ms>, p99=<ms>, timeout=<ms>, retry=<回数>` template.
+- A finding that no traffic assumption exists — peak QPS, payload size, data
+  growth rate, and the period they cover are all absent, so no capacity figure in
+  this document can be checked. Severity major, with the
+  `前提: peakQPS=<>, payload=<>, dataGrowth=<>, 期間=<>` template.
+- A finding that the dependency's rate limit / quota and its behaviour under
+  degradation are unstated, and no backpressure or shedding policy exists for
+  queue overflow or rate-limit responses. Severity major.
+- A finding that per-call billing is asserted to be small with no volume behind
+  it: cost drivers are not enumerated and no budget cap, monitoring metric, or
+  alert threshold can be derived. Severity major, with the
+  `コスト: ドライバー=<>, 上限=<>, 監視=<メトリクス>` template.
+- At most 8 findings total, per the Rule.
+- No finding prescribing a specific cache implementation or query rewrite — the
+  Non-goals exclude implementation-level tuning and infrastructure product
+  choices.
+
+<!-- expected:
+findings:
+  - severity: critical
+    reason: 1 リクエストあたり 5 並列 × 各 3 回リトライで依存先劣化時に負荷が最大 15 倍へ増幅する前提になっており、タイムアウトもリトライ予算も無い
+    anchor: docs/design/search-enrichment.md:6
+  - severity: major
+    reason: 想定 QPS・ピーク・データ量・成長率とその期間の前提が無く、容量の妥当性を検証できない
+    anchor: docs/design/search-enrichment.md:10
+  - severity: major
+    reason: 依存する在庫 API の上限（レート制限/クォータ）と劣化時のふるまい、キュー溢れ時の backpressure・落としどころが無い
+    anchor: docs/design/search-enrichment.md:5
+  - severity: major
+    reason: コストドライバーが列挙されず、呼び出し量の前提なしに従量課金を「多くならない」と断定しているため上限・監視・アラートを導出できない
+    anchor: docs/design/search-enrichment.md:14
+-->

--- a/skills/upstream/capacity-cost-design/fixtures/02-poc-out-of-operation-should-not-detect.md
+++ b/skills/upstream/capacity-cost-design/fixtures/02-poc-out-of-operation-should-not-detect.md
@@ -1,0 +1,67 @@
+# Fixture 02 — Budgets in a referenced capacity plan, PoC scope declared (False-Positive Guard)
+
+## Description
+
+The diff changes a document under `docs/**/*design*.md` and it does touch
+performance and cost wording, so both content conditions of the Pre-execution
+Gate are satisfied. Two suppression paths apply and neither depends on the gate
+failing:
+
+- The document declares itself PoC / not operated in production, which is the
+  skill's guard「PoC/運用対象外と明記されている場合は、必須要件としては扱わず
+  “確認” に留める」.
+- The production traffic assumptions, latency budget, dependency limits, and cost
+  drivers it references live in an existing capacity plan that this diff links to
+  and does not change.
+
+Repository context (not part of the diff):
+
+```text
+docs/design/search-capacity.md (existing, unchanged) states: peak 3,200 rps,
+average payload 4 KB, 8%/month growth over 12 months; p95 180 ms / p99 400 ms
+with a per-hop breakdown; inventory API quota 500 rps with a 250 ms timeout and
+a 1-retry budget under a circuit breaker at 10% error rate; queue overflow sheds
+enrichment and returns un-enriched results; cost drivers (external API calls,
+egress, log volume) with a monthly cap and an 80%-of-cap alert.
+```
+
+## Input Diff
+
+```diff
+diff --git a/docs/design/search-enrichment-poc.md b/docs/design/search-enrichment-poc.md
+new file mode 100644
+--- /dev/null
++++ b/docs/design/search-enrichment-poc.md
+@@ -0,0 +1,13 @@
++# Search enrichment: batching shape PoC
++
++> スコープ: 本 PoC は開発環境の固定データセットに対してのみ実行し、本番運用対象外。
++> 本番トラフィックもコストも発生しない。
++
++## 目的
++
++在庫付与のバッチ粒度 2 案について、開発環境でレイテンシの相対差のみを測る。
++
++## 本番の前提
++
++ピーク QPS・成長率・p95/p99 予算・依存 API の上限とタイムアウト・backpressure・
++コストドライバーと上限は [容量計画](./search-capacity.md) が正であり、本 PoC では変更しない。
+```
+
+## Expected Behavior
+
+- `findings: []` (a summary line may still be emitted; it is not a finding).
+- Traffic assumptions, the latency budget and its breakdown, the dependency quota
+  with timeout and retry budget, the backpressure policy, and cost drivers with a
+  cap and alert are all delegated to the linked capacity plan, which this diff
+  leaves unchanged. Re-raising them would be a duplicate finding.
+- The PoC scope is declared explicitly and bounded (development environment,
+  fixed dataset, no production traffic and no billed cost), so the skill keeps
+  these items as confirmations rather than mandatory requirements, per the guard.
+- No cost finding is raised for the PoC itself: it incurs no metered usage, so
+  there is no cost driver to cap or alert on.
+
+<!-- expected:
+findings: []
+reason: 本番運用対象外の PoC と明記されており（抑制条件に該当）、トラフィック前提・性能予算・依存上限・backpressure・コストドライバーと上限は不変の容量計画で管理され参照が明確
+-->

--- a/skills/upstream/data-flow-state-ownership/fixtures/01-dual-write-no-sot-should-detect.md
+++ b/skills/upstream/data-flow-state-ownership/fixtures/01-dual-write-no-sot-should-detect.md
@@ -1,0 +1,79 @@
+# Fixture 01 — Same state written from two boundaries with no source of truth (Happy Path)
+
+## Description
+
+A data-flow document adds a second writer for an existing entity. Four Checklist
+items of this skill fail deterministically from the text alone:
+
+1. **状態所有（Source of Truth）** — 同じ `orders.status` を注文サービスと配送サービス
+   の 2 つの境界から更新する設計なのに、どちらが SoT かが明示されず、二重更新を許す
+   理由もガードも無い。
+2. **境界横断の書き込み** — 配送サービスからの書き込みが同期か非同期か、順序保証が
+   あるかが書かれておらず、重複配信への対策（冪等性キー、upsert、dedupe）も無い。
+   さらにイベントは at-least-once と明記されている。
+3. **整合性と競合** — 強整合か最終整合かの選択も、同時更新の競合解決（楽観ロック、
+   解決戦略、再試行方針）も無い。
+4. **リカバリ** — 失敗イベントの再処理・リプレイ・DLQ・補償処理の前提が無い。
+
+The Pre-execution Gate is satisfied: the path matches `docs/**/*flow*.md`, and
+the diff adds a cross-boundary write to shared state.
+
+## Input Diff
+
+```diff
+diff --git a/docs/design/order-flow.md b/docs/design/order-flow.md
+--- a/docs/design/order-flow.md
++++ b/docs/design/order-flow.md
+@@ -20,6 +20,13 @@
+ 注文サービスが `orders.status` を更新する。
+
++## 配送側からの反映
++
++配送サービスは出荷イベントを受け取ったら、自分で `orders.status` を `shipped` に
++更新する。イベント基盤は at-least-once 配信。
++
++同時に注文サービス側でもキャンセル操作で `orders.status` を書き換える。
++
++失敗したイベントについては特に決めていない。
+```
+
+## Expected Behavior
+
+- A summary line first (`(summary):1: ...`), naming the new writer and the state
+  it touches.
+- A finding that `orders.status` is now written from two boundaries with no
+  declared source of truth and no guard, so a cancel and a shipment racing on the
+  same order silently produce a different final state depending on arrival order.
+  Severity critical, with the
+  `SoT: <エンティティ>=<所有者境界> / 更新元: <境界> / 反映: <同期/非同期> / 冪等性: <キー>`
+  template.
+- A finding that the delivery is declared at-least-once while no idempotency key,
+  upsert, or dedupe strategy is defined, so a redelivered shipment event can
+  overwrite a later state. Severity critical.
+- A finding that neither the consistency model (strong vs eventual) nor the
+  concurrent-update resolution (optimistic locking, resolution strategy, retry
+  policy) is stated, so the user-visible behaviour under conflict is undefined.
+  Severity major, with the
+  `整合性: <強/最終> / 競合: <方針> / 失敗時: <再試行/補償/再処理>` template.
+- A finding that failed events have no reprocessing, replay, DLQ, or compensation
+  path, so a dropped shipment event leaves the order permanently stale. Severity
+  major.
+- At most 8 findings total, per the Rule.
+- No general lecture on distributed-systems theory and no queue/DB tuning advice
+  — the Non-goals exclude both.
+
+<!-- expected:
+findings:
+  - severity: critical
+    reason: orders.status を注文サービスと配送サービスの 2 境界から更新する設計なのに SoT が明示されず、二重更新を許す理由もガードも無い
+    anchor: docs/design/order-flow.md:24
+  - severity: critical
+    reason: at-least-once 配信を前提としながら冪等性キー・upsert・dedupe のいずれも設計に無く、再配信で後続の状態を上書きしうる
+    anchor: docs/design/order-flow.md:25
+  - severity: major
+    reason: 強整合／最終整合の選択と同時更新の競合解決（楽観ロック・解決戦略・再試行方針）が無く、競合時のユーザー体験が未定義
+    anchor: docs/design/order-flow.md:27
+  - severity: major
+    reason: 失敗イベントの再処理・リプレイ・DLQ・補償処理の前提が無く、イベント欠落時に注文状態が恒久的にずれる
+    anchor: docs/design/order-flow.md:29
+-->

--- a/skills/upstream/data-flow-state-ownership/fixtures/02-ownership-declared-in-referenced-doc-should-not-detect.md
+++ b/skills/upstream/data-flow-state-ownership/fixtures/02-ownership-declared-in-referenced-doc-should-not-detect.md
@@ -1,0 +1,63 @@
+# Fixture 02 — Ownership and idempotency fully specified inline (False-Positive Guard)
+
+## Description
+
+The diff changes a document under `docs/**/*flow*.md` and it does add a
+cross-boundary write, so both content conditions of the Pre-execution Gate are
+satisfied. The skill stays silent because every Checklist item it would raise is
+answered in the diff itself or in the referenced ownership map that this change
+does not touch: the source of truth is declared, the second boundary is
+explicitly a reader-and-requester rather than a writer, delivery is
+idempotency-keyed, the consistency model and conflict policy are stated, and the
+failure path names a DLQ with a compensation step.
+
+Repository context (not part of the diff):
+
+```text
+docs/architecture/state-ownership.md (existing, unchanged) records
+`orders.status` with owner = order service, allowed transitions, the optimistic
+locking column (`orders.lock_version`), and the rule that no other boundary may
+write it directly.
+```
+
+## Input Diff
+
+```diff
+diff --git a/docs/design/order-flow.md b/docs/design/order-flow.md
+--- a/docs/design/order-flow.md
++++ b/docs/design/order-flow.md
+@@ -20,6 +20,18 @@
+ 注文サービスが `orders.status` を更新する。
+
++## 配送側からの反映
++
++`orders.status` の SoT は注文サービス（[状態所有マップ](../architecture/state-ownership.md)
++で管理、本変更では不変）。配送サービスはこれを直接書かず、出荷イベントを
++`ShipmentCompleted` として発行するだけにする。
++
++反映は非同期。注文サービスが購読側で、イベントの `shipmentId` を冪等性キーとして
++`processed_events` に upsert し、既処理なら破棄する（at-least-once 再配信を吸収）。
++更新は `orders.lock_version` の楽観ロックで行い、キャンセル済み注文への出荷反映は
++適用せず `ShipmentAfterCancel` を発行して補償処理へ回す（キャンセル優先）。
++
++整合性は最終整合で、UI では反映待ちを「出荷手続き中」と表示する。処理に 5 回失敗した
++イベントは DLQ へ送り、Runbook の再処理手順でリプレイする。相関IDは `orderId` を使う。
+```
+
+## Expected Behavior
+
+- `findings: []` (a summary line may still be emitted; it is not a finding).
+- Source of truth is declared and the second boundary is explicitly not a writer,
+  so the dual-write concern does not exist here.
+- At-least-once redelivery is absorbed by a named idempotency key and a processed-
+  event upsert, and concurrent updates are resolved by optimistic locking with a
+  stated precedence rule (cancel wins) and a compensation event.
+- The consistency model is chosen (eventual) and its user-visible effect is
+  described, satisfying the 整合性と競合 checklist item rather than leaving it open.
+- Recovery is specified: a retry bound, a DLQ, and a replay procedure; tracking
+  uses `orderId` as the correlation id, satisfying the 監査と追跡 item.
+
+<!-- expected:
+findings: []
+reason: SoT が注文サービスと明示され配送側は書き込まない設計、冪等性キー・楽観ロック・優先規則・補償イベント・最終整合の選択・DLQ とリプレイ・相関IDまで揃っており全チェックリスト項目が充足している
+-->

--- a/skills/upstream/migration-rollout-rollback/fixtures/01-irreversible-cutover-no-rollback-should-detect.md
+++ b/skills/upstream/migration-rollout-rollback/fixtures/01-irreversible-cutover-no-rollback-should-detect.md
@@ -1,0 +1,83 @@
+# Fixture 01 — Big-bang cutover with a destructive step and no rollback (Happy Path)
+
+## Description
+
+A release plan describes a one-shot cutover that drops the old columns in the
+same deploy. Four Checklist items of this skill fail deterministically from the
+text alone:
+
+1. **互換性** — 旧クライアントが残る前提が触れられておらず、破壊的変更に対する
+   バージョニングも移行ガイドも無い。
+2. **段階移行** — ステップ（準備→並行稼働→切替→清掃）が無く、一度に全テナントを
+   切り替える。Feature flag も段階リリースの単位も切替条件も無い。
+3. **ロールバック** — 戻す条件（どのメトリクス/症状で戻すか）が無く、同一デプロイで
+   旧カラムを DROP するため戻したときの整合性が担保できない（実質ロールバック不能）。
+4. **観測性** — リリース中に見るべきメトリクス・ログ・ダッシュボード・アラートが無く、
+   切り分けに使う相関IDの設計も無い。
+
+The Pre-execution Gate is satisfied: the path matches `**/*release*.md` and lives
+under `docs/`, and the diff is about rollout and migration.
+
+## Input Diff
+
+```diff
+diff --git a/docs/release/pricing-v2-release.md b/docs/release/pricing-v2-release.md
+new file mode 100644
+--- /dev/null
++++ b/docs/release/pricing-v2-release.md
+@@ -0,0 +1,12 @@
++# Pricing v2 release
++
++## 手順
++
++リリース当日に全テナントを新価格計算へ一斉に切り替える。
++
++同じデプロイで、旧価格テーブルの `legacy_price` と `legacy_currency` カラムを
++DROP する。
++
++## 確認
++
++リリース後、問題がなさそうならそのまま。問題があれば直す。
+```
+
+## Expected Behavior
+
+- A summary line first (`(summary):1: ...`), naming what changes (pricing
+  calculation, schema) and whether a migration is required.
+- A finding that the cutover is irreversible: dropping `legacy_price` and
+  `legacy_currency` in the same deploy destroys the data a rollback would need,
+  so returning to the old calculation is impossible without a restore. Severity
+  critical, with the
+  `ロールバック条件: <監視指標/閾値/期間> / 手順: <戻す操作> / 注意: <データ整合性>`
+  template.
+- A finding that no staged migration exists: preparation, parallel run, cutover,
+  and cleanup are not separated, there is no feature flag or rollout unit, and no
+  switch condition, so a defect reaches 100% of tenants at once. Severity
+  critical, with the
+  `移行ステップ: 1) 準備, 2) 並行稼働, 3) 切替, 4) 清掃（各ステップの完了条件も）`
+  template.
+- A finding that compatibility with old clients and stored data is not addressed:
+  a breaking pricing change ships with no versioning and no migration guide.
+  Severity major.
+- A finding that「問題がなさそうなら」is not an observable criterion — no metric,
+  log, dashboard, alert, or correlation id is defined for the release window, so
+  a problem cannot be detected or triaged. Severity major.
+- At most 8 findings total, per the Rule.
+- No finding designing the CI/CD pipeline itself — the Non-goals exclude that,
+  except where a missing prerequisite is what causes the gap.
+
+<!-- expected:
+findings:
+  - severity: critical
+    reason: 同一デプロイで legacy_price / legacy_currency を DROP するためロールバック時に必要なデータが失われ、実質ロールバック不能になる
+    anchor: docs/release/pricing-v2-release.md:8
+  - severity: critical
+    reason: 準備→並行稼働→切替→清掃の段階が無く、feature flag も段階リリース単位も切替条件も無いまま全テナントを一斉切替する
+    anchor: docs/release/pricing-v2-release.md:5
+  - severity: major
+    reason: 破壊的な価格計算変更に対する旧クライアント互換期間・バージョニング・移行ガイドが無い
+    anchor: docs/release/pricing-v2-release.md:5
+  - severity: major
+    reason: リリース中に見るべきメトリクス・ログ・ダッシュボード・アラートと切り分け用の相関IDが無く、「問題がなさそう」を観測可能な基準にできない
+    anchor: docs/release/pricing-v2-release.md:12
+-->

--- a/skills/upstream/migration-rollout-rollback/fixtures/02-experiment-only-no-production-impact-should-not-detect.md
+++ b/skills/upstream/migration-rollout-rollback/fixtures/02-experiment-only-no-production-impact-should-not-detect.md
@@ -1,0 +1,57 @@
+# Fixture 02 — Staged rollout fully specified, verification-only phase declared (False-Positive Guard)
+
+## Description
+
+The diff changes a document matching `**/*rollout*.md` under `docs/`, so the
+Pre-execution Gate is satisfied. The skill stays silent because both suppression
+paths hold at once and neither depends on the gate failing:
+
+- The phase this diff adds is explicitly「検証のみ・本番影響なし」（shadow 実行で結果を
+  破棄する）, which is the skill's guard「影響範囲が明確に “実験/検証のみ・本番影響なし”
+  と書かれている場合は、過度に厳しくしない」.
+- The production rollout it belongs to already specifies compatibility window,
+  staged steps with completion conditions, rollback criteria with data-consistency
+  notes, and release-window observability — all in this same document, unchanged
+  by the diff.
+
+## Input Diff
+
+```diff
+diff --git a/docs/release/pricing-v2-rollout.md b/docs/release/pricing-v2-rollout.md
+--- a/docs/release/pricing-v2-rollout.md
++++ b/docs/release/pricing-v2-rollout.md
+@@ -30,6 +30,15 @@
+ ステップ 3) 切替: canary 1% → 10% → 50% → 100%。各段階の完了条件は
+ 「価格差分アラート 0 件かつ p99 が基準比 +10ms 以内で 24 時間経過」。
+ ロールバック条件: 価格差分アラートが 5 分継続、または決済失敗率 > 1%。
+ 手順: feature flag `pricing_v2` を off に戻す（旧カラムは清掃フェーズまで保持）。
+ 観測: 価格差分ダッシュボード、決済失敗率、相関ID `orderId`。
+
++## ステップ 0) shadow 検証（本番影響なし）
++
++切替前に、新価格計算を shadow 実行する。本フェーズは検証のみで本番影響は無い:
++算出結果はレスポンスにも DB にも反映せず、比較ログにのみ書き出して破棄する。
++書き込み・課金・ユーザー向け表示のいずれも発生しない。
++
++比較ログの保持は 14 日。差分率が 0.1% を下回ったらステップ 1 へ進む。
++清掃フェーズ（ステップ 4）で旧カラムを DROP する条件は既存の記載どおり変更しない。
+```
+
+## Expected Behavior
+
+- `findings: []` (a summary line may still be emitted; it is not a finding).
+- The added phase writes nothing, bills nothing, and shows nothing to users, and
+  says so explicitly, so the skill does not demand rollback criteria or a
+  compatibility window for it — there is no production state to return.
+- Compatibility, staged steps with completion conditions, rollback criteria and
+  procedure with the data-consistency note, and release-window observability are
+  already stated in the unchanged part of the same document; re-raising them
+  would be a duplicate finding on content this diff does not modify.
+- The one thing the added phase must define — its exit condition into the next
+  step — is present (difference rate below 0.1%), so the 段階移行 checklist item is
+  satisfied rather than open.
+
+<!-- expected:
+findings: []
+reason: 追加フェーズは書き込み・課金・ユーザー表示のいずれも発生しない検証のみ・本番影響なしと明記され（抑制条件に該当）、互換性・段階と完了条件・ロールバック条件と整合性注意・観測性は同一文書の不変部分に既述、追加分にも次段階への移行条件がある
+-->

--- a/skills/upstream/operability-slo/fixtures/01-no-slo-no-runbook-should-detect.md
+++ b/skills/upstream/operability-slo/fixtures/01-no-slo-no-runbook-should-detect.md
@@ -1,0 +1,81 @@
+# Fixture 01 — New on-call surface with no SLO, alert, or runbook (Happy Path)
+
+## Description
+
+An operations document introduces a nightly reconciliation job that customers
+depend on, but defines nothing an on-call engineer could act on. Four Checklist
+items of this skill fail deterministically from the text alone:
+
+1. **SLO/SLI** — 重要フローの SLI（成功率・レイテンシ）も SLO（目標値）も無く、
+   計測の定義（分母/分子、除外条件、期間）も無い。「だいたい朝までに終わる」だけ。
+2. **監視/アラート** — 直後に見るべきメトリクス/ログ/ダッシュボードが無く、アラート
+   条件（閾値、継続時間、抑制条件）も当番の初動も無い。
+3. **切り分け** — 相関IDや主要属性（tenantId 等）のログ方針が無く、外部依存（対向の
+   決済プロバイダ）の障害時にどこまでが自チームの責任範囲かも書かれていない。
+4. **障害対応/ロールバック** — 失敗時にリトライするのか止めるのか縮退するのかの基準が
+   無く、Runbook の最小要素（症状・確認手順・復旧手順・エスカレーション先）も無い。
+
+The Pre-execution Gate is satisfied: the path matches `**/*operat*.md` under
+`docs/`, and the diff is about operations and monitoring.
+
+## Input Diff
+
+```diff
+diff --git a/docs/operations/nightly-reconciliation.md b/docs/operations/nightly-reconciliation.md
+new file mode 100644
+--- /dev/null
++++ b/docs/operations/nightly-reconciliation.md
+@@ -0,0 +1,11 @@
++# Nightly reconciliation
++
++毎晩 2:00 に決済プロバイダの明細を取り込み、社内の売上テーブルと突合する。
++突合結果は翌営業日の請求に使う。
++
++だいたい朝までに終わる。
++
++失敗したら気づいた人が直す。
++
++外部プロバイダが落ちているときは、まあどうしようもない。
+```
+
+## Expected Behavior
+
+- A summary line first (`(summary):1: ...`), naming the operated surface, the
+  expectation it carries, and what is undecided.
+- A finding that no runbook exists for a job that feeds next-day billing: the
+  symptom, the check procedure, the recovery operation, and the escalation
+  contact are all absent, and「気づいた人が直す」names no responsible party.
+  Severity critical, with the
+  `Runbook: 症状=<何が起きる>, 確認=<見るべきダッシュボード/ログ>, 復旧=<操作>, エスカレーション=<連絡先>`
+  template.
+- A finding that no SLI/SLO is defined and「だいたい朝までに終わる」has no measurable
+  form — no completion deadline, success-rate definition, denominator/numerator,
+  exclusion condition, or period. Severity major, with the
+  `SLO: <対象フロー> / SLI=<指標定義> / 目標=<例: 99.9%/30d> / 計測=<どこで測る>`
+  template.
+- A finding that there is no alert: a silent overnight failure is only discovered
+  by whoever happens to look, and no threshold, duration, suppression condition,
+  or first on-call action is defined. Severity major.
+- A finding that the boundary of responsibility for the payment provider's
+  outages is asserted rather than defined ("どうしようもない"), and that no
+  correlation id or key attribute logging policy exists to separate our failure
+  from theirs. Severity major.
+- At most 8 findings total, per the Rule.
+- No finding recommending a specific monitoring product — the Non-goals exclude
+  tool selection.
+
+<!-- expected:
+findings:
+  - severity: critical
+    reason: 翌営業日の請求に使うジョブに Runbook の最小要素（症状・確認手順・復旧手順・エスカレーション先）が無く、責任者も決まっていない
+    anchor: docs/operations/nightly-reconciliation.md:9
+  - severity: major
+    reason: 重要フローの SLI/SLO が無く「だいたい朝までに終わる」が計測可能な形（完了期限・成功率定義・分母分子・除外条件・期間）になっていない
+    anchor: docs/operations/nightly-reconciliation.md:7
+  - severity: major
+    reason: アラート条件（閾値・継続時間・抑制条件）と当番の初動が無く、夜間の無言失敗を検知できない
+    anchor: docs/operations/nightly-reconciliation.md:9
+  - severity: major
+    reason: 外部決済プロバイダ障害時の責任範囲が定義されておらず、相関IDや主要属性のログ方針も無いため自他の障害を切り分けられない
+    anchor: docs/operations/nightly-reconciliation.md:11
+-->

--- a/skills/upstream/operability-slo/fixtures/02-local-only-tool-should-not-detect.md
+++ b/skills/upstream/operability-slo/fixtures/02-local-only-tool-should-not-detect.md
@@ -1,0 +1,69 @@
+# Fixture 02 — Local-only developer tool, SLO kept in a referenced doc (False-Positive Guard)
+
+## Description
+
+The diff changes a document matching `**/*operat*.md` under `docs/`, so the
+Pre-execution Gate is satisfied. The skill stays silent because both suppression
+paths hold at once and neither depends on the gate failing:
+
+- The subject is a developer-machine-only helper with no production surface, and
+  the document says so, which is the skill's guard「運用対象外（PoC/ローカルのみ）と
+  明記されている場合は、SLO などの要求を過剰に強制しない」.
+- The production reconciliation job's SLO, alerting, triage policy, and runbook
+  live in an existing operations document that this diff links to and does not
+  change.
+
+Repository context (not part of the diff):
+
+```text
+docs/operations/nightly-reconciliation.md (existing, unchanged) defines the SLI
+(records reconciled / records received, excluding provider-side 5xx), the SLO
+(99.5% completed by 06:00 JST, measured monthly), the alert (job not finished by
+06:00, or mismatch rate > 0.2% for 15 min, suppressed during declared provider
+maintenance), the first on-call action, the correlation id (`batchId`,
+`tenantId`), the responsibility boundary against the payment provider, and the
+runbook (symptom, checks, recovery, escalation to the payments on-call).
+```
+
+## Input Diff
+
+```diff
+diff --git a/docs/operations/reconciliation-local-tool.md b/docs/operations/reconciliation-local-tool.md
+new file mode 100644
+--- /dev/null
++++ b/docs/operations/reconciliation-local-tool.md
+@@ -0,0 +1,12 @@
++# Reconciliation diff viewer (local only)
++
++> スコープ: 開発者のローカル環境でのみ実行する調査補助ツール。本番・ステージングの
++> どちらにもデプロイせず、運用対象外。当番も SLO も持たない。
++
++## 使い方
++
++ローカルに落とした突合結果のダンプ 2 つを読み込み、差分を表示するだけ。
++外部への通信もデータの書き戻しも行わない。
++
++## 本番ジョブの運用
++
++SLO・アラート条件・当番の初動・相関ID・責任範囲・Runbook は
++[夜間突合の運用ドキュメント](./nightly-reconciliation.md) が正であり、本変更では変えない。
+```
+
+## Expected Behavior
+
+- `findings: []` (a summary line may still be emitted; it is not a finding).
+- The tool is declared out of operational scope (local only, never deployed, no
+  on-call, no SLO) and it neither writes data nor talks to anything, so demanding
+  an SLO, alert, or runbook for it would be the over-enforcement the guard
+  excludes.
+- The SLI/SLO definition, alert thresholds with suppression, first on-call
+  action, correlation ids, responsibility boundary, and runbook are delegated to
+  the linked operations document, which this diff leaves unchanged. Re-raising
+  them would be a duplicate finding.
+- No triage finding is raised for the missing correlation id in the tool: it
+  reads local dumps only, so there is no cross-service request to correlate.
+
+<!-- expected:
+findings: []
+reason: ローカル実行のみ・運用対象外と明記されており（抑制条件に該当）、本番ジョブの SLO・アラート・当番初動・相関ID・責任範囲・Runbook は不変の運用ドキュメントで管理され参照が明確
+-->

--- a/skills/upstream/requirements-acceptance/fixtures/01-vague-scope-no-acceptance-criteria-should-detect.md
+++ b/skills/upstream/requirements-acceptance/fixtures/01-vague-scope-no-acceptance-criteria-should-detect.md
@@ -1,0 +1,85 @@
+# Fixture 01 — PRD with undefined terms and no testable acceptance criteria (Happy Path)
+
+## Description
+
+A PRD adds a feature whose scope and acceptance are left to the implementer.
+Four Checklist items of this skill fail deterministically from the text alone:
+
+1. **用語とスコープ** — 「管理者」「一括」の定義が無く、対象データも対象外（やらない
+   こと）も既存仕様との違いも書かれていない。
+2. **受け入れ条件** — Given-When-Then のようなテスト可能な受け入れ条件が無い。
+   「使いやすいこと」は観測できない。代表的な例外系（権限なし/入力不備/データなし/
+   タイムアウト/競合）にも一切触れていない。
+3. **非機能** — 期待性能（件数上限、レイテンシ）・可用性/SLO・コスト前提が無く、
+   監査ログ・データ保持・PII の要求も無い。ただし CSV に個人情報が含まれる。
+4. **依存とリスク** — 依存（既存の権限 API、CSV 取り込み基盤）も、未決事項の期限・
+   意思決定者・判断材料も書かれていない。
+
+The Pre-execution Gate is satisfied: the path matches `**/*prd*.md` under `docs/`,
+and the diff adds requirement statements.
+
+## Input Diff
+
+```diff
+diff --git a/docs/product/member-bulk-import-prd.md b/docs/product/member-bulk-import-prd.md
+new file mode 100644
+--- /dev/null
++++ b/docs/product/member-bulk-import-prd.md
+@@ -0,0 +1,11 @@
++# 会員一括取り込み
++
++## やること
++
++管理者が会員情報を一括で取り込めるようにする。CSV をアップロードすると会員が
++作られる。氏名・メールアドレス・電話番号を含む。
++
++## 受け入れ
++
++使いやすいこと。速いこと。
++
++権限まわりは既存に合わせる。
+```
+
+## Expected Behavior
+
+- A summary line first (`(summary):1: ...`), stating what this document decides
+  and what it leaves undecided.
+- A finding that no testable acceptance criteria exist: 「使いやすいこと」「速いこと」
+  cannot be turned into a test, and no exception cases (no permission, malformed
+  input, empty file, timeout, duplicate rows) are covered — so the feature cannot
+  be verified as done. Severity major, with a paste-ready
+  `Given <前提>, When <操作>, Then <期待結果>` 追記案 covering 3〜5 本. No
+  `CriterionRefs:` label is attached to this finding, because no acceptance
+  criterion exists to reference yet.
+- A finding that「管理者」「一括」の定義と対象外（何をやらないか）が無く、既存の会員
+  作成フローとの違いも書かれていないため、実装スコープが人によって変わる。
+  Severity major.
+- A finding that the CSV carries personal data (name, email, phone) while no PII
+  handling, retention period, or audit-log requirement is stated. Severity major.
+- A finding that no non-functional expectation exists — row-count ceiling,
+  processing time, and the behaviour when the limit is exceeded are all unstated,
+  so「速いこと」cannot be sized or tested. Severity major.
+- A finding that「権限まわりは既存に合わせる」names no existing specification, so the
+  dependency is unresolved rather than delegated. Severity minor.
+- At most 8 findings total, per the Rule.
+- No finding prescribing a UI design or an implementation approach — the
+  Non-goals exclude adjudicating those.
+
+<!-- expected:
+findings:
+  - severity: major
+    reason: テスト可能な受け入れ条件が無く（「使いやすい」「速い」は観測不能）、権限なし・入力不備・データなし・タイムアウト・重複行などの例外系も未定義で、完了を検証できない
+    anchor: docs/product/member-bulk-import-prd.md:10
+  - severity: major
+    reason: 「管理者」「一括」の定義と対象外（やらないこと）・既存の会員作成フローとの違いが無く、実装スコープが確定しない
+    anchor: docs/product/member-bulk-import-prd.md:5
+  - severity: major
+    reason: 氏名・メールアドレス・電話番号という個人情報を扱うのに PII の取り扱い・保持期間・監査ログの要求が書かれていない
+    anchor: docs/product/member-bulk-import-prd.md:6
+  - severity: major
+    reason: 件数上限・処理時間・上限超過時の挙動といった非機能要求が無く「速いこと」を見積も検証もできない
+    anchor: docs/product/member-bulk-import-prd.md:10
+  - severity: minor
+    reason: 「権限まわりは既存に合わせる」が参照先の仕様を示しておらず、依存が委譲ではなく未決のまま残っている
+    anchor: docs/product/member-bulk-import-prd.md:12
+-->

--- a/skills/upstream/requirements-acceptance/fixtures/02-existing-spec-outside-diff-should-not-detect.md
+++ b/skills/upstream/requirements-acceptance/fixtures/02-existing-spec-outside-diff-should-not-detect.md
@@ -1,0 +1,72 @@
+# Fixture 02 — Scoped clarification with criteria; older sections left alone (False-Positive Guard)
+
+## Description
+
+The diff changes a document matching `**/*requirements*.md` under `docs/`, so the
+Pre-execution Gate is satisfied. The skill stays silent for two reasons, and
+neither depends on the gate failing:
+
+- What the diff adds is complete on its own terms: the new rule has testable
+  acceptance criteria including exception cases, a stated non-functional bound,
+  the PII handling it needs, and the open question carries an owner, a deadline,
+  and the material required to decide it.
+- The rest of the document — written earlier, unchanged here — is thinner, but
+  the skill's guard is「差分外の既存仕様まで掘り返して問題視しない（今回の変更と
+  直結する範囲に限定）」, so those older sections are out of scope for this review.
+
+Repository context (not part of the diff):
+
+```text
+docs/product/member-bulk-import-requirements.md contains earlier sections
+(「画面レイアウト」「将来的な拡張」) that have no acceptance criteria and no
+non-functional requirements. They are untouched by this diff.
+```
+
+## Input Diff
+
+```diff
+diff --git a/docs/product/member-bulk-import-requirements.md b/docs/product/member-bulk-import-requirements.md
+--- a/docs/product/member-bulk-import-requirements.md
++++ b/docs/product/member-bulk-import-requirements.md
+@@ -40,6 +40,20 @@
+ ## 取り込み時の重複判定
+
++本節で決めること: 同一メールアドレスの行が既存会員と衝突した場合の扱い。
++対象外: 電話番号の重複（本リリースでは判定に使わない）。
++
++受け入れ条件:
++
++- AC-11: Given 既存会員と同じメールアドレスの行がある, When 取り込みを実行する,
++  Then その行は作成せず skipped として結果 CSV に理由付きで出力される。
++- AC-12: Given 取り込み権限を持たない管理者, When 取り込みを実行する,
++  Then 403 を返し、ファイルは保存されない。
++- AC-13: Given 1 ファイル内に同一メールアドレスの行が 2 件ある, When 取り込みを実行する,
++  Then 先頭行のみ作成し、2 件目は duplicate-in-file として skipped になる。
++
++非機能: 1 ファイル 50,000 行まで、5 分以内に完了する。超過分は 400 で拒否する。
++PII: 結果 CSV にメールアドレスを含めるため、保持期間は 7 日、監査ログに実行者と件数を残す。
++
++未決 Q-9: 大文字小文字を区別しない照合にするか。判断材料: 既存会員のメール表記ゆれ件数。
++Owner: PM / 期限: 実装着手前レビュー（2026-09-12）。
+```
+
+## Expected Behavior
+
+- `findings: []` (a summary line may still be emitted; it is not a finding).
+- The added rule defines its scope and its explicit exclusion, so the 用語とスコープ
+  checklist item is satisfied.
+- Acceptance criteria are given in Given-When-Then form and cover the exception
+  cases relevant to this rule (permission denied, in-file duplication), satisfying
+  the 受け入れ条件 item including its exception-case requirement.
+- The non-functional bound (row ceiling, completion time, over-limit behaviour)
+  and the PII handling (retention period, audit log) are stated, satisfying 非機能.
+- The remaining open question is recorded as open with decision material, owner,
+  and deadline — the Non-goals state that an undecided point managed as undecided
+  is not a defect.
+- The document's older, thinner sections are not raised: they are outside this
+  diff, which the guard excludes.
+
+<!-- expected:
+findings: []
+reason: 差分が追加した規則はスコープ・対象外・Given-When-Then の受け入れ条件（例外系含む）・非機能上限・PII 保持と監査ログ・Owner と期限付きの未決まで揃っており、差分外の既存節は抑制条件により掘り返さない
+-->

--- a/skills/upstream/trust-boundaries-authz/fixtures/01-unverified-claims-across-boundary-should-detect.md
+++ b/skills/upstream/trust-boundaries-authz/fixtures/01-unverified-claims-across-boundary-should-detect.md
@@ -1,0 +1,84 @@
+# Fixture 01 — Internal services trust unverified headers across the boundary (Happy Path)
+
+## Description
+
+A security design document introduces a service-to-service call that carries
+identity in plain headers. Four Checklist items of this skill fail
+deterministically from the text alone:
+
+1. **Trust boundary** — 外部→Gateway→内部サービスのどこが信頼境界かが書かれておらず、
+   境界を跨いだ先で「何を信頼できない」かも明示されていない。「内部だから信頼する」
+   とだけ書かれている。
+2. **Authn/Authz の責務** — 認可を Gateway に集約するのか各サービスで判定するのかが
+   決まっておらず、Gateway/BFF/各サービスの責務分担が無い。
+3. **Identity/Claims の伝播** — `X-User-Id` / `X-Tenant-Id` を素のヘッダで伝播し、
+   署名も改ざん防止も無く、受け側での再検証方針も無い。
+4. **監査と特権操作** — 他テナントのデータ閲覧という特権操作を追加しているのに、
+   監査対象の明示も、誰がいつ何をしたかの記録要件も無い。
+
+The Pre-execution Gate is satisfied: the path matches `docs/**/*security*.md`,
+the change is about authn/authz and trust boundaries, and it is not a typo or
+link-only edit.
+
+## Input Diff
+
+```diff
+diff --git a/docs/security/internal-api-security.md b/docs/security/internal-api-security.md
+--- a/docs/security/internal-api-security.md
++++ b/docs/security/internal-api-security.md
+@@ -12,6 +12,14 @@
+ Gateway が外部リクエストを受ける。
+
++## 内部サービス間の呼び出し
++
++Gateway は認証後、`X-User-Id` と `X-Tenant-Id` をヘッダに詰めて内部サービスへ渡す。
++内部サービスはこれをそのまま信頼する。内部ネットワークなので検証は不要とする。
++
++サポート業務のため、サポートサービスは `X-Tenant-Id` を任意の値に差し替えて
++他テナントのデータを参照できる。
++
++認可をどこで見るかは実装時に決める。
+```
+
+## Expected Behavior
+
+- A summary line first (`(summary):1: ...`), naming the new boundary, the
+  principals, and the privileges involved.
+- A finding that identity claims cross the boundary as unsigned plain headers
+  with no verification on the receiving side, so anything that can reach an
+  internal service can assert any user or tenant. Combined with the support
+  service being allowed to substitute `X-Tenant-Id`, this is a cross-tenant
+  access path. Severity critical (the Rule limits `critical` to「権限漏れ/越境の
+  温床」, which this is), with a paste-ready
+  `境界: 外部→Gateway→ServiceA の trust boundary と、token 検証責務を明記` 追記案.
+- A finding that the tenant-override capability is a privileged operation with no
+  audit requirement: who overrode which tenant, when, and for which case is not
+  recorded. Severity critical.
+- A finding that the authn/authz responsibility split is explicitly deferred
+  to implementation time, so neither central enforcement at the Gateway nor
+  per-service checks is guaranteed and the gap is invisible in review. Severity
+  major.
+- A finding that no permission matrix (role × action × resource) exists for the
+  representative use cases, and the multi-tenant boundary has no stated
+  cross-tenant prevention premise. Severity major, with the
+  `権限マトリクス: role={Admin,User}, action={read,write,delete}, resource={X} を表に追記`
+  template.
+- At most 8 findings total, per the Rule.
+- No finding prescribing a specific IdP product or cloud configuration, and no
+  implementation-level vulnerability review — the Non-goals exclude both.
+
+<!-- expected:
+findings:
+  - severity: critical
+    reason: 署名も改ざん防止も無い素のヘッダで identity claims を境界越しに伝播し受け側で再検証しないうえ、サポートサービスが X-Tenant-Id を任意に差し替えられるためテナント越境の温床になる
+    anchor: docs/security/internal-api-security.md:16
+  - severity: critical
+    reason: 他テナントデータ参照という特権操作を追加しながら監査対象の明示も「誰がいつ何をしたか」の記録要件も無い
+    anchor: docs/security/internal-api-security.md:19
+  - severity: major
+    reason: 認可の判定箇所（Gateway 集約か各サービス分散か）と Gateway/BFF/各サービスの責務分担が実装時送りになっており、設計として保証されていない
+    anchor: docs/security/internal-api-security.md:21
+  - severity: major
+    reason: 代表ユースケースの権限マトリクス（役割×操作×リソース）が無く、マルチテナントの越境防止の前提も書かれていない
+    anchor: docs/security/internal-api-security.md:14
+-->

--- a/skills/upstream/trust-boundaries-authz/fixtures/02-reference-update-only-should-not-detect.md
+++ b/skills/upstream/trust-boundaries-authz/fixtures/02-reference-update-only-should-not-detect.md
@@ -1,0 +1,67 @@
+# Fixture 02 — Authorization terms delegated to an unchanged permission spec (False-Positive Guard)
+
+## Description
+
+The diff changes a document under `docs/**/*security*.md`, the change concerns
+authn/authz and trust boundaries, and it is more than a typo or link edit, so all
+three Pre-execution Gate conditions are satisfied. The skill stays silent because
+every Checklist item it would raise is already settled in an existing permission
+specification that this diff points to and does not change — the skill's guard
+「参照先（セキュリティ設計書/権限仕様）ですでに明確で、差分が参照更新のみの場合は
+重複指摘しない」— and the one operational detail the diff adds is fully specified.
+
+Repository context (not part of the diff):
+
+```text
+docs/security/permission-spec.md (existing, unchanged) defines: the trust
+boundary (external → Gateway is untrusted; Gateway → internal is trusted only
+for mTLS peers), that the Gateway performs authn and each service re-verifies
+authz, claims propagation as a signed short-lived internal JWT (userId,
+tenantId, roles, scopes) that every service re-validates against the issuer's
+JWKS, the audit requirements for privileged operations (actor, target tenant,
+case id, timestamp, retained 1 year), and the permission matrix
+(role × action × resource) including the tenant-isolation rule.
+```
+
+## Input Diff
+
+```diff
+diff --git a/docs/security/internal-api-security.md b/docs/security/internal-api-security.md
+--- a/docs/security/internal-api-security.md
++++ b/docs/security/internal-api-security.md
+@@ -12,6 +12,14 @@
+ Gateway が外部リクエストを受ける。
+
++## 内部サービス間の呼び出し
++
++信頼境界の定義、authn/authz の責務分担、claims の伝播形式と再検証、特権操作の監査
++要件、権限マトリクスとテナント分離規則は [権限仕様](./permission-spec.md) が正であり、
++本変更では変更しない。
++
++## 内部トークンの有効期限
++
++権限仕様が定める内部 JWT の有効期限を 5 分とし、受け側は 30 秒のクロックスキューまで
++許容する。期限切れは 401 で拒否し、呼び出し元がリトライ前に再発行する（延長・再利用は
++しない）。
+```
+
+## Expected Behavior
+
+- `findings: []` (a summary line may still be emitted; it is not a finding).
+- The trust boundary, the authn/authz responsibility split, the signed-claims
+  propagation format with issuer-side re-validation, the audit requirements for
+  privileged operations, and the permission matrix with tenant isolation are all
+  delegated to the linked permission spec, which this diff leaves unchanged.
+  Re-raising them would be a duplicate finding.
+- The one thing this diff decides — the internal token lifetime — is specified
+  completely: the validity window, the clock-skew tolerance, the rejection
+  status, and the rule that expired tokens are re-issued rather than extended or
+  reused. It narrows the trust window rather than widening it, so it opens no new
+  privilege path.
+- No `critical` is emitted: the Rule reserves `critical` for「権限漏れ/越境の温床」,
+  and nothing here creates one.
+
+<!-- expected:
+findings: []
+reason: 信頼境界・authn/authz の責務分担・claims 伝播と再検証・特権操作の監査要件・権限マトリクスは不変の権限仕様で管理され参照が明確（重複指摘の抑制条件に該当）、追加された内部トークン有効期限も許容スキュー・拒否時挙動・再発行方針まで明記され新たな越境経路を作らない
+-->


### PR DESCRIPTION
## 概要

fixtures も eval も持たない skill への S1 fixtures 追加、第 3 波（#1826 のパイロット 5 件、#1834 の第 2 波 8 件に続く）。upstream skill 8 件に positive / negative の fixture 対を追加し、`scripts/validate-skills.mjs` の `GRANDFATHERED_WITHOUT_EVAL` から該当 8 件を削除して S1 免除を機械的に外す。

手順は `docs/development/s1-fixture-convention.md`「未整備 skill への横展開手順」に従う。

## 選定 8 件と理由

免除リスト（`GRANDFATHERED_WITHOUT_EVAL`）に残っていた upstream skill はこの 8 件がすべてで、8 件とも `skills/registry.yaml` で `recommended: true`。planner-dataset（`tests/fixtures/planner-dataset/cases.json`）の登場回数は 8 件とも 0 回で並ぶため、第 3 基準の `applyTo` パターン数の少ない順に並べた。

| # | skill | recommended | planner 登場 | applyTo 数 | 選定理由 |
| - | ----- | ----------- | ------------ | ---------- | -------- |
| 1 | `requirements-acceptance` | true | 0 | 6 | 免除掲載 + applyTo 最少 |
| 2 | `architecture-risk-register` | true | 0 | 7 | 免除掲載 |
| 3 | `availability-architecture` | true | 0 | 7 | 免除掲載 |
| 4 | `migration-rollout-rollback` | true | 0 | 7 | 免除掲載 |
| 5 | `operability-slo` | true | 0 | 8 | 免除掲載 |
| 6 | `capacity-cost-design` | true | 0 | 9 | 免除掲載 |
| 7 | `trust-boundaries-authz` | true | 0 | 9 | 免除掲載 |
| 8 | `data-flow-state-ownership` | true | 0 | 11 | 免除掲載（残る upstream 免除の最後の 1 件） |

`recommended: false` の skill は 1 件も選んでいない。8 件はいずれも `## Check N` 見出しを持たないため `findings[].check` は使わず、frontmatter（`inputContext` / `dependencies` / `tags`）は不変（planner-dataset テストへの影響なし）。

## 免除解除の効果実証

`operability-slo` の `fixtures/` を退避して `npm run skills:validate` を実行した実出力:

```
EXIT_WITH_FIXTURES_REMOVED=1
❌ recommended skill "operability-slo" has no eval/ or fixtures/ directory; add quality evidence (see #1231) or, only for already-shipped skills, GRANDFATHERED_WITHOUT_EVAL in scripts/validate-skills.mjs
```

原状復帰後:

```
EXIT_RESTORED=0
✅ recommended eval coverage: 55/55 recommended skill(s) satisfied (incl. 10 grandfathered)
✅ fixture drift: 29 skill(s) with expected blocks consistent
```

免除を外したことで、fixtures を失えば CI が exit 1 になる状態になっている（免除に載ったままなら緑のまま通過していた）。

## 保有件数の推移

| 指標 | 前 | 後 |
| ---- | -- | -- |
| `recommended eval coverage` の grandfathered | 18 | 10 |
| `fixture drift` の対象 skill | 21 | 29 |

今回は 8 件すべてが `recommended: true` のため、grandfathered もちょうど 8 件減る（第 2 波では `pre-mortem` が `recommended: false` の死にエントリだったため 8 件外して 7 しか減らなかった）。

`GRANDFATHERED_WITHOUT_EVAL` に残るエントリは 11 件（`review-automation-boundary` / `design-source-conformance` / `component-variants-states` / `test-existence` / `coverage-gap` / `war-game` / `logic-torturing` / `self-contradiction` / `refactor-claim-audit` / `cross-file-leakage` / `e2e-wiring`）。うち coverage 指標に計上されるのは `recommended: true` の 10 件。層の内訳は midstream 9 件・downstream 2 件で、**upstream の未整備免除はこれで 0 件**になる。

## 死にエントリの調査結果（報告のみ・修正はスコープ外）

免除リストの全 19 エントリ（本 PR 前）と `skills/registry.yaml` の `recommended` を突き合わせた結果、`recommended: false` なのに免除リストに載っている死にエントリは **`logic-torturing` の 1 件のみ**（`skills/midstream/logic-torturing`）。第 2 波で判明した `pre-mortem` はすでに免除リストから外れているため、現存する死にエントリはこの 1 件に絞られる。外しても coverage 指標は動かない。

## 検証

| コマンド | exit code |
| -------- | --------- |
| `npm run skills:validate` | 0 |
| `npm run agent-skills:validate` | 0 |
| `npm run skills:manifest:check` | 0 |
| `npm run lint` | 0 |
| `npm test` | 1（後述の既知の環境依存失敗のみ） |

`npm test` は `tests/count-in-clean-tree.test.mjs` の 4 件が exit 141（SIGPIPE）で失敗する。**本変更と無関係な既存の環境依存失敗**で、変更を含まない `origin/main` の作業ツリーで同ファイルを単独実行しても同じ 4 件が失敗することを確認済み（`node --test tests/count-in-clean-tree.test.mjs` → `# pass 2 / # fail 4`）。それ以外は 3208 pass。

マニフェスト再生成は `npm run lint` の後に実行し、`skills:manifest:check` の陳腐化を回避している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

