### PR TITLE
fix(scripts): dist に焼き込まれる作業ディレクトリ名を正規化する

### DIFF
--- a/docs/development/dist-check-rebuild-guide.md
+++ b/docs/development/dist-check-rebuild-guide.md
@@ -77,6 +77,34 @@ git add runners/github-action/dist/
 git commit -m "chore(action): rebuild github-action dist"
 ```
 
+## 作業ディレクトリ名の焼き込み（worktree での rebuild）
+
+ncc は relocate した asset を「ビルドルートの親」からの相対パスで解決します。その結果、bundle 内の asset 参照 `__webpack_require__.ab + "<ディレクトリ名>/"` と、生成される `dist/<ディレクトリ名>/` の両方に、ビルド時の作業ディレクトリ名が焼き込まれます。
+
+CI の checkout 先はリポジトリ名と同じ `river-review` です。agent worktree は `.claude/worktrees/agent-<id>/` に作られるため、そこで rebuild すると同一 src からでも CI と異なるバイト列になります（#1894 で実際に発生）。
+
+### 検出
+
+```bash
+git grep -n '__webpack_require__.ab + "' -- runners/github-action/dist
+find runners/github-action/dist -maxdepth 1 -type d
+```
+
+- 前者の出力に `river-review/` 以外のディレクトリ名が混じっていれば焼き込みである
+- 後者に `runners/github-action/dist/river-review` 以外のディレクトリが出た場合も原因は同じである
+
+### スクリプトが自動で行うこと
+
+`build:action` の第 2 段である `scripts/normalize-dist.mjs` が、rebuild のたびに次を実行します。
+
+- `package.json` の `name` を正規名とし、`__webpack_require__.ab` 直後の asset 参照だけを正規名へ書き換える
+- `dist/<作業ディレクトリ名>/` を `dist/<正規名>/` へ移す（正規名のディレクトリが既にある場合は統合する）
+- 作業ディレクトリ名が正規名と一致するときは何もしない（`river-review` という名前の checkout では no-op）
+
+### 手で直す場合
+
+上記と同じ 2 つの変換を適用します。`river-review` という文字列はパッケージ名・URL・vendored パスにも現れるので、一括置換は避けて `__webpack_require__.ab` 直後の該当箇所だけを書き換えてください。asset ディレクトリは `mv runners/github-action/dist/<作業ディレクトリ名> runners/github-action/dist/river-review` で移します。
+
 ## いつ rebuild が必要か
 
 以下のいずれかを触った場合:
@@ -102,6 +130,7 @@ git commit -m "chore(action): rebuild github-action dist"
 | rebuild しても差分が残り続ける                                                  | `node_modules` が stale                                             | `npm ci` で依存再解決後に `npm run build:action`                                  |
 | `index.mjs.map` のみの大量差分                                                  | sourcemap の決定論性問題                                            | Node を `.nvmrc` に揃えれば通常解消                                               |
 | merge 後に rebuild したのに dist に差分が出ない（stale なのに clean に見える）  | `git merge` で依存が更新されたのに `node_modules` が merge 前のまま | `git merge origin/main` の**後**に `npm ci` を実行してから `npm run build:action` |
+| dist に `river-review/` 以外のディレクトリ名が現れる                            | worktree など checkout 名が `river-review` でない場所で build した  | `npm run build:action` が自動で正規化する（詳細は本書の作業ディレクトリ名の節）   |
 
 ## 関連
 

--- a/scripts/normalize-dist.mjs
+++ b/scripts/normalize-dist.mjs
@@ -1,21 +1,105 @@
 #!/usr/bin/env node
-// Normalize line endings in the GitHub Action dist to LF.
-// ncc bundles tslib and other deps with CRLF on some platforms;
-// this ensures cross-platform deterministic output.
-import { readFileSync, writeFileSync, readdirSync } from 'fs';
-import { join } from 'path';
+// Normalize the GitHub Action dist so its bytes depend only on the sources,
+// never on the machine or the directory the build happened to run in.
+//
+// Two normalizations run here:
+//
+//   1. Line endings -> LF. ncc bundles tslib and other deps with CRLF on some
+//      platforms; this ensures cross-platform deterministic output.
+//   2. Build-directory name -> the canonical checkout name (see below).
+import {
+  readFileSync,
+  writeFileSync,
+  readdirSync,
+  existsSync,
+  renameSync,
+  cpSync,
+  rmSync,
+} from 'fs';
+import { basename, join } from 'path';
+import { fileURLToPath } from 'url';
 
-const distDir = new URL('../runners/github-action/dist', import.meta.url).pathname;
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+const distDir = join(repoRoot, 'runners/github-action/dist');
+
+// --- 2. build-directory name -------------------------------------------------
+//
+// ncc resolves relocated assets relative to the PARENT of the build root, so
+// both the emitted asset directory (dist/<name>/...) and the asset references
+// inside the bundle (`__webpack_require__.ab + "<name>/..."`) are prefixed with
+// `basename(repoRoot)`. The committed dist was therefore built in a directory
+// named after the repository, which is what `actions/checkout` produces in CI.
+// A build run from a git worktree such as `.claude/worktrees/agent-<id>/` bakes
+// that directory name in instead, and `Action dist freshness` then reports a
+// diff for a bundle whose sources did not change (observed in #1894).
+//
+// The canonical name is read from package.json `name` rather than hardcoded,
+// so a repository rename only has to be applied in one place. It is not read
+// from the git remote: the build must also work from a source tarball or a CI
+// cache where no git metadata is present, and a remote can be renamed or
+// missing without the checkout directory changing.
+const canonicalName = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8')).name.replace(
+  /^@[^/]+\//,
+  ''
+);
+const buildDirName = basename(repoRoot.replace(/[/\\]+$/, ''));
+
+// Only the ncc asset-prefix expression is rewritten, never a bare occurrence of
+// the directory name. The repository name also appears in the bundle as a
+// package name, as a URL, and inside vendored source paths such as
+// `skills/agent-skills/river-review/...`; a plain string replacement would
+// corrupt those. Anchoring on `__webpack_require__.ab` restricts the rewrite to
+// strings ncc itself generated for asset resolution.
+const escapeRegExp = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const assetPrefixPattern = new RegExp(
+  `(__webpack_require__\\.ab\\s*\\+\\s*")${escapeRegExp(buildDirName)}/`,
+  'g'
+);
+
+const renameBuildDirName = buildDirName !== canonicalName;
+
 let normalized = 0;
 for (const file of readdirSync(distDir)) {
   if (file.endsWith('.mjs') || file.endsWith('.map') || file.endsWith('.cjs')) {
     const path = join(distDir, file);
     const content = readFileSync(path, 'utf8');
-    const fixed = content.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+    let fixed = content.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+    if (renameBuildDirName) {
+      fixed = fixed.replace(assetPrefixPattern, `$1${canonicalName}/`);
+    }
     if (fixed !== content) {
       writeFileSync(path, fixed, 'utf8');
       normalized++;
     }
   }
 }
