### PR TITLE
feat(skills): fixture diff パーサの記法・構造カバレッジを広げる

### DIFF
--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -894,6 +894,48 @@ const RE_NEW_FILE_HEADER = /^\+\+\+ (?:b\/)?(\S+)/;
 const RE_ANCHOR = /^(.*\S):(\d+)$/;
 
 /**
+ * Canonical spelling of a diff/anchor path (#1856,残件 3).
+ *
+ * `./docs/note.md` and `docs/note.md` name the same file, but a raw string
+ * compare against the `+++ b/docs/note.md` header misses, and the gate then
+ * reports "no `+++ b/./docs/note.md` appears in the fixture's diff blocks" —
+ * a message that sends the maintainer looking for a missing diff instead of a
+ * redundant `./`. Both sides of the comparison go through this function, so the
+ * two spellings resolve to one key.
+ *
+ * `path.posix` is used deliberately: fixture diffs are unified diffs, whose
+ * separator is `/` on every platform. `path.normalize` on Windows would rewrite
+ * them to `\` and break the comparison it is meant to fix.
+ *
+ * @param {string} p
+ * @returns {string}
+ */
+export function normalizeDiffPath(p) {
+  return path.posix.normalize(String(p ?? '')).replace(/^\.\//, '');
+}
+
+/**
+ * True when a ```diff block body carries at least one added/removed content
+ * line. `+++ ` / `--- ` file headers and the `\ No newline` marker are not
+ * content, and a block made of nothing else (e.g. the intentionally empty diff
+ * in skills/upstream/plangate-exec-conformance/fixtures/03-fallback-diff-empty.md)
+ * carries no line an anchor could point at.
+ *
+ * @param {string} blockText
+ * @returns {boolean}
+ */
+function hasDiffContentLines(blockText) {
+  return String(blockText ?? '')
+    .split('\n')
+    .some(
+      (line) =>
+        (line.startsWith('+') || line.startsWith('-')) &&
+        !line.startsWith('+++ ') &&
+        !line.startsWith('--- ')
+    );
+}
+
+/**
  * True when `lines[i]` opens a `--- old` / `+++ new` file-header PAIR.
  *
  * A bare `startsWith('--- ')` test is ambiguous: deleting a line that itself
@@ -967,7 +1009,7 @@ export function parseUnifiedDiff(diffText) {
     const fileMatch = RE_NEW_FILE_HEADER.exec(line);
     if (fileMatch) {
       // `+++ /dev/null` marks a deletion: no new-side lines to reconstruct.
-      currentFile = fileMatch[1] === '/dev/null' ? null : fileMatch[1];
+      currentFile = fileMatch[1] === '/dev/null' ? null : normalizeDiffPath(fileMatch[1]);
       if (currentFile && !files.has(currentFile)) files.set(currentFile, { lines: new Map() });
       i += 1;
       continue;
@@ -1045,19 +1087,39 @@ export function parseUnifiedDiff(diffText) {
  * Merge every ```diff block of one fixture into a single new-side view.
  * Pure and exported for unit testing.
  *
+ * Two structural defects are detected here rather than in parseUnifiedDiff,
+ * because both are properties of the fixture as a whole (#1856):
+ *
+ * - `headerlessBlocks`: a ```diff block that carries `+`/`-` content lines but
+ *   declares no `@@` header. Its new-side numbering cannot be reconstructed, so
+ *   every line it contributes is invisible to the anchor check — and the #1854
+ *   surplus-header guard cannot see it either, because that guard compares two
+ *   counts that are both 0 here.
+ * - `orderIssues`: two hunks of the same file whose new-side ranges overlap, or
+ *   that appear out of ascending order. The merge below is last-write-wins, so
+ *   an overlap silently replaces the earlier hunk's lines and an anchor into
+ *   the earlier hunk is then validated against the later hunk's text.
+ *
  * @param {string} text - fixture file content
  * @returns {{
  *   files: Map<string, { lines: Map<number, string> }>,
  *   hunks: Array<object>,
  *   unknownPrefixLines: string[],
+ *   headerlessBlocks: number[],
+ *   orderIssues: Array<{
+ *     file: string, previous: string, current: string, previousRange: string,
+ *   }>,
  * }}
  */
 export function parseFixtureDiffs(text) {
   const files = new Map();
   const hunks = [];
   const unknownPrefixLines = [];
-  for (const block of extractDiffBlocks(text)) {
+  const headerlessBlocks = [];
+  const blocks = extractDiffBlocks(text);
+  for (const [index, block] of blocks.entries()) {
     const parsed = parseUnifiedDiff(block);
+    if (parsed.hunks.length === 0 && hasDiffContentLines(block)) headerlessBlocks.push(index);
     for (const [file, entry] of parsed.files) {
       if (!files.has(file)) files.set(file, { lines: new Map() });
       const target = files.get(file);
@@ -1066,7 +1128,36 @@ export function parseFixtureDiffs(text) {
     hunks.push(...parsed.hunks);
     unknownPrefixLines.push(...parsed.unknownPrefixLines);
   }
-  return { files, hunks, unknownPrefixLines };
+
+  const orderIssues = [];
+  const seenByFile = new Map();
+  for (const hunk of hunks) {
+    if (!hunk.file) continue;
+    const previous = seenByFile.get(hunk.file);
+    if (previous) {
+      // Half-open new-side range. A pure-deletion hunk has actualNew === 0, so
+      // its range is empty and a following hunk starting at the same line is
+      // neither an overlap nor out of order.
+      //
+      // One comparison covers both defects the issue names. `newStart` going
+      // backwards always lands inside or before the preceding range, because
+      // that range starts at the preceding `newStart`; so "not ascending" is a
+      // strict subset of "overlaps", and a separate monotonicity branch would
+      // be unreachable.
+      const previousEnd = previous.newStart + previous.actualNew;
+      if (hunk.newStart < previousEnd) {
+        orderIssues.push({
+          file: hunk.file,
+          previous: previous.header,
+          current: hunk.header,
+          previousRange: `${previous.newStart}..${previousEnd - 1}`,
+        });
+      }
+    }
+    seenByFile.set(hunk.file, hunk);
+  }
+
+  return { files, hunks, unknownPrefixLines, headerlessBlocks, orderIssues };
 }
 
 /**
@@ -1074,9 +1165,13 @@ export function parseFixtureDiffs(text) {
  * `<!-- expected: -->` blocks. Pure and exported for unit testing.
  *
  * Only `findings[].anchor` is read — the same field validateFixtureDrift()
- * consumes. Anchors that are not in `<file>:<line>` form (e.g. the
- * `(summary):1` pseudo-anchor) are skipped: they name no diff file, so no
- * deterministic judgment is possible.
+ * consumes. Pseudo-anchors that name no file (`(summary):1` and friends, i.e.
+ * anything starting with `(`) are skipped: no deterministic judgment is
+ * possible for them. Anchors that name a file but are not in `<file>:<line>`
+ * form are NOT skipped — extractMalformedAnchors() reports them (#1856).
+ *
+ * The `file` field is returned in normalizeDiffPath() form so it compares
+ * directly against the keys parseFixtureDiffs() produces.
  *
  * @param {string} text - fixture file content
  * @returns {Array<{ raw: string, file: string, line: number }>}
@@ -1100,10 +1195,47 @@ export function extractFixtureAnchors(text) {
       if (!match) continue;
       const file = match[1].trim();
       if (file.startsWith('(')) continue; // `(summary):1` and friends
-      anchors.push({ raw: raw.trim(), file, line: Number(match[2]) });
+      anchors.push({ raw: raw.trim(), file: normalizeDiffPath(file), line: Number(match[2]) });
     }
   }
   return anchors;
+}
+
+/**
+ * Collect the `findings[].anchor` strings that name a file but are NOT in
+ * `<file>:<line>` form, so the gate can reject them instead of skipping them
+ * (#1856,残件 1). The motivating case is the range form `docs/note.md:1-5`:
+ * RE_ANCHOR does not match it, extractFixtureAnchors() drops it, and the
+ * finding is then never checked against the diff while CI stays green.
+ *
+ * Pseudo-anchors starting with `(` stay exempt — they intentionally name no
+ * file, and extractFixtureAnchors() skips them for the same reason.
+ *
+ * @param {string} text - fixture file content
+ * @returns {string[]} the offending raw anchor strings
+ */
+export function extractMalformedAnchors(text) {
+  const malformed = [];
+  for (const block of extractExpectedBlocks(text)) {
+    let parsed;
+    try {
+      parsed = yaml.load(block);
+    } catch {
+      // Reported by validateFixtureDrift(); nothing to anchor-check here.
+      continue;
+    }
+    const findings = parsed?.findings;
+    if (!Array.isArray(findings)) continue;
+    for (const finding of findings) {
+      const raw = finding?.anchor;
+      if (typeof raw !== 'string') continue;
+      const trimmed = raw.trim();
+      if (trimmed.startsWith('(')) continue;
+      if (RE_ANCHOR.test(trimmed)) continue;
+      malformed.push(trimmed);
+    }
+  }
+  return malformed;
 }
 
 /**
@@ -1116,9 +1248,16 @@ export function extractFixtureAnchors(text) {
  * - a hunk header's declared line counts must equal the hunk body's actual
  *   counts, on the old side and the new side;
  * - an anchor's file must appear as a `+++ b/<path>` header in one of the
- *   fixture's diff blocks;
+ *   fixture's diff blocks (compared after normalizeDiffPath(), so `./a` and `a`
+ *   are one path — #1856,残件 3);
  * - the anchored line must exist in the reconstructed new-side numbering and
- *   must not be blank.
+ *   must not be blank;
+ * - a ```diff block with `+`/`-` content lines must declare a `@@` hunk header
+ *   (#1856,残件 1 — the #1854 surplus check is blind here, both counts are 0);
+ * - an anchor that names a file must be in `<file>:<line>` form, not a range
+ *   like `docs/note.md:1-5` (#1856,残件 1);
+ * - two hunks of one file must not overlap on the new side, and must appear in
+ *   ascending new-side order (#1856,残件 2).
  *
  * Rationale (#1850 adversarial review): CI was fully green while anchors
  * pointed at blank lines and hunk headers disagreed with their bodies, because
@@ -1166,7 +1305,13 @@ export async function validateFixtureDiffStructure({
       const fixturePath = path.join(fixturesDir, name);
       const fixtureRel = path.relative(repoRoot, fixturePath);
       const content = await fs.readFile(fixturePath, 'utf8');
-      const { files: diffFiles, hunks, unknownPrefixLines } = parseFixtureDiffs(content);
+      const {
+        files: diffFiles,
+        hunks,
+        unknownPrefixLines,
+        headerlessBlocks,
+        orderIssues,
+      } = parseFixtureDiffs(content);
 
       // Unrecognized-notation guard (#1854 review, major 2 — partial). Every
       // hunk header in the file must sit inside a fence this gate recognizes.
@@ -1186,8 +1331,48 @@ export async function validateFixtureDiffStructure({
         success = false;
       }
 
+      // Headerless-notation guard (#1856,残件 1). The surplus-header check above
+      // compares two counts that are both 0 for a bare ± excerpt, so it cannot
+      // see this shape at all: the block is recognized, contains real changes,
+      // and contributes nothing the anchor check can resolve.
+      for (const index of headerlessBlocks) {
+        console.error(
+          `❌ ${fixtureRel}: \`\`\`diff block #${index + 1} has +/- lines but no ` +
+            '"@@ -a,b +c,d @@" hunk header — without it the new-side line numbers ' +
+            'cannot be reconstructed and the block is skipped by the anchor check'
+        );
+        success = false;
+      }
+
       if (!hunks.length && !diffFiles.size) continue;
       checkedFixtures += 1;
+
+      // Malformed-anchor guard (#1856,残件 1). `docs/note.md:1-5` names a file
+      // but is silently dropped by extractFixtureAnchors(), so the finding it
+      // belongs to is never validated against the diff. Kept below the skip
+      // above so the gate stays opt-in by structure: a fixture with no diff has
+      // nothing to resolve an anchor against in the first place.
+      for (const raw of extractMalformedAnchors(content)) {
+        console.error(
+          `❌ ${fixtureRel}: expected block anchor ${JSON.stringify(raw)} is not in ` +
+            '"<file>:<line>" form — a range or suffix makes the anchor unresolvable ' +
+            'and it would be skipped without this error'
+        );
+        success = false;
+      }
+
+      // Hunk-ordering guard (#1856,残件 2). Overlapping hunks make the merged
+      // new-side view last-write-wins, so an anchor into the earlier hunk is
+      // validated against the later hunk's text and passes for the wrong reason.
+      for (const issue of orderIssues) {
+        console.error(
+          `❌ ${fixtureRel}: hunk "${issue.current}" of ${issue.file} overlaps the ` +
+            `new-side range ${issue.previousRange} already covered by "${issue.previous}" — ` +
+            "the later hunk overwrites the earlier hunk's reconstructed lines, so an " +
+            'anchor into the earlier hunk resolves to the wrong text'
+        );
+        success = false;
+      }
 
       for (const line of unknownPrefixLines) {
         console.error(

--- a/tests/validate-fixture-diff-structure.test.mjs
+++ b/tests/validate-fixture-diff-structure.test.mjs
@@ -22,6 +22,8 @@ import {
   parseUnifiedDiff,
   parseFixtureDiffs,
   extractFixtureAnchors,
+  extractMalformedAnchors,
+  normalizeDiffPath,
 } from '../scripts/validate-skills.mjs';
 import { createTempDirAsync } from './helpers/temp-dir.mjs';
 
@@ -223,6 +225,199 @@ ${ANCHORED(3)}
   assert.ok(errors.some((e) => /2 hunk header\(s\) in the file but only 1 inside/.test(e)));
 });
 
+// --- #1856,残件 1: notation that carries no `@@` header at all --------------
+//
+// The #1854 surplus check compares countHunkHeaders() against the number of
+// hunks inside a recognized fence. When the diff has no `@@` at all, both sides
+// are 0 and the check is blind — the block is recognized, carries real changes,
+// and contributes nothing an anchor can resolve against.
+
+test('fails when a recognized diff block has +/- lines but no @@ header', async () => {
+  const body = ['+++ b/docs/note.md', '+# Note', '-old line'].join('\n');
+  const { ok, errors } = await runGate({ '01-no-hunk-header.md': FIXTURE(body, ANCHORED(1)) });
+  assert.equal(ok, false);
+  assert.ok(
+    errors.some((e) => /block #1 has \+\/- lines but no .*hunk header/.test(e)),
+    errors.join('\n')
+  );
+});
+
+test('fails on a bare +/- excerpt with neither a +++ header nor a @@ header', async () => {
+  const body = ['-const timeout = 30;', '+const timeout = undefined;'].join('\n');
+  const { ok, errors } = await runGate({
+    '01-bare-excerpt.md': FIXTURE(body, 'findings: []'),
+  });
+  assert.equal(ok, false);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /block #1 has \+\/- lines but no/);
+});
+
+// An intentionally empty ```diff block is a legitimate fixture shape — see
+// skills/upstream/plangate-exec-conformance/fixtures/03-fallback-diff-empty.md,
+// which feeds an empty diff to assert a NO_REVIEW verdict. The guard above must
+// not reach it, so the trigger is "+/- content lines present", not "no header".
+test('accepts an intentionally empty diff block (no +/- lines)', async () => {
+  const { ok, errors } = await runGate({ '01-empty-diff.md': FIXTURE('', 'findings: []') });
+  assert.equal(ok, true, errors.join('\n'));
+  assert.deepEqual(errors, []);
+});
+
+test('fails when an anchor uses the unresolvable range form path:1-5', async () => {
+  const yamlBlock = `findings:
+  - severity: major
+    reason: range anchors are silently dropped by RE_ANCHOR
+    anchor: docs/note.md:1-5`;
+  const { ok, errors } = await runGate({ '01-range-anchor.md': FIXTURE(DIFF_BODY, yamlBlock) });
+  assert.equal(ok, false);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /"docs\/note\.md:1-5" is not in "<file>:<line>" form/);
+});
+
+test('a pseudo-anchor with no line number stays exempt', async () => {
+  const yamlBlock = `findings:
+  - severity: major
+    reason: whole-diff observation
+    anchor: (summary)`;
+  const { ok, errors } = await runGate({ '01-pseudo-anchor.md': FIXTURE(DIFF_BODY, yamlBlock) });
+  assert.equal(ok, true, errors.join('\n'));
+  assert.deepEqual(errors, []);
+});
+
+test('extractMalformedAnchors reports only file-naming anchors of the wrong shape', () => {
+  const text = `<!-- expected:
+findings:
+  - anchor: src/a.ts:12
+  - anchor: (summary):1
+  - anchor: (summary)
+  - anchor: src/a.ts:3-9
+  - anchor: src/a.ts
+  - reason: no anchor at all
+-->`;
+  assert.deepEqual(extractMalformedAnchors(text), ['src/a.ts:3-9', 'src/a.ts']);
+});
+
+// --- #1856,残件 2: overlapping / out-of-order hunks --------------------------
+//
+// parseFixtureDiffs merges every block into one new-side view, last write wins.
+// Two hunks covering the same new-side line therefore leave only the later
+// hunk's text behind, and an anchor into the earlier hunk passes against
+// content it never named.
+
+const TWO_BLOCK_FIXTURE = (firstHeader, secondHeader) => `# Fixture
+
+\`\`\`diff
+--- a/docs/note.md
++++ b/docs/note.md
+${firstHeader}
++alpha
++beta
+\`\`\`
+
+\`\`\`diff
+--- a/docs/note.md
++++ b/docs/note.md
+${secondHeader}
++gamma
+\`\`\`
+
+<!-- expected:
+findings: []
+-->
+`;
+
+test('fails when two hunks of one file overlap on the new side', async () => {
+  const { ok, errors } = await runGate({
+    '01-overlap.md': TWO_BLOCK_FIXTURE('@@ -0,0 +1,2 @@', '@@ -0,0 +2,1 @@'),
+  });
+  assert.equal(ok, false);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /overlaps the new-side range 1\.\.2/);
+  assert.match(errors[0], /docs\/note\.md/);
+});
+
+// Non-ascending starts are the same defect seen from the other side: a hunk
+// that starts before the preceding one always lands inside the preceding
+// range, so the overlap comparison reports it.
+test('fails when a later hunk of one file starts before the preceding one', async () => {
+  const { ok, errors } = await runGate({
+    '01-descending.md': TWO_BLOCK_FIXTURE('@@ -0,0 +10,2 @@', '@@ -0,0 +3,1 @@'),
+  });
+  assert.equal(ok, false);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /overlaps the new-side range 10\.\.11/);
+});
+
+test('accepts ascending, non-overlapping hunks of one file across two blocks', async () => {
+  const { ok, errors } = await runGate({
+    '01-ascending.md': TWO_BLOCK_FIXTURE('@@ -0,0 +1,2 @@', '@@ -0,0 +9,1 @@'),
+  });
+  assert.equal(ok, true, errors.join('\n'));
+  assert.deepEqual(errors, []);
+});
+
+// A pure-deletion hunk contributes an empty new-side range, so the next hunk
+// may legitimately start at the same new-side line. Flagging that would be a
+// false positive on ordinary deletion diffs.
+test('accepts a pure-deletion hunk followed by a hunk at the same new-side line', () => {
+  const text = [
+    '```diff',
+    '+++ b/a.txt',
+    '@@ -4,2 +3,0 @@',
+    '-gone one',
+    '-gone two',
+    '@@ -8,1 +3,2 @@',
+    ' kept',
+    '+added',
+    '```',
+  ].join('\n');
+  assert.deepEqual(parseFixtureDiffs(text).orderIssues, []);
+});
+
+// --- #1856,残件 3: anchor path normalization ---------------------------------
+
+test('resolves an anchor written as ./path against a +++ b/path header', async () => {
+  const yamlBlock = `findings:
+  - severity: major
+    reason: dot-slash prefix must not read as a different file
+    anchor: ./docs/note.md:3`;
+  const { ok, errors } = await runGate({ '01-dot-slash.md': FIXTURE(DIFF_BODY, yamlBlock) });
+  assert.equal(ok, true, errors.join('\n'));
+  assert.deepEqual(errors, []);
+});
+
+// Proves the normalization resolved the file rather than skipping the anchor:
+// line 2 of the same file is blank, so the blank-line error must still fire.
+// The fixture name deliberately avoids the words the assertions match on —
+// every error line embeds the fixture path, so a name like `01-dot-slash-blank`
+// would satisfy /blank/ no matter which error was produced.
+test('a normalized anchor is still checked for the blank-line defect', async () => {
+  const yamlBlock = `findings:
+  - severity: major
+    reason: normalization must not turn into a skip
+    anchor: ./docs/note.md:2`;
+  const { ok, errors } = await runGate({ '01-dotted-empty.md': FIXTURE(DIFF_BODY, yamlBlock) });
+  assert.equal(ok, false);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /that line is blank/);
+});
+
+test('normalizeDiffPath strips ./ and collapses . and .. segments', () => {
+  assert.equal(normalizeDiffPath('./docs/note.md'), 'docs/note.md');
+  assert.equal(normalizeDiffPath('docs/./note.md'), 'docs/note.md');
+  assert.equal(normalizeDiffPath('docs/sub/../note.md'), 'docs/note.md');
+  assert.equal(normalizeDiffPath('docs/note.md'), 'docs/note.md');
+});
+
+test('extractFixtureAnchors returns the normalized file', () => {
+  const text = `<!-- expected:
+findings:
+  - anchor: ./docs/note.md:3
+-->`;
+  assert.deepEqual(extractFixtureAnchors(text), [
+    { raw: './docs/note.md:3', file: 'docs/note.md', line: 3 },
+  ]);
+});
+
 test('countHunkHeaders ignores headers carrying a diff-body prefix', () => {
   assert.equal(
     countHunkHeaders(
@@ -265,14 +460,19 @@ test('skips non-file:line anchors such as the (summary) pseudo-anchor', async ()
  * this gate can lose its real input — breaking RE_DIFF_FENCE, adding a path
  * filter, renaming the `fixtures/` directory, changing the `.md` filter —
  * leaves `ok: true` with the counters at 0. Measured on this commit:
- * 198 fixtures / 250 hunks / 100 anchors (`npm run skills:validate` prints the
+ * 200 fixtures / 258 hunks / 101 anchors (`npm run skills:validate` prints the
  * same three numbers). The floors sit ~20% below that, which
  *
  * - fails on every collapse mode above (all of them drive the counters to 0);
  * - fails if either large tier stops being scanned (midstream = 122 fixtures /
- *   155 hunks, upstream = 57 fixtures / 64 hunks / 83 anchors);
- * - leaves ~48 fixtures / 50 hunks / 20 anchors of headroom, so ordinary
+ *   155 hunks / 14 anchors, upstream = 59 fixtures / 72 hunks / 84 anchors);
+ * - leaves 50 fixtures / 58 hunks / 21 anchors of headroom, so ordinary
  *   fixture churn does not fail the suite for no reason.
+ *
+ * #1856: re-measured after #1875 added 2 fixtures. The values stay as they are —
+ * coverage grew, so the floors are further from the ceiling, and each property
+ * above still holds (dropping midstream leaves 78 fixtures < 150; dropping
+ * upstream leaves 141 fixtures < 150, 186 hunks < 200, 17 anchors < 80).
  *
  * RAISE these when coverage grows. Lowering one is only correct alongside a
  * deliberate, explained removal of fixtures — never to make a red suite green.


### PR DESCRIPTION
closes #1856

#1854 で導入した fixture 構造ゲートが「黙ってスキップする／誤って素通りする」3 クラスを検査対象に加える。変更は `scripts/validate-skills.mjs` と `tests/validate-fixture-diff-structure.test.mjs` の 2 ファイルのみ。`src/**` は無変更（`git status --porcelain` を後掲）。

## 1. `@@` を持たない記法揺れ（issue 残件 1 / major）

#1854 の超過ヘッダ検査は `countHunkHeaders(file)` と「認識済みブロック内の hunk 数」を比べる。`@@` が 1 つも無い diff では両辺が 0 になるため構造的に検出できない。2 つの入口を塞いだ。

- **ヘッダ無し diff ブロック**: `parseFixtureDiffs` が、`+`/`-` の**内容行**を持つのに hunk が 0 件のブロックを `headerlessBlocks` として返し、ゲートがエラー化する。`+++ b/x` も無い素の ± 抜粋もここで落ちる。
  - 判定条件は「ヘッダが無い」ではなく「± の内容行がある」にした。`skills/upstream/plangate-exec-conformance/fixtures/03-fallback-diff-empty.md` は空の ```diff ブロックを意図的に持つ正当な fixture であり（`NO_REVIEW` を検証する）、これを落としてはならないため。`+++ ` / `--- ` のファイルヘッダは内容行に数えない。
- **範囲 anchor**: `extractMalformedAnchors()` を追加し、ファイル名を持つのに `<file>:<line>` 形でない anchor（`docs/note.md:1-5` など）をエラー化する。`(` 始まりの擬似 anchor（`(summary):1` / `(summary)`）は従来どおり免除。

## 2. hunk の重複・非単調（issue 残件 2 / minor）

`parseFixtureDiffs` のマージは last-write-wins なので、同一ファイルの new 側レンジが重なると後続 hunk が先行 hunk の行を上書きし、先行 hunk を指す anchor が**別の本文**に対して検証されて緑になる。`orderIssues` として検出しエラー化する。

- 比較は半開区間 `[newStart, newStart + actualNew)` の 1 本のみ。`newStart` が後退するケースは必ず先行レンジの内側か手前に入る（先行レンジは先行 `newStart` から始まるため）ので、「単調性」は「重複」の真部分集合になる。独立した単調性分岐は到達不能なので置いていない（コメントに明記）。
- 純削除 hunk（`actualNew === 0`）はレンジが空になるため、直後の hunk が同じ `newStart` から始まっても誤検出しない。この非誤検出をテストで固定した。

## 3. anchor のパス正規化（issue 残件 3 / minor）

`normalizeDiffPath()`（`path.posix.normalize` + 先頭 `./` 除去）を追加し、**diff 側（`parseUnifiedDiff` の `currentFile`）と anchor 側（`extractFixtureAnchors` の `file`）の両方**に適用する。`./docs/note.md` が `+++ b/docs/note.md` と一致するようになり、「diff に無い」という誤誘導メッセージが出なくなる。

`path.posix` を明示している。fixture の diff は unified diff であり区切りは常に `/` なので、Windows で `path.normalize` を使うと `\` に書き換えられて比較が壊れる。

## 現行 fixture 全件で違反 0 件（実測）

追加前に、3 件それぞれが現行 fixture で何件当たるかをスクラッチ計測した（`skills/**/fixtures/**.md` 220 件を走査）。

| 検査 | 該当件数 |
| --- | --- |
| ± 内容行を持つのに `@@` が無い diff ブロック | 0 |
| `@@` が無い diff ブロック（± 内容行の有無を問わず） | 1（前掲の意図的な空 diff。判定条件により対象外） |
| `<file>:<line>` 形でない anchor（`(` 始まりを除く） | 0 |
| 同一ファイルの new 側レンジの重複 | 0 |
| 同一ファイルの `newStart` の後退 | 0 |
| 正規化で綴りが変わる anchor パス | 0 |

追加後の `npm run skills:validate` も緑で、カウンタは変更前と同一（258 hunks / 101 anchors / 200 fixtures）。既存 fixture の内容修正は 1 件も行っていない。

なお **issue 本文の「現行は複数 diff ブロックを持つ fixture が 0 件」は現時点では誤り**で、#1875 が追加した `skills/upstream/plangate-plan-integrity/fixtures/04-*.md` と `05-*.md` が各 4 ブロックを持つ。ただし 4 ブロックはそれぞれ別ファイル（`pbi-input.md` / `plan.md` / `todo.md` / `test-cases.md`）を宣言するため、重複検出は発火しない（上表のとおり 0 件）。

## COVERAGE_FLOORS の判断: 据え置き

- 現在値: `{ fixtures: 150, hunks: 200, anchors: 80 }`
- 実測（本 PR 時点）: **200 fixtures / 258 hunks / 101 anchors**（#1854 当時は 198 / 250 / 100）
- tier 別実測: agent-skills 7/8/0、downstream 12/23/3、midstream 122/155/14、upstream 59/72/84

カバレッジは増えており、下限は天井からより遠ざかっただけなので**値は据え置き**。既存コメントが謳う 2 つの性質が今も成立することを実測で確認した。

- midstream が走査から外れる → 78 fixtures < 150 で fail
- upstream が走査から外れる → 141 fixtures < 150、186 hunks < 200、17 anchors < 80 で fail

コメント側の実測値（198/250/100 と旧 tier 内訳）は最新値へ更新し、再測定した旨を追記した。

## 変異検証（実測）

`tests/validate-fixture-diff-structure.test.mjs` は全 39 テスト。実装から検査を外して落ちることを 4 通りで確認した（毎回 `cp` バックアップから復元）。

| 変異 | 落ちたテスト | `# fail` |
| --- | --- | --- |
| `headerlessBlocks.push(...)` を削除 | 10, 11 | 2 |
| ゲートの `extractMalformedAnchors(content)` を空配列に置換 | 13 | 1 |
| `orderIssues` の push 条件を `false &&` で無効化 | 16, 17 | 2 |
| `normalizeDiffPath` を恒等関数に置換 | 20, 21, 22, 23 | 4 |

無変異時は `# pass 39 / # fail 0`。

### 変異検証で自分のテストの欠陥を 1 件発見して直した

`normalizeDiffPath` 恒等化のとき、当初 `# fail 3` で「正規化後も blank 検査が効く」テストだけが緑のまま残った。原因は fixture 名を `01-dot-slash-blank.md` にしていたことで、**エラー行には必ず fixture パスが埋め込まれるため `/blank/` がメッセージ本体ではなくファイル名に当たっていた**。fixture 名を `01-dotted-empty.md` に変え、判定も `/that line is blank/` に絞った結果 `# fail 4` になった。この落とし穴はテスト内コメントに残してある。

## 検証（Node 22.22.2 / worktree で `npm ci` 済み）

```
$ npm run skills:validate
✅ registry paths: 117 entry path(s) resolve to existing files
✅ registry ids: 117 entry id(s) match their SKILL.md frontmatter id
✅ fixture drift: 40 skill(s) with expected blocks consistent
✅ fixture diff structure: 258 hunk(s) and 101 anchor(s) across 200 fixture(s) consistent
✅ naming collisions: 128 identifier(s) unique after hyphen-normalization
(exit 0)

$ npm test
1..1665
# tests 3353
# suites 338
# pass 3353
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 29119.741625
(exit 0)

$ npm run lint:code
✅ code hygiene OK（duplicate-import / tmp-literal / mkdtemp-cleanup / phantom-dep）
(exit 0)

$ npm run format:check
Checking formatting...
All matched files use Prettier code style!
(exit 0)

$ npm run meta:validate
Meta consistency: OK
Doc enumerations: OK (14 spec(s) checked, 0 ignored)
Sidebar reachability: OK (91 page(s) in sidebar, 11 allowlisted)
skills catalog is up to date: pages/reference/skills-catalog.md (128 skills).
(exit 0)

$ git status --porcelain
(空 — コミット後、未追跡ファイル無し)
```

`src/**` は無変更のため `npm run build:action` は不要。

## スコープ外（本 PR では触っていない）

- 既存テスト `fails when an anchor points at a blank line`（現 124 行付近）は fixture 名 `01-blank-anchor.md` に対して `/blank/` を当てており、上で自分のテストに見つけたのと同じ「ファイル名に当たる」弱さがある。同テストは `/docs\/note\.md:2/` も検査しているため無意味ではないが、`/blank/` の側は実質的に自明。既存 fixture / 既存テストの修正はスコープ外として報告のみ。
