### PR TITLE
feat(skills): fixture の diff 構造を検証するゲートを追加する

### DIFF
--- a/docs/data/skill-manifest.json
+++ b/docs/data/skill-manifest.json
@@ -6,13 +6,13 @@
     {
       "id": "a11y-accessible-name",
       "path": "skills/midstream/a11y-accessible-name",
-      "checksum": "sha256:25ec2bbc16dd98893a54bf1344be36e350c6495c7b2a9fbc8feeb13db6013f3e",
+      "checksum": "sha256:9fe48476ff9cc15fe58b9ad9910c4eb080e6e36613a80ab8ab10af7da4115750",
       "files": 9
     },
     {
       "id": "adr-decision-quality",
       "path": "skills/upstream/adr-decision-quality",
-      "checksum": "sha256:795a47c8d593036e45e655220e26da3105bef6fe2d007a7657b9bb1a82b2ce15",
+      "checksum": "sha256:43e54eeec365ca2e60ded231083a5679b670ac4e059908e62f322c6bbd3d9bf7",
       "files": 3
     },
     {
@@ -36,31 +36,31 @@
     {
       "id": "altitude-generalization",
       "path": "skills/midstream/altitude-generalization",
-      "checksum": "sha256:a0c36f752b3cdf102980a3dbe9a525e9ab42a9252b96aa08c460cacbb85a62cf",
+      "checksum": "sha256:1ba5bc5ced4acb15408a999392f0c287d2ef8ecca31b038712cb83451e5ca523",
       "files": 10
     },
     {
       "id": "api-compatibility",
       "path": "skills/midstream/api-compatibility",
-      "checksum": "sha256:9915ae63478f2c29997431ad41c1f0f9844ffabea850049150132a84d2f98440",
+      "checksum": "sha256:09471ed05c568480e0d1b0c9f92772e10ef4580b7d418485163649a2eb223a6f",
       "files": 5
     },
     {
       "id": "api-design",
       "path": "skills/upstream/api-design",
-      "checksum": "sha256:12f25f1372f8760a3bf6ba809c2db2170956b86e284bf0e921edfe413c8cb74b",
+      "checksum": "sha256:4c2931e8600f684b67cdb857878d4fee6844bc31ae784da18c129d50477846d9",
       "files": 3
     },
     {
       "id": "api-versioning-compat",
       "path": "skills/upstream/api-versioning-compat",
-      "checksum": "sha256:241033776b24dba6cc9fab9a66cdbfb34fcd70dc705321ba015529695be7a40b",
+      "checksum": "sha256:6794ce4eb1d25fa3c37315ce9064e7c7c9c3aa714e26db50f66cfd5152838634",
       "files": 3
     },
     {
       "id": "architecture-boundaries",
       "path": "skills/upstream/architecture-boundaries",
-      "checksum": "sha256:2d277665b0980236de226ec8e2e0dbcdb8540813830e77b6a1aed9c00195efee",
+      "checksum": "sha256:cd853a4260bd23f3e2d4c5ccc0abd27ce75d002dd5633635a86b0cfcb9de62c1",
       "files": 3
     },
     {
@@ -72,31 +72,31 @@
     {
       "id": "architecture-risk-register",
       "path": "skills/upstream/architecture-risk-register",
-      "checksum": "sha256:83d790949e808bfe4f7f1319e5a6efe1828fcc5a7bb59520d78de50a8da4fac6",
+      "checksum": "sha256:7f45cf88c477693eaeb490fbe34a5bf7a22b06280f8fe4c506897c5a9c4624a3",
       "files": 3
     },
     {
       "id": "architecture-traceability",
       "path": "skills/upstream/architecture-traceability",
-      "checksum": "sha256:b151063536c481c8fc0ae4360c43a44cd7c98342a1f335ad86202ab4e21156a1",
+      "checksum": "sha256:fb2d37e2e9580896dd075ebf20fc011887b81297a1f0172a2d0a6c2a6a0a1455",
       "files": 3
     },
     {
       "id": "architecture-validation-plan",
       "path": "skills/upstream/architecture-validation-plan",
-      "checksum": "sha256:f781576f81bfe108eec5e36a9025dd5fecaab5745a84dadf816fef90bc6e5f3b",
+      "checksum": "sha256:fa81dd1b4ef69c711b9932fea5d1da32420b121f6444a66b7046df9de229c3b1",
       "files": 9
     },
     {
       "id": "assumption-resolution-trace",
       "path": "skills/midstream/assumption-resolution-trace",
-      "checksum": "sha256:d3813c3191543485dc3f75c53ae21b095c010d3177a26cb62d1fcdb539b8f7b8",
+      "checksum": "sha256:70ea89a7d76a2906c6e15cc84a60ebd1d509e63610e282bbdc442db0bc82df36",
       "files": 3
     },
     {
       "id": "async-correctness",
       "path": "skills/midstream/async-correctness",
-      "checksum": "sha256:efeeb9ef33613f27d5e4efbb1a16595d84f74ff0aca711ba6ddcd5e93f53a11b",
+      "checksum": "sha256:3c05d7b721fff339d103e89cde93446d47cc051a23b70ca278a2a500059bb66b",
       "files": 3
     },
     {
@@ -108,7 +108,7 @@
     {
       "id": "behavior-structure-separation",
       "path": "skills/midstream/behavior-structure-separation",
-      "checksum": "sha256:436ee0c8bce446c41d6bdf5dcfe640fbad07de3332f2ea3bf7936b023e641717",
+      "checksum": "sha256:1545321ae0c44cef807d1688b9f6859e1916decc7b387ea7c512383333be5571",
       "files": 4
     },
     {
@@ -120,7 +120,7 @@
     {
       "id": "cache-strategy-consistency",
       "path": "skills/upstream/cache-strategy-consistency",
-      "checksum": "sha256:5f8f9ce9b52c172c0530b762d0cedea535695085cb1c52a292bb5a131937e888",
+      "checksum": "sha256:768de30b3acdedb875d41864b7594a6242016245161a1b405229ae839d5b11a9",
       "files": 9
     },
     {
@@ -138,7 +138,7 @@
     {
       "id": "closure-scope-retention",
       "path": "skills/midstream/closure-scope-retention",
-      "checksum": "sha256:5371b7f7078955a0db36d5302b53b8d00ef54c7fbe403fcaca2f5a7e3ac26cd6",
+      "checksum": "sha256:385645dd1bcd69e9e178e2c8c1bd3292b6c03bf25a85489d9f996a68cafa572f",
       "files": 10
     },
     {
@@ -216,13 +216,13 @@
     {
       "id": "data-flow-state-ownership",
       "path": "skills/upstream/data-flow-state-ownership",
-      "checksum": "sha256:ee73c1feb55c104f2274996e5ede3234afb0c1bc4a68d11f9505a0f8efe74ca8",
+      "checksum": "sha256:1248d658dc1d83ba307fabd85a185a6f56d17bd7608b0486f2570f41eeeb78c1",
       "files": 3
     },
     {
       "id": "data-model-db-design",
       "path": "skills/upstream/data-model-db-design",
-      "checksum": "sha256:c875fa7aed6c7fa9c8f075ccad57e9ecc9eeaac743bd20c65ad5cd9d3325c27c",
+      "checksum": "sha256:a5a9ec099d1d00c4fbbeeb6acf49fc0616715047524891fe983fa10af3584581",
       "files": 3
     },
     {
@@ -234,19 +234,19 @@
     {
       "id": "design-system-component-reuse",
       "path": "skills/midstream/design-system-component-reuse",
-      "checksum": "sha256:4171ab663d3ec59e974e6e62e0cfd156a2be7eec6d0c16826b8ffb821dff7c51",
+      "checksum": "sha256:5df97b3500053853736400d3fea0bf9c12f0f85ab7408ff603d0508404f05f7b",
       "files": 9
     },
     {
       "id": "design-token-enforcement",
       "path": "skills/midstream/design-token-enforcement",
-      "checksum": "sha256:b7d3d196e27162dba712e65f8865a4afcce823dfc38ba36ae9443408d7e65a11",
+      "checksum": "sha256:774efb0868b06e6fa55cab81f83c60d9f86f59da68b6a505f25c4e6ac7b6f764",
       "files": 9
     },
     {
       "id": "doc-hygiene",
       "path": "skills/midstream/doc-hygiene",
-      "checksum": "sha256:2011bdeb615a231c371663140bbd0bd19b422359770202754e62433212fc2189",
+      "checksum": "sha256:cce4f42fc8b70a8d3b5c579b30ac6813a77e179f65176a1384f1455b3c4e44eb",
       "files": 4
     },
     {
@@ -270,31 +270,31 @@
     {
       "id": "event-driven-semantics",
       "path": "skills/upstream/event-driven-semantics",
-      "checksum": "sha256:78959100575e00c6245d09d03eb7f7e2a2c0badca53cc9ff5b6753702451353c",
+      "checksum": "sha256:2fadbfcc3ddaaa095e157cd38616eeee2026ec243c2982b484dc27bc9b652aa0",
       "files": 3
     },
     {
       "id": "existing-pattern-conformance",
       "path": "skills/midstream/existing-pattern-conformance",
-      "checksum": "sha256:60b1e638ab99e654a7c56ba6733156f7cf3fa6bd73e1f6f5a59872398b24b103",
+      "checksum": "sha256:28d7583aa240137b2b526b907cfc75b67380bcbd0d7d5023515ba0dcddc6d014",
       "files": 3
     },
     {
       "id": "external-dependencies",
       "path": "skills/upstream/external-dependencies",
-      "checksum": "sha256:fedcb1a00d19fb7510ce1bed9a7180de0728f3d8051ac502f81e9f0969d9034e",
+      "checksum": "sha256:d44258aa74a9fc94b52ecde41ada1eb048c107dac2eb0d893ae0a50db8fa60f2",
       "files": 3
     },
     {
       "id": "failure-modes-observability",
       "path": "skills/upstream/failure-modes-observability",
-      "checksum": "sha256:f4d18975c005588109510615d282c9d090f75acaded58f52753cd435c25d7d6d",
+      "checksum": "sha256:4f377e963298b5611da3ed0fce653e834e8d1db4288b42bc99e581096092161c",
       "files": 3
     },
     {
       "id": "firebase-security-rules",
       "path": "skills/midstream/firebase-security-rules",
-      "checksum": "sha256:dd8f260481e1ab77b45d5842f26a1cf21ca23e678b363955d2a6369001af2d76",
+      "checksum": "sha256:38af51530475db3441090adc41f043c2a7f25a15d1fa91e08cab47193e88cca1",
       "files": 4
     },
     {
@@ -318,13 +318,13 @@
     {
       "id": "gha-workflow-security",
       "path": "skills/downstream/gha-workflow-security",
-      "checksum": "sha256:129fcd3e90b5ec41cd768fa6373e135ddb26625e76837fc1146cacd20af8bf8c",
+      "checksum": "sha256:c8fa1837654a619524b2ba291e374ac9aff567256fd48689b5027f17009ade08",
       "files": 4
     },
     {
       "id": "hallucinated-reference",
       "path": "skills/midstream/hallucinated-reference",
-      "checksum": "sha256:3af7f1364671db3066019c6ba0f868425e59a8004c5582685d2298719fa793b6",
+      "checksum": "sha256:a3488d8d9ac939cd576a5db40806c1ad84df0a027988388f9087869223a422ec",
       "files": 3
     },
     {
@@ -336,19 +336,19 @@
     {
       "id": "i18n-unused-key",
       "path": "skills/midstream/i18n-unused-key",
-      "checksum": "sha256:b4bc3f91e74311dc416dd5ab7e51d4e467156d412e829a888a4092974e96d186",
+      "checksum": "sha256:72728b065a3aae97a11df4db603443c698ce47cfa9a158dddb0e945c3b91d56d",
       "files": 5
     },
     {
       "id": "impact-evidence-coverage",
       "path": "skills/midstream/impact-evidence-coverage",
-      "checksum": "sha256:5572826fca5ec1a1f3ab7303fb3d5e0689eea07efd37be21e5404d2c00343f5e",
+      "checksum": "sha256:3e0e9f34edd111e38ea355fb1e33a89b29bdab9c2f423679b5360443660994bd",
       "files": 3
     },
     {
       "id": "independent-review-synthesis",
       "path": "skills/midstream/independent-review-synthesis",
-      "checksum": "sha256:dbfd173fc6d0e62046595b54a8c1e5b9665058609cc6ba4acff7c42fc8d954d2",
+      "checksum": "sha256:3e2190c1a3b35482c5bc99ef3f4c3c6f5a2bccfe198ecdc5a67f127e0a2a7dbd",
       "files": 9
     },
     {
@@ -366,37 +366,37 @@
     {
       "id": "knowledge-to-code-alignment",
       "path": "skills/midstream/knowledge-to-code-alignment",
-      "checksum": "sha256:6e814a0b099d5d95007151b19073b27055a79897a706909cdfbc2693e1e788af",
+      "checksum": "sha256:8c13f6142f21bb171a4a1548b40a6cbeb1e83793d210312f02655b0448f71873",
       "files": 4
     },
     {
       "id": "laravel-eloquent-nplus1",
       "path": "skills/midstream/laravel-eloquent-nplus1",
-      "checksum": "sha256:e9dfa13a71c6fb52222e9b6c237a08c564639a65e1b67e6c7728425f845781b1",
+      "checksum": "sha256:1e3b6039a9f19143e64c301f5b56d33dd3a8147db79972eb12d25dfd2008bd91",
       "files": 4
     },
     {
       "id": "laravel-mass-assignment",
       "path": "skills/midstream/laravel-mass-assignment",
-      "checksum": "sha256:f75e32ff6aa80c7d88bd914e9fd637817c7013d6794627e6f9f24b1e7f3d5bc6",
+      "checksum": "sha256:cfdfbc7135ca9802019ecc1d6cd1bd6d1f6a75a063bceeb3abb353440a5e6d8a",
       "files": 4
     },
     {
       "id": "laravel-migration-safety",
       "path": "skills/upstream/laravel-migration-safety",
-      "checksum": "sha256:1b5dbb830ff3f0a78b9cc46d238dc6027ec5ca336609ce4d2cfd7a66891d98c4",
+      "checksum": "sha256:2b92c3707aaf9aab2c44c88936de3d0b830c3c45add3c1e21b4cf849957ae590",
       "files": 4
     },
     {
       "id": "loading-state",
       "path": "skills/midstream/loading-state",
-      "checksum": "sha256:9ae03e7a415e0a502481ad0d0ba6f835ddbf58f74ef3dfd5ebe4355b8e1c4a2c",
+      "checksum": "sha256:a1029bd223ab319c23c60676926482878f7c271505d3fea2abfa817698cb06a2",
       "files": 5
     },
     {
       "id": "logging-observability",
       "path": "skills/midstream/logging-observability",
-      "checksum": "sha256:41cccd7a9a71431b4d79d51bdef6436871fe35ee137b92134aed9d30b712bb3f",
+      "checksum": "sha256:203387a265a356c4b44e68c8d1f63558d6558c983d51d38600c988a685d27429",
       "files": 18
     },
     {
@@ -408,37 +408,37 @@
     {
       "id": "migration-rollout-rollback",
       "path": "skills/upstream/migration-rollout-rollback",
-      "checksum": "sha256:82b7872451b0c45a35590fe5c025b6616bd1c3664d9599d3023755f715026e02",
+      "checksum": "sha256:f724f6ff9dc955faa951665e1bef65eed88e3a746145de3057ff7842118683e1",
       "files": 3
     },
     {
       "id": "migration-safety",
       "path": "skills/upstream/migration-safety",
-      "checksum": "sha256:cb13be4d97f5769caf7b20bf869541a40e867f7c9959c0e1cb46e9d3c6b3c961",
+      "checksum": "sha256:f11167b6bbc2c91a294970430e29a86b6ce7355f344bd7607a0c1141bb0aa370",
       "files": 3
     },
     {
       "id": "modern-web-a11y-interactive",
       "path": "skills/midstream/modern-web-a11y-interactive",
-      "checksum": "sha256:5d2e338dba80600b8f50ef4922e5bca6af2097778f60348740688340acc09c25",
+      "checksum": "sha256:2f0af16ae83ae5421b30423106e1f569c4c1d1ca5f64fa501ecaf27f127a12df",
       "files": 9
     },
     {
       "id": "modern-web-browser-compat",
       "path": "skills/midstream/modern-web-browser-compat",
-      "checksum": "sha256:98e9dd19e90a7f011e8ac680c903f35e99d5e6800011f7754fc1a2aeab4a3c95",
+      "checksum": "sha256:cfea908e05b007b1e879ed1e63d8ade557c019b30d4f008bb57f677abb749679",
       "files": 9
     },
     {
       "id": "modern-web-performance",
       "path": "skills/midstream/modern-web-performance",
-      "checksum": "sha256:2983b6bfba658200df07ef66f2f046567e76170d7bdad9d1e719a5b291baf1fa",
+      "checksum": "sha256:1403f1ce365f522d4311835cdc5b9c27a537ad2a01e7ee1a97b90ec8d56bf430",
       "files": 9
     },
     {
       "id": "modern-web-semantic",
       "path": "skills/midstream/modern-web-semantic",
-      "checksum": "sha256:db478a93d8f6be937acbffcbff6e55150284edd29c4d7acfcd98fa9ea1867f52",
+      "checksum": "sha256:faf548938677fea7ec195008514f4f07e30ec466745f2b2ec3e817013a7bf0a5",
       "files": 9
     },
     {
@@ -450,37 +450,37 @@
     {
       "id": "nextjs-app-router-boundary",
       "path": "skills/midstream/nextjs-app-router-boundary",
-      "checksum": "sha256:456f29701850742a5f22764a601a9a1ffc0b2dea0b7237bca06d863221250464",
+      "checksum": "sha256:102e5b043d6dd4f8e2ed66560218f537bb4e82e863955a0ada6331c2d609c943",
       "files": 9
     },
     {
       "id": "nextjs-server-action-security",
       "path": "skills/midstream/nextjs-server-action-security",
-      "checksum": "sha256:95aac7e47b6574ae70b9e4d1b1fc7af1681ea98be0748ab3095f7bdaa0ddf66c",
+      "checksum": "sha256:3e1a3b73d80ab8b5fd05c9e4d2ad6e8f503f08f4917416bf6279e948758ac807",
       "files": 4
     },
     {
       "id": "normalization-consistency",
       "path": "skills/midstream/normalization-consistency",
-      "checksum": "sha256:e42bce67d067337cea013d6f14aa1d0578f9bf41715c44b32298dd2cc66d84a7",
+      "checksum": "sha256:cded944fdfa6f889e8fbbd953581ac7e5ec5f171cf6ee1bb16acb96180849eb5",
       "files": 5
     },
     {
       "id": "nullability-contract",
       "path": "skills/midstream/nullability-contract",
-      "checksum": "sha256:e8934255f544914791c6a8e46bc28c9f7f2853a8ac6e896f6c075817b0058f8f",
+      "checksum": "sha256:3326a5b5a1b9683291616bdb97b589d89f6d3ca3288796e88875475841b3825c",
       "files": 7
     },
     {
       "id": "openapi-contract",
       "path": "skills/upstream/openapi-contract",
-      "checksum": "sha256:088081ac65c95216253e55306bc616c77ac7f61f815bb152181cea7291606c73",
+      "checksum": "sha256:bdade1a63ebc8b038915d4167f808b7639418730e61754eb0c1d09cb70402af7",
       "files": 3
     },
     {
       "id": "operability-slo",
       "path": "skills/upstream/operability-slo",
-      "checksum": "sha256:fc83f6fbc993346e6771aabb89bb2c58f99b6a555b827ff57f564996b823ebc4",
+      "checksum": "sha256:a86de8fd68a209d9fcb3d06a685f89035a174a9683b88f148a2c889c0a7e07b7",
       "files": 3
     },
     {
@@ -492,7 +492,7 @@
     {
       "id": "plangate-exec-conformance",
       "path": "skills/upstream/plangate-exec-conformance",
-      "checksum": "sha256:01cba7b7de7e71944252ecb2d87827994d181978ac5c5076bed3ad45a1f2975f",
+      "checksum": "sha256:ef14079adb5a5e39fdb3d46c73b2e3b610c78f5b442472074216fcbcdd4cd97f",
       "files": 14
     },
     {
@@ -540,19 +540,19 @@
     {
       "id": "pre-mortem",
       "path": "skills/upstream/pre-mortem",
-      "checksum": "sha256:a5b5bd8896f3d761e0acadafff3795ca9391515ba8997bdf75796cd5d55d8344",
+      "checksum": "sha256:f3ee434f6ed91db0dce720d899c4cf17e13b8a5e6a48493b0e7ded556ef92b7c",
       "files": 3
     },
     {
       "id": "react-router-action-contract",
       "path": "skills/midstream/react-router-action-contract",
-      "checksum": "sha256:cec8645007e80bb444223f68911bc3e2ae382780094f918b4854b464e42fd312",
+      "checksum": "sha256:e79c5aaa1f69dc239bfc1da889ad37e59dc4cc24738f2f79ec2a7283c9321873",
       "files": 4
     },
     {
       "id": "react-router-loader-boundary",
       "path": "skills/midstream/react-router-loader-boundary",
-      "checksum": "sha256:82ab8e124b31e88d795d1f0a82f171809e522484d0888db0111f9fb9394dcab2",
+      "checksum": "sha256:d4e73de4e47a65a1d9e9b80be06b8140557e04415008a100b4d1f0b9d6ca2d3c",
       "files": 4
     },
     {
@@ -564,7 +564,7 @@
     {
       "id": "requirements-acceptance",
       "path": "skills/upstream/requirements-acceptance",
-      "checksum": "sha256:1d4f8e41421e8de123944b8a1e30244463e8acdcf11dc6073fac148db0323b47",
+      "checksum": "sha256:d0ea2940bb1d5f0c4c584950c046e1d94b6f0945396d87bd94d4e40cf1d3f00c",
       "files": 3
     },
     {
@@ -582,7 +582,7 @@
     {
       "id": "review-criteria-integrity",
       "path": "skills/midstream/review-criteria-integrity",
-      "checksum": "sha256:2d608cb1080bd59bde0ed276a64adc0bec7b86232acc17a955093582f24433b9",
+      "checksum": "sha256:3b0bf99431b98fe8acefce6cb4d05e8aadc02d6d59e0912f94d54938bff09139",
       "files": 5
     },
     {
@@ -612,7 +612,7 @@
     {
       "id": "river-review",
       "path": "skills/agent-skills/river-review",
-      "checksum": "sha256:9fe52f0ce82b329cfad498f523a29e7295254b6578d403690f1dc2f495515fdd",
+      "checksum": "sha256:e4c733c949ae61cd6a3cfc955458fe9d52e6263ec2f0123357e3c25109a401d7",
       "files": 10
     },
     {
@@ -660,19 +660,19 @@
     {
       "id": "secret-credential-scan",
       "path": "skills/midstream/secret-credential-scan",
-      "checksum": "sha256:6d8f5ef3d44e77767808aa3e27442215ec9a3d9b3abb84222b8f3ef665d0fce8",
+      "checksum": "sha256:76a63b5713bd519e89cdf51b4ca98ee7bec49ba9728781f7636f0b60639d937d",
       "files": 10
     },
     {
       "id": "security-basic",
       "path": "skills/midstream/security-basic",
-      "checksum": "sha256:eab9674357e90d305c130bae747b0995ea05d8e4cdc6365823fd738b0b574db7",
+      "checksum": "sha256:9442d34e67f637296b18aecdbbf3f059c8647855f8b829b18567bfe7d7f53ba6",
       "files": 9
     },
     {
       "id": "security-privacy-design",
       "path": "skills/upstream/security-privacy-design",
-      "checksum": "sha256:a9705c254d8c58fc2287c999ae2e4bc9b8cde64227f0c6787f5cfcda5154f3b3",
+      "checksum": "sha256:3305480abdb220f6e2923c75c82274d05b1af87522d3c3d95bf07c8e3095ddaa",
       "files": 9
     },
     {
@@ -684,25 +684,25 @@
     {
       "id": "supabase-rls-policy",
       "path": "skills/midstream/supabase-rls-policy",
-      "checksum": "sha256:b7bd0da8665c3a0d87640f86bd1cd7debc440574ce40c73c76ebef3e495cca48",
+      "checksum": "sha256:78b75cb363342013ea31b41f4d9f2c92618fcbd02fb622dfc1741991013b52e8",
       "files": 4
     },
     {
       "id": "suppression-feedback",
       "path": "skills/midstream/suppression-feedback",
-      "checksum": "sha256:e8183852b301f380ea2d810c19706aa00a828e230c038c4bfa9489dac5354a2f",
+      "checksum": "sha256:0bb1123880b381128296df086f3dc21dd06773be0a0f3591cfc9fa54794944ba",
       "files": 10
     },
     {
       "id": "tailwind-class-hygiene",
       "path": "skills/midstream/tailwind-class-hygiene",
-      "checksum": "sha256:fdd43409e2236b24467ce219685236cf02e18f0df405bc81f32fe63959880504",
+      "checksum": "sha256:75477ed61c9fbf8413ac69250c539e3d19c7276bba764be6c0d01e1b3ad7241a",
       "files": 4
     },
     {
       "id": "test-assertion-effectiveness",
       "path": "skills/downstream/test-assertion-effectiveness",
-      "checksum": "sha256:6acf580cfade4ff661c07d166e4f5602113948785a53481c94436ac7d7f088d8",
+      "checksum": "sha256:04b49ccd0734aff73aa658b7a7a5702d58ffb1917e58a68cab75ad9b4709a474",
       "files": 7
     },
     {
@@ -726,25 +726,25 @@
     {
       "id": "trust-boundaries-authz",
       "path": "skills/upstream/trust-boundaries-authz",
-      "checksum": "sha256:09ecab5132883b228f1d93879cb96703db77335f5c05d3b18ab1ac64a6bb826e",
+      "checksum": "sha256:5c9696fd3e76e8365f50377237375fe5901cc749605fba1829814f78a4949dd7",
       "files": 3
     },
     {
       "id": "type-driven-design",
       "path": "skills/midstream/type-driven-design",
-      "checksum": "sha256:2372d4e53450239dc2bb981b402ae3aaf1abf42e2e86925038231524599c64a6",
+      "checksum": "sha256:f9fe5b77ea72a4d325a9c73d423c13cf2e92b0ccbbfd3d890612b907593e47f4",
       "files": 7
     },
     {
       "id": "typescript-nullcheck",
       "path": "skills/midstream/typescript-nullcheck",
-      "checksum": "sha256:93bb8009b128a23b237322c078b8f97a7868cd08b0a442f1a2d96475e58ee8a0",
+      "checksum": "sha256:a8dabf496753afb6ae6d079f3a87edbec9e8e893782112a1de33712cbe38c50b",
       "files": 7
     },
     {
       "id": "typescript-strict",
       "path": "skills/midstream/typescript-strict",
-      "checksum": "sha256:e39e0cad95645c791a66d583d4db9f07e13ef867ad65eb013e0b52980126ce30",
+      "checksum": "sha256:de42d210bbd7f46dd012b29169d11482e8561eabf06e4abf484ce58549f3cf5c",
       "files": 7
     },
     {
@@ -756,13 +756,13 @@
     {
       "id": "unknown-coverage-review",
       "path": "skills/agent-skills/unknown-coverage-review",
-      "checksum": "sha256:7a43c7896302491402a437c8da61bba7ec252fb89b7991822b7c42c473ab537d",
+      "checksum": "sha256:d0571b9aeaeff4d9b1376593843bc871b47e2b19456c470b37f71fdfec9503b1",
       "files": 5
     },
     {
       "id": "vitest-mock-isolation",
       "path": "skills/midstream/vitest-mock-isolation",
-      "checksum": "sha256:bc87dfbb360e96e3bdeba0e5f597c752e000f9153e706c67761c24d505184528",
+      "checksum": "sha256:fedee8b860b344421502289593f785566f858edbb8696658449e3f065d80c9b8",
       "files": 4
     },
     {

--- a/docs/development/s1-fixture-convention.md
+++ b/docs/development/s1-fixture-convention.md
@@ -81,15 +81,38 @@ negative fixture は `findings: []` と `reason` を書く。`findings: []` の 
 
 見出しを持たない skill（上記パイロット 5 件はすべてこの型）では `check:` を書かない。書かないことで description 列挙ゲートは発火せず、frontmatter を触らずに済む。frontmatter の `inputContext` / `dependencies` / `tags` を変更すると `tests/planner-dataset-eval.test.mjs` が落ちるため、fixtures 追加だけの PR では frontmatter を触らないこと。
 
+### 3-2. diff ブロックの記法と構造条件
+
+`anchor` の行番号は fixture 内の diff ブロックから機械的に解決されます。そのため入力 diff は unified diff として書き、`scripts/validate-skills.mjs` の `validateFixtureDiffStructure()` が認識できる記法に揃える必要があります。
+
+記法の要件は次のとおりである。
+
+- fence は行頭の ` ```diff ` とする。小文字であり、info string（` ```diff title="x" ` 等）を付けない。インデントした fence も認識されない
+- diff 本体に 3 バックティックの fence を含む場合は、外側を 4 バックティック（` ````diff `）にして閉じる。閉じ位置を間違えると後続の散文が diff 本体として読まれる
+- 新しい側のファイルは `+++ b/<path>` で宣言する。`anchor` のパスはこの宣言と完全一致させる
+- hunk は `@@ -<old開始>,<old行数> +<new開始>,<new行数> @@` とする
+
+上記に対して 4 つの機械条件がかかる。いずれも決定論で判定され、違反はエラーとなる。
+
+- hunk ヘッダの宣言行数が本体の実カウントと一致すること（old 側・new 側とも）。context 行は両側、`+` 行は new 側、`-` 行は old 側を進める
+- `anchor` のパスが、その fixture の diff ブロックのいずれかに `+++ b/<path>` として現れること
+- `anchor` の行番号が new 側の再構成結果に実在し、その行が空行でないこと
+- ファイル内の `@@` ヘッダ数が、認識された diff ブロック内のヘッダ数と一致すること（超過は未認識記法の混入を意味する）
+
+`findings: []` の negative fixture のように `anchor` を持たない fixture は、anchor 検査の対象外となる。`(summary):1` 形式の疑似 anchor も同様に対象外である。
+
 ### 4. 免除を外す
 
 対象 skill が `GRANDFATHERED_WITHOUT_EVAL` に載っている場合、fixtures を足したのと同じコミットでその id を集合から削除する。削除しないと、置かれた fixtures は機械的に検証されない状態のまま残る。
 
 ### 5. 実測で確認する
 
-`npm run skills:validate` の出力にある次の 2 行が、fixtures が実際に検証対象へ入ったことの証跡となる。作業前後の値を控えて差分を報告する。
+`npm run skills:validate` の出力にある次の 3 行が、fixtures が実際に検証対象へ入ったことの証跡となる。作業前後の値を控えて差分を報告する。
 
 - `recommended eval coverage: N/M ... (incl. K grandfathered)` の K が、外した件数だけ減る
 - `fixture drift: N skill(s) with expected blocks consistent` の N が、fixtures を足した skill 数だけ増える
+- `fixture diff structure: H hunk(s) and A anchor(s) across F fixture(s) consistent` の H / A / F が、足した diff ブロック・anchor・fixture の数だけ増える
 
 パイロットでは grandfathered が 30 から 25 へ、expected blocks を持つ skill が 8 から 13 へ動いている。
+
+3 行目の H / A / F は「ゲートが実際に何を見たか」を表す。緑であることと検査したことは別であり、記法の取り違えや走査範囲の変更があると、エラーを出さないまま 0 に落ちる。`tests/validate-fixture-diff-structure.test.mjs` の `COVERAGE_FLOORS` がこの 3 つに下限を設けており、走査範囲が黙って縮むとテストが落ちる。fixtures を大きく増減させたときは、この下限も同じ PR で見直すこと。

--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -870,11 +870,49 @@ const RE_DIFF_FENCE = /^(`{3,})diff[ \t]*\r?\n([\s\S]*?)^\1[ \t]*$/gm;
 /** `@@ -oldStart[,oldCount] +newStart[,newCount] @@` unified-diff hunk header. */
 const RE_HUNK_HEADER = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/;
 
+/**
+ * Same shape as RE_HUNK_HEADER, global+multiline, for counting hunk headers in a
+ * whole fixture file. A header inside a diff body is never at line start (it
+ * would carry a ` `, `+` or `-` prefix), so this counts real headers only.
+ */
+const RE_HUNK_HEADER_LINE = /^@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@/gm;
+
+/**
+ * Count `@@ ... @@` hunk headers in raw text. Pure and exported for unit testing.
+ *
+ * @param {string} text
+ * @returns {number}
+ */
+export function countHunkHeaders(text) {
+  return [...String(text ?? '').matchAll(RE_HUNK_HEADER_LINE)].length;
+}
+
 /** `+++ b/path` (or `+++ path`) new-side file header. */
 const RE_NEW_FILE_HEADER = /^\+\+\+ (?:b\/)?(\S+)/;
 
 /** `<file>:<line>` anchor, as emitted in fixture `<!-- expected: -->` blocks. */
 const RE_ANCHOR = /^(.*\S):(\d+)$/;
+
+/**
+ * True when `lines[i]` opens a `--- old` / `+++ new` file-header PAIR.
+ *
+ * A bare `startsWith('--- ')` test is ambiguous: deleting a line that itself
+ * begins with `-- ` (an SQL or Lua comment — fixtures carry SQL, e.g.
+ * skills/upstream/data-model-db-design/fixtures/01-*.md) produces the diff line
+ * `--- foo`, which is a DELETION, not a header. Mistaking it for a header ends
+ * the hunk early and makes the gate report a wrong "expected" hunk header, so a
+ * maintainer following the message would break a correct fixture. Unified diff
+ * always emits the two headers adjacently, so requiring the pair disambiguates
+ * deterministically: a deleted `-- comment` is never followed by a `+++ ` line
+ * that starts a file section.
+ *
+ * @param {string[]} lines
+ * @param {number} i
+ * @returns {boolean}
+ */
+function isFileHeaderPairStart(lines, i) {
+  return lines[i].startsWith('--- ') && (lines[i + 1] ?? '').startsWith('+++ ');
+}
 
 /**
  * Extract the bodies of every fenced ```diff block in a fixture file.
@@ -952,11 +990,15 @@ export function parseUnifiedDiff(diffText) {
 
     while (i < lines.length) {
       const body = lines[i];
+      // `+++ ` ends the hunk only as the second half of a header pair; on its
+      // own it is an added line whose text starts with `++ ` (mirror of the
+      // `--- ` ambiguity documented on isFileHeaderPairStart).
+      const isPairedNewHeader = body.startsWith('+++ ') && (lines[i - 1] ?? '').startsWith('--- ');
       if (
         RE_HUNK_HEADER.test(body) ||
         body.startsWith('diff --git ') ||
-        body.startsWith('--- ') ||
-        body.startsWith('+++ ')
+        isFileHeaderPairStart(lines, i) ||
+        isPairedNewHeader
       ) {
         break;
       }
@@ -1083,8 +1125,17 @@ export function extractFixtureAnchors(text) {
  * validateFixtureDrift() only reads the expected block's YAML. These fixtures
  * are never executed by eval:fixtures, so nothing else would ever catch it.
  *
+ * The return value carries the coverage counters, not just the verdict: a gate
+ * that inspects NOTHING also returns `ok: true`, so "no error was printed" is
+ * not evidence that the gate ran. Every way this gate can lose its real input —
+ * a broken RE_DIFF_FENCE, a path filter, a renamed `fixtures/` directory, a
+ * changed `.md` filter — collapses the counters while leaving the verdict green.
+ * tests/validate-fixture-diff-structure.test.mjs asserts floors on them so that
+ * silent coverage loss fails the suite (#1854 review, major 1).
+ *
  * @param {{ skillsDir?: string, repoRoot?: string }} [options]
- * @returns {Promise<boolean>} false (→ exitCode 1) on any structural error.
+ * @returns {Promise<{ ok: boolean, checkedFixtures: number, checkedHunks: number,
+ *   checkedAnchors: number }>} `ok: false` (→ exitCode 1) on any structural error.
  */
 export async function validateFixtureDiffStructure({
   skillsDir = defaultPaths.skillsDir,
@@ -1095,7 +1146,7 @@ export async function validateFixtureDiffStructure({
     files = await listSkillFiles(skillsDir);
   } catch (err) {
     console.error(`❌ Failed to list skills: ${err.message}`);
-    return false;
+    return { ok: false, checkedFixtures: 0, checkedHunks: 0, checkedAnchors: 0 };
   }
 
   let success = true;
@@ -1116,6 +1167,25 @@ export async function validateFixtureDiffStructure({
       const fixtureRel = path.relative(repoRoot, fixturePath);
       const content = await fs.readFile(fixturePath, 'utf8');
       const { files: diffFiles, hunks, unknownPrefixLines } = parseFixtureDiffs(content);
+
+      // Unrecognized-notation guard (#1854 review, major 2 — partial). Every
+      // hunk header in the file must sit inside a fence this gate recognizes.
+      // A surplus means the fixture carries a diff written in a notation
+      // extractDiffBlocks() does not match (` ```Diff `, ` ```diff title="x" `,
+      // an indented fence, a bare ``` fence), and that diff would be skipped in
+      // silence — the same failure class this gate exists to close, one fixture
+      // at a time rather than repo-wide. Measured 0 surplus across all current
+      // fixtures, so this is forward-protective without grandfathering.
+      const headersInFile = countHunkHeaders(content);
+      if (headersInFile > hunks.length) {
+        console.error(
+          `❌ ${fixtureRel}: ${headersInFile} hunk header(s) in the file but only ` +
+            `${hunks.length} inside a recognized diff block — write the diff in a ` +
+            'plain ```diff fence at line start (no info string, lowercase) so it is checked'
+        );
+        success = false;
+      }
+
       if (!hunks.length && !diffFiles.size) continue;
       checkedFixtures += 1;
 
@@ -1178,7 +1248,7 @@ export async function validateFixtureDiffStructure({
         `across ${checkedFixtures} fixture(s) consistent`
     );
   }
-  return success;
+  return { ok: success, checkedFixtures, checkedHunks, checkedAnchors };
 }
 
 /**
@@ -1287,7 +1357,9 @@ if (isDirectRun(import.meta.url)) {
   const registryPathsOk = await validateRegistryPaths({ registry });
   const registryIdsOk = await validateRegistryIdMatch({ registry });
   const fixtureDriftOk = await validateFixtureDrift();
-  const fixtureDiffStructureOk = await validateFixtureDiffStructure();
+  // Destructure `.ok` explicitly: the function returns an object (coverage
+  // counters ride along), and an object is always truthy.
+  const { ok: fixtureDiffStructureOk } = await validateFixtureDiffStructure();
   const namingCollisionsOk = await validateNamingCollisions({ registry });
   const ok =
     skillsOk &&

--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -855,6 +855,332 @@ export async function validateFixtureDrift({
   return success;
 }
 
+// ---------------------------------------------------------------------------
+// Fixture diff-block structural validation (#1852)
+// ---------------------------------------------------------------------------
+
+/**
+ * Matches a fenced ```diff block. The backreference on the opening run of
+ * backticks keeps 4-backtick fences (used when the diff body itself contains a
+ * 3-backtick fence, e.g. skills/midstream/self-contradiction/fixtures/01-*.md)
+ * from terminating early.
+ */
+const RE_DIFF_FENCE = /^(`{3,})diff[ \t]*\r?\n([\s\S]*?)^\1[ \t]*$/gm;
+
+/** `@@ -oldStart[,oldCount] +newStart[,newCount] @@` unified-diff hunk header. */
+const RE_HUNK_HEADER = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/;
+
+/** `+++ b/path` (or `+++ path`) new-side file header. */
+const RE_NEW_FILE_HEADER = /^\+\+\+ (?:b\/)?(\S+)/;
+
+/** `<file>:<line>` anchor, as emitted in fixture `<!-- expected: -->` blocks. */
+const RE_ANCHOR = /^(.*\S):(\d+)$/;
+
+/**
+ * Extract the bodies of every fenced ```diff block in a fixture file.
+ * Pure and exported for unit testing.
+ *
+ * @param {string} text - fixture file content
+ * @returns {string[]} raw diff bodies (fence lines excluded)
+ */
+export function extractDiffBlocks(text) {
+  return [...(text ?? '').matchAll(RE_DIFF_FENCE)].map((m) => m[2]);
+}
+
+/**
+ * Parse a unified-diff body and reconstruct the new-side (post-image) line
+ * numbering, so that an `<file>:<line>` anchor can be resolved deterministically.
+ * Pure and exported for unit testing.
+ *
+ * Reconstruction rules (standard unified diff):
+ * - a ` ` (context) line advances both sides;
+ * - a `+` line advances the new side only;
+ * - a `-` line advances the old side only;
+ * - a `\` line (`\ No newline at end of file`) advances neither.
+ *
+ * A completely empty line inside a hunk body is treated as a context line whose
+ * content is empty — that is how a trailing-whitespace-stripped context line
+ * appears in a markdown fixture. The trailing empty element produced by
+ * splitting on the final newline is dropped first so it is not miscounted.
+ *
+ * @param {string} diffText - body of one ```diff block
+ * @returns {{
+ *   files: Map<string, { lines: Map<number, string> }>,
+ *   hunks: Array<{
+ *     file: string|null, header: string,
+ *     oldStart: number, declaredOld: number, actualOld: number,
+ *     newStart: number, declaredNew: number, actualNew: number,
+ *   }>,
+ *   unknownPrefixLines: string[],
+ * }}
+ */
+export function parseUnifiedDiff(diffText) {
+  const files = new Map();
+  const hunks = [];
+  const unknownPrefixLines = [];
+  const lines = String(diffText ?? '').split('\n');
+  while (lines.length && lines[lines.length - 1] === '') lines.pop();
+
+  let currentFile = null;
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+
+    const fileMatch = RE_NEW_FILE_HEADER.exec(line);
+    if (fileMatch) {
+      // `+++ /dev/null` marks a deletion: no new-side lines to reconstruct.
+      currentFile = fileMatch[1] === '/dev/null' ? null : fileMatch[1];
+      if (currentFile && !files.has(currentFile)) files.set(currentFile, { lines: new Map() });
+      i += 1;
+      continue;
+    }
+
+    const hunkMatch = RE_HUNK_HEADER.exec(line);
+    if (!hunkMatch) {
+      i += 1;
+      continue;
+    }
+
+    const oldStart = Number(hunkMatch[1]);
+    const declaredOld = hunkMatch[2] === undefined ? 1 : Number(hunkMatch[2]);
+    const newStart = Number(hunkMatch[3]);
+    const declaredNew = hunkMatch[4] === undefined ? 1 : Number(hunkMatch[4]);
+    let actualOld = 0;
+    let actualNew = 0;
+    let newLine = newStart;
+    i += 1;
+
+    while (i < lines.length) {
+      const body = lines[i];
+      if (
+        RE_HUNK_HEADER.test(body) ||
+        body.startsWith('diff --git ') ||
+        body.startsWith('--- ') ||
+        body.startsWith('+++ ')
+      ) {
+        break;
+      }
+      if (body.startsWith('\\')) {
+        i += 1;
+        continue;
+      }
+      if (body.startsWith('+')) {
+        actualNew += 1;
+        if (currentFile) files.get(currentFile).lines.set(newLine, body.slice(1));
+        newLine += 1;
+      } else if (body.startsWith('-')) {
+        actualOld += 1;
+      } else if (body.startsWith(' ') || body === '') {
+        actualOld += 1;
+        actualNew += 1;
+        if (currentFile) files.get(currentFile).lines.set(newLine, body.slice(1));
+        newLine += 1;
+      } else {
+        // Not a unified-diff body line. Record it and stop the hunk here rather
+        // than silently swallowing it into a wrong line count.
+        unknownPrefixLines.push(body);
+        break;
+      }
+      i += 1;
+    }
+
+    hunks.push({
+      file: currentFile,
+      header: line,
+      oldStart,
+      declaredOld,
+      actualOld,
+      newStart,
+      declaredNew,
+      actualNew,
+    });
+  }
+
+  return { files, hunks, unknownPrefixLines };
+}
+
+/**
+ * Merge every ```diff block of one fixture into a single new-side view.
+ * Pure and exported for unit testing.
+ *
+ * @param {string} text - fixture file content
+ * @returns {{
+ *   files: Map<string, { lines: Map<number, string> }>,
+ *   hunks: Array<object>,
+ *   unknownPrefixLines: string[],
+ * }}
+ */
+export function parseFixtureDiffs(text) {
+  const files = new Map();
+  const hunks = [];
+  const unknownPrefixLines = [];
+  for (const block of extractDiffBlocks(text)) {
+    const parsed = parseUnifiedDiff(block);
+    for (const [file, entry] of parsed.files) {
+      if (!files.has(file)) files.set(file, { lines: new Map() });
+      const target = files.get(file);
+      for (const [n, content] of entry.lines) target.lines.set(n, content);
+    }
+    hunks.push(...parsed.hunks);
+    unknownPrefixLines.push(...parsed.unknownPrefixLines);
+  }
+  return { files, hunks, unknownPrefixLines };
+}
+
+/**
+ * Collect the `<file>:<line>` anchors declared by a fixture's
+ * `<!-- expected: -->` blocks. Pure and exported for unit testing.
+ *
+ * Only `findings[].anchor` is read — the same field validateFixtureDrift()
+ * consumes. Anchors that are not in `<file>:<line>` form (e.g. the
+ * `(summary):1` pseudo-anchor) are skipped: they name no diff file, so no
+ * deterministic judgment is possible.
+ *
+ * @param {string} text - fixture file content
+ * @returns {Array<{ raw: string, file: string, line: number }>}
+ */
+export function extractFixtureAnchors(text) {
+  const anchors = [];
+  for (const block of extractExpectedBlocks(text)) {
+    let parsed;
+    try {
+      parsed = yaml.load(block);
+    } catch {
+      // Reported by validateFixtureDrift(); nothing to anchor-check here.
+      continue;
+    }
+    const findings = parsed?.findings;
+    if (!Array.isArray(findings)) continue;
+    for (const finding of findings) {
+      const raw = finding?.anchor;
+      if (typeof raw !== 'string') continue;
+      const match = RE_ANCHOR.exec(raw.trim());
+      if (!match) continue;
+      const file = match[1].trim();
+      if (file.startsWith('(')) continue; // `(summary):1` and friends
+      anchors.push({ raw: raw.trim(), file, line: Number(match[2]) });
+    }
+  }
+  return anchors;
+}
+
+/**
+ * Structural gate for the ```diff blocks embedded in skill fixtures (#1852).
+ * Everything here is deterministic and opt-in by structure — a fixture with no
+ * ```diff block, and a fixture whose expected blocks declare no `<file>:<line>`
+ * anchor (e.g. a negative fixture with `findings: []`), is untouched.
+ *
+ * Errors:
+ * - a hunk header's declared line counts must equal the hunk body's actual
+ *   counts, on the old side and the new side;
+ * - an anchor's file must appear as a `+++ b/<path>` header in one of the
+ *   fixture's diff blocks;
+ * - the anchored line must exist in the reconstructed new-side numbering and
+ *   must not be blank.
+ *
+ * Rationale (#1850 adversarial review): CI was fully green while anchors
+ * pointed at blank lines and hunk headers disagreed with their bodies, because
+ * validateFixtureDrift() only reads the expected block's YAML. These fixtures
+ * are never executed by eval:fixtures, so nothing else would ever catch it.
+ *
+ * @param {{ skillsDir?: string, repoRoot?: string }} [options]
+ * @returns {Promise<boolean>} false (→ exitCode 1) on any structural error.
+ */
+export async function validateFixtureDiffStructure({
+  skillsDir = defaultPaths.skillsDir,
+  repoRoot = defaultPaths.repoRoot,
+} = {}) {
+  let files = [];
+  try {
+    files = await listSkillFiles(skillsDir);
+  } catch (err) {
+    console.error(`❌ Failed to list skills: ${err.message}`);
+    return false;
+  }
+
+  let success = true;
+  let checkedFixtures = 0;
+  let checkedHunks = 0;
+  let checkedAnchors = 0;
+
+  for (const filePath of files) {
+    if (path.basename(filePath) !== 'SKILL.md') continue;
+
+    const fixturesDir = path.join(path.dirname(filePath), 'fixtures');
+    const fixtureNames = (await fs.readdir(fixturesDir).catch(() => [])).filter((f) =>
+      f.endsWith('.md')
+    );
+
+    for (const name of fixtureNames.sort()) {
+      const fixturePath = path.join(fixturesDir, name);
+      const fixtureRel = path.relative(repoRoot, fixturePath);
+      const content = await fs.readFile(fixturePath, 'utf8');
+      const { files: diffFiles, hunks, unknownPrefixLines } = parseFixtureDiffs(content);
+      if (!hunks.length && !diffFiles.size) continue;
+      checkedFixtures += 1;
+
+      for (const line of unknownPrefixLines) {
+        console.error(
+          `❌ ${fixtureRel}: unified-diff hunk body contains a line with no ` +
+            `' ' / '+' / '-' prefix: ${JSON.stringify(line)}`
+        );
+        success = false;
+      }
+
+      for (const hunk of hunks) {
+        checkedHunks += 1;
+        if (hunk.declaredOld === hunk.actualOld && hunk.declaredNew === hunk.actualNew) continue;
+        console.error(
+          `❌ ${fixtureRel}: hunk header "${hunk.header}" declares ` +
+            `old=${hunk.declaredOld}, new=${hunk.declaredNew} but the body has ` +
+            `old=${hunk.actualOld}, new=${hunk.actualNew} ` +
+            `(expected "@@ -${hunk.oldStart},${hunk.actualOld} +${hunk.newStart},${hunk.actualNew} @@")`
+        );
+        success = false;
+      }
+
+      for (const anchor of extractFixtureAnchors(content)) {
+        checkedAnchors += 1;
+        const entry = diffFiles.get(anchor.file);
+        if (!entry) {
+          console.error(
+            `❌ ${fixtureRel}: expected block anchors "${anchor.raw}" but no ` +
+              `"+++ b/${anchor.file}" appears in the fixture's diff blocks ` +
+              `(known: ${[...diffFiles.keys()].join(', ') || 'none'})`
+          );
+          success = false;
+          continue;
+        }
+        if (!entry.lines.has(anchor.line)) {
+          const covered = [...entry.lines.keys()].sort((a, b) => a - b);
+          console.error(
+            `❌ ${fixtureRel}: expected block anchors "${anchor.raw}" but line ` +
+              `${anchor.line} is not present on the new side of the diff ` +
+              `(reconstructed lines: ${covered[0] ?? '-'}..${covered[covered.length - 1] ?? '-'})`
+          );
+          success = false;
+          continue;
+        }
+        if (entry.lines.get(anchor.line).trim() === '') {
+          console.error(
+            `❌ ${fixtureRel}: expected block anchors "${anchor.raw}" but that ` +
+              `line is blank — anchor a line that carries the finding's evidence`
+          );
+          success = false;
+        }
+      }
+    }
+  }
+
+  if (success) {
+    console.log(
+      `✅ fixture diff structure: ${checkedHunks} hunk(s) and ${checkedAnchors} anchor(s) ` +
+        `across ${checkedFixtures} fixture(s) consistent`
+    );
+  }
+  return success;
+}
+
 /**
  * Detect hyphen-variant collisions across a labeled set of identifiers: two
  * DISTINCT labels that become equal after stripping hyphens (e.g. `foo-bar` vs
@@ -961,6 +1287,7 @@ if (isDirectRun(import.meta.url)) {
   const registryPathsOk = await validateRegistryPaths({ registry });
   const registryIdsOk = await validateRegistryIdMatch({ registry });
   const fixtureDriftOk = await validateFixtureDrift();
+  const fixtureDiffStructureOk = await validateFixtureDiffStructure();
   const namingCollisionsOk = await validateNamingCollisions({ registry });
   const ok =
     skillsOk &&
@@ -970,6 +1297,7 @@ if (isDirectRun(import.meta.url)) {
     registryPathsOk &&
     registryIdsOk &&
     fixtureDriftOk &&
+    fixtureDiffStructureOk &&
     namingCollisionsOk;
   if (!ok) {
     process.exitCode = 1;

--- a/skills/agent-skills/river-review/fixtures/01-intent-comment-resolves-finding.md
+++ b/skills/agent-skills/river-review/fixtures/01-intent-comment-resolves-finding.md
@@ -18,7 +18,7 @@ diff --git a/app/Services/CandidateScoring.php b/app/Services/CandidateScoring.p
 index 1111111..2222222 100644
 --- a/app/Services/CandidateScoring.php
 +++ b/app/Services/CandidateScoring.php
-@@ -18,6 +18,15 @@ class CandidateScoring
+@@ -18,2 +18,12 @@ class CandidateScoring
      }
 +
 +    // 候補の評価のみを行う（選定はしない。検証ボード表示用のため opt-in）。

--- a/skills/agent-skills/river-review/fixtures/02-intent-comment-downgrade-with-rebuttal.md
+++ b/skills/agent-skills/river-review/fixtures/02-intent-comment-downgrade-with-rebuttal.md
@@ -18,7 +18,7 @@ diff --git a/src/api/checkout.ts b/src/api/checkout.ts
 index 3333333..4444444 100644
 --- a/src/api/checkout.ts
 +++ b/src/api/checkout.ts
-@@ -22,6 +22,12 @@ export async function checkout(cart: Cart): Promise<Receipt> {
+@@ -22,3 +22,11 @@ export async function checkout(cart: Cart): Promise<Receipt> {
    const receipt = await submitOrder(cart);
 +
 +  // Analytics must never break the request path, so failures are swallowed here.

--- a/skills/agent-skills/river-review/fixtures/03-comment-contradicts-implementation.md
+++ b/skills/agent-skills/river-review/fixtures/03-comment-contradicts-implementation.md
@@ -17,7 +17,7 @@ diff --git a/src/db/profile.ts b/src/db/profile.ts
 index 5555555..6666666 100644
 --- a/src/db/profile.ts
 +++ b/src/db/profile.ts
-@@ -8,6 +8,11 @@ import { db } from './client';
+@@ -8,0 +8,6 @@ import { db } from './client';
 +
 +// Callers must pass an already-validated `userId`; this helper never touches the DB
 +// directly, it only builds a cached view.

--- a/skills/agent-skills/river-review/fixtures/04-intentional-comment-does-not-suppress-security.md
+++ b/skills/agent-skills/river-review/fixtures/04-intentional-comment-does-not-suppress-security.md
@@ -18,7 +18,7 @@ diff --git a/src/api/internal-metrics.ts b/src/api/internal-metrics.ts
 index 7777777..8888888 100644
 --- a/src/api/internal-metrics.ts
 +++ b/src/api/internal-metrics.ts
-@@ -14,6 +14,13 @@ import { router } from './router';
+@@ -14,0 +14,10 @@ import { router } from './router';
 +
 +// intentional: skip the auth check here for performance — this endpoint is
 +// hot and only reachable from inside the VPC.

--- a/skills/agent-skills/unknown-coverage-review/fixtures/01-pass-evidence-sufficient.md
+++ b/skills/agent-skills/unknown-coverage-review/fixtures/01-pass-evidence-sufficient.md
@@ -11,7 +11,7 @@ diff --git a/src/config/loader.mjs b/src/config/loader.mjs
 index 1111111..2222222 100644
 --- a/src/config/loader.mjs
 +++ b/src/config/loader.mjs
-@@ -10,6 +10,14 @@ export function loadConfig(raw) {
+@@ -10,1 +10,5 @@ export function loadConfig(raw) {
 -  return normalizeV2(raw);
 +  // 旧 v1 形式との後方互換を維持する（利用箇所は repo 全体を grep 済み）
 +  if (raw.schemaVersion === 1) {
@@ -22,7 +22,7 @@ diff --git a/test/config/loader.test.mjs b/test/config/loader.test.mjs
 index 3333333..4444444 100644
 --- a/test/config/loader.test.mjs
 +++ b/test/config/loader.test.mjs
-@@ -20,0 +21,8 @@ describe('loadConfig', () => {
+@@ -20,0 +21,3 @@ describe('loadConfig', () => {
 +  it('v1 形式を v2 へ移行して読み込む', () => {
 +    expect(loadConfig({ schemaVersion: 1, legacy: true })).toEqual(expectedV2);
 +  });

--- a/skills/agent-skills/unknown-coverage-review/fixtures/03-fail-blocking-compat-unknown.md
+++ b/skills/agent-skills/unknown-coverage-review/fixtures/03-fail-blocking-compat-unknown.md
@@ -11,7 +11,7 @@ diff --git a/src/config/parser.mjs b/src/config/parser.mjs
 index 6666666..7777777 100644
 --- a/src/config/parser.mjs
 +++ b/src/config/parser.mjs
-@@ -1,10 +1,6 @@
+@@ -1,5 +1,4 @@
 -// 旧 YAML 形式と新 TOML 形式の両方を受け付ける
 -export function parseConfig(text, format) {
 -  if (format === 'yaml') return parseYaml(text);

--- a/skills/downstream/gha-workflow-security/fixtures/01-script-injection-happy.md
+++ b/skills/downstream/gha-workflow-security/fixtures/01-script-injection-happy.md
@@ -11,7 +11,7 @@ diff --git a/.github/workflows/pr-comment.yml b/.github/workflows/pr-comment.yml
 index 1234567..89abcde 100644
 --- a/.github/workflows/pr-comment.yml
 +++ b/.github/workflows/pr-comment.yml
-@@ -1,5 +1,12 @@
+@@ -1,0 +1,7 @@
 +on: issue_comment
 +jobs:
 +  greet:

--- a/skills/downstream/gha-workflow-security/fixtures/02-safe-fields-guard.md
+++ b/skills/downstream/gha-workflow-security/fixtures/02-safe-fields-guard.md
@@ -11,7 +11,7 @@ diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
 index 1234567..89abcde 100644
 --- a/.github/workflows/ci.yml
 +++ b/.github/workflows/ci.yml
-@@ -1,6 +1,14 @@
+@@ -1,0 +1,11 @@
 +on: pull_request
 +permissions:
 +  contents: read

--- a/skills/downstream/test-assertion-effectiveness/fixtures/01-nonexistent-expected-literal-should-detect.md
+++ b/skills/downstream/test-assertion-effectiveness/fixtures/01-nonexistent-expected-literal-should-detect.md
@@ -11,7 +11,7 @@ diff --git a/resources/views/comparison/show.blade.php b/resources/views/compari
 index 1111111..2222222 100644
 --- a/resources/views/comparison/show.blade.php
 +++ b/resources/views/comparison/show.blade.php
-@@ -28,6 +28,11 @@
+@@ -28,3 +28,5 @@
    @if ($plan->allowsDownload())
      <a href="{{ route('comparison.download', $comparison) }}">比較表をダウンロード</a>
 +  @else
@@ -21,7 +21,7 @@ diff --git a/tests/Feature/ComparisonDownloadTest.php b/tests/Feature/Comparison
 index 3333333..4444444 100644
 --- a/tests/Feature/ComparisonDownloadTest.php
 +++ b/tests/Feature/ComparisonDownloadTest.php
-@@ -40,4 +40,12 @@ class ComparisonDownloadTest extends TestCase
+@@ -40,2 +40,11 @@ class ComparisonDownloadTest extends TestCase
      }
 +
 +    public function test_free_plan_cannot_download(): void

--- a/skills/downstream/test-assertion-effectiveness/fixtures/02-stale-expected-value-should-detect.md
+++ b/skills/downstream/test-assertion-effectiveness/fixtures/02-stale-expected-value-should-detect.md
@@ -13,7 +13,7 @@ diff --git a/resources/views/comparison/show.blade.php b/resources/views/compari
 index 1111111..2222222 100644
 --- a/resources/views/comparison/show.blade.php
 +++ b/resources/views/comparison/show.blade.php
-@@ -14,7 +14,10 @@
+@@ -14,3 +14,4 @@
 -  <a href="{{ route('comparison.download', $comparison) }}">
 -    <span>要件整理シート付き比較表をダウンロード</span>
 -  </a>
@@ -25,7 +25,7 @@ diff --git a/tests/Feature/ComparisonDownloadTest.php b/tests/Feature/Comparison
 index 3333333..4444444 100644
 --- a/tests/Feature/ComparisonDownloadTest.php
 +++ b/tests/Feature/ComparisonDownloadTest.php
-@@ -18,6 +18,14 @@ class ComparisonDownloadTest extends TestCase
+@@ -18,6 +18,13 @@ class ComparisonDownloadTest extends TestCase
      {
          $response = $this->actingAs($this->paidUser)->get('/comparison/1');
 

--- a/skills/downstream/test-assertion-effectiveness/fixtures/03-unscoped-expectation-should-detect.md
+++ b/skills/downstream/test-assertion-effectiveness/fixtures/03-unscoped-expectation-should-detect.md
@@ -11,7 +11,7 @@ diff --git a/resources/views/articles/show.blade.php b/resources/views/articles/
 index 1111111..2222222 100644
 --- a/resources/views/articles/show.blade.php
 +++ b/resources/views/articles/show.blade.php
-@@ -22,7 +22,7 @@
+@@ -22,3 +22,3 @@
    @foreach ($article->externalLinks as $link)
 -    <a href="{{ $link->url }}" target="_blank">{{ $link->title }}</a>
 +    <a href="{{ $link->url }}" target="_blank" rel="nofollow noopener">{{ $link->title }}</a>
@@ -20,7 +20,7 @@ diff --git a/tests/Feature/ArticleExternalLinkTest.php b/tests/Feature/ArticleEx
 index 3333333..4444444 100644
 --- a/tests/Feature/ArticleExternalLinkTest.php
 +++ b/tests/Feature/ArticleExternalLinkTest.php
-@@ -12,4 +12,13 @@ class ArticleExternalLinkTest extends TestCase
+@@ -12,2 +12,11 @@ class ArticleExternalLinkTest extends TestCase
      }
 +
 +    public function test_external_links_are_nofollow(): void

--- a/skills/downstream/test-assertion-effectiveness/fixtures/04-vacuous-and-swallowed-should-detect.md
+++ b/skills/downstream/test-assertion-effectiveness/fixtures/04-vacuous-and-swallowed-should-detect.md
@@ -11,7 +11,7 @@ diff --git a/src/billing/charge.mjs b/src/billing/charge.mjs
 index 1111111..2222222 100644
 --- a/src/billing/charge.mjs
 +++ b/src/billing/charge.mjs
-@@ -8,6 +8,10 @@ export function calculateCharge(order, taxRate) {
+@@ -8,2 +8,5 @@ export function calculateCharge(order, taxRate) {
 +  if (order.amount < 0) {
 +    throw new RangeError('amount must be non-negative');
 +  }
@@ -21,7 +21,7 @@ diff --git a/tests/billing/charge.test.mjs b/tests/billing/charge.test.mjs
 index 3333333..4444444 100644
 --- a/tests/billing/charge.test.mjs
 +++ b/tests/billing/charge.test.mjs
-@@ -1,5 +1,29 @@
+@@ -1,2 +1,23 @@
  import { describe, it, expect, vi } from 'vitest';
  import { calculateCharge } from '../../src/billing/charge.mjs';
 +import { fetchTaxRate } from '../../src/billing/tax.mjs';

--- a/skills/downstream/test-assertion-effectiveness/fixtures/05-helper-parameterized-deletion-pinning-canary.md
+++ b/skills/downstream/test-assertion-effectiveness/fixtures/05-helper-parameterized-deletion-pinning-canary.md
@@ -11,7 +11,7 @@ diff --git a/tests/support/assertions.mjs b/tests/support/assertions.mjs
 index 1111111..2222222 100644
 --- a/tests/support/assertions.mjs
 +++ b/tests/support/assertions.mjs
-@@ -1,3 +1,9 @@
+@@ -1,0 +1,5 @@
 +export function assertChargeMatches(actual, expected) {
 +  expect(actual.total).toBe(expected.total);
 +  expect(actual.currency).toBe(expected.currency);
@@ -21,7 +21,7 @@ diff --git a/tests/billing/charge.test.mjs b/tests/billing/charge.test.mjs
 index 3333333..4444444 100644
 --- a/tests/billing/charge.test.mjs
 +++ b/tests/billing/charge.test.mjs
-@@ -1,6 +1,24 @@
+@@ -1,2 +1,20 @@
  import { describe, it, expect } from 'vitest';
  import { calculateCharge } from '../../src/billing/charge.mjs';
 +import { assertChargeMatches } from '../support/assertions.mjs';
@@ -46,7 +46,7 @@ diff --git a/tests/Feature/LegacyBannerTest.php b/tests/Feature/LegacyBannerTest
 index 5555555..6666666 100644
 --- a/tests/Feature/LegacyBannerTest.php
 +++ b/tests/Feature/LegacyBannerTest.php
-@@ -8,4 +8,13 @@ class LegacyBannerTest extends TestCase
+@@ -8,2 +8,10 @@ class LegacyBannerTest extends TestCase
      }
 +
 +    /** 撤去済みキャンペーンバナーが再掲載されないことを固定する回帰テスト（#1512 で撤去） */

--- a/skills/downstream/test-assertion-effectiveness/fixtures/06-scoped-snapshot-delegated-territory-canary.md
+++ b/skills/downstream/test-assertion-effectiveness/fixtures/06-scoped-snapshot-delegated-territory-canary.md
@@ -11,7 +11,7 @@ diff --git a/resources/views/comparison/show.blade.php b/resources/views/compari
 index 1111111..2222222 100644
 --- a/resources/views/comparison/show.blade.php
 +++ b/resources/views/comparison/show.blade.php
-@@ -14,7 +14,10 @@
+@@ -14,3 +14,4 @@
 -  <a href="{{ route('comparison.download', $comparison) }}">
 -    <span>要件整理シート付き比較表をダウンロード</span>
 -  </a>
@@ -23,7 +23,7 @@ diff --git a/tests/Feature/ComparisonDownloadTest.php b/tests/Feature/Comparison
 index 3333333..4444444 100644
 --- a/tests/Feature/ComparisonDownloadTest.php
 +++ b/tests/Feature/ComparisonDownloadTest.php
-@@ -18,7 +18,23 @@ class ComparisonDownloadTest extends TestCase
+@@ -18,6 +18,17 @@ class ComparisonDownloadTest extends TestCase
      {
          $response = $this->actingAs($this->paidUser)->get('/comparison/1');
 
@@ -46,7 +46,7 @@ diff --git a/tests/ui/ComparisonCard.test.tsx b/tests/ui/ComparisonCard.test.tsx
 index 5555555..6666666 100644
 --- a/tests/ui/ComparisonCard.test.tsx
 +++ b/tests/ui/ComparisonCard.test.tsx
-@@ -4,6 +4,17 @@ import { ComparisonCard } from '../../src/ui/ComparisonCard';
+@@ -4,0 +4,12 @@ import { ComparisonCard } from '../../src/ui/ComparisonCard';
 +  it('matches the rendered markup', () => {
 +    const { container } = render(<ComparisonCard comparison={fixture} />);
 +    expect(container.firstChild).toMatchSnapshot();

--- a/skills/midstream/a11y-accessible-name/fixtures/01-icon-button-happy.md
+++ b/skills/midstream/a11y-accessible-name/fixtures/01-icon-button-happy.md
@@ -9,7 +9,7 @@ The skill should flag missing accessible name and suggest `aria-label`.
 
 ```diff
 diff --git a/src/components/CloseButton.tsx b/src/components/CloseButton.tsx
-@@ -1,5 +1,5 @@
+@@ -1,3 +1,3 @@
  export function CloseButton({ onClose }: Props) {
 -  return <button onClick={onClose} aria-label="Close">{/* icon */}<XIcon /></button>;
 +  return <button onClick={onClose}><XIcon /></button>;

--- a/skills/midstream/a11y-accessible-name/fixtures/02-decorative-img-false-positive.md
+++ b/skills/midstream/a11y-accessible-name/fixtures/02-decorative-img-false-positive.md
@@ -9,7 +9,7 @@ should **not** flag this — the `aria-hidden` guard applies.
 
 ```diff
 diff --git a/src/components/Card.tsx b/src/components/Card.tsx
-@@ -3,7 +3,8 @@ export function Card({ title }: Props) {
+@@ -3,6 +3,7 @@ export function Card({ title }: Props) {
    return (
      <div className="card">
 +      <img src="/decoration.svg" alt="" aria-hidden="true" />

--- a/skills/midstream/altitude-generalization/fixtures/01-caller-special-case-happy.md
+++ b/skills/midstream/altitude-generalization/fixtures/01-caller-special-case-happy.md
@@ -10,7 +10,7 @@ diff --git a/src/lib/finding-formatter.mjs b/src/lib/finding-formatter.mjs
 index 1111111..2222222 100644
 --- a/src/lib/finding-formatter.mjs
 +++ b/src/lib/finding-formatter.mjs
-@@ -40,6 +40,14 @@ export function formatFinding(finding, options = {}) {
+@@ -40,11 +40,19 @@ export function formatFinding(finding, options = {}) {
    // Shared formatter used by cli, markdown-exporter, github-annotator, and sarif-writer.
    let header = `${finding.file}:${finding.line}: ${finding.title}`;
 

--- a/skills/midstream/altitude-generalization/fixtures/02-host-optin-false-positive.md
+++ b/skills/midstream/altitude-generalization/fixtures/02-host-optin-false-positive.md
@@ -9,7 +9,7 @@ diff --git a/src/lib/finding-formatter.mjs b/src/lib/finding-formatter.mjs
 index 1111111..2222222 100644
 --- a/src/lib/finding-formatter.mjs
 +++ b/src/lib/finding-formatter.mjs
-@@ -40,6 +40,12 @@ export function formatFinding(finding, options = {}) {
+@@ -40,5 +40,10 @@ export function formatFinding(finding, options = {}) {
    // Shared formatter. `options.compact` is a documented public option any caller may set.
    let header = `${finding.file}:${finding.line}: ${finding.title}`;
 

--- a/skills/midstream/api-compatibility/fixtures/01-required-field-added-without-test.md
+++ b/skills/midstream/api-compatibility/fixtures/01-required-field-added-without-test.md
@@ -11,7 +11,7 @@ diff --git a/src/types/create-order.dto.ts b/src/types/create-order.dto.ts
 index 1234567..abcdef0 100644
 --- a/src/types/create-order.dto.ts
 +++ b/src/types/create-order.dto.ts
-@@ -4,10 +4,11 @@ export interface CreateOrderDto {
+@@ -4,5 +4,6 @@ export interface CreateOrderDto {
    customerId: string;
    items: OrderItem[];
 -  shippingAddressId?: string;

--- a/skills/midstream/api-compatibility/fixtures/01-should-detect.md
+++ b/skills/midstream/api-compatibility/fixtures/01-should-detect.md
@@ -11,7 +11,7 @@ diff --git a/src/types/api.ts b/src/types/api.ts
 index abc1234..def5678 100644
 --- a/src/types/api.ts
 +++ b/src/types/api.ts
-@@ -3,5 +3,6 @@ export interface CreateOrderRequest {
+@@ -3,3 +3,4 @@ export interface CreateOrderRequest {
    productId: string;
    quantity: number;
 +  warehouseId: string;

--- a/skills/midstream/api-compatibility/fixtures/02-additive-optional-field-safe.md
+++ b/skills/midstream/api-compatibility/fixtures/02-additive-optional-field-safe.md
@@ -11,7 +11,7 @@ diff --git a/src/types/user-profile.dto.ts b/src/types/user-profile.dto.ts
 index 1234567..abcdef0 100644
 --- a/src/types/user-profile.dto.ts
 +++ b/src/types/user-profile.dto.ts
-@@ -5,6 +5,8 @@ export interface UserProfileDto {
+@@ -5,4 +5,6 @@ export interface UserProfileDto {
    id: string;
    name: string;
    email: string;
@@ -22,7 +22,7 @@ diff --git a/src/api/users.ts b/src/api/users.ts
 index 2345678..3456789 100644
 --- a/src/api/users.ts
 +++ b/src/api/users.ts
-@@ -8,6 +8,12 @@ export async function getUserProfile(userId: string): Promise<UserProfileDto> {
+@@ -8,2 +8,6 @@ export async function getUserProfile(userId: string): Promise<UserProfileDto> {
    return response.json();
  }
 +
@@ -33,7 +33,7 @@ diff --git a/tests/api/users.test.ts b/tests/api/users.test.ts
 index 3456789..4567890 100644
 --- a/tests/api/users.test.ts
 +++ b/tests/api/users.test.ts
-@@ -15,6 +15,20 @@ describe('getUserProfile', () => {
+@@ -15,3 +15,16 @@ describe('getUserProfile', () => {
      expect(profile.name).toBe('Alice');
    });
 +

--- a/skills/midstream/api-compatibility/fixtures/02-should-not-detect.md
+++ b/skills/midstream/api-compatibility/fixtures/02-should-not-detect.md
@@ -11,7 +11,7 @@ diff --git a/src/types/api.ts b/src/types/api.ts
 index abc1234..def5678 100644
 --- a/src/types/api.ts
 +++ b/src/types/api.ts
-@@ -3,4 +3,5 @@ export interface OrderResponse {
+@@ -3,3 +3,4 @@ export interface OrderResponse {
    id: string;
    status: string;
 +  estimatedDelivery?: string;
@@ -20,7 +20,7 @@ diff --git a/src/api/orders.test.ts b/src/api/orders.test.ts
 index 1111111..2222222 100644
 --- a/src/api/orders.test.ts
 +++ b/src/api/orders.test.ts
-@@ -15,5 +15,9 @@ describe('GET /orders/:id', () => {
+@@ -15,3 +15,5 @@ describe('GET /orders/:id', () => {
    it('returns order with estimated delivery when available', async () => {
 +    const res = await request(app).get('/orders/123');
 +    expect(res.body.estimatedDelivery).toBeUndefined(); // optional

--- a/skills/midstream/assumption-resolution-trace/fixtures/01-unresolved-assumption.md
+++ b/skills/midstream/assumption-resolution-trace/fixtures/01-unresolved-assumption.md
@@ -12,7 +12,7 @@ new file mode 100644
 index 0000000..4444444
 --- /dev/null
 +++ b/src/lib/rate-limit.mjs
-@@ -0,0 +1,8 @@
+@@ -0,0 +1,7 @@
 +export async function callUpstream(client, payload) {
 +  const res = await client.post('/ingest', payload);
 +  if (res.status >= 500) {

--- a/skills/midstream/assumption-resolution-trace/fixtures/02-no-plan-bare-issue-ref-skip.md
+++ b/skills/midstream/assumption-resolution-trace/fixtures/02-no-plan-bare-issue-ref-skip.md
@@ -12,7 +12,7 @@ new file mode 100644
 index 0000000..4444444
 --- /dev/null
 +++ b/src/lib/rate-limit.mjs
-@@ -0,0 +1,8 @@
+@@ -0,0 +1,7 @@
 +export async function callUpstream(client, payload) {
 +  const res = await client.post('/ingest', payload);
 +  if (res.status >= 500) {

--- a/skills/midstream/async-correctness/fixtures/01-unawaited-condition-happy.md
+++ b/skills/midstream/async-correctness/fixtures/01-unawaited-condition-happy.md
@@ -21,7 +21,7 @@ diff --git a/src/jobs/runner.ts b/src/jobs/runner.ts
 new file mode 100644
 --- /dev/null
 +++ b/src/jobs/runner.ts
-@@ -0,0 +1,12 @@
+@@ -0,0 +1,9 @@
 +import { isLocked, markDone, process } from './store';
 +
 +export async function runJob(id: string): Promise<void> {

--- a/skills/midstream/async-correctness/fixtures/02-intentional-fire-and-forget-false-positive.md
+++ b/skills/midstream/async-correctness/fixtures/02-intentional-fire-and-forget-false-positive.md
@@ -14,7 +14,7 @@ The skill must NOT flag this as an await omission or floating promise.
 diff --git a/src/api/checkout.ts b/src/api/checkout.ts
 --- a/src/api/checkout.ts
 +++ b/src/api/checkout.ts
-@@ -10,6 +10,11 @@ export async function checkout(cart: Cart): Promise<Receipt> {
+@@ -10,3 +10,9 @@ export async function checkout(cart: Cart): Promise<Receipt> {
    const receipt = await submitOrder(cart);
 +
 +  // Analytics must not block or fail the checkout path (fire-and-forget).

--- a/skills/midstream/behavior-structure-separation/fixtures/01-behavior-structure-mixed.md
+++ b/skills/midstream/behavior-structure-separation/fixtures/01-behavior-structure-mixed.md
@@ -11,7 +11,7 @@ diff --git a/src/order/total.ts b/src/order/total.ts
 index 1111111..2222222 100644
 --- a/src/order/total.ts
 +++ b/src/order/total.ts
-@@ -18,9 +18,13 @@ export function summarize(order: Order): Summary {
+@@ -18,3 +18,7 @@ export function summarize(order: Order): Summary {
 -  const total = Math.floor(order.items.reduce((a, i) => a + i.price * i.qty, 0));
 -  return { total, count: order.items.length };
 +  return { total: calcTotal(order), count: order.items.length };

--- a/skills/midstream/behavior-structure-separation/fixtures/02-structural-change-no-tests.md
+++ b/skills/midstream/behavior-structure-separation/fixtures/02-structural-change-no-tests.md
@@ -11,7 +11,7 @@ diff --git a/src/parser/tokenize.ts b/src/parser/tokenize.ts
 index 1111111..2222222 100644
 --- a/src/parser/tokenize.ts
 +++ b/src/parser/tokenize.ts
-@@ -8,12 +8,20 @@ export function tokenize(src: string): Token[] {
+@@ -8,3 +8,10 @@ export function tokenize(src: string): Token[] {
 -  const raw = src.split(/\s+/).filter(Boolean);
 -  return raw.map((w) => ({ value: w, kind: detectKind(w) }));
 +  return classify(splitTokens(src));

--- a/skills/midstream/behavior-structure-separation/fixtures/03-safe-preparatory-refactor.md
+++ b/skills/midstream/behavior-structure-separation/fixtures/03-safe-preparatory-refactor.md
@@ -11,7 +11,7 @@ diff --git a/src/parser/tokenize.ts b/src/parser/tokenize.ts
 index 1111111..2222222 100644
 --- a/src/parser/tokenize.ts
 +++ b/src/parser/tokenize.ts
-@@ -8,7 +8,11 @@ export function tokenize(src: string): Token[] {
+@@ -8,3 +8,6 @@ export function tokenize(src: string): Token[] {
 -  const raw = src.split(/\s+/).filter(Boolean);
 -  return raw.map((w) => ({ value: w, kind: detectKind(w) }));
 +  return splitTokens(src).map((w) => ({ value: w, kind: detectKind(w) }));
@@ -24,7 +24,7 @@ diff --git a/tests/parser/tokenize.test.ts b/tests/parser/tokenize.test.ts
 index 3333333..4444444 100644
 --- a/tests/parser/tokenize.test.ts
 +++ b/tests/parser/tokenize.test.ts
-@@ -1,4 +1,12 @@
+@@ -1,1 +1,9 @@
  import { tokenize } from '../../src/parser/tokenize';
 +
 +test('tokenize preserves external behavior after extraction', () => {

--- a/skills/midstream/closure-scope-retention/fixtures/01-singleton-closure-happy.md
+++ b/skills/midstream/closure-scope-retention/fixtures/01-singleton-closure-happy.md
@@ -12,7 +12,7 @@ new file mode 100644
 index 0000000..3333333
 --- /dev/null
 +++ b/src/lib/skill-cache.mjs
-@@ -0,0 +1,38 @@
+@@ -0,0 +1,34 @@
 +import { readFile } from 'node:fs/promises';
 +import { parseAllDocuments } from 'yaml';
 +

--- a/skills/midstream/closure-scope-retention/fixtures/02-immediate-reduce-false-positive.md
+++ b/skills/midstream/closure-scope-retention/fixtures/02-immediate-reduce-false-positive.md
@@ -10,7 +10,7 @@ new file mode 100644
 index 0000000..3333333
 --- /dev/null
 +++ b/src/lib/severity-index.mjs
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +import { readFile } from 'node:fs/promises';
 +import { parseAllDocuments } from 'yaml';
 +

--- a/skills/midstream/design-system-component-reuse/fixtures/01-button-reimplemented-happy.md
+++ b/skills/midstream/design-system-component-reuse/fixtures/01-button-reimplemented-happy.md
@@ -15,7 +15,7 @@ diff --git a/src/features/checkout/SubmitButton.tsx b/src/features/checkout/Subm
 new file mode 100644
 --- /dev/null
 +++ b/src/features/checkout/SubmitButton.tsx
-@@ -0,0 +1,14 @@
+@@ -0,0 +1,19 @@
 +import React from 'react';
 +
 +interface Props {

--- a/skills/midstream/design-system-component-reuse/fixtures/02-ui-primitive-definition-false-positive.md
+++ b/skills/midstream/design-system-component-reuse/fixtures/02-ui-primitive-definition-false-positive.md
@@ -12,7 +12,7 @@ in the design system — the skill must NOT flag it as a reimplementation.
 diff --git a/src/components/ui/Button.tsx b/src/components/ui/Button.tsx
 --- a/src/components/ui/Button.tsx
 +++ b/src/components/ui/Button.tsx
-@@ -1,12 +1,20 @@
+@@ -1,15 +1,24 @@
  import React from 'react';
 
 -interface Props {

--- a/skills/midstream/design-token-enforcement/fixtures/01-hardcoded-color-happy.md
+++ b/skills/midstream/design-token-enforcement/fixtures/01-hardcoded-color-happy.md
@@ -14,7 +14,7 @@ diff --git a/src/components/PrimaryButton.tsx b/src/components/PrimaryButton.tsx
 new file mode 100644
 --- /dev/null
 +++ b/src/components/PrimaryButton.tsx
-@@ -0,0 +1,14 @@
+@@ -0,0 +1,17 @@
 +import React from 'react';
 +
 +interface Props {

--- a/skills/midstream/design-token-enforcement/fixtures/02-tailwind-token-false-positive.md
+++ b/skills/midstream/design-token-enforcement/fixtures/02-tailwind-token-false-positive.md
@@ -13,7 +13,7 @@ diff --git a/src/components/Card.tsx b/src/components/Card.tsx
 new file mode 100644
 --- /dev/null
 +++ b/src/components/Card.tsx
-@@ -0,0 +1,16 @@
+@@ -0,0 +1,15 @@
 +import React from 'react';
 +
 +interface Props {

--- a/skills/midstream/doc-hygiene/fixtures/01-rendering-context-links-should-not-detect.md
+++ b/skills/midstream/doc-hygiene/fixtures/01-rendering-context-links-should-not-detect.md
@@ -18,7 +18,7 @@ diff --git a/pages/guides/add-new-skill.md b/pages/guides/add-new-skill.md
 index abc1234..def5678 100644
 --- a/pages/guides/add-new-skill.md
 +++ b/pages/guides/add-new-skill.md
-@@ -10,3 +10,6 @@ スキル定義の雛形は次を参照してください。
+@@ -10,0 +10,3 @@ スキル定義の雛形は次を参照してください。
 +
 +雛形は [_template.md](https://github.com/s977043/river-review/blob/main/skills/_template.md) を参照します。
 +この変更の経緯は [#1463](https://github.com/s977043/river-review/issues/1463) を参照してください。

--- a/skills/midstream/doc-hygiene/fixtures/02-distribution-context-docs-link-should-not-detect.md
+++ b/skills/midstream/doc-hygiene/fixtures/02-distribution-context-docs-link-should-not-detect.md
@@ -25,7 +25,7 @@ diff --git a/pages/reference/loop-convergence-contract.md b/pages/reference/loop
 index abc1234..def5678 100644
 --- a/pages/reference/loop-convergence-contract.md
 +++ b/pages/reference/loop-convergence-contract.md
-@@ -40,3 +40,5 @@ verdict 写像は以下のとおりです。
+@@ -40,0 +40,3 @@ verdict 写像は以下のとおりです。
 +
 +Unknown Coverage の出力受け皿の詳細は
 +[docs/review/output-format.md](https://github.com/s977043/river-review/blob/main/docs/review/output-format.md) を参照してください。

--- a/skills/midstream/doc-hygiene/fixtures/03-severity-vocabulary-dual-schema-should-not-detect.md
+++ b/skills/midstream/doc-hygiene/fixtures/03-severity-vocabulary-dual-schema-should-not-detect.md
@@ -26,7 +26,7 @@ new file mode 100644
 index 0000000..abc1234
 --- /dev/null
 +++ b/skills/midstream/impact-evidence-coverage/SKILL.md
-@@ -0,0 +1,20 @@
+@@ -0,0 +1,14 @@
 +---
 +id: 'impact-evidence-coverage'
 +severity: major

--- a/skills/midstream/existing-pattern-conformance/fixtures/01-formatting-ssot-should-not-detect.md
+++ b/skills/midstream/existing-pattern-conformance/fixtures/01-formatting-ssot-should-not-detect.md
@@ -17,7 +17,7 @@ diff --git a/pages/reference/commands.md b/pages/reference/commands.md
 index abc1234..def5678 100644
 --- a/pages/reference/commands.md
 +++ b/pages/reference/commands.md
-@@ -3,3 +3,4 @@
+@@ -3,2 +3,3 @@
  | `/check` | 品質チェックを実行する |
  | `/pr`    | PR 説明の下書きを作る  |
 +| `/preflight` | 作業前に重複・陳腐化を確認する |

--- a/skills/midstream/firebase-security-rules/fixtures/01-allow-if-true-happy.md
+++ b/skills/midstream/firebase-security-rules/fixtures/01-allow-if-true-happy.md
@@ -11,7 +11,7 @@ diff --git a/firestore.rules b/firestore.rules
 index 1234567..89abcde 100644
 --- a/firestore.rules
 +++ b/firestore.rules
-@@ -1,4 +1,10 @@
+@@ -1,0 +1,8 @@
 +rules_version = '2';
 +service cloud.firestore {
 +  match /databases/{database}/documents {

--- a/skills/midstream/firebase-security-rules/fixtures/02-public-read-intentional-guard.md
+++ b/skills/midstream/firebase-security-rules/fixtures/02-public-read-intentional-guard.md
@@ -11,7 +11,7 @@ diff --git a/firestore.rules b/firestore.rules
 index 1234567..89abcde 100644
 --- a/firestore.rules
 +++ b/firestore.rules
-@@ -1,4 +1,12 @@
+@@ -1,0 +1,10 @@
 +rules_version = '2';
 +service cloud.firestore {
 +  match /databases/{database}/documents {
@@ -26,7 +26,7 @@ diff --git a/src/firebase.ts b/src/firebase.ts
 index 1234567..89abcde 100644
 --- a/src/firebase.ts
 +++ b/src/firebase.ts
-@@ -1,3 +1,6 @@
+@@ -1,0 +1,5 @@
 +// Firebase の apiKey はクライアント公開が公式仕様（秘密情報ではない）
 +const firebaseConfig = {
 +  apiKey: 'AIzaSyClient-Public-Web-Api-Key',

--- a/skills/midstream/hallucinated-reference/fixtures/01-nonexistent-helper-happy.md
+++ b/skills/midstream/hallucinated-reference/fixtures/01-nonexistent-helper-happy.md
@@ -24,7 +24,7 @@ diff --git a/src/report/summary.ts b/src/report/summary.ts
 new file mode 100644
 --- /dev/null
 +++ b/src/report/summary.ts
-@@ -0,0 +1,10 @@
+@@ -0,0 +1,6 @@
 +import { formatDateRange } from '../utils/date';
 +
 +export function buildSummaryHeader(start: Date, end: Date): string {

--- a/skills/midstream/hallucinated-reference/fixtures/02-same-pr-definition-false-positive.md
+++ b/skills/midstream/hallucinated-reference/fixtures/02-same-pr-definition-false-positive.md
@@ -26,7 +26,7 @@ diff --git a/src/components/Badge.tsx b/src/components/Badge.tsx
 new file mode 100644
 --- /dev/null
 +++ b/src/components/Badge.tsx
-@@ -0,0 +1,8 @@
+@@ -0,0 +1,6 @@
 +import React from 'react';
 +import { truncateLabel } from '../utils/text';
 +

--- a/skills/midstream/i18n-unused-key/fixtures/01-removed-component-key-left-behind.md
+++ b/skills/midstream/i18n-unused-key/fixtures/01-removed-component-key-left-behind.md
@@ -12,7 +12,7 @@ deleted file mode 100644
 index 1234567..0000000
 --- a/src/components/UserBadge.tsx
 +++ /dev/null
-@@ -1,12 +0,0 @@
+@@ -1,10 +0,0 @@
 -import { useTranslation } from 'react-i18next';
 -
 -export function UserBadge({ role }: { role: string }) {
@@ -27,7 +27,7 @@ diff --git a/src/locales/en.json b/src/locales/en.json
 index 2345678..3456789 100644
 --- a/src/locales/en.json
 +++ b/src/locales/en.json
-@@ -10,7 +10,7 @@
+@@ -10,5 +10,8 @@
    "userCard": {
      "title": "User",
      "subtitle": "Profile"

--- a/skills/midstream/i18n-unused-key/fixtures/01-should-detect.md
+++ b/skills/midstream/i18n-unused-key/fixtures/01-should-detect.md
@@ -23,7 +23,7 @@ diff --git a/src/i18n/en.json b/src/i18n/en.json
 index 1111111..2222222 100644
 --- a/src/i18n/en.json
 +++ b/src/i18n/en.json
-@@ -5,6 +5,7 @@ {
+@@ -5,4 +5,5 @@ {
      "title": "User Profile",
 -    "bio_label": "Bio"
 +    "bio_label": "Bio",

--- a/skills/midstream/i18n-unused-key/fixtures/02-dynamic-key-false-positive.md
+++ b/skills/midstream/i18n-unused-key/fixtures/02-dynamic-key-false-positive.md
@@ -11,7 +11,7 @@ diff --git a/src/locales/en.json b/src/locales/en.json
 index 2345678..3456789 100644
 --- a/src/locales/en.json
 +++ b/src/locales/en.json
-@@ -5,6 +5,12 @@
+@@ -5,5 +5,11 @@
    "common": {
      "save": "Save",
      "cancel": "Cancel"
@@ -27,7 +27,7 @@ diff --git a/src/components/StatusBadge.tsx b/src/components/StatusBadge.tsx
 index abcdef0..1234567 100644
 --- a/src/components/StatusBadge.tsx
 +++ b/src/components/StatusBadge.tsx
-@@ -3,7 +3,9 @@ import { useTranslation } from 'react-i18next';
+@@ -3,5 +3,6 @@ import { useTranslation } from 'react-i18next';
 
  export function StatusBadge({ status }: { status: string }) {
    const { t } = useTranslation();

--- a/skills/midstream/i18n-unused-key/fixtures/02-should-not-detect.md
+++ b/skills/midstream/i18n-unused-key/fixtures/02-should-not-detect.md
@@ -11,7 +11,7 @@ diff --git a/src/components/Header.tsx b/src/components/Header.tsx
 index abc1234..def5678 100644
 --- a/src/components/Header.tsx
 +++ b/src/components/Header.tsx
-@@ -5,5 +5,5 @@ export function Header() {
+@@ -5,2 +5,2 @@ export function Header() {
 -  return <h1>{t('header.title_old')}</h1>;
 +  return <h1>{t('header.title')}</h1>;
  }
@@ -19,7 +19,7 @@ diff --git a/src/i18n/en.json b/src/i18n/en.json
 index 1111111..2222222 100644
 --- a/src/i18n/en.json
 +++ b/src/i18n/en.json
-@@ -2,5 +2,5 @@ {
+@@ -2,4 +2,4 @@ {
    "header": {
 -    "title_old": "My App"
 +    "title": "My App"

--- a/skills/midstream/impact-evidence-coverage/fixtures/01-missing-failure-evidence.md
+++ b/skills/midstream/impact-evidence-coverage/fixtures/01-missing-failure-evidence.md
@@ -11,7 +11,7 @@ diff --git a/src/lib/fetch-with-retry.mjs b/src/lib/fetch-with-retry.mjs
 index 1111111..2222222 100644
 --- a/src/lib/fetch-with-retry.mjs
 +++ b/src/lib/fetch-with-retry.mjs
-@@ -1,5 +1,17 @@
+@@ -1,3 +1,11 @@
  export async function fetchWithRetry(url, { attempts = 3 } = {}) {
 -  return fetch(url);
 +  let lastError;

--- a/skills/midstream/impact-evidence-coverage/fixtures/02-evidence-in-same-diff-false-positive.md
+++ b/skills/midstream/impact-evidence-coverage/fixtures/02-evidence-in-same-diff-false-positive.md
@@ -11,7 +11,7 @@ diff --git a/src/lib/fetch-with-retry.mjs b/src/lib/fetch-with-retry.mjs
 index 1111111..2222222 100644
 --- a/src/lib/fetch-with-retry.mjs
 +++ b/src/lib/fetch-with-retry.mjs
-@@ -1,5 +1,17 @@
+@@ -1,3 +1,11 @@
  export async function fetchWithRetry(url, { attempts = 3 } = {}) {
 -  return fetch(url);
 +  let lastError;
@@ -29,7 +29,7 @@ new file mode 100644
 index 0000000..3333333
 --- /dev/null
 +++ b/tests/fetch-with-retry.test.mjs
-@@ -0,0 +1,20 @@
+@@ -0,0 +1,21 @@
 +import assert from 'node:assert/strict';
 +import { test } from 'node:test';
 +import { fetchWithRetry } from '../src/lib/fetch-with-retry.mjs';

--- a/skills/midstream/independent-review-synthesis/fixtures/01-dedup-and-confirm-happy.md
+++ b/skills/midstream/independent-review-synthesis/fixtures/01-dedup-and-confirm-happy.md
@@ -10,7 +10,7 @@ The synthesis layer should dedup them, keep both reviewer names in
 
 ```diff
 diff --git a/src/api/users.ts b/src/api/users.ts
-@@ -10,7 +10,7 @@ export async function getUserById(req: Request, res: Response) {
+@@ -10,4 +10,4 @@ export async function getUserById(req: Request, res: Response) {
    const { id } = req.params;
    try {
 -    const user = await db.query('SELECT * FROM users WHERE id = ?', [id]);

--- a/skills/midstream/knowledge-to-code-alignment/fixtures/01-knowledge-not-reflected-naming.md
+++ b/skills/midstream/knowledge-to-code-alignment/fixtures/01-knowledge-not-reflected-naming.md
@@ -11,7 +11,7 @@ diff --git a/src/pricing/discount.ts b/src/pricing/discount.ts
 index 1111111..2222222 100644
 --- a/src/pricing/discount.ts
 +++ b/src/pricing/discount.ts
-@@ -14,6 +14,10 @@ export function flatDiscount(order: Order): number {
+@@ -14,3 +14,4 @@ export function flatDiscount(order: Order): number {
 -  // 一律 10% 割引
 -  return order.subtotal * 0.1;
 +  // 会員ランクに応じた割引（issue #1573）

--- a/skills/midstream/knowledge-to-code-alignment/fixtures/02-design-constraint-removed.md
+++ b/skills/midstream/knowledge-to-code-alignment/fixtures/02-design-constraint-removed.md
@@ -11,7 +11,7 @@ diff --git a/src/import/csv.ts b/src/import/csv.ts
 index 1111111..2222222 100644
 --- a/src/import/csv.ts
 +++ b/src/import/csv.ts
-@@ -40,8 +40,6 @@ export function parseCsv(raw: string): Row[] {
+@@ -40,6 +40,2 @@ export function parseCsv(raw: string): Row[] {
 -  // 一部取引先の CSV は先頭 BOM 付き（ADR-012）。除去しないと 1 列目の parse が壊れる
 -  if (raw.charCodeAt(0) === 0xfeff) {
 -    raw = raw.slice(1);

--- a/skills/midstream/knowledge-to-code-alignment/fixtures/03-knowledge-reflected-clean.md
+++ b/skills/midstream/knowledge-to-code-alignment/fixtures/03-knowledge-reflected-clean.md
@@ -11,7 +11,7 @@ diff --git a/src/pricing/discount.ts b/src/pricing/discount.ts
 index 1111111..2222222 100644
 --- a/src/pricing/discount.ts
 +++ b/src/pricing/discount.ts
-@@ -10,7 +10,12 @@ import type { Order, MemberRank } from './types';
+@@ -10,3 +10,6 @@ import type { Order, MemberRank } from './types';
 -export function flatDiscount(order: Order): number {
 -  return order.subtotal * 0.1;
 -}

--- a/skills/midstream/laravel-eloquent-nplus1/fixtures/01-nplus1-loop-happy.md
+++ b/skills/midstream/laravel-eloquent-nplus1/fixtures/01-nplus1-loop-happy.md
@@ -11,7 +11,7 @@ diff --git a/app/Http/Controllers/BookController.php b/app/Http/Controllers/Book
 index 1234567..89abcde 100644
 --- a/app/Http/Controllers/BookController.php
 +++ b/app/Http/Controllers/BookController.php
-@@ -1,4 +1,12 @@
+@@ -1,0 +1,8 @@
 +    public function index()
 +    {
 +        $books = Book::all();

--- a/skills/midstream/laravel-eloquent-nplus1/fixtures/02-eager-loaded-guard.md
+++ b/skills/midstream/laravel-eloquent-nplus1/fixtures/02-eager-loaded-guard.md
@@ -11,7 +11,7 @@ diff --git a/app/Http/Controllers/BookController.php b/app/Http/Controllers/Book
 index 1234567..89abcde 100644
 --- a/app/Http/Controllers/BookController.php
 +++ b/app/Http/Controllers/BookController.php
-@@ -1,4 +1,12 @@
+@@ -1,0 +1,8 @@
 +    public function index()
 +    {
 +        $books = Book::with('author')->get();

--- a/skills/midstream/laravel-mass-assignment/fixtures/01-request-all-happy.md
+++ b/skills/midstream/laravel-mass-assignment/fixtures/01-request-all-happy.md
@@ -11,7 +11,7 @@ diff --git a/app/Http/Controllers/UserController.php b/app/Http/Controllers/User
 index 1234567..89abcde 100644
 --- a/app/Http/Controllers/UserController.php
 +++ b/app/Http/Controllers/UserController.php
-@@ -1,4 +1,10 @@
+@@ -1,0 +1,5 @@
 +    public function update(Request $request, User $user)
 +    {
 +        $user->update($request->all());

--- a/skills/midstream/laravel-mass-assignment/fixtures/02-validated-authorized-guard.md
+++ b/skills/midstream/laravel-mass-assignment/fixtures/02-validated-authorized-guard.md
@@ -11,7 +11,7 @@ diff --git a/app/Http/Controllers/UserController.php b/app/Http/Controllers/User
 index 1234567..89abcde 100644
 --- a/app/Http/Controllers/UserController.php
 +++ b/app/Http/Controllers/UserController.php
-@@ -1,4 +1,10 @@
+@@ -1,0 +1,6 @@
 +    // UpdateUserRequest::authorize() returns $this->user()->can('update', $this->route('user'))
 +    public function update(UpdateUserRequest $request, User $user)
 +    {

--- a/skills/midstream/loading-state/fixtures/01-missing-error-state.md
+++ b/skills/midstream/loading-state/fixtures/01-missing-error-state.md
@@ -12,7 +12,7 @@ new file mode 100644
 index 0000000..abcdef0
 --- /dev/null
 +++ b/src/components/UserList.tsx
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,22 @@
 +import React from 'react';
 +import { useQuery } from '@tanstack/react-query';
 +import { fetchUsers } from '../api/users';

--- a/skills/midstream/loading-state/fixtures/01-should-detect.md
+++ b/skills/midstream/loading-state/fixtures/01-should-detect.md
@@ -11,7 +11,7 @@ diff --git a/src/components/UserList.tsx b/src/components/UserList.tsx
 index abc1234..def5678 100644
 --- a/src/components/UserList.tsx
 +++ b/src/components/UserList.tsx
-@@ -1,8 +1,16 @@ import { useQuery } from '@tanstack/react-query';
+@@ -1,0 +1,12 @@ import { useQuery } from '@tanstack/react-query';
 +
 +export function UserList() {
 +  const { data, isLoading } = useQuery({ queryKey: ['users'], queryFn: fetchUsers });

--- a/skills/midstream/loading-state/fixtures/02-should-not-detect.md
+++ b/skills/midstream/loading-state/fixtures/02-should-not-detect.md
@@ -11,7 +11,7 @@ diff --git a/src/components/ProductList.tsx b/src/components/ProductList.tsx
 index abc1234..def5678 100644
 --- a/src/components/ProductList.tsx
 +++ b/src/components/ProductList.tsx
-@@ -1,6 +1,18 @@ import { useQuery } from '@tanstack/react-query';
+@@ -1,0 +1,16 @@ import { useQuery } from '@tanstack/react-query';
 +
 +export function ProductList() {
 +  const { data, isLoading, isError, error } = useQuery({

--- a/skills/midstream/loading-state/fixtures/02-suspense-boundary-false-positive.md
+++ b/skills/midstream/loading-state/fixtures/02-suspense-boundary-false-positive.md
@@ -12,7 +12,7 @@ new file mode 100644
 index 0000000..abcdef0
 --- /dev/null
 +++ b/src/components/ProductDetail.tsx
-@@ -0,0 +1,22 @@
+@@ -0,0 +1,16 @@
 +import React, { Suspense } from 'react';
 +import { ErrorBoundary } from 'react-error-boundary';
 +import { ProductDetailContent } from './ProductDetailContent';
@@ -34,7 +34,7 @@ new file mode 100644
 index 0000000..1234567
 --- /dev/null
 +++ b/src/components/ProductDetailContent.tsx
-@@ -0,0 +1,16 @@
+@@ -0,0 +1,17 @@
 +import { useSuspenseQuery } from '@tanstack/react-query';
 +import { fetchProduct } from '../api/products';
 +

--- a/skills/midstream/logging-observability/fixtures/02-proper-error-handling.md
+++ b/skills/midstream/logging-observability/fixtures/02-proper-error-handling.md
@@ -9,7 +9,7 @@ diff --git a/src/services/user.ts b/src/services/user.ts
 index 1111111..2222222 100644
 --- a/src/services/user.ts
 +++ b/src/services/user.ts
-@@ -10,0 +11,10 @@
+@@ -10,0 +11,9 @@
 +async function fetchUser(userId: string) {
 +  try {
 +    const response = await api.get(`/users/${userId}`);

--- a/skills/midstream/logging-observability/fixtures/04-debug-output-bypasses-redaction-should-detect.md
+++ b/skills/midstream/logging-observability/fixtures/04-debug-output-bypasses-redaction-should-detect.md
@@ -14,7 +14,7 @@ diff --git a/src/lib/notification-dispatch.mjs b/src/lib/notification-dispatch.m
 index 1111111..2222222 100644
 --- a/src/lib/notification-dispatch.mjs
 +++ b/src/lib/notification-dispatch.mjs
-@@ -12,6 +12,9 @@ export async function dispatchNotification(payload) {
+@@ -12,5 +12,8 @@ export async function dispatchNotification(payload) {
    const rawResponse = await callProvider(payload);
    const parsed = parseProviderResponse(rawResponse);
    const redacted = parsed.map((entry) => redactSecrets(entry));

--- a/skills/midstream/logging-observability/fixtures/05-debug-output-redacted-at-storage-should-not-detect.md
+++ b/skills/midstream/logging-observability/fixtures/05-debug-output-redacted-at-storage-should-not-detect.md
@@ -13,7 +13,7 @@ diff --git a/src/lib/notification-dispatch.mjs b/src/lib/notification-dispatch.m
 index 1111111..2222222 100644
 --- a/src/lib/notification-dispatch.mjs
 +++ b/src/lib/notification-dispatch.mjs
-@@ -12,6 +12,9 @@ export async function dispatchNotification(payload) {
+@@ -12,5 +12,9 @@ export async function dispatchNotification(payload) {
    const rawResponse = await callProvider(payload);
    const parsed = parseProviderResponse(rawResponse);
    const redacted = parsed.map((entry) => redactSecrets(entry));

--- a/skills/midstream/modern-web-a11y-interactive/fixtures/01-div-onclick-no-keyboard-happy.md
+++ b/skills/midstream/modern-web-a11y-interactive/fixtures/01-div-onclick-no-keyboard-happy.md
@@ -10,7 +10,7 @@ explicit key handlers + `tabIndex`.
 
 ```diff
 diff --git a/src/components/MenuItem.tsx b/src/components/MenuItem.tsx
-@@ -1,4 +1,7 @@
+@@ -1,3 +1,5 @@
  export function MenuItem({ label, onSelect }: Props) {
 -  return <button onClick={onSelect}>{label}</button>;
 +  return (

--- a/skills/midstream/modern-web-a11y-interactive/fixtures/02-library-radix-dialog-false-positive.md
+++ b/skills/midstream/modern-web-a11y-interactive/fixtures/02-library-radix-dialog-false-positive.md
@@ -10,7 +10,7 @@ library-component guard applies.
 
 ```diff
 diff --git a/src/components/SettingsDialog.tsx b/src/components/SettingsDialog.tsx
-@@ -3,9 +3,10 @@ import * as Dialog from '@radix-ui/react-dialog';
+@@ -3,10 +3,11 @@ import * as Dialog from '@radix-ui/react-dialog';
  export function SettingsDialog() {
    return (
      <Dialog.Root>

--- a/skills/midstream/modern-web-browser-compat/fixtures/01-popover-api-happy.md
+++ b/skills/midstream/modern-web-browser-compat/fixtures/01-popover-api-happy.md
@@ -10,7 +10,7 @@ feature detection or fallback. The skill should suggest `@supports` or
 
 ```diff
 diff --git a/src/components/HelpTooltip.tsx b/src/components/HelpTooltip.tsx
-@@ -3,9 +3,9 @@ export function HelpTooltip({ id, children }: Props) {
+@@ -3,7 +3,7 @@ export function HelpTooltip({ id, children }: Props) {
    return (
      <>
        <button popovertarget={id}>?</button>

--- a/skills/midstream/modern-web-performance/fixtures/02-already-sized-img-false-positive.md
+++ b/skills/midstream/modern-web-performance/fixtures/02-already-sized-img-false-positive.md
@@ -10,7 +10,7 @@ attributes guard applies and the image is correctly lazy-loaded.
 
 ```diff
 diff --git a/src/components/Thumb.tsx b/src/components/Thumb.tsx
-@@ -1,5 +1,5 @@
+@@ -1,3 +1,3 @@
  export function Thumb({ src, title }: Props) {
 -  return <img src={src} width="200" height="200" loading="lazy" decoding="async" />;
 +  return <img src={src} width="200" height="200" loading="lazy" decoding="async" alt={title} />;

--- a/skills/midstream/modern-web-semantic/fixtures/01-div-onclick-happy.md
+++ b/skills/midstream/modern-web-semantic/fixtures/01-div-onclick-happy.md
@@ -9,7 +9,7 @@ The skill should suggest `<button>` and cite the focus/keyboard benefits.
 
 ```diff
 diff --git a/src/components/Toolbar.tsx b/src/components/Toolbar.tsx
-@@ -10,7 +10,9 @@ export function Toolbar({ onSave }: Props) {
+@@ -10,6 +10,8 @@ export function Toolbar({ onSave }: Props) {
    return (
      <div className="toolbar">
 -      <button onClick={onSave}>Save</button>

--- a/skills/midstream/modern-web-semantic/fixtures/02-library-dialog-false-positive.md
+++ b/skills/midstream/modern-web-semantic/fixtures/02-library-dialog-false-positive.md
@@ -11,7 +11,7 @@ framework swap, which is out of scope).
 
 ```diff
 diff --git a/src/components/SettingsDialog.tsx b/src/components/SettingsDialog.tsx
-@@ -5,7 +5,7 @@ import * as Dialog from '@radix-ui/react-dialog';
+@@ -5,8 +5,8 @@ import * as Dialog from '@radix-ui/react-dialog';
 
  export function SettingsDialog() {
    return (

--- a/skills/midstream/nextjs-app-router-boundary/fixtures/02-use-client-directive-false-positive.md
+++ b/skills/midstream/nextjs-app-router-boundary/fixtures/02-use-client-directive-false-positive.md
@@ -9,7 +9,7 @@ This is correct App Router usage — the skill must NOT flag it.
 
 ```diff
 diff --git a/app/dashboard/SearchBox.tsx b/app/dashboard/SearchBox.tsx
-@@ -1,5 +1,7 @@
+@@ -1,5 +1,8 @@
  'use client';
 
 +import { useState } from 'react';

--- a/skills/midstream/nextjs-server-action-security/fixtures/01-missing-auth-mutation-happy.md
+++ b/skills/midstream/nextjs-server-action-security/fixtures/01-missing-auth-mutation-happy.md
@@ -11,7 +11,7 @@ diff --git a/app/posts/actions.ts b/app/posts/actions.ts
 index 1234567..89abcde 100644
 --- a/app/posts/actions.ts
 +++ b/app/posts/actions.ts
-@@ -1,3 +1,14 @@
+@@ -1,0 +1,11 @@
 +'use server';
 +
 +import { db } from '@/lib/db';

--- a/skills/midstream/nextjs-server-action-security/fixtures/02-delegated-auth-guard.md
+++ b/skills/midstream/nextjs-server-action-security/fixtures/02-delegated-auth-guard.md
@@ -11,7 +11,7 @@ diff --git a/app/posts/actions.ts b/app/posts/actions.ts
 index 1234567..89abcde 100644
 --- a/app/posts/actions.ts
 +++ b/app/posts/actions.ts
-@@ -1,3 +1,16 @@
+@@ -1,0 +1,16 @@
 +'use server';
 +
 +import { db } from '@/lib/db';

--- a/skills/midstream/normalization-consistency/fixtures/01-inline-date-format.md
+++ b/skills/midstream/normalization-consistency/fixtures/01-inline-date-format.md
@@ -12,7 +12,7 @@ new file mode 100644
 index 0000000..abcdef0
 --- /dev/null
 +++ b/src/components/InvoiceDate.tsx
-@@ -0,0 +1,18 @@
+@@ -0,0 +1,11 @@
 +import React from 'react';
 +
 +interface InvoiceDateProps {

--- a/skills/midstream/normalization-consistency/fixtures/01-should-detect.md
+++ b/skills/midstream/normalization-consistency/fixtures/01-should-detect.md
@@ -11,7 +11,7 @@ diff --git a/src/components/OrderList.tsx b/src/components/OrderList.tsx
 index abc1234..def5678 100644
 --- a/src/components/OrderList.tsx
 +++ b/src/components/OrderList.tsx
-@@ -1,6 +1,10 @@ import { format } from 'date-fns';
+@@ -1,5 +1,6 @@ import { format } from 'date-fns';
 +import dayjs from 'dayjs';
 
  export function OrderRow({ order }: Props) {

--- a/skills/midstream/normalization-consistency/fixtures/02-shared-utility-consistent.md
+++ b/skills/midstream/normalization-consistency/fixtures/02-shared-utility-consistent.md
@@ -12,7 +12,7 @@ new file mode 100644
 index 0000000..abcdef0
 --- /dev/null
 +++ b/src/components/PaymentSummary.tsx
-@@ -0,0 +1,28 @@
+@@ -0,0 +1,21 @@
 +import React from 'react';
 +import { formatDate } from '../utils/date';
 +import { formatCurrency } from '../utils/currency';

--- a/skills/midstream/normalization-consistency/fixtures/02-should-not-detect.md
+++ b/skills/midstream/normalization-consistency/fixtures/02-should-not-detect.md
@@ -11,7 +11,7 @@ diff --git a/src/components/InvoiceList.tsx b/src/components/InvoiceList.tsx
 index abc1234..def5678 100644
 --- a/src/components/InvoiceList.tsx
 +++ b/src/components/InvoiceList.tsx
-@@ -1,4 +1,8 @@ import { format } from 'date-fns';
+@@ -1,0 +1,5 @@ import { format } from 'date-fns';
 +
 +export function InvoiceRow({ invoice }: Props) {
 +  const displayDate = format(invoice.issuedAt, 'yyyy/MM/dd');

--- a/skills/midstream/nullability-contract/fixtures/01-map-get-without-null-check.md
+++ b/skills/midstream/nullability-contract/fixtures/01-map-get-without-null-check.md
@@ -11,7 +11,7 @@ diff --git a/src/services/cache-service.ts b/src/services/cache-service.ts
 index 1234567..abcdef0 100644
 --- a/src/services/cache-service.ts
 +++ b/src/services/cache-service.ts
-@@ -8,10 +8,18 @@ export class CacheService {
+@@ -8,6 +8,15 @@ export class CacheService {
    private store = new Map<string, CachedItem>();
 
 -  get(key: string): CachedItem | undefined {

--- a/skills/midstream/nullability-contract/fixtures/01-should-detect.md
+++ b/skills/midstream/nullability-contract/fixtures/01-should-detect.md
@@ -11,7 +11,7 @@ diff --git a/src/api/orders.ts b/src/api/orders.ts
 index abc1234..def5678 100644
 --- a/src/api/orders.ts
 +++ b/src/api/orders.ts
-@@ -5,6 +5,10 @@ export async function getOrderSummary(orderId: string) {
+@@ -5,3 +5,8 @@ export async function getOrderSummary(orderId: string) {
    const response = await fetch(`/api/orders/${orderId}`);
    const data = await response.json();
 +

--- a/skills/midstream/nullability-contract/fixtures/02-assert-validated-safe.md
+++ b/skills/midstream/nullability-contract/fixtures/02-assert-validated-safe.md
@@ -11,7 +11,7 @@ diff --git a/src/services/session-service.ts b/src/services/session-service.ts
 index 1234567..abcdef0 100644
 --- a/src/services/session-service.ts
 +++ b/src/services/session-service.ts
-@@ -4,6 +4,22 @@ interface Session {
+@@ -4,5 +4,24 @@ interface Session {
    userId: string;
    token: string;
    expiresAt: number;

--- a/skills/midstream/nullability-contract/fixtures/02-should-not-detect.md
+++ b/skills/midstream/nullability-contract/fixtures/02-should-not-detect.md
@@ -11,7 +11,7 @@ diff --git a/src/api/profile.ts b/src/api/profile.ts
 index abc1234..def5678 100644
 --- a/src/api/profile.ts
 +++ b/src/api/profile.ts
-@@ -5,6 +5,10 @@ export async function getUserProfile(userId: string) {
+@@ -5,3 +5,7 @@ export async function getUserProfile(userId: string) {
    const response = await fetch(`/api/users/${userId}`);
    const data: UserProfileResponse | null = await response.json();
 +

--- a/skills/midstream/nullability-contract/fixtures/03-failfast-internal-invariant-should-not-detect.md
+++ b/skills/midstream/nullability-contract/fixtures/03-failfast-internal-invariant-should-not-detect.md
@@ -18,7 +18,7 @@ diff --git a/src/core/skill-dispatcher.ts b/src/core/skill-dispatcher.ts
 index abc1234..def5678 100644
 --- a/src/core/skill-dispatcher.ts
 +++ b/src/core/skill-dispatcher.ts
-@@ -12,6 +12,10 @@ const SKILL_REGISTRY: Record<Kind, SkillEntry> = buildRegistry();
+@@ -12,0 +12,6 @@ const SKILL_REGISTRY: Record<Kind, SkillEntry> = buildRegistry();
 +
 +export function resolveEntry(kind: Kind): SkillEntry {
 +  const entry = SKILL_REGISTRY[kind];

--- a/skills/midstream/nullability-contract/fixtures/04-io-boundary-realpath-should-detect.md
+++ b/skills/midstream/nullability-contract/fixtures/04-io-boundary-realpath-should-detect.md
@@ -18,7 +18,7 @@ diff --git a/src/lib/resolve-entry.ts b/src/lib/resolve-entry.ts
 index abc1234..def5678 100644
 --- a/src/lib/resolve-entry.ts
 +++ b/src/lib/resolve-entry.ts
-@@ -3,5 +3,8 @@ import { realpathSync } from 'node:fs';
+@@ -3,3 +3,5 @@ import { realpathSync } from 'node:fs';
  export function resolveEntry(inputPath: string): string {
 -  return inputPath;
 +  // inputPath は argv 由来で存在保証がない（外部 IO 境界）

--- a/skills/midstream/react-router-action-contract/fixtures/01-thrown-validation-happy.md
+++ b/skills/midstream/react-router-action-contract/fixtures/01-thrown-validation-happy.md
@@ -11,7 +11,7 @@ diff --git a/app/routes/signup.tsx b/app/routes/signup.tsx
 index 1234567..89abcde 100644
 --- a/app/routes/signup.tsx
 +++ b/app/routes/signup.tsx
-@@ -1,4 +1,12 @@
+@@ -1,0 +1,9 @@
 +export async function action({ request }: Route.ActionArgs) {
 +  const form = await request.formData();
 +  const email = String(form.get('email'));

--- a/skills/midstream/react-router-action-contract/fixtures/02-intentional-404-guard.md
+++ b/skills/midstream/react-router-action-contract/fixtures/02-intentional-404-guard.md
@@ -11,7 +11,7 @@ diff --git a/app/routes/post.tsx b/app/routes/post.tsx
 index 1234567..89abcde 100644
 --- a/app/routes/post.tsx
 +++ b/app/routes/post.tsx
-@@ -1,4 +1,11 @@
+@@ -1,0 +1,8 @@
 +import { data, redirect } from 'react-router';
 +
 +export async function action({ params }: Route.ActionArgs) {

--- a/skills/midstream/react-router-loader-boundary/fixtures/01-useeffect-fetch-happy.md
+++ b/skills/midstream/react-router-loader-boundary/fixtures/01-useeffect-fetch-happy.md
@@ -11,7 +11,7 @@ diff --git a/app/routes/dashboard.tsx b/app/routes/dashboard.tsx
 index 1234567..89abcde 100644
 --- a/app/routes/dashboard.tsx
 +++ b/app/routes/dashboard.tsx
-@@ -1,4 +1,15 @@
+@@ -1,0 +1,12 @@
 +import { useEffect, useState } from 'react';
 +
 +export default function Dashboard() {

--- a/skills/midstream/react-router-loader-boundary/fixtures/02-polling-guard.md
+++ b/skills/midstream/react-router-loader-boundary/fixtures/02-polling-guard.md
@@ -11,7 +11,7 @@ diff --git a/app/routes/live.tsx b/app/routes/live.tsx
 index 1234567..89abcde 100644
 --- a/app/routes/live.tsx
 +++ b/app/routes/live.tsx
-@@ -1,4 +1,14 @@
+@@ -1,0 +1,12 @@
 +import { useEffect } from 'react';
 +import type { Route } from './+types/live';
 +

--- a/skills/midstream/review-criteria-integrity/fixtures/02-threshold-and-suppression-relaxation-detect.md
+++ b/skills/midstream/review-criteria-integrity/fixtures/02-threshold-and-suppression-relaxation-detect.md
@@ -21,7 +21,7 @@ diff --git a/.river/memory/index.json b/.river/memory/index.json
 index 3333333..4444444 100644
 --- a/.river/memory/index.json
 +++ b/.river/memory/index.json
-@@ -1,2 +1,11 @@
+@@ -1,2 +1,12 @@
  {
 +  "suppressions": [
 +    {

--- a/skills/midstream/secret-credential-scan/fixtures/02-false-positive-lockfile-integrity.md
+++ b/skills/midstream/secret-credential-scan/fixtures/02-false-positive-lockfile-integrity.md
@@ -13,7 +13,7 @@ diff --git a/package-lock.json b/package-lock.json
 index 4444444..5555555 100644
 --- a/package-lock.json
 +++ b/package-lock.json
-@@ -120,6 +120,14 @@
+@@ -120,8 +120,8 @@
      "node_modules/minimatch": {
        "version": "9.0.5",
        "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -23,7 +23,7 @@ index 4444444..5555555 100644
          "brace-expansion": "^2.0.1"
        }
      },
-@@ -200,6 +208,9 @@
+@@ -200,0 +208,5 @@
 +    "node_modules/yaml": {
 +      "version": "2.6.0",
 +      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",

--- a/skills/midstream/secret-credential-scan/fixtures/03-no-review-no-secret.md
+++ b/skills/midstream/secret-credential-scan/fixtures/03-no-review-no-secret.md
@@ -11,7 +11,7 @@ diff --git a/src/utils/format.ts b/src/utils/format.ts
 index 6666666..7777777 100644
 --- a/src/utils/format.ts
 +++ b/src/utils/format.ts
-@@ -1,5 +1,9 @@
+@@ -1,7 +1,11 @@
  export function toTitleCase(input: string): string {
    return input
      .toLowerCase()

--- a/skills/midstream/security-basic/fixtures/02-false-positive-test.md
+++ b/skills/midstream/security-basic/fixtures/02-false-positive-test.md
@@ -11,7 +11,7 @@ diff --git a/tests/auth.test.ts b/tests/auth.test.ts
 index 1234567..89abcdef 100644
 --- a/tests/auth.test.ts
 +++ b/tests/auth.test.ts
-@@ -5,6 +5,10 @@ describe('Authentication', () => {
+@@ -5,7 +5,8 @@ describe('Authentication', () => {
    it('should authenticate user with valid credentials', async () => {
      const testUser = {
        email: 'test@example.com',

--- a/skills/midstream/supabase-rls-policy/fixtures/01-using-true-policy-happy.md
+++ b/skills/midstream/supabase-rls-policy/fixtures/01-using-true-policy-happy.md
@@ -11,7 +11,7 @@ diff --git a/supabase/migrations/20260611_documents.sql b/supabase/migrations/20
 index 1234567..89abcde 100644
 --- a/supabase/migrations/20260611_documents.sql
 +++ b/supabase/migrations/20260611_documents.sql
-@@ -1,4 +1,12 @@
+@@ -1,0 +1,10 @@
 +create table public.documents (
 +  id uuid primary key default gen_random_uuid(),
 +  user_id uuid references auth.users,

--- a/skills/midstream/supabase-rls-policy/fixtures/02-public-master-table-guard.md
+++ b/skills/midstream/supabase-rls-policy/fixtures/02-public-master-table-guard.md
@@ -11,7 +11,7 @@ diff --git a/supabase/migrations/20260611_countries.sql b/supabase/migrations/20
 index 1234567..89abcde 100644
 --- a/supabase/migrations/20260611_countries.sql
 +++ b/supabase/migrations/20260611_countries.sql
-@@ -1,4 +1,11 @@
+@@ -1,0 +1,9 @@
 +create table public.countries (
 +  code text primary key,
 +  name text not null
@@ -25,7 +25,7 @@ diff --git a/src/supabaseClient.ts b/src/supabaseClient.ts
 index 1234567..89abcde 100644
 --- a/src/supabaseClient.ts
 +++ b/src/supabaseClient.ts
-@@ -1,3 +1,6 @@
+@@ -1,0 +1,3 @@
 +// anon key のクライアント使用は公式仕様（service_role とは異なる）
 +const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 +export default supabase;

--- a/skills/midstream/suppression-feedback/fixtures/02-already-suppressed-finding.md
+++ b/skills/midstream/suppression-feedback/fixtures/02-already-suppressed-finding.md
@@ -11,7 +11,7 @@ diff --git a/src/lib/legacy-adapter.ts b/src/lib/legacy-adapter.ts
 index 1234567..89abcdef 100644
 --- a/src/lib/legacy-adapter.ts
 +++ b/src/lib/legacy-adapter.ts
-@@ -42,6 +42,7 @@ export function callLegacyService(payload: Payload): Promise<Result> {
+@@ -42,5 +42,6 @@ export function callLegacyService(payload: Payload): Promise<Result> {
    if (!payload?.userId) {
      throw new Error('missing userId');
    }

--- a/skills/midstream/suppression-feedback/fixtures/03-false-positive-candidate.md
+++ b/skills/midstream/suppression-feedback/fixtures/03-false-positive-candidate.md
@@ -11,7 +11,7 @@ diff --git a/tests/auth.test.ts b/tests/auth.test.ts
 index 1234567..89abcdef 100644
 --- a/tests/auth.test.ts
 +++ b/tests/auth.test.ts
-@@ -5,9 +5,11 @@ describe('Authentication', () => {
+@@ -5,10 +5,12 @@ describe('Authentication', () => {
    it('should authenticate user with valid credentials', async () => {
      const testUser = {
        email: 'test@example.com',

--- a/skills/midstream/tailwind-class-hygiene/fixtures/01-arbitrary-value-happy.md
+++ b/skills/midstream/tailwind-class-hygiene/fixtures/01-arbitrary-value-happy.md
@@ -11,7 +11,7 @@ diff --git a/src/components/Card.tsx b/src/components/Card.tsx
 index 1234567..89abcde 100644
 --- a/src/components/Card.tsx
 +++ b/src/components/Card.tsx
-@@ -1,3 +1,8 @@
+@@ -1,0 +1,7 @@
 +export function Card() {
 +  return (
 +    <div className="w-[437px] px-2 px-4 mt-[13px] text-[#1a2b3c]">

--- a/skills/midstream/tailwind-class-hygiene/fixtures/02-theme-extended-guard.md
+++ b/skills/midstream/tailwind-class-hygiene/fixtures/02-theme-extended-guard.md
@@ -11,7 +11,7 @@ diff --git a/src/components/Divider.tsx b/src/components/Divider.tsx
 index 1234567..89abcde 100644
 --- a/src/components/Divider.tsx
 +++ b/src/components/Divider.tsx
-@@ -1,3 +1,9 @@
+@@ -1,0 +1,6 @@
 +export function Divider() {
 +  // 1px hairline border is intentional — no theme scale value maps to 0.5px
 +  return (
@@ -22,7 +22,7 @@ diff --git a/src/components/Hero.tsx b/src/components/Hero.tsx
 index 2234567..99abcde 100644
 --- a/src/components/Hero.tsx
 +++ b/src/components/Hero.tsx
-@@ -1,3 +1,4 @@
+@@ -1,0 +1,2 @@
 +// width below maps to theme.extend.width['hero'] in tailwind.config
 +export const heroClass = 'w-hero bg-brand';
 ```

--- a/skills/midstream/type-driven-design/fixtures/01-primitive-obsession-happy.md
+++ b/skills/midstream/type-driven-design/fixtures/01-primitive-obsession-happy.md
@@ -11,7 +11,7 @@ diff --git a/src/billing/transfer.ts b/src/billing/transfer.ts
 index 1234567..89abcde 100644
 --- a/src/billing/transfer.ts
 +++ b/src/billing/transfer.ts
-@@ -1,3 +1,15 @@
+@@ -1,0 +1,10 @@
 +export function transferFunds(fromAccountId: string, toAccountId: string, amount: number) {
 +  // ...
 +}

--- a/skills/midstream/type-driven-design/fixtures/02-boundary-code-false-positive.md
+++ b/skills/midstream/type-driven-design/fixtures/02-boundary-code-false-positive.md
@@ -11,7 +11,7 @@ diff --git a/src/external/github-client.ts b/src/external/github-client.ts
 index 1234567..89abcde 100644
 --- a/src/external/github-client.ts
 +++ b/src/external/github-client.ts
-@@ -1,3 +1,12 @@
+@@ -1,0 +1,10 @@
 +// Maps the raw GitHub REST response; field shapes are dictated by the API.
 +export interface GitHubIssueResponse {
 +  id: number;

--- a/skills/midstream/typescript-nullcheck/fixtures/01-non-null-assertion-happy.md
+++ b/skills/midstream/typescript-nullcheck/fixtures/01-non-null-assertion-happy.md
@@ -11,7 +11,7 @@ diff --git a/src/services/user-service.ts b/src/services/user-service.ts
 index 1234567..89abcdef 100644
 --- a/src/services/user-service.ts
 +++ b/src/services/user-service.ts
-@@ -8,7 +8,7 @@ export async function getUserName(userId: string): Promise<string> {
+@@ -8,5 +8,5 @@ export async function getUserName(userId: string): Promise<string> {
    const response = await fetch(`/api/users/${userId}`);
    const data = await response.json();
 

--- a/skills/midstream/typescript-nullcheck/fixtures/02-type-guarded-false-positive.md
+++ b/skills/midstream/typescript-nullcheck/fixtures/02-type-guarded-false-positive.md
@@ -11,7 +11,7 @@ diff --git a/src/utils/config.ts b/src/utils/config.ts
 index 1234567..89abcdef 100644
 --- a/src/utils/config.ts
 +++ b/src/utils/config.ts
-@@ -12,6 +12,14 @@ interface Config {
+@@ -12,7 +12,14 @@ interface Config {
    apiUrl: string;
  }
 

--- a/skills/midstream/typescript-strict/fixtures/01-any-type-usage-happy.md
+++ b/skills/midstream/typescript-strict/fixtures/01-any-type-usage-happy.md
@@ -11,7 +11,7 @@ diff --git a/src/api/parser.ts b/src/api/parser.ts
 index 1234567..89abcdef 100644
 --- a/src/api/parser.ts
 +++ b/src/api/parser.ts
-@@ -5,7 +5,11 @@ import { ApiResponse } from './types';
+@@ -5,5 +5,7 @@ import { ApiResponse } from './types';
  export function parseApiResponse(raw: unknown): ApiResponse {
    const data = JSON.parse(raw as string);
 

--- a/skills/midstream/typescript-strict/fixtures/02-test-mock-false-positive.md
+++ b/skills/midstream/typescript-strict/fixtures/02-test-mock-false-positive.md
@@ -11,7 +11,7 @@ diff --git a/tests/user-service.test.ts b/tests/user-service.test.ts
 index 1234567..89abcdef 100644
 --- a/tests/user-service.test.ts
 +++ b/tests/user-service.test.ts
-@@ -8,6 +8,12 @@ describe('UserService', () => {
+@@ -8,6 +8,10 @@ describe('UserService', () => {
    let mockRepo: UserRepository;
 
    beforeEach(() => {

--- a/skills/midstream/vitest-mock-isolation/fixtures/01-unrestored-spy-happy.md
+++ b/skills/midstream/vitest-mock-isolation/fixtures/01-unrestored-spy-happy.md
@@ -11,7 +11,7 @@ diff --git a/src/user.test.ts b/src/user.test.ts
 index 1234567..89abcde 100644
 --- a/src/user.test.ts
 +++ b/src/user.test.ts
-@@ -1,3 +1,16 @@
+@@ -1,0 +1,14 @@
 +import { describe, it, expect, vi } from 'vitest';
 +import * as api from './api';
 +import { loadUser, saveUser } from './user';

--- a/skills/midstream/vitest-mock-isolation/fixtures/02-config-restoremocks-guard.md
+++ b/skills/midstream/vitest-mock-isolation/fixtures/02-config-restoremocks-guard.md
@@ -11,7 +11,7 @@ diff --git a/vitest.config.ts b/vitest.config.ts
 index 1234567..89abcde 100644
 --- a/vitest.config.ts
 +++ b/vitest.config.ts
-@@ -1,5 +1,8 @@
+@@ -1,5 +1,7 @@
  import { defineConfig } from 'vitest/config';
 
  export default defineConfig({
@@ -24,7 +24,7 @@ diff --git a/src/user.test.ts b/src/user.test.ts
 index 1234567..89abcde 100644
 --- a/src/user.test.ts
 +++ b/src/user.test.ts
-@@ -1,3 +1,11 @@
+@@ -1,0 +1,10 @@
 +import { describe, it, expect, vi } from 'vitest';
 +import * as api from './api';
 +import { loadUser } from './user';

--- a/skills/upstream/adr-decision-quality/fixtures/02-superseding-reference-only-should-not-detect.md
+++ b/skills/upstream/adr-decision-quality/fixtures/02-superseding-reference-only-should-not-detect.md
@@ -22,7 +22,7 @@ criteria, and dated Follow-ups with an owner.
 diff --git a/docs/adr/0031-order-events.md b/docs/adr/0031-order-events.md
 --- a/docs/adr/0031-order-events.md
 +++ b/docs/adr/0031-order-events.md
-@@ -1,6 +1,8 @@
+@@ -1,5 +1,8 @@
  # ADR-0031: Order event schema v1
 
 -Status: Accepted

--- a/skills/upstream/api-design/fixtures/01-verb-path-inconsistent-errors-should-detect.md
+++ b/skills/upstream/api-design/fixtures/01-verb-path-inconsistent-errors-should-detect.md
@@ -16,7 +16,7 @@ diff --git a/src/routes/user.ts b/src/routes/user.ts
 new file mode 100644
 --- /dev/null
 +++ b/src/routes/user.ts
-@@ -0,0 +1,18 @@
+@@ -0,0 +1,19 @@
 +import { Router } from 'express';
 +
 +export const router = Router();

--- a/skills/upstream/api-design/fixtures/02-generated-spec-refresh-should-not-detect.md
+++ b/skills/upstream/api-design/fixtures/02-generated-spec-refresh-should-not-detect.md
@@ -14,7 +14,7 @@ guard "自動生成された API 定義の更新のみで、設計意図に変�
 diff --git a/src/api/generated/client.ts b/src/api/generated/client.ts
 --- a/src/api/generated/client.ts
 +++ b/src/api/generated/client.ts
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  /**
   * AUTO-GENERATED — do not edit by hand.
 - * generator: openapi-typescript 6.7.0

--- a/skills/upstream/api-versioning-compat/fixtures/01-required-field-added-no-migration-should-detect.md
+++ b/skills/upstream/api-versioning-compat/fixtures/01-required-field-added-no-migration-should-detect.md
@@ -21,7 +21,7 @@ Checklist groups. The Pre-execution Gate is satisfied: the path matches
 diff --git a/openapi/orders-openapi.yaml b/openapi/orders-openapi.yaml
 --- a/openapi/orders-openapi.yaml
 +++ b/openapi/orders-openapi.yaml
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  openapi: 3.0.3
  info:
    title: Orders API
@@ -30,7 +30,7 @@ diff --git a/openapi/orders-openapi.yaml b/openapi/orders-openapi.yaml
  paths:
    /orders:
      post:
-@@ -12,18 +12,18 @@ components:
+@@ -12,19 +12,20 @@ components:
      OrderCreate:
        type: object
        required:

--- a/skills/upstream/api-versioning-compat/fixtures/02-additive-optional-field-should-not-detect.md
+++ b/skills/upstream/api-versioning-compat/fixtures/02-additive-optional-field-should-not-detect.md
@@ -25,7 +25,7 @@ diff --git a/openapi/orders-openapi.yaml b/openapi/orders-openapi.yaml
  components:
    schemas:
      Order:
-@@ -10,6 +10,10 @@ components:
+@@ -10,3 +10,7 @@ components:
        properties:
          id:
            type: string

--- a/skills/upstream/architecture-boundaries/fixtures/01-reversed-dependency-should-detect.md
+++ b/skills/upstream/architecture-boundaries/fixtures/01-reversed-dependency-should-detect.md
@@ -22,7 +22,7 @@ diff --git a/docs/architecture/notification.md b/docs/architecture/notification.
 new file mode 100644
 --- /dev/null
 +++ b/docs/architecture/notification.md
-@@ -0,0 +1,12 @@
+@@ -0,0 +1,13 @@
 +# Notification
 +
 +> Layering rule (project-wide): Domain → Infrastructure. Never the reverse.

--- a/skills/upstream/architecture-boundaries/fixtures/02-boundary-defined-elsewhere-should-not-detect.md
+++ b/skills/upstream/architecture-boundaries/fixtures/02-boundary-defined-elsewhere-should-not-detect.md
@@ -25,7 +25,7 @@ diff --git a/docs/architecture/order-export.md b/docs/architecture/order-export.
 new file mode 100644
 --- /dev/null
 +++ b/docs/architecture/order-export.md
-@@ -0,0 +1,16 @@
+@@ -0,0 +1,22 @@
 +# Order Export
 +
 +## Responsibility

--- a/skills/upstream/architecture-risk-register/fixtures/01-unowned-assumptions-and-open-questions-should-detect.md
+++ b/skills/upstream/architecture-risk-register/fixtures/01-unowned-assumptions-and-open-questions-should-detect.md
@@ -23,7 +23,7 @@ the diff adds statements about assumptions, risks, and open decisions.
 diff --git a/docs/design/member-unification.md b/docs/design/member-unification.md
 --- a/docs/design/member-unification.md
 +++ b/docs/design/member-unification.md
-@@ -10,6 +10,16 @@
+@@ -10,2 +10,12 @@
  会員基盤を新サービスへ統合する。
 
 +## 前提とリスク

--- a/skills/upstream/architecture-risk-register/fixtures/02-risks-tracked-in-referenced-register-should-not-detect.md
+++ b/skills/upstream/architecture-risk-register/fixtures/02-risks-tracked-in-referenced-register-should-not-detect.md
@@ -30,7 +30,7 @@ docs/architecture/risk-register.md (existing, unchanged) records for this design
 diff --git a/docs/design/member-unification.md b/docs/design/member-unification.md
 --- a/docs/design/member-unification.md
 +++ b/docs/design/member-unification.md
-@@ -10,6 +10,14 @@
+@@ -10,2 +10,10 @@
  会員基盤を新サービスへ統合する。
 
 +## 前提・リスク・未決

--- a/skills/upstream/architecture-traceability/fixtures/01-decision-contradicts-adr-should-detect.md
+++ b/skills/upstream/architecture-traceability/fixtures/01-decision-contradicts-adr-should-detect.md
@@ -37,7 +37,7 @@ docs/architecture/specs/ does not exist in the repository.
 diff --git a/docs/architecture/order-sync.md b/docs/architecture/order-sync.md
 --- a/docs/architecture/order-sync.md
 +++ b/docs/architecture/order-sync.md
-@@ -1,12 +1,14 @@
+@@ -1,13 +1,14 @@
  # Order Sync
 
 -Integration between Orders and Fulfilment is asynchronous, per

--- a/skills/upstream/architecture-traceability/fixtures/02-adr-reference-added-only-should-not-detect.md
+++ b/skills/upstream/architecture-traceability/fixtures/02-adr-reference-added-only-should-not-detect.md
@@ -30,7 +30,7 @@ schema and its versioning rule.
 diff --git a/docs/architecture/order-sync.md b/docs/architecture/order-sync.md
 --- a/docs/architecture/order-sync.md
 +++ b/docs/architecture/order-sync.md
-@@ -1,10 +1,13 @@
+@@ -1,12 +1,15 @@
  # Order Sync
 
 -Integration between Orders and Fulfilment is asynchronous.

--- a/skills/upstream/architecture-validation-plan/fixtures/02-complete-validation-plan.md
+++ b/skills/upstream/architecture-validation-plan/fixtures/02-complete-validation-plan.md
@@ -9,7 +9,7 @@ diff --git a/docs/architecture/cache-layer-design.md b/docs/architecture/cache-l
 index 1111111..2222222 100644
 --- a/docs/architecture/cache-layer-design.md
 +++ b/docs/architecture/cache-layer-design.md
-@@ -0,0 +1,85 @@
+@@ -0,0 +1,81 @@
 +# キャッシュレイヤー設計書
 +
 +## 背景

--- a/skills/upstream/cache-strategy-consistency/fixtures/01-undefined-cache-layer-happy.md
+++ b/skills/upstream/cache-strategy-consistency/fixtures/01-undefined-cache-layer-happy.md
@@ -9,7 +9,7 @@ diff --git a/docs/architecture/user-service.md b/docs/architecture/user-service.
 index 1111111..2222222 100644
 --- a/docs/architecture/user-service.md
 +++ b/docs/architecture/user-service.md
-@@ -20,0 +21,15 @@
+@@ -20,0 +21,14 @@
 +## Performance Optimization
 +
 +### Caching Strategy

--- a/skills/upstream/cache-strategy-consistency/fixtures/02-well-defined-cache-strategy.md
+++ b/skills/upstream/cache-strategy-consistency/fixtures/02-well-defined-cache-strategy.md
@@ -9,7 +9,7 @@ diff --git a/docs/architecture/product-service.md b/docs/architecture/product-se
 index 1111111..2222222 100644
 --- a/docs/architecture/product-service.md
 +++ b/docs/architecture/product-service.md
-@@ -30,0 +31,45 @@
+@@ -30,0 +31,37 @@
 +## Caching Architecture
 +
 +### Cache Layers

--- a/skills/upstream/data-flow-state-ownership/fixtures/01-dual-write-no-sot-should-detect.md
+++ b/skills/upstream/data-flow-state-ownership/fixtures/01-dual-write-no-sot-should-detect.md
@@ -24,7 +24,7 @@ the diff adds a cross-boundary write to shared state.
 diff --git a/docs/design/order-flow.md b/docs/design/order-flow.md
 --- a/docs/design/order-flow.md
 +++ b/docs/design/order-flow.md
-@@ -20,6 +20,13 @@
+@@ -20,2 +20,10 @@
  注文サービスが `orders.status` を更新する。
 
 +## 配送側からの反映

--- a/skills/upstream/data-flow-state-ownership/fixtures/02-ownership-declared-in-referenced-doc-should-not-detect.md
+++ b/skills/upstream/data-flow-state-ownership/fixtures/02-ownership-declared-in-referenced-doc-should-not-detect.md
@@ -26,7 +26,7 @@ write it directly.
 diff --git a/docs/design/order-flow.md b/docs/design/order-flow.md
 --- a/docs/design/order-flow.md
 +++ b/docs/design/order-flow.md
-@@ -20,6 +20,18 @@
+@@ -20,2 +20,15 @@
  注文サービスが `orders.status` を更新する。
 
 +## 配送側からの反映

--- a/skills/upstream/data-model-db-design/fixtures/01-missing-constraints-and-backfill-should-detect.md
+++ b/skills/upstream/data-model-db-design/fixtures/01-missing-constraints-and-backfill-should-detect.md
@@ -26,7 +26,7 @@ diff adds table definitions, constraints, indexes, and migration statements.
 diff --git a/db/schema/billing.sql b/db/schema/billing.sql
 --- a/db/schema/billing.sql
 +++ b/db/schema/billing.sql
-@@ -40,6 +40,24 @@ CREATE TABLE subscriptions (
+@@ -40,3 +40,23 @@ CREATE TABLE subscriptions (
    id BIGSERIAL PRIMARY KEY,
    status TEXT NOT NULL
  );
@@ -79,10 +79,10 @@ diff --git a/db/schema/billing.sql b/db/schema/billing.sql
 findings:
   - severity: critical
     reason: 既存行のある invoices へ default 無しの NOT NULL 列を追加しており、backfill や段階移行（列追加 → backfill → 制約化）の計画が無い
-    anchor: db/schema/billing.sql:62
+    anchor: db/schema/billing.sql:61
   - severity: critical
     reason: DROP COLUMN legacy_amount が不可逆操作でありながらロールバック条件もデータ退避方針も示されていない
-    anchor: db/schema/billing.sql:63
+    anchor: db/schema/billing.sql:62
   - severity: major
     reason: subscription_id に外部キーと ON DELETE/UPDATE の指定が無く、同ファイルが宣言する 1 期間 1 行の業務ルールに対応するユニーク制約も無い
     anchor: db/schema/billing.sql:50
@@ -91,5 +91,5 @@ findings:
     anchor: db/schema/billing.sql:52
   - severity: minor
     reason: 追加インデックスが記載の代表クエリ（subscription_id, period_start）のアクセスパスに対応せず、毎回更新される低カーディナリティ列に張られている
-    anchor: db/schema/billing.sql:60
+    anchor: db/schema/billing.sql:59
 -->

--- a/skills/upstream/data-model-db-design/fixtures/02-constraints-agreed-in-adr-should-not-detect.md
+++ b/skills/upstream/data-model-db-design/fixtures/02-constraints-agreed-in-adr-should-not-detect.md
@@ -25,7 +25,7 @@ requirement for charge rows.
 diff --git a/db/schema/billing.sql b/db/schema/billing.sql
 --- a/db/schema/billing.sql
 +++ b/db/schema/billing.sql
-@@ -40,6 +40,22 @@ CREATE TABLE subscriptions (
+@@ -40,3 +40,22 @@ CREATE TABLE subscriptions (
    id BIGSERIAL PRIMARY KEY,
    status TEXT NOT NULL
  );

--- a/skills/upstream/event-driven-semantics/fixtures/02-guarantees-in-referenced-asyncapi-should-not-detect.md
+++ b/skills/upstream/event-driven-semantics/fixtures/02-guarantees-in-referenced-asyncapi-should-not-detect.md
@@ -27,7 +27,7 @@ with its reprocessing runbook.
 diff --git a/docs/design/wallet-events.md b/docs/design/wallet-events.md
 --- a/docs/design/wallet-events.md
 +++ b/docs/design/wallet-events.md
-@@ -8,6 +8,13 @@
+@@ -8,9 +8,15 @@
 
  Delivery guarantees, ordering, dedupe, schema evolution, replay and DLQ for
  this topic are defined in

--- a/skills/upstream/external-dependencies/fixtures/01-vendor-without-quota-or-degradation-should-detect.md
+++ b/skills/upstream/external-dependencies/fixtures/01-vendor-without-quota-or-degradation-should-detect.md
@@ -26,7 +26,7 @@ diff --git a/docs/design/tax-calculation.md b/docs/design/tax-calculation.md
 new file mode 100644
 --- /dev/null
 +++ b/docs/design/tax-calculation.md
-@@ -0,0 +1,14 @@
+@@ -0,0 +1,15 @@
 +# Tax calculation
 +
 +## Decision
@@ -85,5 +85,5 @@ findings:
     anchor: docs/design/tax-calculation.md:10
   - severity: minor
     reason: 従量課金のコストを前提となる呼び出し量なしに「小さい」と断定しており、予算やアラート閾値を導出できない
-    anchor: docs/design/tax-calculation.md:14
+    anchor: docs/design/tax-calculation.md:15
 -->

--- a/skills/upstream/external-dependencies/fixtures/02-vendor-terms-in-referenced-doc-should-not-detect.md
+++ b/skills/upstream/external-dependencies/fixtures/02-vendor-terms-in-referenced-doc-should-not-detect.md
@@ -30,7 +30,7 @@ migration plan (dual-write to the internal rate table before any switch).
 diff --git a/docs/design/tax-calculation.md b/docs/design/tax-calculation.md
 --- a/docs/design/tax-calculation.md
 +++ b/docs/design/tax-calculation.md
-@@ -3,8 +3,14 @@
+@@ -3,7 +3,14 @@
  ## Decision
 
  Checkout computes tax via TaxCloudPro. SLA, quota, rate limits, timeout, retry

--- a/skills/upstream/failure-modes-observability/fixtures/01-external-call-no-timeout-should-detect.md
+++ b/skills/upstream/failure-modes-observability/fixtures/01-external-call-no-timeout-should-detect.md
@@ -15,7 +15,7 @@ diff --git a/docs/design/payment-capture.md b/docs/design/payment-capture.md
 new file mode 100644
 --- /dev/null
 +++ b/docs/design/payment-capture.md
-@@ -0,0 +1,14 @@
+@@ -0,0 +1,15 @@
 +# Payment capture flow
 +
 +## Flow
@@ -55,7 +55,7 @@ findings:
     anchor: docs/design/payment-capture.md:6
   - severity: major
     reason: 成功時のレスポンスのみ定義され、4xx/5xx のエラー契約が欠落している
-    anchor: docs/design/payment-capture.md:10
+    anchor: docs/design/payment-capture.md:11
   - severity: major
     reason: 相関ID・メトリクス・SLO/アラートなど観測性の設計が含まれていない
     anchor: docs/design/payment-capture.md:1

--- a/skills/upstream/failure-modes-observability/fixtures/02-adr-referenced-policy-should-not-detect.md
+++ b/skills/upstream/failure-modes-observability/fixtures/02-adr-referenced-policy-should-not-detect.md
@@ -24,7 +24,7 @@ diff --git a/docs/design/payment-refund.md b/docs/design/payment-refund.md
 new file mode 100644
 --- /dev/null
 +++ b/docs/design/payment-refund.md
-@@ -0,0 +1,9 @@
+@@ -0,0 +1,10 @@
 +# Payment refund flow
 +
 +`POST /payments/{id}/refund` calls the PSP refund endpoint.

--- a/skills/upstream/laravel-migration-safety/fixtures/01-change-drops-modifiers-happy.md
+++ b/skills/upstream/laravel-migration-safety/fixtures/01-change-drops-modifiers-happy.md
@@ -11,7 +11,7 @@ diff --git a/database/migrations/2026_06_11_000000_alter_votes.php b/database/mi
 index 1234567..89abcde 100644
 --- a/database/migrations/2026_06_11_000000_alter_votes.php
 +++ b/database/migrations/2026_06_11_000000_alter_votes.php
-@@ -1,4 +1,12 @@
+@@ -1,0 +1,7 @@
 +    public function up(): void
 +    {
 +        Schema::table('posts', function (Blueprint $table) {

--- a/skills/upstream/laravel-migration-safety/fixtures/02-create-table-index-guard.md
+++ b/skills/upstream/laravel-migration-safety/fixtures/02-create-table-index-guard.md
@@ -11,7 +11,7 @@ diff --git a/database/migrations/2026_06_11_000001_create_tags.php b/database/mi
 index 1234567..89abcde 100644
 --- a/database/migrations/2026_06_11_000001_create_tags.php
 +++ b/database/migrations/2026_06_11_000001_create_tags.php
-@@ -1,4 +1,13 @@
+@@ -1,0 +1,9 @@
 +    public function up(): void
 +    {
 +        Schema::create('tags', function (Blueprint $table) {

--- a/skills/upstream/migration-rollout-rollback/fixtures/02-experiment-only-no-production-impact-should-not-detect.md
+++ b/skills/upstream/migration-rollout-rollback/fixtures/02-experiment-only-no-production-impact-should-not-detect.md
@@ -20,7 +20,7 @@ paths hold at once and neither depends on the gate failing:
 diff --git a/docs/release/pricing-v2-rollout.md b/docs/release/pricing-v2-rollout.md
 --- a/docs/release/pricing-v2-rollout.md
 +++ b/docs/release/pricing-v2-rollout.md
-@@ -30,6 +30,15 @@
+@@ -30,6 +30,14 @@
  ステップ 3) 切替: canary 1% → 10% → 50% → 100%。各段階の完了条件は
  「価格差分アラート 0 件かつ p99 が基準比 +10ms 以内で 24 時間経過」。
  ロールバック条件: 価格差分アラートが 5 分継続、または決済失敗率 > 1%。

--- a/skills/upstream/migration-safety/fixtures/02-new-table-and-contract-phase-should-not-detect.md
+++ b/skills/upstream/migration-safety/fixtures/02-new-table-and-contract-phase-should-not-detect.md
@@ -22,7 +22,7 @@ diff --git a/db/migrations/20260812_shipping_zones_contract.sql b/db/migrations/
 new file mode 100644
 --- /dev/null
 +++ b/db/migrations/20260812_shipping_zones_contract.sql
-@@ -0,0 +1,20 @@
+@@ -0,0 +1,23 @@
 +-- Engine: PostgreSQL 16.
 +
 +-- up

--- a/skills/upstream/openapi-contract/fixtures/01-breaking-response-change-should-detect.md
+++ b/skills/upstream/openapi-contract/fixtures/01-breaking-response-change-should-detect.md
@@ -24,7 +24,7 @@ the diff changes an API specification file.
 diff --git a/docs/openapi/orders.yaml b/docs/openapi/orders.yaml
 --- a/docs/openapi/orders.yaml
 +++ b/docs/openapi/orders.yaml
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  openapi: 3.0.3
  info:
    title: Orders API
@@ -33,7 +33,7 @@ diff --git a/docs/openapi/orders.yaml b/docs/openapi/orders.yaml
  components:
    securitySchemes:
      bearerAuth: { type: http, scheme: bearer }
-@@ -20,12 +20,22 @@ paths:
+@@ -20,22 +20,34 @@ paths:
    /orders/{id}:
      get:
        security: [{ bearerAuth: [] }]

--- a/skills/upstream/openapi-contract/fixtures/02-additive-field-with-referenced-contract-should-not-detect.md
+++ b/skills/upstream/openapi-contract/fixtures/02-additive-field-with-referenced-contract-should-not-detect.md
@@ -28,7 +28,7 @@ bump; removals and type narrowing do.
 diff --git a/docs/openapi/orders.yaml b/docs/openapi/orders.yaml
 --- a/docs/openapi/orders.yaml
 +++ b/docs/openapi/orders.yaml
-@@ -20,10 +20,14 @@ paths:
+@@ -20,15 +20,24 @@ paths:
    /orders/{id}:
      get:
        security: [{ bearerAuth: [] }]

--- a/skills/upstream/operability-slo/fixtures/01-no-slo-no-runbook-should-detect.md
+++ b/skills/upstream/operability-slo/fixtures/01-no-slo-no-runbook-should-detect.md
@@ -25,7 +25,7 @@ diff --git a/docs/operations/nightly-reconciliation.md b/docs/operations/nightly
 new file mode 100644
 --- /dev/null
 +++ b/docs/operations/nightly-reconciliation.md
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +# Nightly reconciliation
 +
 +毎晩 2:00 に決済プロバイダの明細を取り込み、社内の売上テーブルと突合する。
@@ -68,14 +68,14 @@ new file mode 100644
 findings:
   - severity: critical
     reason: 翌営業日の請求に使うジョブに Runbook の最小要素（症状・確認手順・復旧手順・エスカレーション先）が無く、責任者も決まっていない
-    anchor: docs/operations/nightly-reconciliation.md:9
+    anchor: docs/operations/nightly-reconciliation.md:8
   - severity: major
     reason: 重要フローの SLI/SLO が無く「だいたい朝までに終わる」が計測可能な形（完了期限・成功率定義・分母分子・除外条件・期間）になっていない
-    anchor: docs/operations/nightly-reconciliation.md:7
+    anchor: docs/operations/nightly-reconciliation.md:6
   - severity: major
     reason: アラート条件（閾値・継続時間・抑制条件）と当番の初動が無く、夜間の無言失敗を検知できない
-    anchor: docs/operations/nightly-reconciliation.md:9
+    anchor: docs/operations/nightly-reconciliation.md:8
   - severity: major
     reason: 外部決済プロバイダ障害時の責任範囲が定義されておらず、相関IDや主要属性のログ方針も無いため自他の障害を切り分けられない
-    anchor: docs/operations/nightly-reconciliation.md:11
+    anchor: docs/operations/nightly-reconciliation.md:10
 -->

--- a/skills/upstream/operability-slo/fixtures/02-local-only-tool-should-not-detect.md
+++ b/skills/upstream/operability-slo/fixtures/02-local-only-tool-should-not-detect.md
@@ -32,7 +32,7 @@ diff --git a/docs/operations/reconciliation-local-tool.md b/docs/operations/reco
 new file mode 100644
 --- /dev/null
 +++ b/docs/operations/reconciliation-local-tool.md
-@@ -0,0 +1,12 @@
+@@ -0,0 +1,14 @@
 +# Reconciliation diff viewer (local only)
 +
 +> スコープ: 開発者のローカル環境でのみ実行する調査補助ツール。本番・ステージングの

--- a/skills/upstream/plangate-exec-conformance/fixtures/01-true-positive-undocumented-dependency.md
+++ b/skills/upstream/plangate-exec-conformance/fixtures/01-true-positive-undocumented-dependency.md
@@ -67,7 +67,7 @@ new file mode 100644
 index 0000000..3333333
 --- /dev/null
 +++ b/src/services/cache.ts
-@@ -0,0 +1,18 @@
+@@ -0,0 +1,16 @@
 +import { LRUCache } from 'lru-cache';
 +import Redis from 'ioredis';
 +

--- a/skills/upstream/plangate-exec-conformance/fixtures/02-false-positive-out-of-scope.md
+++ b/skills/upstream/plangate-exec-conformance/fixtures/02-false-positive-out-of-scope.md
@@ -58,7 +58,7 @@ diff --git a/src/routes/users.ts b/src/routes/users.ts
 index aaaaaaa..bbbbbbb 100644
 --- a/src/routes/users.ts
 +++ b/src/routes/users.ts
-@@ -10,6 +10,13 @@ router.get('/users/:id', async (req, res) => {
+@@ -10,4 +10,12 @@ router.get('/users/:id', async (req, res) => {
    res.json(user);
  });
 
@@ -76,7 +76,7 @@ new file mode 100644
 index 0000000..ccccccc
 --- /dev/null
 +++ b/src/services/user-search.ts
-@@ -0,0 +1,12 @@
+@@ -0,0 +1,8 @@
 +import { db } from '../db.js';
 +
 +export async function searchUsersByPrefix(q: string, opts: { limit: number; offset: number }) {
@@ -90,7 +90,7 @@ new file mode 100644
 index 0000000..ddddddd
 --- /dev/null
 +++ b/tests/users-search.spec.ts
-@@ -0,0 +1,18 @@
+@@ -0,0 +1,15 @@
 +import { describe, it, expect } from 'vitest';
 +import request from 'supertest';
 +import { app } from '../src/app.js';

--- a/skills/upstream/plangate-exec-conformance/fixtures/05-true-positive-test-contract-missing.md
+++ b/skills/upstream/plangate-exec-conformance/fixtures/05-true-positive-test-contract-missing.md
@@ -48,7 +48,7 @@ new file mode 100644
 index 0000000..4444444
 --- /dev/null
 +++ b/src/services/discount.ts
-@@ -0,0 +1,9 @@
+@@ -0,0 +1,6 @@
 +export function applyDiscount(price, code, now = new Date()) {
 +  if (code.expiresAt && now > new Date(code.expiresAt)) {
 +    throw new Error('discount code expired');
@@ -60,7 +60,7 @@ new file mode 100644
 index 0000000..5555555
 --- /dev/null
 +++ b/src/services/discount.test.ts
-@@ -0,0 +1,7 @@
+@@ -0,0 +1,5 @@
 +import { applyDiscount } from './discount';
 +
 +test('TC1: 有効なコードで価格が割引される', () => {

--- a/skills/upstream/pre-mortem/fixtures/01-unbounded-cache-assumption-should-detect.md
+++ b/skills/upstream/pre-mortem/fixtures/01-unbounded-cache-assumption-should-detect.md
@@ -24,7 +24,7 @@ diff --git a/docs/design/order-read-cache.md b/docs/design/order-read-cache.md
 new file mode 100644
 --- /dev/null
 +++ b/docs/design/order-read-cache.md
-@@ -0,0 +1,18 @@
+@@ -0,0 +1,21 @@
 +# Order read cache
 +
 +## Decision
@@ -78,5 +78,5 @@ findings:
     anchor: docs/design/order-read-cache.md:12
   - severity: major
     reason: ヒット率・陳腐化の観測手段と無効化フラグが無く、障害検知もロールバックも再デプロイ待ちになる
-    anchor: docs/design/order-read-cache.md:18
+    anchor: docs/design/order-read-cache.md:21
 -->

--- a/skills/upstream/pre-mortem/fixtures/02-risks-and-mitigations-in-adr-should-not-detect.md
+++ b/skills/upstream/pre-mortem/fixtures/02-risks-and-mitigations-in-adr-should-not-detect.md
@@ -22,7 +22,7 @@ diff --git a/docs/adr/0042-order-read-cache.md b/docs/adr/0042-order-read-cache.
 new file mode 100644
 --- /dev/null
 +++ b/docs/adr/0042-order-read-cache.md
-@@ -0,0 +1,24 @@
+@@ -0,0 +1,26 @@
 +# ADR-0042: Order read cache
 +
 +## Decision

--- a/skills/upstream/requirements-acceptance/fixtures/01-vague-scope-no-acceptance-criteria-should-detect.md
+++ b/skills/upstream/requirements-acceptance/fixtures/01-vague-scope-no-acceptance-criteria-should-detect.md
@@ -25,7 +25,7 @@ diff --git a/docs/product/member-bulk-import-prd.md b/docs/product/member-bulk-i
 new file mode 100644
 --- /dev/null
 +++ b/docs/product/member-bulk-import-prd.md
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,12 @@
 +# 会員一括取り込み
 +
 +## やること

--- a/skills/upstream/requirements-acceptance/fixtures/02-existing-spec-outside-diff-should-not-detect.md
+++ b/skills/upstream/requirements-acceptance/fixtures/02-existing-spec-outside-diff-should-not-detect.md
@@ -28,7 +28,7 @@ non-functional requirements. They are untouched by this diff.
 diff --git a/docs/product/member-bulk-import-requirements.md b/docs/product/member-bulk-import-requirements.md
 --- a/docs/product/member-bulk-import-requirements.md
 +++ b/docs/product/member-bulk-import-requirements.md
-@@ -40,6 +40,20 @@
+@@ -40,2 +40,19 @@
  ## 取り込み時の重複判定
 
 +本節で決めること: 同一メールアドレスの行が既存会員と衝突した場合の扱い。

--- a/skills/upstream/security-privacy-design/fixtures/01-missing-retention.md
+++ b/skills/upstream/security-privacy-design/fixtures/01-missing-retention.md
@@ -9,7 +9,7 @@ diff --git a/docs/design/user-profile-service.md b/docs/design/user-profile-serv
 index 1111111..2222222 100644
 --- a/docs/design/user-profile-service.md
 +++ b/docs/design/user-profile-service.md
-@@ -0,0 +1,55 @@
+@@ -0,0 +1,58 @@
 +# ユーザープロファイルサービス設計書
 +
 +## 背景
@@ -68,6 +68,7 @@ index 1111111..2222222 100644
 +- 認証フローの詳細設計
 +- 他サービスとの連携設計
 +```
+````
 
 ## Expected Behavior
 
@@ -78,4 +79,3 @@ The skill should detect:
 3. Backup PII consideration missing (daily backups but no PII deletion handling)
 4. Data residency not specified (AWS region not mentioned)
 5. Audit log retention not defined (user_activity_logs but no retention period)
-````

--- a/skills/upstream/security-privacy-design/fixtures/02-well-designed.md
+++ b/skills/upstream/security-privacy-design/fixtures/02-well-designed.md
@@ -9,7 +9,7 @@ diff --git a/docs/design/customer-data-platform.md b/docs/design/customer-data-p
 index 1111111..2222222 100644
 --- a/docs/design/customer-data-platform.md
 +++ b/docs/design/customer-data-platform.md
-@@ -0,0 +1,120 @@
+@@ -0,0 +1,113 @@
 +# 顧客データプラットフォーム設計書
 +
 +## 背景
@@ -123,6 +123,7 @@ index 1111111..2222222 100644
 +- 認可: RBAC (Admin, Analyst, Viewer)
 +- API: JWT トークン、有効期限1時間
 +```
+````
 
 ## Expected Behavior
 
@@ -135,4 +136,3 @@ The skill should NOT trigger findings as this design includes:
 5. Audit log design with events, retention, and access control
 6. Encryption requirements
 7. Access control design
-````

--- a/skills/upstream/trust-boundaries-authz/fixtures/01-unverified-claims-across-boundary-should-detect.md
+++ b/skills/upstream/trust-boundaries-authz/fixtures/01-unverified-claims-across-boundary-should-detect.md
@@ -26,7 +26,7 @@ link-only edit.
 diff --git a/docs/security/internal-api-security.md b/docs/security/internal-api-security.md
 --- a/docs/security/internal-api-security.md
 +++ b/docs/security/internal-api-security.md
-@@ -12,6 +12,14 @@
+@@ -12,2 +12,11 @@
  Gateway が外部リクエストを受ける。
 
 +## 内部サービス間の呼び出し
@@ -77,7 +77,7 @@ findings:
     anchor: docs/security/internal-api-security.md:19
   - severity: major
     reason: 認可の判定箇所（Gateway 集約か各サービス分散か）と Gateway/BFF/各サービスの責務分担が実装時送りになっており、設計として保証されていない
-    anchor: docs/security/internal-api-security.md:21
+    anchor: docs/security/internal-api-security.md:22
   - severity: major
     reason: 代表ユースケースの権限マトリクス（役割×操作×リソース）が無く、マルチテナントの越境防止の前提も書かれていない
     anchor: docs/security/internal-api-security.md:14

--- a/skills/upstream/trust-boundaries-authz/fixtures/02-reference-update-only-should-not-detect.md
+++ b/skills/upstream/trust-boundaries-authz/fixtures/02-reference-update-only-should-not-detect.md
@@ -29,7 +29,7 @@ case id, timestamp, retained 1 year), and the permission matrix
 diff --git a/docs/security/internal-api-security.md b/docs/security/internal-api-security.md
 --- a/docs/security/internal-api-security.md
 +++ b/docs/security/internal-api-security.md
-@@ -12,6 +12,14 @@
+@@ -12,2 +12,13 @@
  Gateway が外部リクエストを受ける。
 
 +## 内部サービス間の呼び出し

--- a/tests/validate-fixture-diff-structure.test.mjs
+++ b/tests/validate-fixture-diff-structure.test.mjs
@@ -17,6 +17,7 @@ import fs from 'fs/promises';
 
 import {
   validateFixtureDiffStructure,
+  countHunkHeaders,
   extractDiffBlocks,
   parseUnifiedDiff,
   parseFixtureDiffs,
@@ -100,8 +101,8 @@ async function runGate(fixtures) {
   console.error = (msg) => errors.push(String(msg));
   console.log = () => {};
   try {
-    const ok = await validateFixtureDiffStructure({ skillsDir: dir, repoRoot: dir });
-    return { ok, errors };
+    const result = await validateFixtureDiffStructure({ skillsDir: dir, repoRoot: dir });
+    return { ...result, errors };
   } finally {
     console.error = originalError;
     console.log = originalLog;
@@ -182,6 +183,55 @@ test('fails when a hunk body carries a line with no diff prefix', async () => {
   assert.ok(errors.some((e) => /no ' ' \/ '\+' \/ '-' prefix/.test(e)));
 });
 
+// #1854 review, major 2 (partial): a diff written in a notation the fence regex
+// does not match is skipped in silence. The surplus-header count catches it per
+// fixture; the coverage floors catch the repo-wide version of the same class.
+test('fails when a diff sits in an unrecognized fence (```Diff)', async () => {
+  const text = `# Fixture
+
+\`\`\`Diff
+${DIFF_BODY}
+\`\`\`
+
+<!-- expected:
+findings: []
+-->
+`;
+  const { ok, errors } = await runGate({ '01-uppercase-fence.md': text });
+  assert.equal(ok, false);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /1 hunk header\(s\) in the file but only 0 inside a recognized/);
+});
+
+test('fails when only one of two diffs uses a recognized fence', async () => {
+  const text = `# Fixture
+
+\`\`\`diff
+${DIFF_BODY}
+\`\`\`
+
+\`\`\`diff title="second"
+${DIFF_BODY}
+\`\`\`
+
+<!-- expected:
+${ANCHORED(3)}
+-->
+`;
+  const { ok, errors } = await runGate({ '01-mixed-fences.md': text });
+  assert.equal(ok, false);
+  assert.ok(errors.some((e) => /2 hunk header\(s\) in the file but only 1 inside/.test(e)));
+});
+
+test('countHunkHeaders ignores headers carrying a diff-body prefix', () => {
+  assert.equal(
+    countHunkHeaders(
+      ['@@ -1,2 +1,2 @@', ' @@ -9,9 +9,9 @@', '+@@ -9,9 +9,9 @@', '-@@ -9,9 +9,9 @@'].join('\n')
+    ),
+    1
+  );
+});
+
 test('skips a negative fixture that declares no anchor (findings: [])', async () => {
   const { ok, errors } = await runGate({
     '02-no-findings.md': FIXTURE(DIFF_BODY, 'findings: []'),
@@ -208,14 +258,80 @@ test('skips non-file:line anchors such as the (summary) pseudo-anchor', async ()
   assert.deepEqual(errors, []);
 });
 
+/**
+ * Coverage floors for the repository-wide run (#1854 review, major 1).
+ *
+ * A green verdict is NOT evidence that the gate inspected anything: every way
+ * this gate can lose its real input — breaking RE_DIFF_FENCE, adding a path
+ * filter, renaming the `fixtures/` directory, changing the `.md` filter —
+ * leaves `ok: true` with the counters at 0. Measured on this commit:
+ * 198 fixtures / 250 hunks / 100 anchors (`npm run skills:validate` prints the
+ * same three numbers). The floors sit ~20% below that, which
+ *
+ * - fails on every collapse mode above (all of them drive the counters to 0);
+ * - fails if either large tier stops being scanned (midstream = 122 fixtures /
+ *   155 hunks, upstream = 57 fixtures / 64 hunks / 83 anchors);
+ * - leaves ~48 fixtures / 50 hunks / 20 anchors of headroom, so ordinary
+ *   fixture churn does not fail the suite for no reason.
+ *
+ * RAISE these when coverage grows. Lowering one is only correct alongside a
+ * deliberate, explained removal of fixtures — never to make a red suite green.
+ */
+const COVERAGE_FLOORS = { fixtures: 150, hunks: 200, anchors: 80 };
+
 test('every fixture in the repository passes the gate', async () => {
   const originalLog = console.log;
   console.log = () => {};
+  let result;
   try {
-    assert.equal(await validateFixtureDiffStructure(), true);
+    result = await validateFixtureDiffStructure();
   } finally {
     console.log = originalLog;
   }
+  assert.equal(result.ok, true);
+});
+
+test('the repository-wide run actually inspects fixtures (coverage floors)', async () => {
+  const originalLog = console.log;
+  console.log = () => {};
+  let result;
+  try {
+    result = await validateFixtureDiffStructure();
+  } finally {
+    console.log = originalLog;
+  }
+  assert.ok(
+    result.checkedFixtures >= COVERAGE_FLOORS.fixtures,
+    `inspected ${result.checkedFixtures} fixtures, floor is ${COVERAGE_FLOORS.fixtures} — ` +
+      'the gate lost its input rather than passing it'
+  );
+  assert.ok(
+    result.checkedHunks >= COVERAGE_FLOORS.hunks,
+    `inspected ${result.checkedHunks} hunks, floor is ${COVERAGE_FLOORS.hunks}`
+  );
+  assert.ok(
+    result.checkedAnchors >= COVERAGE_FLOORS.anchors,
+    `inspected ${result.checkedAnchors} anchors, floor is ${COVERAGE_FLOORS.anchors}`
+  );
+});
+
+test('an empty skills tree reports zero coverage instead of a silent pass', async () => {
+  const dir = await createTempDirAsync({ prefix: TMP_PREFIX });
+  const originalLog = console.log;
+  console.log = () => {};
+  let result;
+  try {
+    result = await validateFixtureDiffStructure({ skillsDir: dir, repoRoot: dir });
+  } finally {
+    console.log = originalLog;
+  }
+  // The verdict alone cannot distinguish "nothing to check" from "all good" —
+  // which is exactly why the floors above are asserted separately.
+  assert.equal(result.ok, true);
+  assert.deepEqual(
+    { f: result.checkedFixtures, h: result.checkedHunks, a: result.checkedAnchors },
+    { f: 0, h: 0, a: 0 }
+  );
 });
 
 // --- pure helpers -----------------------------------------------------------
@@ -254,6 +370,61 @@ test('parseUnifiedDiff treats an omitted count as 1 and ignores the no-newline m
   assert.equal(hunks[0].declaredNew, 1);
   assert.equal(hunks[0].actualOld, 1);
   assert.equal(hunks[0].actualNew, 1);
+});
+
+// #1854 review, major 3: `--- foo` is the deletion of an SQL/Lua comment line
+// `-- foo`, not a file header. Treating it as a header truncated the hunk and
+// made the gate print a WRONG "expected" header, which would corrupt a correct
+// fixture if a maintainer applied it. Fixtures do carry SQL
+// (skills/upstream/data-model-db-design/fixtures/01-*.md).
+test('parseUnifiedDiff counts a deleted `-- comment` line as a deletion, not a header', () => {
+  const { hunks, files, unknownPrefixLines } = parseUnifiedDiff(
+    [
+      '+++ b/db/schema/billing.sql',
+      '@@ -1,2 +1,2 @@',
+      '--- legacy amount column, dropped in v2',
+      '+-- amount_cents is mandatory',
+      ' CREATE TABLE invoices (',
+    ].join('\n')
+  );
+  assert.equal(unknownPrefixLines.length, 0);
+  assert.equal(hunks.length, 1);
+  assert.equal(hunks[0].actualOld, 2);
+  assert.equal(hunks[0].actualNew, 2);
+  assert.deepEqual(
+    [...files.get('db/schema/billing.sql').lines.entries()],
+    [
+      [1, '-- amount_cents is mandatory'],
+      [2, 'CREATE TABLE invoices ('],
+    ]
+  );
+});
+
+test('parseUnifiedDiff still splits on a real `--- ` / `+++ ` header pair', () => {
+  const { files, hunks } = parseUnifiedDiff(
+    [
+      '--- a/one.txt',
+      '+++ b/one.txt',
+      '@@ -1,1 +1,1 @@',
+      '+alpha',
+      '--- a/two.txt',
+      '+++ b/two.txt',
+      '@@ -1,1 +1,1 @@',
+      '+beta',
+    ].join('\n')
+  );
+  assert.deepEqual([...files.keys()], ['one.txt', 'two.txt']);
+  assert.equal(hunks.length, 2);
+  assert.equal(hunks[0].actualNew, 1);
+  assert.equal(hunks[1].actualNew, 1);
+});
+
+test('parseUnifiedDiff counts an added `++ ` line rather than reading it as a header', () => {
+  const { hunks } = parseUnifiedDiff(
+    ['+++ b/a.md', '@@ -1,1 +1,2 @@', ' intro', '+++ nested bullet'].join('\n')
+  );
+  assert.equal(hunks.length, 1);
+  assert.equal(hunks[0].actualNew, 2);
 });
 
 test('parseUnifiedDiff ignores the new side of a deletion (+++ /dev/null)', () => {

--- a/tests/validate-fixture-diff-structure.test.mjs
+++ b/tests/validate-fixture-diff-structure.test.mjs
@@ -1,0 +1,300 @@
+/**
+ * Tests for validateFixtureDiffStructure in scripts/validate-skills.mjs (#1852).
+ *
+ * The gate parses the ```diff blocks embedded in skill fixtures and checks two
+ * things deterministically: that a hunk header's declared line counts match its
+ * body, and that every `<file>:<line>` anchor in an `<!-- expected: -->` block
+ * resolves to a real, non-blank line of the reconstructed new side.
+ *
+ * #1850's adversarial review found both classes of defect surviving a fully
+ * green CI, so the negative cases below are the regression pins: each one is a
+ * fixture broken in exactly one way, and each must make the gate return false.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import fs from 'fs/promises';
+
+import {
+  validateFixtureDiffStructure,
+  extractDiffBlocks,
+  parseUnifiedDiff,
+  parseFixtureDiffs,
+  extractFixtureAnchors,
+} from '../scripts/validate-skills.mjs';
+import { createTempDirAsync } from './helpers/temp-dir.mjs';
+
+const TMP_PREFIX = 'validate-fixture-diff-structure-';
+
+const SKILL_MD = `---
+id: diff-structure-skill
+name: Diff Structure Skill
+description: 'Fixture diff structure gate test skill.'
+category: upstream
+phase: upstream
+applyTo:
+  - 'docs/**/*.md'
+tags: [test, upstream]
+severity: major
+inputContext: [diff]
+outputKind: [findings]
+---
+
+## Rule
+
+body
+`;
+
+/**
+ * A 4-line new file. Line 2 is blank, so `docs/note.md:2` is the blank-anchor
+ * case and `docs/note.md:5` is the out-of-range case.
+ */
+const DIFF_BODY = [
+  'diff --git a/docs/note.md b/docs/note.md',
+  'new file mode 100644',
+  '--- /dev/null',
+  '+++ b/docs/note.md',
+  '@@ -0,0 +1,4 @@',
+  '+# Note',
+  '+',
+  '+Timeouts are undefined.',
+  '+Retries are unbounded.',
+].join('\n');
+
+const FIXTURE = (diffBody, expectedYaml) =>
+  `# Fixture
+
+## Input Diff
+
+\`\`\`diff
+${diffBody}
+\`\`\`
+
+<!-- expected:
+${expectedYaml}
+-->
+`;
+
+const ANCHORED = (line) => `findings:
+  - severity: major
+    reason: no timeout is defined
+    anchor: docs/note.md:${line}`;
+
+async function buildSkill(fixtures) {
+  const dir = await createTempDirAsync({ prefix: TMP_PREFIX });
+  const skillDir = path.join(dir, 'upstream', 'diff-structure-skill');
+  const fixturesDir = path.join(skillDir, 'fixtures');
+  await fs.mkdir(fixturesDir, { recursive: true });
+  await fs.writeFile(path.join(skillDir, 'SKILL.md'), SKILL_MD, 'utf8');
+  for (const [name, content] of Object.entries(fixtures)) {
+    await fs.writeFile(path.join(fixturesDir, name), content, 'utf8');
+  }
+  return dir;
+}
+
+async function runGate(fixtures) {
+  const dir = await buildSkill(fixtures);
+  const errors = [];
+  const originalError = console.error;
+  const originalLog = console.log;
+  console.error = (msg) => errors.push(String(msg));
+  console.log = () => {};
+  try {
+    const ok = await validateFixtureDiffStructure({ skillsDir: dir, repoRoot: dir });
+    return { ok, errors };
+  } finally {
+    console.error = originalError;
+    console.log = originalLog;
+  }
+}
+
+test('passes on a fixture whose hunk header and anchor are both correct', async () => {
+  const { ok, errors } = await runGate({ '01-ok.md': FIXTURE(DIFF_BODY, ANCHORED(3)) });
+  assert.equal(ok, true, errors.join('\n'));
+  assert.deepEqual(errors, []);
+});
+
+// (a) anchor points at a blank line
+test('fails when an anchor points at a blank line', async () => {
+  const { ok, errors } = await runGate({ '01-blank-anchor.md': FIXTURE(DIFF_BODY, ANCHORED(2)) });
+  assert.equal(ok, false);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /docs\/note\.md:2/);
+  assert.match(errors[0], /blank/);
+});
+
+// (b) anchor points at a line number that does not exist
+test('fails when an anchor points at a nonexistent line number', async () => {
+  const { ok, errors } = await runGate({ '01-out-of-range.md': FIXTURE(DIFF_BODY, ANCHORED(5)) });
+  assert.equal(ok, false);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /docs\/note\.md:5/);
+  assert.match(errors[0], /not present on the new side/);
+});
+
+// (c) hunk header declares counts that disagree with the body
+test('fails when a hunk header line count disagrees with the body', async () => {
+  const broken = DIFF_BODY.replace('@@ -0,0 +1,4 @@', '@@ -0,0 +1,9 @@');
+  const { ok, errors } = await runGate({ '01-bad-count.md': FIXTURE(broken, ANCHORED(3)) });
+  assert.equal(ok, false);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /declares old=0, new=9 but the body has old=0, new=4/);
+  assert.match(errors[0], /@@ -0,0 \+1,4 @@/);
+});
+
+test('fails when the old-side declared count disagrees with the body', async () => {
+  const body = [
+    'diff --git a/docs/note.md b/docs/note.md',
+    '--- a/docs/note.md',
+    '+++ b/docs/note.md',
+    '@@ -3,4 +3,2 @@',
+    ' context line',
+    '-removed line',
+    '+added line',
+  ].join('\n');
+  const { ok, errors } = await runGate({ '01-bad-old.md': FIXTURE(body, ANCHORED(3)) });
+  assert.equal(ok, false);
+  assert.ok(errors.some((e) => /declares old=4, new=2 but the body has old=2, new=2/.test(e)));
+});
+
+test('fails when an anchor names a file absent from the diff blocks', async () => {
+  const yamlBlock = `findings:
+  - severity: major
+    reason: anchored to a file the diff never shows
+    anchor: docs/other.md:1`;
+  const { ok, errors } = await runGate({ '01-unknown-file.md': FIXTURE(DIFF_BODY, yamlBlock) });
+  assert.equal(ok, false);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /no "\+\+\+ b\/docs\/other\.md" appears/);
+});
+
+test('fails when a hunk body carries a line with no diff prefix', async () => {
+  const body = [
+    'diff --git a/docs/note.md b/docs/note.md',
+    '--- /dev/null',
+    '+++ b/docs/note.md',
+    '@@ -0,0 +1,2 @@',
+    '+# Note',
+    'prose that escaped the fence',
+  ].join('\n');
+  const { ok, errors } = await runGate({ '01-stray-line.md': FIXTURE(body, ANCHORED(1)) });
+  assert.equal(ok, false);
+  assert.ok(errors.some((e) => /no ' ' \/ '\+' \/ '-' prefix/.test(e)));
+});
+
+test('skips a negative fixture that declares no anchor (findings: [])', async () => {
+  const { ok, errors } = await runGate({
+    '02-no-findings.md': FIXTURE(DIFF_BODY, 'findings: []'),
+  });
+  assert.equal(ok, true, errors.join('\n'));
+  assert.deepEqual(errors, []);
+});
+
+test('skips a fixture with no diff block at all', async () => {
+  const { ok, errors } = await runGate({
+    '03-prose-only.md': `# Fixture\n\nProse only.\n\n<!-- expected:\n${ANCHORED(3)}\n-->\n`,
+  });
+  assert.equal(ok, true, errors.join('\n'));
+  assert.deepEqual(errors, []);
+});
+
+test('skips non-file:line anchors such as the (summary) pseudo-anchor', async () => {
+  const yamlBlock = `findings:
+  - severity: major
+    reason: summary line
+    anchor: (summary):1`;
+  const { ok, errors } = await runGate({ '04-summary.md': FIXTURE(DIFF_BODY, yamlBlock) });
+  assert.equal(ok, true, errors.join('\n'));
+  assert.deepEqual(errors, []);
+});
+
+test('every fixture in the repository passes the gate', async () => {
+  const originalLog = console.log;
+  console.log = () => {};
+  try {
+    assert.equal(await validateFixtureDiffStructure(), true);
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+// --- pure helpers -----------------------------------------------------------
+
+test('extractDiffBlocks handles a 4-backtick fence wrapping an inner fence', () => {
+  const text = ['````diff', '+```bash', '+echo hi', '+```', '````', '', '```text', 'x', '```'].join(
+    '\n'
+  );
+  const blocks = extractDiffBlocks(text);
+  assert.equal(blocks.length, 1);
+  assert.equal(blocks[0], '+```bash\n+echo hi\n+```\n');
+});
+
+test('parseUnifiedDiff reconstructs new-side numbering across context and deletions', () => {
+  const { files, hunks } = parseUnifiedDiff(
+    ['+++ b/a.txt', '@@ -10,3 +10,3 @@', ' keep', '-gone', '+fresh', ' tail'].join('\n')
+  );
+  const lines = files.get('a.txt').lines;
+  assert.deepEqual(
+    [...lines.entries()],
+    [
+      [10, 'keep'],
+      [11, 'fresh'],
+      [12, 'tail'],
+    ]
+  );
+  assert.equal(hunks[0].actualOld, 3);
+  assert.equal(hunks[0].actualNew, 3);
+});
+
+test('parseUnifiedDiff treats an omitted count as 1 and ignores the no-newline marker', () => {
+  const { hunks } = parseUnifiedDiff(
+    ['+++ b/a.txt', '@@ -1 +1 @@', '-old', '+new', '\\ No newline at end of file'].join('\n')
+  );
+  assert.equal(hunks[0].declaredOld, 1);
+  assert.equal(hunks[0].declaredNew, 1);
+  assert.equal(hunks[0].actualOld, 1);
+  assert.equal(hunks[0].actualNew, 1);
+});
+
+test('parseUnifiedDiff ignores the new side of a deletion (+++ /dev/null)', () => {
+  const { files } = parseUnifiedDiff(
+    ['--- a/a.txt', '+++ /dev/null', '@@ -1,2 +0,0 @@', '-one', '-two'].join('\n')
+  );
+  assert.equal(files.size, 0);
+});
+
+test('parseFixtureDiffs merges multiple diff blocks of one fixture', () => {
+  const text = [
+    '```diff',
+    '+++ b/a.txt',
+    '@@ -0,0 +1,1 @@',
+    '+alpha',
+    '```',
+    '',
+    '```diff',
+    '+++ b/b.txt',
+    '@@ -0,0 +1,1 @@',
+    '+beta',
+    '```',
+  ].join('\n');
+  const { files, hunks } = parseFixtureDiffs(text);
+  assert.deepEqual([...files.keys()], ['a.txt', 'b.txt']);
+  assert.equal(hunks.length, 2);
+});
+
+test('extractFixtureAnchors reads findings[].anchor only', () => {
+  const text = `<!-- expected:
+findings:
+  - severity: major
+    anchor: src/a.ts:12
+  - severity: minor
+    anchor: (summary):1
+  - severity: minor
+    reason: no anchor at all
+notes:
+  anchor: src/ignored.ts:1
+-->`;
+  assert.deepEqual(extractFixtureAnchors(text), [
+    { raw: 'src/a.ts:12', file: 'src/a.ts', line: 12 },
+  ]);
+});


### PR DESCRIPTION
closes #1852

## 概要

fixture の diff ブロックをパースし、次の 2 点を決定論で検証するゲートを `skills:validate`（必須チェック `Skill schema validation`）に追加する。

1. **anchor が指す行が実在し空行でないこと** — `+++ b/<path>` と `@@` から new 側行番号を再構成して判定
2. **hunk ヘッダの宣言行数が実カウントと一致すること** — old 側・new 側とも

## 前提の訂正: 違反はリポジトリ全体で 175 件あった

起票時に引用した「24 hunk 中 23 件」は **#1850 のスコープ内の値**で、リポジトリ全体では違っていた。実測（fixture 218 件 / 250 hunk）:

| 種別 | 件数 |
| --- | ---: |
| hunk ヘッダの宣言行数 ≠ 実カウント | **175 / 250 hunk**（147 ファイル） |
| anchor が空行を指す | 8 |
| anchor が不存在の行番号を指す | 2 |
| fence 未クローズで散文が diff に混入 | 2 ファイル |

ゲートを赤のまま入れられないため、検出された実在不具合をすべて本 PR で修正した。

**fixture の変更は機械的なものに限定されている。** 188 追加 / 188 削除で釣り合い、変更行の内訳は `@@` の count 部・anchor の行番号・fence の閉じ位置のみ。**diff 本体（`+` / `-` / context 行）は 1 行も変えていない。**

## 統合先の判断

独立スクリプトではなく `scripts/validate-skills.mjs` へ統合した。

- 必須チェック `Skill schema validation` が同スクリプトを実行しているため、直接実行ブロックへ配線するだけで CI 強制になる
- fixture 探索（`listSkillFiles` + `fixtures/` 走査）と expected ブロック取り出し（`extractExpectedBlocks`）が同ファイル内に既存。独立させると SSoT を跨いだ import か再実装が必要になる

`extractExpectedBlocks` は `validateFixtureDrift` と同じ SSoT を共有しており、再実装していない。

## 検証

`✅ fixture diff structure: 250 hunk(s) and 100 anchor(s) across 198 fixture(s) consistent`

**ゲートが実際に検出することを、壊して確認している**（テスト 17 件 + オーガナイザー側の独立検証）:

- hunk ヘッダを壊す → `hunk header "@@ -18,2 +18,19 @@ class CandidateScoring" declares old=2, new=19 but the body has old=2, new=12 (expected "@@ -18,2 +18,12 @@")` で exit 1。**期待値まで提示する**
- anchor を不存在行へ → `anchors "src/http/fetch-with-retry.ts:9999" but line 9999 is not present on the new side of the diff (reconstructed lines: 1..15)` で exit 1
- 復元すると exit 0 に戻る（誤検出なし）

skip の妥当性も固定した: `findings: []` の negative fixture / diff ブロック無し / `(summary):1` の疑似 anchor。

`npm ci` / `npm run lint` / `npm test`（3251 pass, 0 fail）/ `npm run skills:validate` / `npm run meta:validate` すべて exit 0。

## スコープ外（報告のみ・未対応）

- **Expected Behavior 散文中の行番号は未検証。** #1852 が挙げた `export.ts:6` のような誤りは散文側にあり、本ゲートは YAML の `findings[].anchor` のみを見る。散文の `path:line` 検証は別 issue 相当
- **fixture の hunk header は元々「飾り」だった**（250 中 175 が不一致）。`docs/development/s1-fixture-convention.md` に「ヘッダ行数は本体と一致させる」旨を書く価値がある

---

## 敵対的レビュー後の修正（fix-first 3 件）

レビュー判定は blocker 0 / major 3 / minor 3 の **fix-first**。必須 3 件を修正した。

### 1. ゲート自身が「0 件検査」で緑を返せた（major）

`RE_DIFF_FENCE` を 1 トークン壊すだけで `0 fixture(s) consistent` / exit 0 になった。合成 fixture を tmpdir に組み立てるユニットテストは全部緑のまま通るため、**実リポジトリのパスだけを落とす変更**を誰も検出できない。**この PR が塞ごうとした失敗モードを、ゲート自身が持っていた。**

`validateFixtureDiffStructure()` の戻り値を `{ ok, checkedFixtures, checkedHunks, checkedAnchors }` にし、リポジトリ全体テストへ `COVERAGE_FLOORS = { fixtures: 150, hunks: 200, anchors: 80 }` の下限 assert を追加。

**変異で実証**（オーガナイザー側でも独立再現）: 実リポジトリのパスだけを落とすフィルタを入れると **24/25 が緑のまま floors テストだけが落ちる** — `inspected 0 fixtures, floor is 150 — the gate lost its input rather than passing it`。

下限は実測 198/250/100 の約 8 割。midstream 喪失で 76 fixtures、upstream 喪失で 141 fixtures となりいずれも下限割れする。**捕まえられない範囲も明示する**: 最小 tier の agent-skills（7 fixtures = 3.5%）単独の喪失は、下限を 100% に張り付けない限り検出できない。この穴は下の記法ガードが fixture 単位で補う。

### 2. `--- ` 判定が SQL コメント削除行を誤認した（minor→必須）

`-- foo` を削除する diff 行は `--- foo` になり、ファイルヘッダと誤認して hunk を打ち切っていた。fixture には SQL（`db/schema/billing.sql`）が実在する。**誤った期待ヘッダを提示するため、その通りに直すと恒久的に壊れる。**

`isFileHeaderPairStart()` を追加し、`--- ` は**次行が `+++ ` のときだけ**ヘッダとみなす。unified diff はヘッダを対で出すため曖昧さが決定論的に消える。`+++ ` 側も対称化（`++ foo` の追加行との衝突回避）。回帰テスト 3 本。

### 3. SSoT `s1-fixture-convention.md` が未更新（major）

同 doc は fixture 作成の SSoT だが `grep -n diff` が 0 hit で、diff ブロックの記法が一切明文化されていなかった。「### 3-2. diff ブロックの記法と構造条件」を新設し、fence 要件・`+++ b/<path>` と anchor パスの一致・hunk ヘッダ書式・4 つの機械条件を明記。「### 5. 実測で確認する」を 2 行 → 3 行へ更新し、**緑であることと検査したことは別**である旨と `COVERAGE_FLOORS` の見直し義務を追記。

### 追加で入れた: 未認識記法ガード

「fixture 内のヘッダ数 > 認識ブロック内のヘッダ数」をエラー化。実測で現行違反 0 件。floors が捕まえられない「1 skill 分だけ記法がずれる」ケースを fixture 単位で塞ぐ。

## フォローアップ（別 issue で追跡）

現行 fixture が一件も踏んでいないため本 PR のスコープ外とした残件 3 件: `@@` を持たない記法揺れ（素の ± 抜粋 / 範囲 anchor `path:1-5`）/ hunk 開始行の単調性・非重複 / anchor のパス正規化。

## 最終検証

`npm run lint` / `npm test`（3259 pass, 0 fail）/ `npm run skills:validate` / `npm run meta:validate` すべて exit 0。新規テストは 17 → **25 件**。