### PR TITLE
docs(pages): 英語版で欠落していた 5 件の節を補う

### DIFF
--- a/pages/guides/governance/skill-policy.en.md
+++ b/pages/guides/governance/skill-policy.en.md
@@ -56,6 +56,31 @@ Treat the following as stable contract; major version bump required for breaking
 - Output format (e.g., `<file>:<line>: <message>` format or meaning of `NO_ISSUES`).
 - Semantics of `severity` / `confidence` (Interpretation expected by users).
 
+## Community → First-party Promotion (`recommended: true`)
+
+A skill placed under `community/` becomes a promotion candidate once it satisfies all of the conditions below.
+
+### Promotion Criteria
+
+1. **Fixture coverage**: `fixtures/` contains `.md` fixtures for both the happy path and a false-positive case (e.g. `01-icon-button-happy.md`, `02-decorative-img-false-positive.md`).
+2. **Golden output**: a matching `golden/<name>.md` exists for every fixture (prose golden output in `Finding:` / `Evidence:` form) and the eval assertions in `eval/promptfoo.yaml` pass.
+3. **False-positive guards / Non-goals**: the skill body states its silence conditions and the cases it does not handle.
+4. **Maintainer review**: at least one maintainer listed in `CODEOWNERS` has approved. Cross-review by several maintainers is preferable, but since `CODEOWNERS` currently has a single owner (`@s977043`) this is treated as a stretch goal.
+
+> For how to run the eval and generate goldens, see `docs/runbook/community-skill-eval.md`.
+
+### How to Request Promotion
+
+1. Once the conditions are met, prefix the PR title with `[promotion-request]`.
+2. State the following in the PR body.
+   - The list of fixtures (file paths and count)
+   - The eval output (for example the path check from `scripts/run-promptfoo-eval.sh`)
+   - The false-positive guards and Non-goals, as bullets
+3. Assign a reviewer from the maintainers listed in `CODEOWNERS`.
+4. After the maintainer approves, flip `recommended: false → true` for that skill in `skills/registry.yaml` and merge the PR.
+
+> **Expected timeline**: a PR that meets the conditions is usually reviewed within two weeks. If there is no response for a long stretch, ping the maintainers on an Issue.
+
 ## Deprecation Policy
 
 - Clean up unused or duplicate skills.

