### PR TITLE
docs(adr): 受入基準を二段に分けて active の着手条件を確定する（ADR-006）

### DIFF
--- a/docs/adr/006-model-aware-review-prompt-compiler.md
+++ b/docs/adr/006-model-aware-review-prompt-compiler.md
@@ -91,6 +91,56 @@ Review Request IR を挟み、モデル非依存の依頼内容と、モデル�
 
 理由は Context のとおり、レビュー実行経路が `openai` 以外を拒否するためです。いま 4 profile を用意しても、2 つは到達不能なコードになります。
 
+### 受入基準の二段構成
+
+受入基準は、送信前に測れるものと、LLM の応答を要するものへ明示的に分けます。
+
+分けない場合、採否条件の充足が `active` の前提となり、`active` の稼働がその充足の前提にもなります。この循環は #1861 で実際に着手を止めました。
+
+段の振り分けは散文の申し合わせではありません。出典は [`src/lib/prompt-compiler-paired.mjs`](../../src/lib/prompt-compiler-paired.mjs) の `ACCEPTANCE_COVERAGE`（`:66-125`）であり、全 9 行のうち `observable: true` の 1 行を段 1、`observable: false` の 8 行を段 2 とします。指標名も同配列の `metric` をそのまま使います。
+
+#### 段 1—送信前に測れる（`observe` で足りる）
+
+| Metric（`ACCEPTANCE_COVERAGE` の `metric`） | 観測経路                                                       |
+| ------------------------------------------- | -------------------------------------------------------------- |
+| `token（送信前のプロンプト推定長）`         | `observe` が legacy / compiled 双方の推定長を 1 run で記録する |
+
+段 1 の判定条件は次のとおりです。
+
+- `river evolve prompt-compare` が成功し、`promptMetrics` へ両側の推定長と差分が載ることである
+- 推定長が増えた場合、その増分を profile の描画差として説明できることである
+- 推定長が減った事実そのものは採用理由にならない（`promptMetrics.note` と同じ扱いである）
+
+2 番目を閾値にしない理由は実測にあります。[`docs/development/1860-prompt-compiler-paired.md`](../development/1860-prompt-compiler-paired.md) `:24-27` の観測では、`legacyPromptEstimate` 800 に対し `compiledPromptEstimate` は 801 でした。差分ゼロを機械的な合格線にすると、この程度の描画差でも段 1 を通せません。
+
+段 1 を満たした時点で、`active` を opt-in で有効化する作業へ進めるものとします。既定は `off` のままです。
+
+#### 段 2—LLM の応答を要する（`active` 稼働後に測る）
+
+| Metric（`ACCEPTANCE_COVERAGE` の `metric`） | 現時点で測れない理由                             |
+| ------------------------------------------- | ------------------------------------------------ |
+| `should-detect recall`                      | candidate 側の findings が存在しない             |
+| `should-not-detect precision`               | candidate 側の findings が存在しない             |
+| `parse 成功率`                              | compiled prompt に対する LLM 応答が無い          |
+| `Evidence / Fix の充足`                     | 充足度を数える対象が存在しない                   |
+| `invalid ArtifactRefs`                      | ArtifactRef の検査対象が存在しない               |
+| `duplicate findings`                        | 重複を数える対象が存在しない                     |
+| `critical 回帰`                             | 両側の run が同一のため差分 0 は未観測を意味する |
+| `latency / cost`                            | compiled prompt を送っておらず計測対象が無い     |
+
+段 2 を満たすまで、既定を `off` から動かしません。
+
+#### 段 2 を測るために揃えるもの
+
+段 2 は「いつか測る」ではなく、次の 4 つが揃った時点で測れます。
+
+1. provider の API キーが repo secret へ登録されていることである。これは代行できない人間作業であり、現時点で未完了である
+2. `active` が opt-in で配線され、`sentPrompt` が compiled の run を保存できることである
+3. 同一 fixture・同一モデル・同一 context で legacy 側の run が並存することである
+4. その 2 系統を受け取る比較経路が存在することである。現行の `river evolve prompt-compare` は `sentPrompt` が legacy でない run を拒否するため、active の run はこの導線では扱わない
+
+1 が未完了である間、段 2 の評価は開始できません。逆に 1 が済めば、残る 3 つは #1861 の実装範囲に収まります。
+
 ## Non-goals
 
 - 汎用のプロンプト最適化器
