### PR TITLE
docs: 転記事故の非頻度属性と不変条件テストの検査対象をチェック観点へ追記する

### DIFF
--- a/docs/development/heuristic-detector-checklist.md
+++ b/docs/development/heuristic-detector-checklist.md
@@ -59,6 +59,7 @@
 
 - [ ] `tests/heuristic-review.test.mjs` に **検出される** ケースを追加する。
 - [ ] **検出されない** ケースを追加する: コメント内の言及 / 行末コメント / 安全な異形（例: `execFile(cmd, [args])` / `setTimeout(() => ...)` / `@ts-expect-error`）/ 条件を満たさない設定（`=1`）。
+- [ ] **不変条件を守るテストは、宣言の対象ではなく実権限の所在を検査する**。「X が Y を変更してはならない」をソース文字列の走査で検査すると、X が持つ間接的な権限（別モジュールへの委譲・動的キー・文字列連結）を素通りする。守りたいのが結果なら結果を測る。対象を全列挙し、同一入力を本番経路へ通して出力が一致することを assert する。ファイル列挙は再帰で行い、列挙結果そのものをパスで pin する（件数ではなくパスで pin すると、走査漏れと新規追加を区別できる）。実例は `tests/prompt-compiler-invariants.test.mjs`。当初は profile のソース文字列だけを非再帰に走査しており、判断側の語を 1 つも含まない profile から `rendererId` 経由で severity を書き換える形が通った（#1867 の `6df05ab7` で振る舞い検査へ移した）。§6 の drift guard canary も、期待値を `SKILL.md` から導出して本番と同じ `minimatch` へ通す点で同じ型にあたる。
 - [ ] `node --test tests/heuristic-review.test.mjs` で確認後、`npm test` で全体を確認する。
 
 ## 8. dist 再ビルド（必須）

--- a/docs/development/worker-discipline-template.md
+++ b/docs/development/worker-discipline-template.md
@@ -102,6 +102,15 @@
 
 「失敗するか」の検証は「常に失敗するか」の検証にならない。事象の再現は頻度の検証ではなく、1 回の再現から「常に」は導けない。頻度を報告や成果物へ書くなら、条件ごとに複数回測って「N 回中 M 回」の形にする。検証していない修飾語は落とすか実測値へ置き換え、委託プロンプトの頻度表現をそのまま成果物へ転記しない。
 
+同じ転記事故は頻度以外の属性でも起きる。委託文へ書く**件数・対象の実在・修正案の有効性**は、issue 本文に書いてあってもオーガナイザー側で数え直してから写す。issue 本文は起票時点の要約であって一次ソースではない。2026-08-18 のセッションでは、委託文が引いた issue の記述と実測が食い違う事例が 4 件出ている。
+
+- 「同ディレクトリの 3 ページが末尾に関連ページ節を持つ」→ 実際に持つのは `concept` と `human-judgment-focus` の 2 系統（ja / en 各 1 で 4 ファイル）で、`design-philosophy` には無い（#1829 / PR #1893）
+- reference 側の候補として 3 ページを列挙 → `pages/reference/` には `skill-metadata.md` を含む 4 ページが実在した（#1829 / PR #1893）
+- 「未マッチの findingFingerprint は `shadowOnly` に落ちるので安全側」→ `shadowOnly` が立つのは fingerprint を持たない行だけ（`src/lib/promotion-candidates.mjs:641`）。未マッチ行は落ちずに別 candidate を生成する（#1823 / PR #1883）
+- issue に書いた対応候補そのものが no-op → 代入先は同じ関数内で組まれた直後のオブジェクトであり、マージしても左辺に既存キーが無い（#1868 / PR #1871）
+
+4 件はいずれもワーカーの実測による訂正のほうが正しく、提出前の成果物へ反映されている。ワーカー側では、委託文が引いた issue の記述も一次ソース確認の対象に含める。
+
 ### gh アカウント guard
 
 `gh` の keyring には `s977043`（本リポジトリ用）と `kominem-unilabo`（別業務用）の2アカウントを登録している。アクティブアカウントはセッション中に無言で切り替わることがある（複数回観測済み）。PreToolUse hook（`.claude/hooks/gh-account-guard.sh`）は defense-in-depth として効く。ただし hook が効かない環境（ワーカーの worktree で `.claude/settings.json` の hook 設定が引き継がれない場合等）もあり得るため、プロンプト側にも明示する。詳細: CLAUDE.md「Verify gh active account before write ops」。