--- a/pages/guides/representative-skills.en.md
+++ b/pages/guides/representative-skills.en.md
@@ -1,0 +1,153 @@
+---
+title: Representative Skills Showcase
+---
+
+This page introduces why River Review skills matter, how they work, and what output they return, using real skills that ship with the repository. Use it as a starting point when designing a new skill, or when you want a reference for how existing skills are written.
+
+For the concept of a skill itself see [Skills: The Heart of River Review](../explanation/skills.en.md), and for an index of every skill see the [Skills Catalog](../reference/skills-catalog.en.md).
+
+Each skill is walked through in the same order:
+
+1. The skill's purpose and why it was chosen
+2. An excerpt of the `SKILL.md` frontmatter
+3. The core of the review instruction
+4. An example fixture (the code it is meant to detect)
+5. A sample of the expected output
+6. The false-positive avoidance rules
+
+## Skill 1: Logging and Observability Guard
+
+Its ID is `logging-observability`, and it runs in the midstream phase.
+
+### Purpose and Why It Was Chosen
+
+This skill detects swallowed exceptions and `catch` blocks without logging, keeping the code in a state where the cause of an incident can still be traced. Swallowing exceptions buries failures silently, which is why it was picked as a representative review perspective for observability.
+
+### Frontmatter Excerpt
+
+```yaml
+id: logging-observability
+name: Logging and Observability Guard
+description: Ensure code changes keep logs/metrics/traces useful for debugging failures and regressions.
+category: midstream
+applyTo:
+  - 'src/**/*.{ts,tsx,js,jsx,mjs,cjs}'
+tags: [observability, logging, reliability, midstream]
+severity: minor
+inputContext: [diff]
+dependencies: [tracing, code_search]
+```
+
+`severity` is `minor`. Missing observability is not a defect in itself, but it lowers debuggability in production, so it is worth flagging.
+
+### The Core of the Review Instruction
+
+`prompt/system.md` looks for three things:
+
+- Whether the logs, metrics, and traces needed to trace the cause of a failure are present and not excessive
+- Whether exceptions are handled with context (a requestId, a summary of the input) instead of being swallowed
+- Whether retry / fallback / cache branches emit hit / miss / attempt signals
+
+It does not weigh in on choosing a logging platform or on detailed design. Findings stay within what the diff shows.
+
+### Example Fixture
+
+`fixtures/01-silent-catch.diff` targets an empty `catch` with neither logging nor a rethrow.
+
+```diff
++  } catch (error) {
++    // ignore
++  }
++}
+```
+
+### Expected Output Sample
+
+`golden/01-silent-catch-happy.md` pins the finding for that fixture. The golden output is written in Japanese because review comments are returned in Japanese by default:
+
+```text
+src/services/user.ts:16: 例外が握りつぶされています。障害時に原因追跡が困難になります。
+Fix: logger.error でエラーをログし、throw error で再送出するか、適切にハンドルしてください。
+```
+
+A finding takes the form `file:line: description. Fix: suggestion`. `severity` is `minor` or `major`, and `confidence` is one of high / medium / low.
+
+### False-positive Avoidance Rules
+
+The skill stays silent in these cases:
+
+- The `catch` block logs, or propagates upward with `throw` or `return Promise.reject(...)`
+- The ignore is clearly deliberate and carries a comment explaining why
+- The ignore is intentional and lives in test code
+
+`golden/02-proper-error-handling.md` pins the behavior of returning `NO_ISSUES` for code that has context-aware logging and a rethrow. A pre-execution gate additionally returns `NO_REVIEW` for diffs unrelated to observability.
+
+## Skill 2: Coverage and Failure Path Gaps
+
+Its ID is `coverage-gap`, and it runs in the downstream phase.
+
+### Purpose and Why It Was Chosen
+
+This skill detects missing tests for critical paths and failure flows in changed code. A change without tests is how regressions slip through, so it was chosen as a downstream quality gate.
+
+### Frontmatter Excerpt
+
+```yaml
+id: coverage-gap
+name: Coverage and Failure Path Gaps
+description: Find missing tests for critical paths, edge cases, and failure handling in changed code.
+category: downstream
+applyTo:
+  - 'src/**/*'
+  - 'lib/**/*'
+  - '**/*.test.*'
+  - '**/*.spec.*'
+tags: [tests, coverage, reliability, downstream]
+severity: major
+inputContext: [diff, tests]
+dependencies: [test_runner, coverage_report]
+```
+
+`severity` is `major`. A missing test on a failure flow leads straight to a regression, so it carries a higher severity than missing logging.
+
+### The Core of the Review Instruction
+
+The Rule in `SKILL.md` checks three things:
+
+- Whether both the main flow and the failure flow have tests
+- Whether error handling — exceptions, timeouts, retries — is tested
+- Whether the branches, boundary values, and fallbacks introduced by the change are covered
+
+It does not go as far as rewriting existing tests wholesale or designing chaos experiments.
+
+### Example Fixture
+
+This skill detects through heuristics rather than fixture files. The typical signals are:
+
+- A new conditional or guard was added, but no corresponding test exists
+- No assertion is visible for exception handling or an error return
+- A critical path such as authentication, billing, or data persistence lacks tests
+
+### Expected Output Sample
+
+Findings are tied to the diff and come with the evidence and the next action. Suggestions are phrased like this:
+
+```text
+新規/変更された分岐ごとに正常系・異常系のテストを追加してください（例外メッセージも検証）。
+タイムアウト/リトライ/フォールバックをモックし、意図した失敗動作を確認してください。
+```
+
+### False-positive Avoidance Rules
+
+The skill stays silent in these cases:
+
+- Existing tests already cover an equivalent failure path sufficiently
+- The change only tracks an external API spec change and adds no execution branch to in-house code
+
+A pre-execution gate returns `NO_REVIEW` for diffs that do not affect the execution path, such as comment-only or documentation-only changes.
+
+## Next Steps
+
+- When writing a new skill, see the [Skill Authoring Guide](./write-a-skill.en.md).
+- For selecting and combining skills, see [Choosing and Combining Skills](./choose-skills.en.md).
+- For schema details, see the [Skill Schema Reference](../reference/skill-schema.en.md).

--- a/pages/guides/write-a-skill.en.md
+++ b/pages/guides/write-a-skill.en.md
@@ -149,13 +149,51 @@ When adding/updating skills, leave the following in PR body:
 - `npm test`
 - Verification perspective for "False positive guards/Non-goals" (What not to say) if possible
 