+
+// The emitted asset directory is renamed rather than left in place or merely
+// reported: leaving `dist/<worktree name>/` behind makes `git status` on dist/
+// dirty (the freshness job compares with `git status --porcelain`), and the
+// bundle references the canonical directory after the rewrite above, so the
+// assets have to live there for the built action to resolve them.
+let renamedDir = false;
+if (renameBuildDirName) {
+  const staleDir = join(distDir, buildDirName);
+  const targetDir = join(distDir, canonicalName);
+  if (existsSync(staleDir)) {
+    if (existsSync(targetDir)) {
+      // A previous build already produced the canonical directory. The two hold
+      // the same assets, so overwrite rather than fail.
+      cpSync(staleDir, targetDir, { recursive: true, force: true });
+      rmSync(staleDir, { recursive: true, force: true });
+    } else {
+      renameSync(staleDir, targetDir);
+    }
+    renamedDir = true;
+  }
+}
+
 if (normalized > 0) console.log(`Normalized ${normalized} file(s) in dist/`);
+if (renameBuildDirName && (normalized > 0 || renamedDir)) {
+  console.log(
+    `Rewrote build directory name "${buildDirName}" to "${canonicalName}" in dist/ ` +
+      `(build ran outside a checkout named "${canonicalName}").`
+  );
+}