### PR DESCRIPTION
振り返りから抽出したチェック観点 2 件を追記する。対応する issue が無いため `closes` は使わない。触ったのは `docs/development/worker-discipline-template.md` と `docs/development/heuristic-detector-checklist.md` の 2 ファイルのみ。

## 追記 1: `worker-discipline-template.md`「確認の対象には、頻度・範囲の修飾語そのものも含める」の直後

**既存項目の拡張**（新規節ではない）。既存段落（`:101-103`、2026-08-13 の `count-in-clean-tree.sh` の「常に」）は頻度の修飾語だけを扱っている。同じ転記事故が頻度以外の属性でも起きることを、「同じ転記事故は頻度以外の属性でも起きる」という接続で足した。趣旨は、委託文へ書く**件数・対象の実在・修正案の有効性**を、issue 本文に書いてあってもオーガナイザー側で数え直してから写す、というもの。

重複チェック（`git grep -n "件数\|実在\|修正案" -- docs/development/worker-discipline-template.md`）:

- `:77` — 報告数値を実出力から転記する（ワーカーの**報告**が対象。委託文の作成側は対象外）
- `:95` / `:97` — ワーカーが委託文の前提を一次ソースで確認する（**受け取る側**の規律）。`:97` に「この値は N 件」の例示がある

新段落はこれらと向きが違い、**委託文を書く側が写す前に数え直す**という点を扱う。したがって既存項目の削除・置換はせず、直後への追加とした。ワーカー側の受け皿として「委託文が引いた issue の記述も一次ソース確認の対象に含める」を 1 文だけ足し、`:95`/`:97` の記述は繰り返していない。

コピペ用テンプレート本体（`:13-89`）は変更していない。第 1 項目が既に「前提・数値」を対象に含んでおり、件数はそこへ収まる。

## 追記 2: `heuristic-detector-checklist.md` §7（テスト）にチェック項目 1 件

**新規項目**。既存書式（`- [ ] **太字の要点**: 説明`）に合わせ、§7 の 2 項目目と 3 項目目の間へ挿入した。趣旨:

> 不変条件を守るテストは、宣言の対象ではなく実権限の所在を検査する。ソース文字列の走査は、間接的な権限（別モジュールへの委譲・動的キー・文字列連結）を素通りする。対象を全列挙し、同一入力を本番経路へ通して出力が一致することを assert する。ファイル列挙は再帰で行い、列挙結果そのものをパスで pin する。

重複チェック（`git grep -n "実権限\|列挙結果\|再帰" -- docs/development/heuristic-detector-checklist.md docs/development/worker-discipline-template.md` → 0 件、`git grep -rn "振る舞い" -- docs/development/` → 該当なし）。§6 の drift guard canary が同じ型（期待値を `SKILL.md` から導出し本番と同じ `minimatch` へ通す）にあたるため、重複でなく関連であることを 1 文で明示した。§7 の既存 2 項目は検出器の positive / negative ケースの話で、不変条件テストの設計は扱っていない。

## 出典として引用した事例の裏取り

委託文が挙げた 4 件を一次ソースで確認した。**4 件とも裏が取れた**ので、いずれも落とさず引いた。