+## Fixtures and the Evaluation Workflow
+
+Each skill can carry sibling directories `fixtures/` (sample input diffs) and `golden/` (expected outputs). Together they form the evaluation set that verifies the Minimum Acceptance Bar objectively.
+
+### Directory Structure
+
+```text
+skills/<phase>/<skill-id>/
+├── SKILL.md
+├── fixtures/
+│   ├── 01-true-positive-<description>.md   # Case that should be flagged
+│   └── 02-false-positive-<description>.md  # Case that should not be flagged
+├── golden/
+│   ├── 01-true-positive-<description>.md   # Expected output
+│   └── 02-false-positive-<description>.md  # Expected output (no finding)
+└── eval/
+    └── promptfoo.yaml                      # promptfoo config (optional)
+```
+
+- Name files `<numeric prefix>-<kind>-<description>.md` (e.g. `01-true-positive-undocumented-dependency.md`).
+- Keep the file names in `fixtures/` and `golden/` identical, since they are evaluated as pairs.
+- A `true-positive` case confirms that the skill returns at least one finding.
+- A `false-positive` case confirms that the skill returns no finding (or at least no unrelated finding).
+
+### Running the Evaluation
+
+```bash
+npm run eval:fixtures
+```
+
+You can also run promptfoo directly with `npx promptfoo eval`. For the full eval setup, see [repo-wide-review.en.md](./repo-wide-review.en.md).
+
+### Why Fixtures Matter
+
+Without fixtures, "does the skill really detect the diffs it should?" and "is the false-positive guard working?" can only be answered by hand. Verification of the Minimum Acceptance Bar (below) becomes reproducible only once fixtures exist.
+
+Fixtures are also mechanically enforced, not merely encouraged: `scripts/validate-skills.mjs` fails when a skill listed as `recommended: true` in `skills/registry.yaml` has neither an `eval/` nor a `fixtures/` directory next to its `SKILL.md`, and `npm run skills:validate` exits 1. The grandfathering set that used to exempt existing skills is now empty, so a new recommended skill must ship its assets from the start.
+
 ## Checklist for Adding/Changing Skills
 
 - [ ] Finding focused on 1 perspective
 - [ ] Evidence (File/Line, Diff fact) is clear
 - [ ] False positive guard (Suppression condition) exists
 - [ ] Non-goals (What not to handle) are written
-- [ ] Fixtures or minimal reproduction steps exist if possible
+- [ ] `fixtures/` and `golden/` carry true-positive / false-positive cases (required to verify the Minimum Acceptance Bar; mandatory for a `recommended: true` skill, which `npm run skills:validate` rejects without `eval/` or `fixtures/`)
 
 ## Minimum Acceptance Bar
 