--- a/tests/normalize-dist.test.mjs
+++ b/tests/normalize-dist.test.mjs
@@ -1,0 +1,142 @@
+// scripts/normalize-dist.mjs の回帰テスト。
+//
+// このスクリプトは `npm run build:action` の第 2 段であり、ncc が出力した
+// dist を「どのディレクトリでビルドしても同じバイト列」に揃える責務を持つ。
+// ncc は relocate した asset を「ビルドルートの親」からの相対パスで解決する
+// ため、bundle 内の `__webpack_require__.ab + "<dir>/"` と、生成される
+// `dist/<dir>/` の両方にビルド時の作業ディレクトリ名が焼き込まれる。
+// worktree（`.claude/worktrees/agent-<id>/`）でビルドすると CI の checkout
+// 名（= リポジトリ名）と一致しなくなる（#1894 で実際に踏んだ）。
+//
+// 期待値は実装から生成していない。入力の asset 参照行は、この worktree で実際に
+// `npm run build:action` を走らせたときに
+// runners/github-action/dist/260.index.mjs:292 に現れた行そのもの（ディレクトリ
+// 名だけ合成値に置換）であり、期待出力は「その行だけが正規名へ変わり、他は 1 文字
+// も変わらない」という契約を手で書き下したリテラルである。実装の出力をそのまま
+// 焼き直すと自己整合になり、置換範囲を広げても緑のまま通ってしまう。
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const scriptPath = fileURLToPath(new URL('../scripts/normalize-dist.mjs', import.meta.url));
+const CANONICAL = 'river-review';
+
+// ncc が実際に吐いた asset 参照行（ディレクトリ名のみ合成）と、置換してはいけない
+// 正当な文脈の行を混ぜた入力。最後の 1 行はビルドディレクトリ名そのものを
+// asset 参照でない文脈に置いてある（sourcemap のパス等で実際に現れうる）。
+const bundleInput = (dirName) =>
+  [
+    'async function loadRunRecord(storeDir, runId) {',
+    `  const resolved = __webpack_require__.ab + "${dirName}/" + base + '/' + runId + '.json';`,
+    '}',
+    '// skills/agent-skills/river-review/references/FEEDBACK_TO_FIXTURE.md (SSoT)',
+    "const homepage = 'https://github.com/s977043/river-review';",
+    'const pkg = "river-review";',
+    `// source: .claude/worktrees/${dirName}/src/lib/result-store.mjs`,
+    '',
+  ].join('\n');
+
+// 期待出力（手書きの契約）: `__webpack_require__.ab` 直後の 1 箇所だけが正規名に
+// なり、パッケージ名・URL・vendored パス・および同じディレクトリ名の非 asset
+// 出現は 1 文字も変わらない。
+const bundleExpected = (dirName) =>
+  [
+    'async function loadRunRecord(storeDir, runId) {',
+    `  const resolved = __webpack_require__.ab + "river-review/" + base + '/' + runId + '.json';`,
+    '}',
+    '// skills/agent-skills/river-review/references/FEEDBACK_TO_FIXTURE.md (SSoT)',
+    "const homepage = 'https://github.com/s977043/river-review';",
+    'const pkg = "river-review";',
+    `// source: .claude/worktrees/${dirName}/src/lib/result-store.mjs`,
+    '',
+  ].join('\n');
+
+/**
+ * `<tmp>/<dirName>/` に、normalize-dist.mjs が必要とする最小限のリポジトリ形状を
+ * 組み立てる。スクリプト自身が `basename(repoRoot)` を見るので、テスト側は
+ * ディレクトリ名を変えるだけでビルド場所の違いを再現できる。
+ */
+function makeFakeRepo(t, dirName, { extraAssetDir = null } = {}) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'normalize-dist-'));
+  t.after(() => fs.rmSync(tmp, { recursive: true, force: true }));
+  const root = path.join(tmp, dirName);
+  const dist = path.join(root, 'runners/github-action/dist');
+  fs.mkdirSync(path.join(root, 'scripts'), { recursive: true });
+  fs.mkdirSync(dist, { recursive: true });
+  fs.copyFileSync(scriptPath, path.join(root, 'scripts/normalize-dist.mjs'));
+  fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ name: CANONICAL }), 'utf8');
+  fs.writeFileSync(path.join(dist, '260.index.mjs'), bundleInput(dirName), 'utf8');
+  fs.writeFileSync(path.join(dist, 'crlf.cjs'), 'a\r\nb\r\n', 'utf8');
+  fs.mkdirSync(path.join(dist, dirName, 'schemas'), { recursive: true });
+  fs.writeFileSync(path.join(dist, dirName, 'schemas/output.schema.json'), '{}\n', 'utf8');
+  if (extraAssetDir) {
+    fs.mkdirSync(path.join(dist, extraAssetDir, 'schemas'), { recursive: true });
+    fs.writeFileSync(
+      path.join(dist, extraAssetDir, 'schemas/stale.json'),
+      '{"old":true}\n',
+      'utf8'
+    );
+  }
+  return { root, dist };
+}
+
+function run(root) {
+  return execFileSync(process.execPath, [path.join(root, 'scripts/normalize-dist.mjs')], {
+    encoding: 'utf8',
+  });
+}
+
+test('作業ディレクトリ名が正規名と一致するとき bundle を書き換えない', (t) => {
+  const { root, dist } = makeFakeRepo(t, CANONICAL);
+  const before = fs.readFileSync(path.join(dist, '260.index.mjs'), 'utf8');
+  const stdout = run(root);
+
+  assert.equal(fs.readFileSync(path.join(dist, '260.index.mjs'), 'utf8'), before);
+  assert.equal(before, bundleExpected(CANONICAL));
+  // asset ディレクトリはそのまま残る（リネームも削除もしない）。
+  assert.ok(fs.existsSync(path.join(dist, CANONICAL, 'schemas/output.schema.json')));
+  assert.ok(!stdout.includes('Rewrote build directory name'));
+});
+
+test('作業ディレクトリ名が異なるとき asset 参照だけを正規名へ書き換える', (t) => {
+  const dirName = 'agent-a358e5d2d4e8dfefe';
+  const { root, dist } = makeFakeRepo(t, dirName);
+  const stdout = run(root);
+
+  assert.equal(fs.readFileSync(path.join(dist, '260.index.mjs'), 'utf8'), bundleExpected(dirName));
+  assert.ok(stdout.includes('Rewrote build directory name'));
+});
+
+test('作業ディレクトリ名が異なるとき asset ディレクトリを正規名へ移す', (t) => {
+  const dirName = 'agent-a358e5d2d4e8dfefe';
+  const { root, dist } = makeFakeRepo(t, dirName);
+  run(root);
+
+  assert.equal(fs.existsSync(path.join(dist, dirName)), false);
+  assert.equal(
+    fs.readFileSync(path.join(dist, CANONICAL, 'schemas/output.schema.json'), 'utf8'),
+    '{}\n'
+  );
+});
+
+test('正規名の asset ディレクトリが既にあるときは統合して残骸を残さない', (t) => {
+  const dirName = 'agent-a358e5d2d4e8dfefe';
+  const { root, dist } = makeFakeRepo(t, dirName, { extraAssetDir: CANONICAL });
+  run(root);
+
+  assert.equal(fs.existsSync(path.join(dist, dirName)), false);
+  assert.ok(fs.existsSync(path.join(dist, CANONICAL, 'schemas/output.schema.json')));
+  assert.ok(fs.existsSync(path.join(dist, CANONICAL, 'schemas/stale.json')));
+});
+
+test('CRLF の LF 正規化は作業ディレクトリ名によらず行われる', (t) => {
+  for (const dirName of [CANONICAL, 'agent-a358e5d2d4e8dfefe']) {
+    const { root, dist } = makeFakeRepo(t, dirName);
+    run(root);
+    assert.equal(fs.readFileSync(path.join(dist, 'crlf.cjs'), 'utf8'), 'a\nb\n');
+  }
+});


