### PR TITLE
docs(reference): config-schema の model.provider をレビュー経路の実態へ揃える

### DIFF
--- a/pages/reference/config-schema.en.md
+++ b/pages/reference/config-schema.en.md
@@ -7,10 +7,12 @@ Place `.river-review.json` in the repository root to customize review model sett
 ### Support Items and Defaults
 
 - `model`
-  - `provider`: `openai` (Default). The config schema also accepts `google` / `anthropic`, but the current review pipeline is OpenAI-only (see #490).
-  - `modelName`: `gpt-4o-mini` (Default)
+  - `provider`: `openai` (Default). The config schema also accepts `google` / `anthropic`, but the current review pipeline is OpenAI-only (see [#490](https://github.com/s977043/river-review/pull/490)).
+    - On the review path (`river review` and the GitHub Action), `resolveOpenAIConfig` in `src/lib/review-engine.mjs` uses `model.provider` as-is. Any other value stops the run before the LLM call and records the skip reason `provider <value> is not supported yet`. There is no `modelName`-prefix client auto-selection on this path.
+    - The multi-provider clients (OpenAI / Gemini / Anthropic) apply only to the `river skills <path>` route (`src/core/skill-dispatcher.mjs` → `src/ai/factory.mjs`). That route resolves the model name from each skill's own `model` / `modelHint` — not from `model.provider` — and picks the client by prefix (`gpt|o1` → OpenAI, `gemini` → Gemini, `claude` → Anthropic). Anthropic support was added in [#804](https://github.com/s977043/river-review/issues/804).
+  - `modelName`: `gpt-4o-mini` (Default). The schema also accepts prefixes such as `claude-sonnet-4-6` or `gemini-2.0-flash`, but `provider` is what decides whether the review path runs; changing the model name alone still skips unless `provider` is `openai`.
   - `temperature`: `0`
-  - `maxTokens`: `600`
+  - `maxTokens`: `600`. This is the value passed to the OpenAI call on the review path. The Anthropic client on the `river skills` route does not read this key; it uses the skill's own `maxTokens`, falling back to a per-model default (8192 for `claude-opus-4-7` and `claude-sonnet-4-6`, 4096 otherwise).
 - `review`
   - `language`: `ja` (Japanese) / `en` (English). Switches prompt body and output language.
   - `severity`: `normal` (Default) / `strict` / `relaxed`

--- a/pages/reference/config-schema.md
+++ b/pages/reference/config-schema.md
@@ -7,10 +7,12 @@
 ### サポート項目とデフォルト
 
 - `model`
-  - `provider`: `openai`（デフォルト）/ `google` / `anthropic`。`modelName` の prefix で実体クライアントが自動選択される（`gpt|o1` → OpenAI, `gemini` → Gemini, `claude` → Anthropic）。Anthropic 対応は [#804](https://github.com/s977043/river-review/issues/804) で追加。
-  - `modelName`: `gpt-4o-mini`（デフォルト）。例: `claude-sonnet-4-6`, `gemini-2.0-flash`。
+  - `provider`: `openai`（デフォルト）。スキーマは `google` / `anthropic` も受理する。ただしレビュー実行経路で実際に動く値は `openai` だけである（[#490](https://github.com/s977043/river-review/pull/490)）。
+    - レビュー実行経路（`river review` と GitHub Action）では、`src/lib/review-engine.mjs` の `resolveOpenAIConfig` が `model.provider` をそのまま採用する。`openai` 以外だと LLM 呼び出しに進まず、`provider <値> is not supported yet` という skip 理由が記録される。`modelName` の prefix からクライアントを自動選択する挙動は、この経路には存在しない。
+    - multi-provider クライアント（OpenAI / Gemini / Anthropic）が効くのは `river skills <path>` 経路だけである（`src/core/skill-dispatcher.mjs` → `src/ai/factory.mjs`）。同経路はモデル名を `model.provider` ではなく skill 側の `model` / `modelHint` から解決し、その prefix（`gpt|o1` → OpenAI, `gemini` → Gemini, `claude` → Anthropic）でクライアントを選ぶ。Anthropic 対応の追加は [#804](https://github.com/s977043/river-review/issues/804) である。
+  - `modelName`: `gpt-4o-mini`（デフォルト）。スキーマは `claude-sonnet-4-6` や `gemini-2.0-flash` のような prefix も受理する。ただしレビュー実行経路の可否を決めるのは `provider` であり、モデル名を差し替えても `provider` が `openai` でなければ skip される。
   - `temperature`: `0`
-  - `maxTokens`: `600`（OpenAI/Gemini 向け。Anthropic クライアントは内部で `max_tokens=4096` を固定使用する）
+  - `maxTokens`: `600`。レビュー実行経路の OpenAI 呼び出しへ渡る値である。`river skills` 経路の Anthropic クライアントはこのキーを参照せず、skill 側の `maxTokens` を使う。skill 側が未指定なら、モデル別の既定値（`claude-opus-4-7` と `claude-sonnet-4-6` は 8192、それ以外は 4096）になる。
 - `review`
   - `language`: `ja`（日本語）/`en`（英語）。プロンプトの本文と出力言語を切り替える。
   - `severity`: `normal`（デフォルト）/`strict`/`relaxed`


### PR DESCRIPTION
closes #1882

## 背景

`pages/reference/config-schema.md`（ja）の `model.provider` は「`modelName` の prefix で実体クライアントが自動選択される」と読めたが、レビュー実行経路にその挙動は無い。en 側（`the current review pipeline is OpenAI-only`）が実態に合っており、ja を en の趣旨へ揃えたうえで、両言語に 3 経路の書き分けを追加した。

## 実態を確認したコマンドと出力

レビュー経路は `openai` 以外を skip する。

```
$ grep -n "is not supported yet" -B6 src/lib/review-engine.mjs
464-
465-  const skipReason = dryRun
466-    ? 'dry-run enabled'
467-    : isOfflineMode()
468-      ? 'offline (rules-only) mode enabled'
469-      : openAIConfig.provider !== 'openai'
470:        ? `provider ${openAIConfig.provider} is not supported yet`
```

provider の解決元は `model.provider` そのもので、`modelName` の prefix は見ていない（`src/lib/review-engine.mjs:62-76`）。

```
62:function resolveOpenAIConfig(options = {}, config = defaultConfig) {
63-  const provider = config.model?.provider ?? 'openai';
64-  const modelName = options.model || ENV_DEFAULT_MODEL || config.model?.modelName;
```

prefix によるクライアント選択は `src/ai/factory.mjs:111-140` にあり、入力は `model.modelName` ではなく skill 側のモデル名である（`src/core/skill-dispatcher.mjs:16-22`, `:139-144`）。

```
111:  static create({ modelName, temperature, maxTokens, disableCache }) {
124-    if (modelName.startsWith('gemini')) {
127-    } else if (modelName.match(/^(gpt|o1)/)) {
130-    } else if (modelName.startsWith('claude')) {
```

呼び出し元は `src/cli/commands/skills.mjs`（`river skills <path>`）のみ。`src/lib/llm-pipeline.mjs:11-16` も factory を統合対象外と明記している。

スキーマの受理値（`src/config/schema.mjs:5`）:

```
5:  provider: z.enum(['google', 'openai', 'anthropic']).optional(),
```

## ja に書き分けた 3 経路

1. **config schema が受理する値**: `openai` / `google` / `anthropic`
2. **レビュー実行経路（`river review` / GitHub Action）が実際に使える値**: `openai` のみ。それ以外は LLM 呼び出しに進まず、`provider <値> is not supported yet` が skip 理由として記録される。prefix による自動選択はこの経路に存在しない
3. **multi-provider クライアントが効く経路**: `river skills <path>`（`skill-dispatcher` → `ai/factory`）。モデル名は `model.provider` ではなく skill 側の `model` / `modelHint` から解決され、その prefix でクライアントが選ばれる

## en を変更したか

**変更した。ただし「en が誤っていたから」ではなく、ja に足した 3 経路の書き分けを en にも同じ粒度で足したもの。** 既存の `the current review pipeline is OpenAI-only (see #490)` という判断は正しいのでそのまま残し、`#490` を PR リンクに、`maxTokens` と `modelName` の説明を ja と同粒度に揃えた。

## issue 参照の確認

番号を写すのではなく実体を確認した。

- `#490` = **PR** `fix(docs): clarify that review pipeline is OpenAI-only`（MERGED）。en の記述の出典として妥当なので残し、`/pull/490` のリンクを付けた
- `#804` = issue `feat: src/ai/factory.mjs に Anthropic (Claude) プロバイダーサポートを追加`（CLOSED）。factory＝skills 経路の話なので、ja では「review の provider の話」から「skills 経路の Anthropic 対応の追加」へ位置づけを変えて残した

## 併せて訂正した点（issue 本文に無かったもの）

ja の `maxTokens` は「Anthropic クライアントは内部で `max_tokens=4096` を固定使用する」と書いていたが、現在の実装は固定ではない。`src/ai/factory.mjs:83-86` の `resolveAnthropicMaxTokens` は skill 側の明示値を優先し、無指定時はモデル別既定（`claude-opus-4-7` / `claude-sonnet-4-6` は 8192、それ以外は 4096）へフォールバックする。この点も両言語で修正した。

## 検証（すべて exit 0）

| コマンド | exit |
| --- | --- |
| `npx textlint --no-cache pages/reference/config-schema.md` | 0 |
| `npm run lint:text:pages` | 0 |
| `npm run fix:dashes` | 0（`No heading/title dash normalizations needed.`） |
| `npm run format:check` | 0（`All matched files use Prettier code style!`） |
| `npm run meta:validate` | 0 |
| `npm test` | 1 回目 0（`# pass 3379 / # fail 0`）、2 回目は既知の flake で 1 |

`npm test` の 2 回目は `tests/validate-fixture-drift.test.mjs` と `tests/validate-registry-id-match.test.mjs` が `uncaughtException: Unable to deserialize cloned data due to invalid or unsupported version.`（node test runner の IPC 起因）で落ちた。assertion 失敗ではなく、当該 2 ファイルの単独再実行は `# pass 16 / # fail 0`（exit 0）。

`src/**` は未変更のため `build:action` は不要（`git status --porcelain` は `pages/reference/config-schema.md` と `pages/reference/config-schema.en.md` の 2 件のみ）。