@@ -106,10 +156,12 @@ Review Request IR を挟み、モデル非依存の依頼内容と、モデル�
 ## Consequences
 
 - プロンプトの調整対象が profile に閉じるため、判断側へ波及しない
-- 採否は「プロンプトが短くなったか」ではなく、recall / precision / parse 成功率 / 証跡の充足 / critical 回帰ゼロで判定する
+- 採否は「プロンプトが短くなったか」ではなく、recall / precision / parse 成功率 / 証跡の充足 / critical 回帰ゼロで判定する。これらは前掲の段 2 にあたる
 - legacy と compiled の突合には、既存の Experiment Manifest（`src/lib/paired-replay.mjs`）を使う。突合と受入基準の評価は実装済みであり、追加で必要なのは同条件の run を 2 本産む導線だけである
 - `src/prompt/**` は `runners/github-action/src/index.mjs` から `src/cli.mjs` 経由で辿られるため dist にバンドルされる。実装 PR では `npm run build:action` による dist 再ビルドが必要である
-- `active` を既定にしません。既定は `off` のままとし、受入基準を満たした場合にのみ opt-in で有効化します
+- `active` を既定にしない。既定は `off` のままとし、段 2 を満たした場合にのみ既定への昇格を検討する
+- `active` の着手条件は「全 9 指標の充足」ではなく「段 1 の充足」へ変わる。#1861 は基準未充足を理由に止めず、opt-in の配線として着手できる
+- 二段に分けても順序は逆転しない。段 2 の評価は `active` の稼働後であり、既定 `off` の解除条件も段 2 のままである
 
 ### 再参入条件
 


### PR DESCRIPTION
## 何を変えたか

`docs/adr/006-model-aware-review-prompt-compiler.md` の受入基準を二段構成へ改訂した。docs のみの変更で `src/**` は触っていない。

- Decision に `### 受入基準の二段構成`（段 1 / 段 2 / 段 2 を測るために揃えるもの）を追加
- Consequences を更新（`active` の着手条件、既定 `off` の解除条件）
- Status / Context / Decision / Non-goals / Consequences の構成は維持。canary / 自動 rollback への言及は追加していない

## 二段に分けた理由（循環）

ADR-006 は「受入基準を満たした場合にのみ `active` を opt-in で有効化する」と定めていた。しかしその受入基準は実レビューの LLM 応答を要し、応答を得るには `active` が要る。**基準の充足が `active` の前提であり、`active` が充足の前提**という循環になっていた（#1861 のコメントで着手保留の理由として記録されている）。

順序を逆転させる宣言（active を先に配線する）ではなく、基準側を精密化して解いた。送信前に測れるものを段 1、応答を要するものを段 2 とし、段 1 を満たせば opt-in 有効化の作業へ進んでよい、と条件を分けた。既定 `off` の解除条件は段 2 のままなので、ADR の一貫性は保たれる。

## 段 1 / 段 2 の振り分けと実装との突合

出典は `src/lib/prompt-compiler-paired.mjs` の `ACCEPTANCE_COVERAGE`（`:66-125`）。ADR の指標名は同配列の `metric` をそのまま使っている。

突合コマンド（`ACCEPTANCE_COVERAGE` を import して 1 行ずつ出力）:

```console
$ node scratchpad/coverage.mjs
total rows: 9
observable true: 1
observable false: 8
不可 | should-detect recall | unblockedBy=#1861 active 配線
不可 | should-not-detect precision | unblockedBy=#1861 active 配線
不可 | parse 成功率 | unblockedBy=#1861 active 配線
不可 | Evidence / Fix の充足 | unblockedBy=#1861 active 配線
不可 | invalid ArtifactRefs | unblockedBy=#1861 active 配線
不可 | duplicate findings | unblockedBy=#1861 active 配線
不可 | critical 回帰 | unblockedBy=#1861 active 配線
可   | token（送信前のプロンプト推定長） | unblockedBy=null
不可 | latency / cost | unblockedBy=#1861 active 配線
```