### PR DESCRIPTION
## 背景

`npm run build:action` は `ncc build ... && node scripts/normalize-dist.mjs` の 2 段構成です。ncc は relocate した asset を **ビルドルートの親** からの相対パスで解決するため、次の 2 か所にビルド時の作業ディレクトリ名が焼き込まれます。

1. bundle 内の asset 参照 `__webpack_require__.ab + "<ディレクトリ名>/"`
2. 生成される asset ディレクトリ `runners/github-action/dist/<ディレクトリ名>/`

CI（`actions/checkout`）の checkout 名はリポジトリ名 `river-review` です。agent worktree（`.claude/worktrees/agent-<id>/`）で rebuild すると同一 src でも CI と異なるバイト列になり、`Action dist freshness` が差分を報告します。2026-08-18 に #1894 で実際に踏み、汚染 1 行を手で戻して回避しました。

## 実測（この worktree で `npm run build:action` を実行）

正規化を入れる前のビルドが生んだ差分は、tracked ファイルでは **1 ファイル 1 行** でした。

```
$ git status --porcelain runners/github-action/dist
 M runners/github-action/dist/260.index.mjs
?? runners/github-action/dist/agent-a358e5d2d4e8dfefe/

$ git diff runners/github-action/dist/260.index.mjs
@@ -289,7 +289,7 @@ async function listRunRecords(storeDir) {
  */
 async function loadRunRecord(storeDir, runId) {
   const base = node_path__WEBPACK_IMPORTED_MODULE_1__.resolve(storeDir);
-  const resolved = __webpack_require__.ab + "river-review/" + base + '/' + runId + '.json';
+  const resolved = __webpack_require__.ab + "agent-a358e5d2d4e8dfefe/" + base + '/' + runId + '.json';
   if (!resolved.startsWith(base + node_path__WEBPACK_IMPORTED_MODULE_1__.sep) && resolved !== base) {
```

