### PR TITLE
chore(plugin): 公式 validator を 2 系統まとめて実行する検証スクリプトを足す

### DIFF
--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -12,6 +12,6 @@ Repo-development slash commands (NOT part of the distributed plugin surface).
 | `/register-plugin-asset` | `register-plugin-asset.md` | Register a new distributed command/agent/agent-skill into the plugin manifests and validate |
 | `/release-kick`          | `release-kick.md`          | Drive a release-please PR from BLOCKED unblock through merge and release verification       |
 
-> **配布対象のコマンド**は #996 で top-level [`commands/`](../../commands/) へ分離し、`.claude-plugin/plugin.json` がそこを参照します。一覧は [`commands/README.md`](../../commands/README.md) が正で、本ディレクトリには repo-dev 専用コマンドのみが残ります。
+> **配布対象のコマンド**は #996 で top-level [`commands/`](../../commands/) へ分離し、`.claude-plugin/plugin.json` がそこを参照します。一覧は [`docs/development/distributed-commands.md`](../../docs/development/distributed-commands.md) が正で、本ディレクトリには repo-dev 専用コマンドのみが残ります。
 >
 > **整合性**: コマンド追加時は配布対象か repo-dev かを判断して正しい場所に置き、CLAUDE.md の `Custom Commands` 表を更新すること。配布対象コマンドの場合はさらに `.claude-plugin/plugin.json` の `commands` にも追加する必要があります。上の表と `.claude/commands/*.md` の一致は `npm run check:doc-enum`（`meta:validate` 経由で CI 必須チェック）が機械検証します。

--- a/.claude/commands/register-plugin-asset.md
+++ b/.claude/commands/register-plugin-asset.md
@@ -20,9 +20,9 @@ git status --short
 
 ### command（`commands/<name>.md`）
 
-`.claude-plugin/plugin.json` の `commands[]` に `"./commands/<name>.md"` を追加する（`README.md` は登録しない）。`.codex-plugin/plugin.json` に commands フィールドはないため対応不要。
+`.claude-plugin/plugin.json` の `commands[]` に `"./commands/<name>.md"` を追加する。`.codex-plugin/plugin.json` に commands フィールドはないため対応不要。`commands/` 直下にはコマンド本体以外（README 等）を置かない（公式 validator が全 `*.md` をコマンドとして走査するため）。
 
-- CLAUDE.md「Custom Commands」表と `commands/README.md` に説明を追記する（`npm run check:doc-enum` が両表と `commands/*.md` の一致を機械検証するため、条件付きではなく必須）
+- CLAUDE.md「Custom Commands」表と `docs/development/distributed-commands.md` に説明を追記する（`npm run check:doc-enum` が両表と `commands/*.md` の一致を機械検証するため、条件付きではなく必須）
 
 ### agent（`agents/<name>.md`）
 
@@ -59,7 +59,7 @@ npm run meta:validate
 
 - 全て pass を確認する。fail は該当項目を修正してから再実行する
 - `plugin:validate` が「参照パス不在」で落ちる＝登録漏れ or パス誤り。`plugin:sync:check` の drift＝同期フィールドの手編集を疑う
-- `check:doc-enum` が落ちる＝`commands/README.md` か CLAUDE.md「Custom Commands」表への追記漏れ（`meta:validate` からも実行されるため CI で必ず止まる）
+- `check:doc-enum` が落ちる＝`docs/development/distributed-commands.md` か CLAUDE.md「Custom Commands」表への追記漏れ（`meta:validate` からも実行されるため CI で必ず止まる）
 
 ## 判定
 

--- a/commands/README.md
+++ b/commands/README.md
@@ -1,3 +1,7 @@
+---
+description: 'Index of the River Review distributed plugin commands (reference only; not a runnable command).'
+---
+
 # commands/ (distributed plugin commands)
 
 Slash commands shipped as part of the River Review plugin (referenced by `.claude-plugin/plugin.json`). Separated from repo-development commands (which stay in [`.claude/commands/`](../.claude/commands/)) per #996.