--- a/pages/reference/config-schema.en.md
+++ b/pages/reference/config-schema.en.md
@@ -39,6 +39,15 @@ Place `.river-review.json` in the repository root to customize review model sett
   - `redact.entropyMinLength`: Default `24`. Minimum substring length the fallback detector considers.
 - `memory` ([#687](https://github.com/s977043/river-review/issues/687))
   - `suppressionEnabled`: `true` (default). Applies suppression entries from Riverbed Memory. Set to `false` to bypass the gate (emergency override).
+  - **`feedbackType` of a suppression entry** (`schemas/suppression-context.schema.json`):
+    - `accepted_risk`: a finding kept deliberately after weighing the risk. **The only value that passes the HIGH_SEVERITY guard** — automatic suppression of `major` / `critical` requires it (the HIGH_SEVERITY guard in `src/lib/suppression-apply.mjs`).
+    - `false_positive`: a misdetection. `major` / `critical` are blocked by the guard and are not suppressed automatically (they stay manual-handle); `minor` / `info` are suppressed automatically.
+    - `wont_fix`: a finding you decided not to fix. As with `false_positive`, `major` / `critical` are blocked by the guard.
+    - `not_relevant`: a finding with little bearing on the context of this PR or file. `major` / `critical` are blocked by the guard.
+    - `duplicate`: a reference to another entry's fingerprint. The `duplicateOfFingerprint` field can point at the referenced entry (optional in the schema, but recording it is the recommended practice). `major` / `critical` are blocked by the guard.
+  - CLI: register an entry interactively with `river suppression add`.
+    - Required flags: `--fingerprint <fp>` / `--feedback <type>` / `--rationale <text>`
+    - Optional flags: `--scope <pattern>` / `--severity <level>` / `--files <glob>` / `--expires <date>` / `--pr <num>` / `--fingerprint-algo <v1|v2>`
 - `context` ([#689](https://github.com/s977043/river-review/issues/689))
   - `reviewMode`: `tiny` / `medium` / `large`. When `budget` is omitted, the preset from `src/lib/context-presets.mjs` is applied. An explicit `budget` always wins.
   - `budget.maxTokens`: `256`–`64000`.
@@ -75,6 +84,87 @@ Place `.river-review.json` in the repository root to customize review model sett
   }
 }
 ```
+
+### Detailed Configuration Example
+
+A configuration example for the more involved sections — `security` / `memory` / `context`:
+
+```json
+{
+  "security": {
+    "redact": {
+      "enabled": true,
+      "extraPatterns": [
+        {
+          "id": "my-api-key",
+          "pattern": "MYAPP_[A-Z0-9]{32}",
+          "replacement": "[REDACTED_MYAPP_KEY]"
+        }
+      ],
+      "allowlist": ["test_token_placeholder"],
+      "denyFiles": ["config/secrets/**", "**/*.vault"],
+      "entropyThreshold": 4.5
+    }
+  },
+  "memory": {
+    "suppressionEnabled": true
+  },
+  "context": {
+    "reviewMode": "medium",
+    "budget": {
+      "maxTokens": 16000,
+      "perSectionCaps": {
+        "fullFile": 4000,
+        "tests": 2000,
+        "usages": 2000,
+        "config": 1000
+      }
+    },
+    "ranking": {
+      "enabled": true,
+      "weights": {
+        "pathProximity": 0.4,
+        "symbolUsage": 0.3,
+        "siblingTest": 0.2,
+        "commitRecency": 0.1
+      }
+    }
+  }
+}
+```
+
+An example invocation of `river suppression add`:
+
+```bash
+river suppression add \
+  --fingerprint abc123def456 \
+  --feedback accepted_risk \
+  --rationale "Intentional use of high-entropy token in test fixture" \
+  --scope "src/auth/**" \
+  --severity major
+```
+
+Expected output:
+
+```text
+Suppression entry added.
+  fingerprint : abc123def456
+  feedback    : accepted_risk
+  scope       : src/auth/**
+  severity    : major
+```
+
+`--fingerprint-algo` selects how a finding is matched. The default `v1` does not include the line number, so it suppresses findings of the same kind across the whole file. `v2` anchors the match to the line, so only the finding on that line is suppressed — but the suppression stops matching as soon as the line shifts. Stay on `v1` when you need a suppression that survives line movement.
+
+### Validation Error Examples
+
+When the Zod schema in `src/config/schema.mjs` rejects the config, errors like the following are printed.
+
+| Example error message                                                              | Cause and fix                                                                                       |
+| ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `Invalid enum value. Expected 'google' \| 'openai' \| 'anthropic', received 'xyz'` | `model.provider` is set to an unsupported value. Use one of `google` / `openai` / `anthropic`.      |
+| `Number must be less than or equal to 6` (`security.redact.entropyThreshold`)      | `entropyThreshold` must be within `3.0`–`6.0`. Change it to a value inside that range.              |
+| `Unrecognized key(s) in object: 'unknownKey'` (`security.redact`)                  | A key that does not exist in the schema was added. Check for a typo and remove the unnecessary key. |
 
 ### Operational Tips
 

--- a/pages/reference/runner-cli-reference.en.md
+++ b/pages/reference/runner-cli-reference.en.md
@@ -1,5 +1,10 @@
 # Runner CLI Reference
 
+> **Scope note**: this page covers only the `--reviewers` flag of `river run` and the validation commands.
+>
+> - For every other `river run` flag (`--phase` / `--planner` / `--dry-run` / `--output` / `--max-cost` / `--debug` / `--estimate` and so on), see **[stable-interfaces.en.md](./stable-interfaces.en.md)**.
+> - For the `river review exec` flags used in a W-check (`--artifact`, `--ensemble`, `--phase`), see the **[W-check guide](../guides/w-check.en.md)** and **[cli-review-exec-spec.en.md](./cli-review-exec-spec.en.md)**.
+
 Use the Runner CLI to validate River Review agents and skills locally or in CI.
 A lightweight Python runner outputs structured review results that follow `schemas/output.schema.json`.
 Install the required dependency with `pip install jsonschema` before running the Python example.
@@ -77,6 +82,71 @@ A cutoff is observable from:
 - Structured output (Python): `python scripts/rr_runner.py --input tests/fixtures/structured-output/sample_llm_response.json`
 
 ## Exit codes
+
+### `river run` / `src/cli.mjs`
+
+| Code | Meaning                                                                                                                     |
+| ---- | --------------------------------------------------------------------------------------------------------------------------- |
+| `0`  | Success                                                                                                                     |
+| `1`  | Runtime error, schema error, or argument error (including an unknown command and a missing or invalid option value)         |
+| `2`  | The `--warn-on` warning threshold was exceeded                                                                              |
+| `3`  | An `--gate` ESCALATE verdict, a configuration error raised by the `review` handler, or an unimplemented `review` subcommand |
+
+The exit code for argument errors (usage errors) was unified to exit 1 plus a stderr summary in #1709. Unknown commands and missing or invalid option values were unified in Slice 2. Unknown options, surplus positionals, and the value-missing paths that remained (for example `--from` / `--cases`) were unified in Slice 3. Printing the full help to stdout and exiting 0 is kept only for an explicit `--help` and for invocation with no arguments.
+
+A missing or unknown `river review` subcommand also moved to exit 1 in #1755. Exit 3 now remains for three families of cases, none of which is about how the arguments were written:
+
+- An `--gate` ESCALATE verdict
+- A configuration error detected by the `review` handler (such as `--output html`)
+- An unimplemented `review` path (`river review verify`, and `river review plan` without `--plan-only`, return exit 3 as "not implemented in Phase 3")
+
+Thanks to this unification, an option-name typo, a surplus positional, and a missing value are all detectable as exit 1 in `$?`. The **validity of the value** is checked in the parse layer for the following options.
+
+- Enumerated values: `--phase` / `--severity` / `--planner` / `--depth` / `--output` / `--format` / `--fail-on` / `--warn-on` / `--source` / `--fingerprint-algo`
+- Numeric values: `--pr` / `--threshold` / `--min` / `--max-cost`
+- Dates: `--expires` / `--month`
+
+No data write (adding a feedback or suppression entry, for instance) ever happens ahead of a usage error.
+
+`--expires` accepts only the RFC 3339 `YYYY-MM-DD` form and the date-time form. A date-only input is read as UTC midnight and normalized to a date-time when stored, because `expiresAt` in `schemas/suppression-context.schema.json` is declared `format: date-time`.
+
+Value validation does not reach every option, though. The following three paths still exit 0, so `$?` alone does not catch them.
+
+- Passing a non-existent path to `--baseline` (the regression comparison is silently skipped)
+- Passing unknown vocabulary to `--context` / `--dependency`
+- Passing an invalid value in the `RIVER_PHASE` environment variable (it silently falls back to the default `midstream`; the `--phase` CLI flag exits 1)
+
+Option values are passed **separated by a space**. The `=`-joined form such as `--output=json` is not accepted and exits 1 as an unknown option (`--run-id=<id>` is the one legacy exception). A value that contains `=` **inside** it, as in `--artifact plan=./plan.md`, is valid.
+
+The target path may be written either before or after the options on these surfaces only:
+
+- `run` / `doctor`
+- `skills` (the form without a subcommand)
+- `review` (`plan` / `exec` / `verify` / `route`)
+- `evolve aggregate` (`evolve replay` is out of scope because it takes its input from `--spec`)
+
+Within that range, `river run . --dry-run` and `river run --dry-run .` mean the same thing. Only one non-option token is read as the target path; a second one is a surplus positional and exits 1.
+
+The `review` subcommands (`plan` / `exec` / `verify` / `route`) may likewise be written before or after the options: `river review plan --plan-only` and `river review --plan-only plan` are equivalent. Forgetting the subcommand, or passing a token outside the vocabulary, exits 1.
+
+Under `review` the subcommand word does not count toward the positional budget above. `river review --plan-only plan ./sub` is accepted as one subcommand plus one path; the surplus positional starts at the third non-option token.
+
+The POSIX `--` terminator works as well. A token placed after `--` is read as a path rather than as an option or a subcommand name. Here too only the first one is taken, and a second exits 1 as a surplus positional. `river run -- .` means the same as `river run .`. `river run -- --dry-run` is treated as specifying a path named `--dry-run`, so the `--dry-run` flag does not take effect.
+
+A token after `--` must be an existing path; if it does not exist, the command exits 1. This prevents a typo such as `river evolve aggregate -- ./typo` from exiting 0 as "a successful aggregation over zero records". A bare `--` with no token after it is accepted as a no-op on every command surface.
+
+Other surfaces (`skills list` / `runs list` / `promote list` / `eval` and so on) do not take a trailing path and exit 1 with a surplus positional. Subcommands that take several non-option tokens by design — `runs diff <id1> <id2> [<id3>...]` or `promote approve <id>` — are handled separately.
+
+### `river review` / `river eval` (`runners/cli`)
+
+The commands in `runners/cli` currently collapse every error into code `1`. Code `3` never occurs.
+
+| Code | Meaning                                                         |
+| ---- | --------------------------------------------------------------- |
+| `0`  | Success                                                         |
+| `1`  | Every abnormal termination, including runtime and schema errors |
+
+### Validation script (Python)
 
 - `0`: validation completed successfully.
 - `1`: schema checks didn't pass or a schema error occurred.


### PR DESCRIPTION
closes #1842

英語版で「翻訳漏れ」ではなく**節そのものが欠落**していた 5 件を en 側へ移植する。`pages/**` のみの変更で、`src/**` と `runners/**` には触れていない。

## 埋めた節（ファイル × 節）

| ファイル | 追加した節 |
| --- | --- |
| `pages/reference/config-schema.en.md` | `memory` 配下の suppression entry `feedbackType`（5 値と HIGH_SEVERITY guard の扱い） / `river suppression add` の必須・任意フラグ / `### Detailed Configuration Example`（security・memory・context の JSON、`river suppression add` 実行例、期待出力、`--fingerprint-algo` v1・v2 の粒度説明） / `### Validation Error Examples`（Zod エラー 3 行の表） |
| `pages/reference/runner-cli-reference.en.md` | 冒頭の Scope note（`stable-interfaces` / W-check / `cli-review-exec-spec` への誘導） / `### river run / src/cli.mjs`（exit code 0–3 の表、usage error 統一の経緯、値検証対象の列挙値・数値・日付、`--expires` の RFC 3339 受理仕様、検証が及ばない 3 経路、`=` 連結形式、positional path と `--` 終端の規則） / `### river review / river eval (runners/cli)` / `### Validation script (Python)` |
| `pages/guides/write-a-skill.en.md` | `## Fixtures and the Evaluation Workflow`（ディレクトリ構造・命名・`npm run eval:fixtures`・なぜ必要か・機械的強制の説明） + チェックリスト最終行の訂正 |
| `pages/guides/governance/skill-policy.en.md` | `## Community → First-party Promotion (recommended: true)`（昇格条件 4 件 + 申請手順 4 ステップ + タイムライン注記） |
| `pages/guides/representative-skills.en.md` | **新規ファイル**（ja のみ存在していた。`.en.md` が無く `check:bilingual` が唯一 missing を報告していたページ） |

## ja / en で実態が食い違っていた箇所

### 1. `write-a-skill` のチェックリスト（en が誤り → 実装に合わせて訂正）

en は `- [ ] Fixtures or minimal reproduction steps exist if possible` で「可能なら」と読めたが、実装は強制している。

- `scripts/validate-skills.mjs:349` — `const hasAssets = entries.some((e) => e === 'eval' || e === 'fixtures');`
- 同 `:359-364` — 満たさない場合 `❌ recommended skill "<id>" has no eval/ or fixtures/ directory` を出して `success = false`（`npm run skills:validate` が exit 1）
- 同 `:29` — `const GRANDFATHERED_WITHOUT_EVAL = new Set([]);` 免除集合は空

ただし**強制の範囲は「`skills/registry.yaml` で `recommended: true` の skill」に限られ、受理されるのは `eval/` または `fixtures/` のどちらか**（`golden/` は gate の条件ではない）。issue 本文の「recommended skill に `eval/` か `fixtures/` を必須」という記述はこの実測と一致する。en 側はこの範囲どおりに書き直した（"if possible" は削除）。ja 側（`:194`）は全 skill に対する必須として書かれており、gate の実際の適用範囲より広い。**ja の修正は本 PR のスコープ外**として報告に留める。

### 2. ja のほうが新しい / 正しかった箇所（ja に合わせた）

`config-schema` の suppression 節、`runner-cli-reference` の exit code 節、`skill-policy` の昇格節、`representative-skills` 全体は ja が正。いずれも一次ソースで裏取りしてから英訳した。

- suppression のフラグ一覧 → `src/cli.mjs:63-67`（usage）と `:336` 以降の `KNOWN_OPTION_TOKENS`
- `--fingerprint-algo` の受理値 → `src/cli.mjs:225`（`SUPPRESSION_FINGERPRINT_ALGOS = ['v1', 'v2']`）
- `--expires` の RFC 3339 受理と UTC 深夜正規化 → `src/cli.mjs:814-844`
- 値検証の対象オプション → `src/cli.mjs` の `must be one of` / `must be an RFC 3339` 各分岐
- `representative-skills` が挙げる fixture / golden のファイル名 → `skills/midstream/logging-observability/{fixtures,golden}/`、`skills/downstream/coverage-gap/fixtures/` に実在

## 行数 before / after

issue と同じ形の実測（issue は `origin/main = f29b6b17` 時点、本 PR の base は `5716d652`）。

```console
$ # before（base 5716d652）
config-schema: ja=187 en=97
runner-cli-reference: ja=165 en=95
write-a-skill: ja=214 en=174
skill-policy: ja=88 en=63
representative-skills: ja=153 en=(ファイルなし)

$ # after
config-schema: ja=187 en=187
runner-cli-reference: ja=165 en=165
write-a-skill: ja=214 en=212
skill-policy: ja=88 en=88
representative-skills: ja=153 en=153
```

## 検証（実出力）

すべて Node v22.22.2（`.nvmrc` = 22.22.2）で実行。

```console
$ npm run lint:text:pages
> textlint 'pages/**/*.md'
（違反なし・exit 0。`.textlintignore` の 1 行目が `**/*.en.md` のため en ページは textlint の対象外）

$ npm run fix:dashes
No heading/title dash normalizations needed.

$ npm run format:check
Checking formatting...
All matched files use Prettier code style!

$ npm run meta:validate
Meta consistency: OK
Doc enumerations: OK (14 spec(s) checked, 0 ignored)
Sidebar reachability: OK (91 page(s) in sidebar, 11 allowlisted)
skills catalog is up to date: pages/reference/skills-catalog.md (128 skills).

$ npm test
ℹ tests 3359
ℹ suites 338
ℹ pass 3359
ℹ fail 0
ℹ duration_ms 26939.84175

$ npm run check:bilingual
📊 Summary: 102 paired, 0 missing .en.md, 0 orphaned .en.md

$ npm run build   # docusaurus build（sidebar / MDX 構文エラーの検出）
[SUCCESS] Generated static files in "build".
```

`check:bilingual` の missing はこれで 0 になった（before は `representative-skills.md` の 1 件）。英語ページは `sidebars.js` に 1 件も登録されていない運用のため、新規 `.en.md` の追加で sidebar 変更は不要（`check-sidebar-reachability.mjs` も分母を日本語ページに限定している）。

## スコープ外として残した事項（フォローアップ候補）

1. `pages/reference/config-schema.en.md:10` — `provider` の説明が `the current review pipeline is OpenAI-only (see #490)` のままで、ja（`:10`）の Anthropic 対応（#804）および実装と食い違う。同様に en の `maxTokens`（`:13`）は Anthropic クライアントが `max_tokens=4096` 固定である旨の注記を欠く。**既存節の内部ドリフトであり本 issue の「節の欠落」とは別問題**のため未修正。
2. `pages/guides/write-a-skill.en.md` 末尾 — `See pages/guides/governance/skill-policy.en.md (if exists, or Japanese version)` の "(if exists...)" は現在は不要な留保。
3. `pages/guides/representative-skills.md`（ja）が `coverage-gap` の重要な前提を落としている: `skills/downstream/coverage-gap/SKILL.md` は「既定 runner の供給コンテキストでは発火しない（`GRANDFATHERED_UNSUPPLIED_CONTEXT` 登録済み、#1606）」と明記している。en は ja と節構成を揃えるため同じ記述にしてあるが、両言語に注記を足す価値がある。
4. `write-a-skill.md`（ja）`:194` の fixtures 必須要件が、gate の実際の適用範囲（`recommended: true` の skill、`eval/` または `fixtures/`）より広い。
5. `runner-cli-reference` の H1 が ja は「`--reviewers` フラグリファレンス」、en は「Runner CLI Reference」で不一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