汚染の走査範囲も実測しました。`dist` 直下のファイルを対象に grep したところ、該当は 1 ファイルのみで、asset ディレクトリ配下（`node_modules` を除く）には 0 件でした。したがって現行スクリプトの非再帰走査で足ります。

```
$ grep -rl 'agent-a358e5d2d4e8dfefe' runners/github-action/dist --exclude-dir=agent-a358e5d2d4e8dfefe
runners/github-action/dist/260.index.mjs

$ grep -rl 'agent-a358e5d2d4e8dfefe' runners/github-action/dist/agent-a358e5d2d4e8dfefe --exclude-dir=node_modules
（出力なし）
```

## 委託文の前提のうち訂正した点

- **「`dist/<作業ディレクトリ名>/` は git 追跡対象外」は誤り。** `git ls-files runners/github-action/dist` は `dist/river-review/` 配下の **64 個** の tracked ファイル（`git ls-files runners/github-action/dist/river-review | wc -l`）（`schemas/*.json`、`tests/fixtures/**`、`docs/data/*.json` など）を返します。追跡対象なので、放置ではなく正規名への移動が必要です。
- `scripts/normalize-dist.mjs` が 21 行・LF 正規化のみ・非再帰である点、および `docs/development/dist-check-rebuild-guide.md` に `worktree` / `cwd` / `作業ディレクトリ` が 0 件（`grep` の exit 1、111 行）である点は、いずれも実測どおりでした。

## 採った設計: 正規化（検出 + exit 1 ではない）

`scripts/normalize-dist.mjs` に作業ディレクトリ名の正規化を追加しました。

- **正規名の出所**: `package.json` の `name`（`@scope/` を除去）。実測で `name` = `river-review` = リポジトリ名 = CI の checkout 名が一致します。ハードコードではなくこれを選んだのは、リポジトリ改名時の変更点を 1 か所に閉じるためです。git remote から引かなかったのは、source tarball や CI キャッシュのように git メタデータが無い状態でもビルドが成立する必要があるためです。理由はスクリプト内コメントに残しています。
- **置換範囲の絞り方**: `__webpack_require__.ab + "<dir>/"` という ncc 生成の asset 参照式にアンカーした正規表現のみ。`river-review` はパッケージ名・URL・`skills/agent-skills/river-review/...` のような vendored パスにも現れるため、素の文字列置換は使いません。ディレクトリ名は正規表現エスケープしています。
- **asset ディレクトリ**: 放置・警告ではなく `dist/<正規名>/` へ移動（正規名側が既に存在する場合は統合してから残骸を削除）。理由は 2 つ。(1) tracked ディレクトリなので残骸があると `git status --porcelain`（`Action dist freshness` の比較手段、`test.yml:225`）が汚れる。(2) 上の書き換え後、bundle は正規名のディレクトリを参照するので、asset の実体もそこに無いと実行時に解決できない。
- **検出 + exit 1 にしなかった理由**: それでは worktree からの rebuild が常に失敗し、`docs/development/dist-check-rebuild-guide.md` が案内する手動 rebuild 手順が worktree で実行できなくなります。正規化は決定論であり（入力はディレクトリ名と `package.json` の `name` のみ）、失敗しても現状より悪くはなりません。
- **main 相当では no-op**: `buildDirName === canonicalName` のとき、置換もディレクトリ移動も行わずファイルを 1 バイトも書きません。

## main 相当で no-op であることの実測