| # | 主張 | 裏取り | 結果 |
| --- | --- | --- | --- |
| 1 | 「3 ページが関連ページ節を持つ」→ 実際は 2 系統 4 ファイル | issue #1829 本文 `## 3.` に「`concept.md` / `human-judgment-focus.md` / `design-philosophy.md` はいずれも末尾に『関連ページ / Related pages』を持つ」。`grep -ln "関連ページ\|Related pages" pages/explanation/{concept,human-judgment-focus,design-philosophy}{,.en}.md` → `concept.md` / `concept.en.md` / `human-judgment-focus.md` / `human-judgment-focus.en.md` の 4 ファイルのみ | ✅ |
| 2 | 「reference 候補は 3 ページ」→ 4 ページ実在 | issue #1829 `## 4.` が `skill-schema.md` / `skill-schema-reference.md` / `metadata-fields.md` の 3 つを列挙。`ls pages/reference/skill-metadata.md` → 実在（4 ページ目） | ✅ |
| 3 | 「未マッチ fingerprint は `shadowOnly` に落ちるので安全側」→ 落ちず別 candidate を生成 | issue #1823 `:15-17` に「恒久的に未マッチとなり `shadowOnly` に落ちる」「安全側の挙動ではあるが」。`grep -n "shadowOnly" src/lib/promotion-candidates.mjs` → `:641 shadowOnly: fingerprintless`（fingerprint を持つ行では立たない）。PR #1883 本文が 3 行の実測表で別 `candidateId` の生成を示している | ✅ |
| 4 | issue に書いた修正案そのものが no-op | PR #1871 本文「Issue の対応候補を採らなかった理由（実測）」。変異 B（issue の候補を適用）が変異 A（未修正）と同一の `# pass 1 / # fail 5` になり、no-op を実証している | ✅ |

追記 2 の出典も確認した。委託文は「PR #1867 の不変条件テストは profile のソース文字列しか見ておらず……現在の実装は `tests/prompt-compiler-invariants.test.mjs`」としていたが、**より正確には PR #1867 の中で訂正されている**（マージ後の別 PR ではない）。

- `git log --follow -- tests/prompt-compiler-invariants.test.mjs` → コミット 1 本（`10aa7dc1`、PR #1867 のスカッシュ）
- `gh api repos/:owner/:repo/pulls/1867/commits` → PR 内に `6df05ab7 test(prompt): 不変条件の検査を振る舞いベースへ移し、抜け道を塞ぐ` がある
- `git show 6df05ab7^:tests/prompt-compiler-invariants.test.mjs` → 当初版は `listSources`（**非再帰**）でソース走査 + export 値の `JSON.stringify` 照合のみ。振る舞い検査は無い
- `grep -rn "rendererId" src/prompt/` → `profiles/generic.mjs:15` / `profiles/openai.mjs:15` が `rendererId` を持ち、`compiler.mjs:33` が `RENDERERS[profile?.rendererId]` を引く。判断側の語を含まない profile から renderer を差し替える経路が実在する
- `6df05ab7` のコミットメッセージ: 「不変条件テストが 6 通りの違反を素通りさせることが判明した。実装（production code）に誤りは無く、検査側だけを直す」

本文では「当初は……（#1867 の `6df05ab7` で振る舞い検査へ移した）」と書き、PR 番号だけでなく訂正コミットを併記して、マージ後の別作業と誤読されないようにした。

## 検証（すべて exit 0）

Node は `/opt/homebrew/opt/node@22/bin`（v22.22.2）。worktree で `npm ci` 済み。

```
$ npx textlint --no-cache -c tools/textlint/docs.textlintrc.json \
    docs/development/worker-discipline-template.md docs/development/heuristic-detector-checklist.md
(出力なし)

$ npm run lint:text:docs
> textlint -c tools/textlint/docs.textlintrc.json 'docs/**/*.md' 'README*.md'
(違反なし)

$ npm run fix:dashes
No heading/title dash normalizations needed.

$ npm run format:check
Checking formatting...
All matched files use Prettier code style!

$ npm run meta:validate
Meta consistency: OK
Doc enumerations: OK (15 spec(s) checked, 0 ignored)
Sidebar reachability: OK (91 page(s) in sidebar, 11 allowlisted)
skills catalog is up to date: pages/reference/skills-catalog.md (128 skills).

$ npm test
ℹ tests 3396
ℹ suites 344
ℹ pass 3396
ℹ fail 0
```

`Doc enumerations` は 15 spec すべて OK。`grep -n "docs/development" scripts/check-doc-enumerations.mjs` の実測では、機械照合されているのは `guard-ledger.yaml` / `pipeline-params-checklist.md` / `distributed-commands.md` で、本 PR の 2 ファイルは対象外。件数宣言のずれは発生していない。

`src/**` は触っていないため `npm run build:action` は不要。

```
$ git status --porcelain
(空)
```
