### PR TITLE
docs(suppression): suppression の有効期限（--expires）を利用者向けドキュメントへ追記

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -249,7 +249,7 @@ Latest release: [v1.76.1](https://github.com/s977043/river-review/releases/lates
 
 ### Major features added in v0.21–v0.28
 
-- **Suppression memory** ([#687](https://github.com/s977043/river-review/issues/687)): use `river suppression add --fingerprint <fp> --feedback accepted_risk` to stop re-surfacing accepted-risk findings. Set `memory.suppressionEnabled: false` to bypass the gate temporarily.
+- **Suppression memory** ([#687](https://github.com/s977043/river-review/issues/687)): use `river suppression add --fingerprint <fp> --feedback accepted_risk` to stop re-surfacing accepted-risk findings. Set `memory.suppressionEnabled: false` to bypass the gate temporarily. Add `--expires` to make the entry stop suppressing after a given date, so the finding returns ([repo-wide review guide](pages/guides/repo-wide-review.en.md)).
 - **Secret redaction** ([#692](https://github.com/s977043/river-review/issues/692)): multi-stage redaction across repo-wide context and LLM prompts. Tune categories, allowlist, and denyFiles via `security.redact.*`.
 - **Context budget / ranking / reviewMode** ([#689](https://github.com/s977043/river-review/issues/689)): `context.budget` for token / char caps, `context.ranking.enabled` for proximity-based reordering, `context.reviewMode: tiny | medium | large` for preset budgets.
 - **Repo-wide eval suite** ([#688](https://github.com/s977043/river-review/issues/688)): `npm run eval:repo-context` reports detection rate, context lift, and false positive rate.

--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ GitHub Actions では:
 
 ### v0.21〜v0.28 で追加された主な機能
 
-- **Riverbed Memory による suppression**（[#687](https://github.com/s977043/river-review/issues/687)）: `river suppression add --fingerprint <fp> --feedback accepted_risk` で確定済み指摘の再表示を抑止する。`memory.suppressionEnabled: false` で gate を一時バイパス可能。
+- **Riverbed Memory による suppression**（[#687](https://github.com/s977043/river-review/issues/687)）: `river suppression add --fingerprint <fp> --feedback accepted_risk` で確定済み指摘の再表示を抑止する。`memory.suppressionEnabled: false` で gate を一時バイパス可能。`--expires` で期限を付けると、その日時以降は抑制が外れて指摘が再び出る（[repo-wide review ガイド](pages/guides/repo-wide-review.md)）。
 - **Secret redaction**（[#692](https://github.com/s977043/river-review/issues/692)）: repo-wide context と LLM プロンプトに対する多段階 redaction。`security.redact.*` でカテゴリ／allowlist／denyFiles を制御する。
 - **Context budget / ranking / reviewMode**（[#689](https://github.com/s977043/river-review/issues/689)）: `context.budget` で token／char 上限を制御。`context.ranking.enabled` で近接度ベースの並び替えを有効化。`context.reviewMode: tiny | medium | large` でプリセット budget を切替。
 - **Repo-wide eval suite**（[#688](https://github.com/s977043/river-review/issues/688)）: `npm run eval:repo-context` が detection / context lift / false positive の 3 指標を出力する。

--- a/pages/guides/repo-wide-review.en.md
+++ b/pages/guides/repo-wide-review.en.md
@@ -310,6 +310,7 @@ river suppression add \
   --severity <info|minor|major|critical> \
   --files src/auth.ts,src/login.ts \
   --pr 123 \
+  --expires 2027-01-01 \
   --fingerprint-algo v1
 ```
 
@@ -318,6 +319,24 @@ Pick the fingerprint from the `Finding fingerprints` block of the `--debug` outp
 ### Suppression granularity (`--fingerprint-algo`)
 
 The default `v1` omits the line number: one entry suppresses every same-kind finding in the same file, and it keeps working when lines shift. `v2` includes the line, so only the finding at that line is suppressed — but the entry stops matching as soon as the line shifts. Take v2 values from the v2 column of the `--debug` output; feeding a v1 hex to `--fingerprint-algo v2` produces an entry that matches nothing.
+
+### Giving a suppression an expiry (`--expires`)
+
+A suppression created with `--expires` stops taking effect once the given instant has passed: the finding it was hiding shows up again on the next review. Omitting `--expires` means no expiry at all — the entry keeps suppressing until it is revoked.
+
+```bash
+river suppression add \
+  --fingerprint <16-hex> \
+  --feedback false_positive \
+  --rationale "<why suppress>" \
+  --expires 2027-01-01
+```
+
+The only accepted forms are an RFC 3339 date (`2027-01-01`) and an RFC 3339 date-time (`2027-01-01T00:00:00Z` / `2027-01-01T09:00:00+09:00`). A date-only input is read as UTC midnight and normalized to the date-time form on write (implementation: `src/lib/expires-at.mjs`). Anything else — `2027`, `March 5, 2027` — exits with code 1 and no entry is created.
+
+An expired entry is not deleted. The skip is recorded in `reviewDebug.suppressionsApplied` as `action: "skipped"` with `reason: "suppression-expired"` (implementation: `src/lib/suppression-apply.mjs`). To extend the suppression, add a new entry with a new expiry.
+
+If a stored `context.expiresAt` cannot be parsed, it fails safe to the same treatment as an expired one: the suppression does not apply, and a warning telling you to repair the value is written to stderr once.
 
 ### Temporarily disabling suppression via config
 

--- a/pages/guides/repo-wide-review.md
+++ b/pages/guides/repo-wide-review.md
@@ -310,6 +310,7 @@ river suppression add \
   --severity <info|minor|major|critical> \
   --files src/auth.ts,src/login.ts \
   --pr 123 \
+  --expires 2027-01-01 \
   --fingerprint-algo v1
 ```
 
@@ -318,6 +319,24 @@ fingerprint は `--debug` 出力の `Finding fingerprints` 節、または `revi
 ### 抑制の粒度（`--fingerprint-algo`）
 
 既定の `v1` は行番号を含みません。そのため同じファイル内で同種の指摘をまとめて抑制し、行がズレても効き続けます。`v2` を指定すると行番号込みの fingerprint になり、その行の指摘だけが対象です。ただし行がズレた時点で抑制は外れます。`v2` の値は `--debug` 出力の v2 列から取得してください（v1 の hex を `--fingerprint-algo v2` に渡すと、何も抑制しないエントリになります）。
+
+### 抑制に期限を付ける（`--expires`）
+
+期限付きの suppression は、`--expires` で指定した日時を過ぎると効かなくなります。抑制されていた finding は、次のレビューから再び出ます。`--expires` を省略した場合は無期限で、revoke するまで抑制が続きます。
+
+```bash
+river suppression add \
+  --fingerprint <16-hex> \
+  --feedback false_positive \
+  --rationale "<なぜ抑制するか>" \
+  --expires 2027-01-01
+```
+
+受け付ける形式は RFC 3339 の日付（`2027-01-01`）と日時（`2027-01-01T00:00:00Z` / `2027-01-01T09:00:00+09:00`）だけです。日付のみの入力は UTC 00:00 と解釈され、保存時に日時形式へ正規化されます（実装: `src/lib/expires-at.mjs`）。`2027` や `March 5, 2027` のようなそれ以外の値は exit 1 で弾かれ、エントリは作成されません。
+
+期限切れのエントリは削除されません。抑制がスキップされた事実は `reviewDebug.suppressionsApplied` に `action: "skipped"`、`reason: "suppression-expired"` として残ります（実装: `src/lib/suppression-apply.mjs`）。抑制を延長したい場合は、新しい期限で登録し直してください。
+
+保存済みの `context.expiresAt` が解釈できない値だった場合、fail-safe として期限切れと同じ扱いになります。抑制は効かず、修復を促す警告が標準エラー出力へ 1 回だけ出ます。
 
 ### config で抑制を一時無効化する
 

--- a/pages/use-cases/suppress-flaky-review-comments.en.md
+++ b/pages/use-cases/suppress-flaky-review-comments.en.md
@@ -44,8 +44,11 @@ There is no dedicated demo — the workflow runs through Riverbed Memory suppres
 river suppression add \
   --fingerprint <fp> \
   --feedback false_positive \
-  --rationale "one or two sentences on why this is a false positive"
+  --rationale "one or two sentences on why this is a false positive" \
+  --expires 2027-01-01
 ```
+
+`--expires` is optional. With it, the entry stops suppressing once that instant has passed and the finding shows up again; without it, the suppression has no expiry. Accepted values and the behaviour after expiry are described in [Repo-wide review](../guides/repo-wide-review.en.md), under "Giving a suppression an expiry".
 
 For the full storage flow into `.river/memory/index.json`, see [Use Riverbed Memory](../guides/use-riverbed-memory.en.md). For the design rationale, see [Riverbed Memory](../explanation/riverbed-memory.en.md).
 

--- a/pages/use-cases/suppress-flaky-review-comments.md
+++ b/pages/use-cases/suppress-flaky-review-comments.md
@@ -41,8 +41,11 @@ River Review は誤検出への対処を 2 つの層に分けています。決�
 river suppression add \
   --fingerprint <fp> \
   --feedback false_positive \
-  --rationale "なぜ誤検知と判断したかを 1〜2 文で残す"
+  --rationale "なぜ誤検知と判断したかを 1〜2 文で残す" \
+  --expires 2027-01-01
 ```
+
+`--expires` は任意です。付けると、その日時を過ぎた時点で抑制が外れ、finding が再び出ます。付けない場合は無期限になります。受け付ける値と期限切れ後の挙動は、[repo-wide review の導入とチューニング](../guides/repo-wide-review.md) の「抑制に期限を付ける」節にまとめています。
 
 登録後の挙動と保存手順は、[Riverbed Memory を使用する](../guides/use-riverbed-memory.md) にまとまっています。決定論的な検出器がどこまで誤検出を防ぐかは、[検出器の評価レポート](../reference/detector-evaluation-report.md) で確認できます。設計思想は [Riverbed Memory](../explanation/riverbed-memory.md) を参照してください。
 


### PR DESCRIPTION
## 背景

`--expires` と期限切れ時の挙動は実装済み（`src/lib/suppression-apply.mjs` / `src/lib/suppression.mjs` / `src/cli.mjs`）だが、利用者向けドキュメントに記述が無かった。

実測（本 PR の変更前、`origin/main` = f29b6b17）:

```console
$ grep -ciE 'expire|期限|--expires' pages/guides/repo-wide-review.md
0
$ grep -ciE 'expire|期限|--expires' pages/use-cases/suppress-flaky-review-comments.md
0
```

`pages/guides/repo-wide-review.md` の `river suppression add` 例は `--scope` / `--severity` / `--files` / `--pr` / `--fingerprint-algo` を並べながら `--expires` だけ欠けていた。

refs #1816

## 追記内容

`pages/guides/repo-wide-review.md` / `.en.md` に「抑制に期限を付ける（`--expires`）」節を新設し、CLI 例へ `--expires 2027-01-01` を追加した。記載した要点は次の 3 点。

- 期限を過ぎた suppression は抑制をやめ、抑制されていた finding が次のレビューから再び出る
- 受け付ける値は RFC 3339 の日付 / 日時のみ。日付のみは UTC 00:00 として日時形式へ正規化され、それ以外は exit 1（`src/lib/expires-at.mjs` の `parseExpiresAt`）
- `--expires` を省略した場合は無期限（`createSuppression` は値がある場合のみ `context.expiresAt` を書く）

あわせて、期限切れエントリは削除されず `reviewDebug.suppressionsApplied` に `action: "skipped"` / `reason: "suppression-expired"` として残ること、保存済み `context.expiresAt` が解釈不能な場合は fail-safe で期限切れ扱いになり警告が stderr へ 1 回出ることを記載した。

`pages/use-cases/suppress-flaky-review-comments.md` / `.en.md` は CLI 例に `--expires` を足し、詳細は repo-wide review ガイドへ相対 `.md` リンクで誘導する。`README.md` / `README.en.md` は suppression の項に 1 文の相互参照を追加した。

## 挙動の確認

`applySuppressions` を Node 22.22.2 で直接呼び、4 通りの `expiresAt` について実測した結果に基づいて記述している。

| `context.expiresAt` | 結果 | `applied` | 警告 |
| --- | --- | --- | --- |
| `2027-01-01T00:00:00Z` | 抑制される | `action: suppressed` | なし |
| `2020-01-01T00:00:00Z` | 抑制されない | `action: skipped`, `reason: suppression-expired` | なし |
| `notadate` | 抑制されない | `action: skipped`, `reason: suppression-expired` | 修復を促す警告 1 件 |
| 未設定 | 抑制される | `action: suppressed` | なし |

## 検証

| コマンド | exit code |
| --- | --- |
| `npx textlint --no-cache pages/guides/repo-wide-review.md pages/use-cases/suppress-flaky-review-comments.md` | 0（README.md は変更前後とも 25 problems で同数、新規違反なし） |
| `npm run fix:dashes` | 0（正規化不要） |
| `npm run lint` | 0 |
| `npm run meta:validate` | 0 |

追加したリンクはいずれも相対 `.md` 形式（`../guides/repo-wide-review.md` / `pages/guides/repo-wide-review.md`）。

## スコープ外

- 実装の変更なし
- #1823（v2 の残存 2 件）
- 英語リファレンス 2 面（`config-schema.en.md` / `runner-cli-reference.en.md`）の全面同期

🤖 Generated with [Claude Code](https://claude.com/claude-code)