テスト 1 本目が `<tmp>/river-review/` に最小リポジトリを合成し、スクリプトを実行して bundle のバイト列が完全一致すること、asset ディレクトリが移動も削除もされないこと、ログに `Rewrote build directory name` が出ないことを確認しています（`# pass` は下記）。

さらに、この worktree で pristine な dist から `npm run build:action` を実行したあと、CI と同じ判定式で差分ゼロを確認しました。

```
$ npm run build:action
...
Normalized 2 file(s) in dist/
Rewrote build directory name "agent-a358e5d2d4e8dfefe" to "river-review" in dist/ (build ran outside a checkout named "river-review").

$ git status --porcelain -- runners/github-action/dist/
（出力なし）

$ find runners/github-action/dist -maxdepth 1 -type d
runners/github-action/dist
runners/github-action/dist/river-review
```

## テストと変異検証

`tests/normalize-dist.test.mjs`（新規、5 ケース）。各ケースは一時ディレクトリに `<tmp>/<dir名>/{package.json,scripts/normalize-dist.mjs,runners/github-action/dist/...}` を合成し、実物のスクリプトを子プロセスで実行します。期待値は実装から生成しておらず、実際のビルドが出した行（ディレクトリ名のみ合成値に置換）と、「asset 参照だけが変わり他は 1 文字も変わらない」という契約を手で書き下したリテラルです（`tests/prompt-sections.test.mjs` 冒頭の経緯に従っています）。

変異検証（いずれも実行して `# fail` の実数を確認）:

| 変異 | 内容 | 結果 |
| --- | --- | --- |
| M1 | 置換先を `canonicalName` から `buildDirName` に変える（実質、内容の正規化を無効化） | `# pass 4` / `# fail 1`（`not ok 2`） |
| M2 | asset ディレクトリ移動の `if (renameBuildDirName)` を `if (false)` にする | `# pass 3` / `# fail 2`（`not ok 3`, `not ok 4`） |
| M3 | 正規表現のアンカー `(__webpack_require__\.ab\s*\+\s*")` を `()` にして過剰置換にする | `# pass 4` / `# fail 1`（`not ok 2`） |

変異はいずれも `cp` バックアップから復元済みです。

## 検証コマンドの実出力

Node は `/opt/homebrew/opt/node@22/bin`（v22.22.2、`.nvmrc` の pin と一致）。worktree で `npm ci` 済み。

```
$ npm test
# tests 3401
# suites 344
# pass 3401
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 114884.356625

$ npm run lint:code
✅ code hygiene OK（duplicate-import / tmp-literal / mkdtemp-cleanup / phantom-dep）

$ npm run format:check
Checking formatting...
All matched files use Prettier code style!

$ npm run meta:validate
Meta consistency: OK
Doc enumerations: OK (15 spec(s) checked, 0 ignored)
Sidebar reachability: OK (91 page(s) in sidebar, 11 allowlisted)
skills catalog is up to date: pages/reference/skills-catalog.md (128 skills).

$ npx textlint --no-cache -c tools/textlint/docs.textlintrc.json docs/development/dist-check-rebuild-guide.md
（出力なし・exit 0）

$ npm run fix:dashes
No heading/title dash normalizations needed.
```

## ドキュメント

`docs/development/dist-check-rebuild-guide.md` に「作業ディレクトリ名の焼き込み（worktree での rebuild）」節を追加し、何が起きるか / `git grep` と `find` による検出 / スクリプトの自動処理 / 手で直す手順を既存節の書式で記載しました。トラブルシューティング表にも 1 行追加しています。

## スコープ外の観察（本 PR では対応しない）

- `src/lib/result-store.mjs` の `loadRunRecord` にある `path.resolve(base, ...)` を、ncc が asset 参照に誤変換しています（`__webpack_require__.ab + ... + base + ...`）。bundle 版では絶対パスの前に dist のパスが連結されるため、この関数は GitHub Action 経由では正しく解決しない可能性があります。本 PR はディレクトリ名の決定性のみを扱い、この挙動は変えていません。
- ローカルで連続して `build:action` を走らせると、前回の `dist/<正規名>/node_modules` を ncc が repo 内 asset として再走査し、`dist/river-review/runners/github-action/dist/...` のような入れ子が生えます。すべて gitignore 配下なので tracked な差分にはならず（実測で `git status --porcelain` は空）、main でも同様に起きる既存挙動です。

## 関連

対応する issue はありません（`closes` なし）。#1894 は本問題を初めて踏んだ PR です。