| 段  | 指標                                                                                                                                                          | 実装の `observable` |
| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
| 1   | `token（送信前のプロンプト推定長）`                                                                                                                           | `true`（1 行）      |
| 2   | `should-detect recall` / `should-not-detect precision` / `parse 成功率` / `Evidence / Fix の充足` / `invalid ArtifactRefs` / `duplicate findings` / `critical 回帰` / `latency / cost` | `false`（8 行）     |

9 行すべてがどちらかの段に入り、取りこぼしと重複はない。

段 1 の合格線を「推定長の差分ゼロ」にはしていない。`docs/development/1860-prompt-compiler-paired.md:24-27` の実測が `legacyPromptEstimate` 800 に対し `compiledPromptEstimate` 801 であり、機械的な差分ゼロ基準ではこの描画差でも段 1 を通せなくなるため。新しい数値閾値は追加していない。「推定長が減ったこと自体は採用理由にならない」という既存の禁止（`promptMetrics.note`）も ADR 側に明記した。

## 段 2 が人間作業に依存する点

段 2 を測るには次の 4 つが揃う必要がある、と ADR に書いた。

1. provider の API キーが repo secret へ登録されていること（**代行できない人間作業。現時点で未完了**）
2. `active` が opt-in で配線され、`sentPrompt` が compiled の run を保存できること
3. 同一 fixture・同一モデル・同一 context で legacy 側の run が並存すること
4. その 2 系統を受け取る比較経路が存在すること（現行の `river evolve prompt-compare` は `sentPrompt` が legacy でない run を拒否する）

1 が未完了である間は段 2 の評価を開始できない。1 が済めば残る 3 つは #1861 の実装範囲に収まる。

## 検証（実出力）

Node は `/opt/homebrew/opt/node@22/bin`（v22.22.2）。worktree で `npm ci` 済み。

```console
$ npx textlint --no-cache docs/adr/006-model-aware-review-prompt-compiler.md
  16:72   error  一文に二回以上利用されている助詞 "が" がみつかりました。 ja-technical-writing/no-doubled-joshi
  24:992  error  Line 24 sentence length(160) exceeds the maximum sentence length of 150. ja-technical-writing/sentence-length
✖ 2 problems (2 errors, 0 warnings, 0 infos)   # exit 1
```

残る 2 件はいずれも Context 節の**既存行**（16 行目・24 行目）で、本 PR では触れていない。`docs/**` に適用される緩和 config はこの 2 ルールを無効化している（`tools/textlint/docs.textlintrc.json`）。CI が実行するのは次:

```console
$ npm run lint:text:docs
> textlint -c tools/textlint/docs.textlintrc.json 'docs/**/*.md' 'README*.md'
   # exit 0（違反なし）

$ npm run fix:dashes
No heading/title dash normalizations needed.   # exit 0

$ npm run format:check
Checking formatting...
All matched files use Prettier code style!   # exit 0

$ npm run meta:validate
Meta consistency: OK
Doc enumerations: OK (14 spec(s) checked, 0 ignored)
Sidebar reachability: OK (91 page(s) in sidebar, 11 allowlisted)
skills catalog is up to date: pages/reference/skills-catalog.md (128 skills).   # exit 0

$ npm test
ℹ tests 3339
ℹ suites 338
ℹ pass 3339
ℹ fail 0
ℹ duration_ms 28247.982292   # exit 0
```

`src/**` を触っていないため `npm run build:action` は不要。

```console
$ git status --porcelain
 M docs/adr/006-model-aware-review-prompt-compiler.md   # コミット前の唯一の変更
```

## スコープ外

- `active` の実装・配線（#1861 本体）
- `src/**` の変更
- canary / 自動 rollback への言及（`src/lib/paired-replay.mjs:14-18` が #1574 で確定した非ゴール。変更なし）

refs #1861
refs #1858