--- a/docs/development/distributed-commands.md
+++ b/docs/development/distributed-commands.md
@@ -1,10 +1,6 @@
----
-description: 'Index of the River Review distributed plugin commands (reference only; not a runnable command).'
----
+# 配布プラグインコマンド一覧（`commands/`）
 
-# commands/ (distributed plugin commands)
-
-Slash commands shipped as part of the River Review plugin (referenced by `.claude-plugin/plugin.json`). Separated from repo-development commands (which stay in [`.claude/commands/`](../.claude/commands/)) per #996.
+River Review プラグインとして配布されるスラッシュコマンドの一覧です（`.claude-plugin/plugin.json` の `commands` が参照します）。リポジトリ開発専用のコマンドは [`.claude/commands/`](../../.claude/commands/) に残しています（#996）。
 
 | Command         | File              | Purpose                                                                                |
 | --------------- | ----------------- | -------------------------------------------------------------------------------------- |
@@ -17,3 +13,11 @@ Slash commands shipped as part of the River Review plugin (referenced by `.claud
 | `/setup-team`   | `setup-team.md`   | Set up River Review in a project (`.river/rules.md`, plugin install, integration mode) |
 
 > **整合性**: 配布対象コマンドの追加・変更時は `.claude-plugin/plugin.json` の `commands` と CLAUDE.md `Custom Commands` 表も更新すること。この表と `commands/*.md` の一致は `npm run check:doc-enum`（`meta:validate` 経由で CI 必須チェック）が機械検証する。
+
+## なぜ `commands/README.md` ではなくここに置くのか
+
+`commands/` はプラグインの配布サーフェスであり、`claude plugin validate` は `commands/` 直下の `*.md` を**すべてコマンドとして走査**する。README も例外ではないため、そこに置くと配布物に実行できない `/README` コマンドが混ざる（frontmatter を足しても走査対象からは外れない）。ドキュメントは配布サーフェスの外に置き、`commands/` には実際のコマンドだけを残すのが安全である。
+
+一方 [`.claude/commands/README.md`](../../.claude/commands/README.md) はリポジトリ開発専用ディレクトリの索引であり、配布されず validator の走査対象にもならないため、コマンドと同居したままで問題ない。
+
+配置先が `docs/development/` である理由は [DOCUMENTATION.md](../policy/DOCUMENTATION.md) のとおりで、この文書は公開サイト（`pages/`）向けではなく、メンテナ向けの開発リファレンスだからである。

--- a/docs/development/doc-enumeration-checks.md
+++ b/docs/development/doc-enumeration-checks.md
@@ -38,6 +38,8 @@ PR #1726 で本 script に spec を 4 件登録した時点の、宣言側と実
 
 表の外にも陳腐化がありました。`.claude/commands/README.md` の散文は配布コマンドを 5 件だけ挙げており（`review-team` / `setup-team` が欠落）、同じ PR で「一覧は `commands/README.md` が正」という参照へ置き換えています。機械検証の対象は表であって散文ではないため、散文で列挙しないほうが安全です。
 
+> 上の 2 つの節は #1726 当時の記録です。配布コマンド表を載せていた `commands/README.md` は、その後 [`distributed-commands.md`](./distributed-commands.md) へ移設しました（公式 validator が `commands/` 直下の `*.md` をすべてコマンドとして走査するため）。`distributed-commands-table` spec の宣言側も同じ移設先を指しています。
+
 ### チェックリストでは止まらなかった
 
 `plugin-asset-registration-checklist.md` には作成時（2026-07-08, #1442）から「CLAUDE.md『Custom Commands』表と `commands/README.md` に説明を追記した」という項目がありました。それでも `commands/README.md` の行は次のとおり放置されました。
@@ -122,7 +124,7 @@ scripts/count-in-clean-tree.sh -- bash -c 'set -o pipefail; git ls-files "*.md" 
 | spec id                                   | 対象ドキュメント                                                 | 宣言側                                             | 実体                                                       |
 | ----------------------------------------- | ---------------------------------------------------------------- | -------------------------------------------------- | ---------------------------------------------------------- |
 | `skills-stream-counts`                    | `docs/skills-structure.md`                                       | ツリー図の `# <n> スキル` コメント                 | `skills/<stream>/` の実ディレクトリ数                      |
-| `distributed-commands-table`              | `commands/README.md`                                             | コマンド表の `File` 列                             | `commands/*.md`（`README.md` を除く）                      |
+| `distributed-commands-table`              | [`distributed-commands.md`](./distributed-commands.md)           | コマンド表の `File` 列                             | `commands/*.md`（`README.md` を除く）                      |
 | `repo-dev-commands-table`                 | `.claude/commands/README.md`                                     | コマンド表の `File` 列                             | `.claude/commands/*.md`（同上）                            |
 | `claude-md-command-table`                 | `CLAUDE.md`                                                      | `Custom Commands` 表の `Command` 列                | 上記 2 ディレクトリのコマンド名の和集合                    |
 | `workflows-readme-table`                  | `.github/workflows/README.md`                                    | ワークフロー一覧表の `ファイル` 列                 | `.github/workflows/` 直下の `*.yml` / `*.yaml`             |

--- a/docs/development/plugin-asset-registration-checklist.md
+++ b/docs/development/plugin-asset-registration-checklist.md
@@ -28,9 +28,10 @@
 
 ### 新しい配布 command（`commands/<name>.md`）を追加した場合
 
-- [ ] `.claude-plugin/plugin.json` の `commands[]` に `"./commands/<name>.md"` を追加した（`README.md` は登録しない）
+- [ ] `.claude-plugin/plugin.json` の `commands[]` に `"./commands/<name>.md"` を追加した
+- [ ] `commands/` 直下にコマンド本体以外のファイルを置いていない（公式 validator が全 `*.md` をコマンドとして走査するため、README 等はここに置かない）
 - [ ] `.codex-plugin/plugin.json` には commands フィールドがない（対応不要）
-- [ ] CLAUDE.md「Custom Commands」表と `commands/README.md` に説明を追記した
+- [ ] CLAUDE.md「Custom Commands」表と [`distributed-commands.md`](./distributed-commands.md) に説明を追記した
 - [ ] `npm run plugin:validate` が pass する
 - [ ] `npm run check:doc-enum` が pass する（上記 2 つの表と `commands/*.md` の一致を機械検証する。詳細は [doc-enumeration-checks.md](./doc-enumeration-checks.md)）
 
@@ -87,7 +88,7 @@ npm run meta:validate         # メタ整合
 | `Unknown field 'composerIcon'`                                  | Codex bundle 契約が必須とするフィールドで、`checkCrossManifestParity` が両 manifest の一致を強制する。Claude Code は無視するだけである |
 | `CLAUDE.md at the plugin root is not loaded as project context` | ルート `CLAUDE.md` はリポジトリ自身の agent instructions であり配布 context ではない。validator に除外機構が無い                       |
 
-`commands/*.md` は README も含めて公式 validator の検査対象になるため、`commands/README.md` には frontmatter（`description`）を置いてある。
+`commands/` 直下の `*.md` は README も含めて公式 validator にコマンドとして走査されるため、旧 `commands/README.md` は [`distributed-commands.md`](./distributed-commands.md) へ移設した。`commands/` にはコマンド本体だけを置く。
 
 ## 関連
 

--- a/docs/development/plugin-asset-registration-checklist.md
+++ b/docs/development/plugin-asset-registration-checklist.md
@@ -73,9 +73,26 @@ npm run meta:validate         # メタ整合
 
 いずれかが fail した場合はマージせず、該当項目を修正してから再実行します。
 
+## 公式 validator（`npm run plugin:validate:official`・ローカル専用）
+
+`npm run plugin:validate` はこのリポジトリ固有のルール（cross-manifest parity・逆ドリフト・version 同期）を見るもので、Claude Code 公式の manifest 契約は見ません。公式 validator は `claude plugin validate` であり、`scripts/validate-plugin-official.mjs` がこれを包んでいます。
+
+- 引数によって読む manifest が変わるため、ラッパーは 2 回実行する。ディレクトリ（`.`）を渡すと `marketplace.json` だけを検証し、`commands/` `agents/` とルート `CLAUDE.md` は `.claude-plugin/plugin.json` を明示したときにだけ到達する。
+- `--strict` は warning を失敗として扱う。本リポジトリが意図的に受容している warning は `ACCEPTED_WARNINGS`（`scripts/validate-plugin-official.mjs`）に理由付きで列挙し、ラッパーはそれ以外の findings でだけ fail する。新しい warning が増えたときに落ちる回帰ゲートである。
+- GitHub Actions runner に `claude` CLI は入っていないため、CI job には追加していない。CLI が無い環境では SKIP して exit 0 になるので、どこから呼んでも安全である。
+- 受容中の warning は次の 2 件である。
+
+| warning                                                         | 受容理由                                                                                                                               |
+| --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `Unknown field 'composerIcon'`                                  | Codex bundle 契約が必須とするフィールドで、`checkCrossManifestParity` が両 manifest の一致を強制する。Claude Code は無視するだけである |
+| `CLAUDE.md at the plugin root is not loaded as project context` | ルート `CLAUDE.md` はリポジトリ自身の agent instructions であり配布 context ではない。validator に除外機構が無い                       |
+
+`commands/*.md` は README も含めて公式 validator の検査対象になるため、`commands/README.md` には frontmatter（`description`）を置いてある。
+
 ## 関連
 
 - `scripts/validate-plugin-manifest.mjs`（`plugin:validate`）
+- `scripts/validate-plugin-official.mjs`（`plugin:validate:official`・公式 CLI ラッパー）
 - `scripts/sync-plugin-fields.mjs`（`plugin:sync` / `plugin:sync:check`）
 - CLAUDE.md「AI Misoperation Guards」>「Plugin bundle mirror」
 - `release-please-config.json` の `extra-files`（version bump は release-please が両 manifest へ反映）

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "check:sidebar-reachability": "node scripts/check-sidebar-reachability.mjs",
     "meta:validate": "node scripts/validate-meta-consistency.mjs && node scripts/check-doc-enumerations.mjs && node scripts/check-sidebar-reachability.mjs && node scripts/generate-skill-catalog.mjs --check",
     "plugin:validate": "node scripts/validate-plugin-manifest.mjs",
+    "plugin:validate:official": "node scripts/validate-plugin-official.mjs",
     "plugin:sync": "node scripts/sync-plugin-fields.mjs",
     "plugin:sync:check": "node scripts/sync-plugin-fields.mjs --check",
     "eval:all": "node scripts/evaluate-all.mjs",

--- a/scripts/check-doc-enumerations.mjs
+++ b/scripts/check-doc-enumerations.mjs
@@ -394,7 +394,7 @@ export const DOC_ENUMERATION_SPECS = [
   },
   {
     id: 'distributed-commands-table',
-    doc: 'commands/README.md',
+    doc: 'docs/development/distributed-commands.md',
     summary: '配布コマンド表の File 列',
     marker: '`Command | File | Purpose` 表',
     kind: 'names',

--- a/scripts/validate-plugin-official.mjs
+++ b/scripts/validate-plugin-official.mjs
@@ -1,0 +1,198 @@
+// Run the Claude Code OFFICIAL plugin validator (`claude plugin validate`)
+// against this repository's manifests.
+//
+// Why a wrapper instead of a bare npm script:
+//
+//  1. Two invocations are required. The argument decides which manifest the
+//     CLI reads: passing a DIRECTORY validates `.claude-plugin/marketplace.json`
+//     only, while the plugin manifest (plus the root CLAUDE.md and the files
+//     under commands/ and agents/) is reached only by naming
+//     `.claude-plugin/plugin.json` explicitly. Neither form is a superset of
+//     the other, so both must run.
+//
+//  2. Two of the warnings `--strict` reports are accepted, not fixable (see
+//     ACCEPTED_WARNINGS below for the per-item reasoning). A plain
+//     `claude plugin validate --strict` therefore always exits 1 here and
+//     would carry no signal. This wrapper keeps `--strict` (so unrecognized
+//     fields and missing metadata are still surfaced) but fails only on
+//     findings that are NOT on the accepted list — i.e. it is a regression
+//     gate for NEW warnings.
+//
+//  3. `claude` is not installed on GitHub Actions runners. When the CLI is
+//     absent the wrapper reports SKIP and exits 0, so it stays safe to call
+//     from any environment. It is wired as a local-only `npm run
+//     plugin:validate:official` target, not as a CI step.
+//
+// This wrapper never replaces `npm run plugin:validate`
+// (scripts/validate-plugin-manifest.mjs), which checks repo-specific rules the
+// official validator knows nothing about (cross-manifest parity with
+// .codex-plugin, asset registration, version sync). Run both.
+
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+
+import { isDirectRun } from './lib/is-direct-run.mjs';
+
+const ROOT = path.resolve(import.meta.dirname, '..');
+
+/**
+ * Targets to validate, in order. The CLI resolves each argument differently:
+ * a path to a plugin manifest validates the plugin (and its commands/agents/
+ * CLAUDE.md); a directory validates the marketplace manifest.
+ */
+export const TARGETS = [
+  { arg: '.claude-plugin/plugin.json', label: 'plugin manifest + commands/agents' },
+  { arg: '.', label: 'marketplace manifest' },
+];
+
+/**
+ * Warnings that `--strict` reports and that this repository has consciously
+ * decided NOT to fix. Each entry documents why. Anything not matched here
+ * fails the check.
+ */
+export const ACCEPTED_WARNINGS = [
+  {
+    id: 'unknown-field-composer-icon',
+    pattern: /Unknown field 'composerIcon'/,
+    reason:
+      'composerIcon is required by the Codex bundle contract (.codex-plugin/plugin.json interface.composerIcon) and scripts/validate-plugin-manifest.mjs enforces parity between the two manifests (checkCrossManifestParity). Claude Code merely ignores the field at load time, so keeping it costs nothing and dropping it would mean relaxing our own parity check.',
+  },
+  {
+    id: 'root-claude-md-not-context',
+    pattern: /CLAUDE\.md at the plugin root is not loaded as project context/,
+    reason:
+      "The root CLAUDE.md is this repository's OWN agent instructions; it is not intended to ship as plugin context. The distributed context lives in skills/. The validator has no exclusion mechanism, so this warning is accepted rather than fixed.",
+  },
+];
+
+/**
+ * Parse the CLI's human-readable output into findings.
+ *
+ * Both errors and warnings are printed as `  ❯ <message>` lines; only the
+ * preceding section header distinguishes them ("✘ Found N errors:" vs
+ * "⚠ Found N warning(s):"). Findings seen before any header are treated as
+ * errors (fail-safe).
+ *
+ * Pure function; exported for unit testing.
+ *
+ * @param {string} output combined stdout+stderr of one CLI invocation
+ * @returns {{kind: 'error'|'warning', message: string}[]}
+ */
+export function parseFindings(output) {
+  const findings = [];
+  let kind = 'error';
+  for (const line of String(output ?? '').split('\n')) {
+    if (/^\s*⚠\s+Found\s+\d+\s+warning/.test(line)) {
+      kind = 'warning';
+      continue;
+    }
+    if (/^\s*✘\s+Found\s+\d+\s+error/.test(line)) {
+      kind = 'error';
+      continue;
+    }
+    const match = line.match(/^\s*❯\s+(.*\S)\s*$/);
+    if (match) findings.push({ kind, message: match[1] });
+  }
+  return findings;
+}
+
+/**
+ * Split findings into accepted (documented, ignorable) and blocking ones.
+ * Errors are never accepted, only warnings can be.
+ *
+ * Pure function; exported for unit testing.
+ *
+ * @param {{kind: string, message: string}[]} findings
+ * @param {typeof ACCEPTED_WARNINGS} accepted
+ * @returns {{accepted: object[], blocking: object[]}}
+ */
+export function classifyFindings(findings, accepted = ACCEPTED_WARNINGS) {
+  const result = { accepted: [], blocking: [] };
+  for (const finding of findings) {
+    const rule =
+      finding.kind === 'warning'
+        ? accepted.find((a) => a.pattern.test(finding.message))
+        : undefined;
+    if (rule) result.accepted.push({ ...finding, id: rule.id });
+    else result.blocking.push(finding);
+  }
+  return result;
+}
+
+/** Whether the `claude` CLI is callable in this environment. */
+export function claudeCliAvailable(run = spawnSync) {
+  const probe = run('claude', ['--version'], { encoding: 'utf8' });
+  return !probe.error && probe.status === 0;
+}
+
+/**
+ * Run the official validator over every target and classify the output.
+ *
+ * @returns {{skipped: boolean, blocking: object[], accepted: object[], transcript: string}}
+ */
+export function validateWithOfficialCli(run = spawnSync) {
+  if (!claudeCliAvailable(run)) {
+    return { skipped: true, blocking: [], accepted: [], transcript: '' };
+  }
+
+  const blocking = [];
+  const accepted = [];
+  const transcript = [];
+
+  for (const target of TARGETS) {
+    const proc = run('claude', ['plugin', 'validate', target.arg, '--strict'], {
+      cwd: ROOT,
+      encoding: 'utf8',
+    });
+    const output = `${proc.stdout ?? ''}${proc.stderr ?? ''}`;
+    transcript.push(
+      `--- claude plugin validate ${target.arg} --strict (${target.label})\n${output}`
+    );
+
+    const classified = classifyFindings(parseFindings(output));
+    for (const finding of classified.blocking) blocking.push({ ...finding, target: target.arg });
+    for (const finding of classified.accepted) accepted.push({ ...finding, target: target.arg });
+
+    // Non-zero exit with no parsed finding means the CLI failed for a reason
+    // this parser does not model (crash, changed output format). Fail loudly
+    // rather than silently passing.
+    if (proc.status !== 0 && classified.blocking.length === 0 && classified.accepted.length === 0) {
+      blocking.push({
+        kind: 'error',
+        message: `claude plugin validate ${target.arg} exited ${proc.status} with no parsable finding`,
+        target: target.arg,
+      });
+    }
+  }
+
+  return { skipped: false, blocking, accepted, transcript: transcript.join('\n') };
+}
+
+// CLI entry point
+if (isDirectRun(import.meta.url)) {
+  const result = validateWithOfficialCli();
+  if (result.skipped) {
+    console.log(
+      'Official plugin validator: SKIP (the `claude` CLI is not available in this environment)'
+    );
+  } else {
+    console.log(result.transcript);
+    for (const finding of result.accepted) {
+      console.log(`Accepted warning [${finding.id}] (${finding.target}): ${finding.message}`);
+    }
+    if (result.blocking.length > 0) {
+      console.error(`Official plugin validator: ${result.blocking.length} blocking finding(s)`);
+      for (const finding of result.blocking) {
+        console.error(`  - [${finding.kind}] (${finding.target}) ${finding.message}`);
+      }
+      console.error(
+        'Fix the finding, or — if it is a warning this repo consciously accepts — add it to ' +
+          'ACCEPTED_WARNINGS in scripts/validate-plugin-official.mjs with a reason.'
+      );
+      process.exitCode = 1;
+    } else {
+      console.log('Official plugin validator: OK (no unaccepted findings)');
+    }
+  }
+}

--- a/tests/check-doc-enumerations.test.mjs
+++ b/tests/check-doc-enumerations.test.mjs
@@ -153,7 +153,7 @@ test('checkDocEnumerations reports a count mismatch', async () => {
 test('checkDocEnumerations reports both directions of a name-set drift', async () => {
   const spec = {
     id: 'name-spec',
-    doc: 'commands/README.md',
+    doc: 'docs/development/distributed-commands.md',
     summary: 'コマンド表',
     marker: '表',
     kind: 'names',
@@ -169,7 +169,7 @@ test('checkDocEnumerations reports both directions of a name-set drift', async (
 test('checkDocEnumerations fails when the declaration marker disappears', async () => {
   const spec = {
     id: 'missing-marker',
-    doc: 'commands/README.md',
+    doc: 'docs/development/distributed-commands.md',
     summary: 'コマンド表',
     marker: '`Command | File | Purpose` 表',
     kind: 'names',
@@ -475,9 +475,9 @@ test('every registered spec declares the fields the engine needs', () => {
 // ここでは production の spec.declare / spec.measure をそのまま通し、
 // 実ファイルの内容を 1 箇所だけ壊して「本当に落ちる」ことを確かめる。
 
-test('distributed-commands-table spec fails when a real row is removed from commands/README.md', async () => {
+test('distributed-commands-table spec fails when a real row is removed from the command doc', async () => {
   const spec = realSpec('distributed-commands-table');
-  const realText = await readRepoFile('commands/README.md');
+  const realText = await readRepoFile('docs/development/distributed-commands.md');
   // 行ごと（改行込みで）落とす。空行を残すと表がそこで終わったと解釈され、
   // 以降の行も丸ごと欠落扱いになってしまう。
   const mutated = realText.replace(/^\|\s*`\/pr`.*\r?\n/m, '');

--- a/tests/validate-plugin-official.test.mjs
+++ b/tests/validate-plugin-official.test.mjs
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  ACCEPTED_WARNINGS,
+  TARGETS,
+  classifyFindings,
+  parseFindings,
+  validateWithOfficialCli,
+} from '../scripts/validate-plugin-official.mjs';
+
+// Real output shapes captured from `claude plugin validate` (v2.x).
+const WARNING_OUTPUT = `Validating plugin manifest: /repo/.claude-plugin/plugin.json
+
+⚠ Found 1 warning:
+
+  ❯ composerIcon: Unknown field 'composerIcon'. Claude Code ignores it at load time.
+
+Validating plugin: /repo/CLAUDE.md
+
+⚠ Found 1 warning:
+
+  ❯ root: CLAUDE.md at the plugin root is not loaded as project context. To ship context with your plugin, use a skill (skills/<name>/SKILL.md) instead.
+
+✘ Validation failed (--strict treats warnings as errors)
+`;
+
+const ERROR_OUTPUT = `Validating plugin manifest: /repo/.claude-plugin/plugin.json
+
+✘ Found 3 errors:
+
+  ❯ name: Plugin name cannot contain spaces. Use kebab-case (e.g., "my-plugin")
+  ❯ version: Invalid input: expected string, received number
+  ❯ commands[0]: Path not found: ./nope.md. The runtime loader will report this as a load failure.
+
+✘ Validation failed
+`;
+
+test('parseFindings labels findings by their section header', () => {
+  const warnings = parseFindings(WARNING_OUTPUT);
+  assert.equal(warnings.length, 2);
+  assert.ok(warnings.every((f) => f.kind === 'warning'));
+
+  const errors = parseFindings(ERROR_OUTPUT);
+  assert.equal(errors.length, 3);
+  assert.ok(errors.every((f) => f.kind === 'error'));
+});
+
+test('classifyFindings accepts only the documented warnings', () => {
+  const { accepted, blocking } = classifyFindings(parseFindings(WARNING_OUTPUT));
+  assert.equal(blocking.length, 0);
+  assert.deepEqual(accepted.map((f) => f.id).sort(), [
+    'root-claude-md-not-context',
+    'unknown-field-composer-icon',
+  ]);
+});
+
+test('classifyFindings never accepts errors, even ones matching an accepted pattern', () => {
+  const findings = [{ kind: 'error', message: "composerIcon: Unknown field 'composerIcon'." }];
+  const { accepted, blocking } = classifyFindings(findings);
+  assert.equal(accepted.length, 0);
+  assert.equal(blocking.length, 1);
+});
+
+test('classifyFindings blocks a new, undocumented warning', () => {
+  const output = `⚠ Found 1 warning:
+
+  ❯ hooks: Unknown field 'somethingNew'.
+`;
+  const { blocking } = classifyFindings(parseFindings(output));
+  assert.equal(blocking.length, 1);
+  assert.match(blocking[0].message, /somethingNew/);
+});
+
+test('ACCEPTED_WARNINGS entries all carry an id, a pattern and a reason', () => {
+  for (const entry of ACCEPTED_WARNINGS) {
+    assert.equal(typeof entry.id, 'string');
+    assert.ok(entry.pattern instanceof RegExp);
+    assert.ok(entry.reason.length > 20, `reason for ${entry.id} must explain the decision`);
+  }
+});
+
+test('validateWithOfficialCli skips (exit-0 path) when the claude CLI is absent', () => {
+  const fakeRun = () => ({ error: new Error('ENOENT'), status: null });
+  const result = validateWithOfficialCli(fakeRun);
+  assert.equal(result.skipped, true);
+  assert.deepEqual(result.blocking, []);
+});
+
+test('validateWithOfficialCli fails when the CLI exits non-zero with unparsable output', () => {
+  const calls = [];
+  const fakeRun = (cmd, args) => {
+    calls.push(args);
+    if (args[0] === '--version') return { status: 0, stdout: '2.0.0' };
+    return { status: 2, stdout: '', stderr: 'boom' };
+  };
+  const result = validateWithOfficialCli(fakeRun);
+  assert.equal(result.skipped, false);
+  assert.equal(result.blocking.length, TARGETS.length);
+  assert.match(result.blocking[0].message, /no parsable finding/);
+});


### PR DESCRIPTION
## 背景

自前の `npm run plugin:validate` は緑なのに、Claude Code 公式の `claude plugin validate --strict` は exit 1 で落ちる。公式 validator はリポジトリのどこからも参照されていなかった（`git grep "plugin validate" -- .github/ scripts/ package.json docs/` が 0 件）。

自前 validator は「こちらが理解したプラットフォーム契約」の実装であり、理解が誤っていれば同じ誤り方をしたまま緑になる。公式 validator を回すことでしか、この種の取りこぼしは検出できない。

## 変更

- `scripts/validate-plugin-official.mjs` を新設。公式 CLI を **2 回**呼ぶ。`claude plugin validate` は引数で読むマニフェストが変わり、ディレクトリを渡すと `marketplace.json` のみ、plugin マニフェストと CLAUDE.md / commands / agents は `.claude-plugin/plugin.json` を明示しないと到達しない
- 許容済みの警告のみ allowlist 化し、それ以外の新規警告と全エラーで落とす。素の `--strict` は恒久的に exit 1 で信号にならないため
- `claude` 不在時は SKIP（exit 0）
- `commands/README.md` に frontmatter を追加（警告 1 件を解消）
- `tests/validate-plugin-official.test.mjs` を新設（7 件）
- `docs/development/plugin-asset-registration-checklist.md` に 2 回呼び出しの規則と許容理由を記載

## 判断の記録

`composerIcon` は **許容**とした。Claude 側マニフェストから外すと `checkCrossManifestParity`（`scripts/validate-plugin-manifest.mjs:172`）が Codex 側の `interface.composerIcon` と突き合わせているため、#1250 が入れた parity ガードを緩める必要が生じる。CLI 自身が「ロード時に無視する」と言っており無害なので、ガードを残す方を選んだ。

ルート `CLAUDE.md` も **許容**。`claude plugin validate --help` に抑制フラグが無く、このファイルは配信コンテキストではなくリポジトリ自身のエージェント指示であるため。

## CI へは追加していない

`claude` CLI は GitHub Actions runner に存在せず、認証なしで動作するかを検証できなかった。毎 PR で落ちるステップになるのを避け、ローカル専用の `npm run` ターゲットとして文書化した。CI 化する場合は「認証なしで動くか」の確認が先。