### PR TITLE
fix(textlint): docs/** の prh を有効化し語境界を厳格化する

### DIFF
--- a/docs/CLI-architecture.md
+++ b/docs/CLI-architecture.md
@@ -51,7 +51,7 @@
 ## 既知の境界 / 注意点
 
 - ルートの `package.json#bin` がメイン CLI (`src/cli.mjs`) にしか登録されていないため、`npx river review …` は **Runner CLI ではなくメイン CLI** に解釈され、メイン CLI には `review` コマンドが無いので unknown command エラーになる。Runner CLI を呼ぶ場合は `node runners/cli/bin/river …` あるいは `runners/cli` 内で `npm exec river …` を使う。
-- GitHub Action は `runners/github-action/dist/` 配下のバンドル済み JS を実行するため、`runners/github-action/src/**` を変更したら `npm run build:action` で `dist/` を再生成しないと CI の "Action dist freshness" が落ちる (`docs/development/dist-check-rebuild-guide.md` 参照)。
+- GitHub Action は `runners/github-action/dist/` 配下のバンドル済み JavaScript を実行するため、`runners/github-action/src/**` を変更したら `npm run build:action` で `dist/` を再生成しないと CI の "Action dist freshness" が落ちる (`docs/development/dist-check-rebuild-guide.md` 参照)。
 - 両 CLI ともデフォルト `phase` は `midstream`。`RIVER_PHASE` / `RIVER_PLANNER_MODE` / `RIVER_AVAILABLE_CONTEXTS` / `RIVER_AVAILABLE_DEPENDENCIES` などの `RIVER_*` 環境変数はメイン CLI でのみ参照される (Runner CLI は対応する `--phase` / `--context` / `--dependency` オプションでの明示が必要)。
 - Runner CLI は `commander` の自動 help を使うため、メイン CLI の `printHelp()` (`src/cli.mjs`) と書式が揃っていない。両ヘルプを同期する責務は今のところ無い。
 

--- a/tests/prh-rules-canary.test.mjs
+++ b/tests/prh-rules-canary.test.mjs
@@ -1,0 +1,88 @@
+// tests/prh-rules-canary.test.mjs
+//
+// Canary + unit coverage for tools/prh-rules/index.yml (issue #1786, stage 2-a).
+//
+// Two responsibilities, per repo principle #1070 (deterministic checks live in
+// static analysis + canary; semantic judgment stays with human/AI review):
+//
+//   1. Canary — pin known false-positive shapes (identifiers, package names,
+//      URL slugs containing "ai"/"GITHUB"/"javascript" as a substring) so a
+//      future loosening of tools/prh-rules/index.yml cannot start flagging
+//      them again. These are the exact 13 false positives found in docs/**
+//      before the index.yml boundary tightening in #1786 stage 2-a.
+//   2. Unit — confirm the true-positive detections the rule exists for are
+//      still caught (bare "github"/"GITHUB", bare "javascript", prose "JS").
+//
+// This test runs the real textlint `prh` rule against tools/prh-rules/index.yml
+// (the actual production rule file, not a re-derivation of its regex) so it
+// cannot go green by drifting out of sync with the shipped rule.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createLinter, loadTextlintrc } from 'textlint';
+
+async function lintWithPrh(text) {
+  const descriptor = await loadTextlintrc({ configFilePath: '.textlintrc.json' });
+  const linter = createLinter({ descriptor });
+  const result = await linter.lintText(`${text}\n`, 'canary-fixture.md');
+  return result.messages.filter((m) => m.ruleId === 'prh');
+}
+
+// ---------------------------------------------------------------------------
+// Canary: known false-positive shapes must never be flagged.
+// ---------------------------------------------------------------------------
+
+test('canary: GITHUB_TOKEN (env var identifier) is not flagged by the GitHub rule', async () => {
+  const messages = await lintWithPrh(
+    'on-disk GITHUB_TOKEN 露出は actions/checkout の既定設定に起因する。'
+  );
+  assert.deepEqual(messages, [], 'GITHUB_TOKEN must not trip the prh GitHub rule');
+});
+
+test('canary: awesome-ai-devtools (repo name slug) is not flagged by the AI rule', async () => {
+  const messages = await lintWithPrh(
+    '[awesome-ai-devtools](https://github.com/jamesmurdza/awesome-ai-devtools) に掲載申請する。'
+  );
+  assert.deepEqual(messages, [], 'awesome-ai-devtools must not trip the prh AI rule');
+});
+
+test('canary: serialize-javascript (npm package name) is not flagged by the JavaScript rule', async () => {
+  const messages = await lintWithPrh(
+    'Dependabot alerts closed: js-yaml x2 dismiss, serialize-javascript / qs / uuid overrides'
+  );
+  assert.deepEqual(messages, [], 'serialize-javascript must not trip the prh JavaScript rule');
+});
+
+// ---------------------------------------------------------------------------
+// Unit: true-positive detections must still fire.
+// ---------------------------------------------------------------------------
+
+test('unit: bare lowercase "github" in prose is still flagged', async () => {
+  const messages = await lintWithPrh('コードは github で公開している。');
+  assert.equal(messages.length, 1);
+  assert.match(messages[0].message, /GitHub/);
+});
+
+test('unit: bare all-caps "GITHUB" (not an identifier) is still flagged', async () => {
+  const messages = await lintWithPrh('GITHUB を利用してホスティングする。');
+  assert.equal(messages.length, 1);
+  assert.match(messages[0].message, /GITHUB => GitHub/);
+});
+
+test('unit: bare lowercase "javascript" in prose is still flagged', async () => {
+  const messages = await lintWithPrh('このスクリプトは javascript で書かれている。');
+  assert.equal(messages.length, 1);
+  assert.match(messages[0].message, /javascript => JavaScript/);
+});
+
+test('unit: prose "JS" abbreviation is still flagged', async () => {
+  const messages = await lintWithPrh('バンドル済み JS を配布する。');
+  assert.equal(messages.length, 1);
+  assert.match(messages[0].message, /JS => JavaScript/);
+});
+
+test('unit: bare lowercase "ai" in prose is still flagged', async () => {
+  const messages = await lintWithPrh('この機能は ai を活用している。');
+  assert.equal(messages.length, 1);
+  assert.match(messages[0].message, /ai => AI/);
+});

--- a/tools/prh-rules/index.yml
+++ b/tools/prh-rules/index.yml
@@ -3,12 +3,12 @@ rules:
   - expected: GitHub
     pattern:
       - /[Gg]ithub/
-      - /GITHUB/
+      - /(?<![A-Za-z0-9_.-])GITHUB(?![A-Za-z0-9_.-])/
   - expected: AI
-    pattern: /(?<![A-Za-z])[Aa][Ii](?![A-Za-z])/
+    pattern: /(?<![A-Za-z0-9_.-])[Aa][Ii](?![A-Za-z0-9_.-])/
   - expected: JavaScript
     pattern:
-      - /[Jj]ava[Ss]cript/
+      - /(?<![A-Za-z0-9_.-])[Jj]ava[Ss]cript(?![A-Za-z0-9_.-])/
       - /\bJS\b/
   - expected: VS Code
     pattern:

--- a/tools/textlint/docs.textlintrc.json
+++ b/tools/textlint/docs.textlintrc.json
@@ -6,8 +6,10 @@
   // 下の `false` は 2 種類ある。区別できるようにセクション見出しを付けている。
   //   - 恒久無効: 既定の .textlintrc.json でも `false`。段階移行が完了しても有効化しない
   //   - 一時無効: 既定の .textlintrc.json では有効。段階移行の各段で順次有効化する
-  // あわせて、既定 config にある `prh`（用語辞書）はこのファイルに定義自体が無く、docs/** と
-  // README*.md では発火しない。これも一時的な差であり、段階移行の最終段で取り込む。
+  // `prh`（用語辞書）は段階 2-a で有効化済み（#1786）。既定 config と同じ tools/prh-rules/index.yml を
+  // 共有する。有効化にあたり index.yml のパターンを語境界厳格化（ハイフン・アンダースコア・ドットを
+  // 境界として扱う）しており、識別子・URL スラッグ内の部分一致を誤検出しない（canary は
+  // tests/prh-rules-canary.test.mjs 参照）。
   "plugins": {},
   "filters": {},
   "rules": {
@@ -31,6 +33,9 @@
       "sentence-length": false,
       "no-mix-dearu-desumasu": false,
       "no-doubled-joshi": false
+    },
+    "prh": {
+      "rulePaths": ["../prh-rules/index.yml"]
     }
   }
 }


### PR DESCRIPTION
## Summary

Issue #1786 の**段階 2-a（prh のみ）**。

`docs/**` + `README*.md` へ既定 textlint config をそのまま当てると 193 件（no-mix-dearu-desumasu 87 / sentence-length 50 / no-doubled-joshi 42 / prh 14）の違反が出るうち、本 PR は **prh 14 件のみ**を対象とする。他 3 ルールは段階 2-b 以降で別 PR にする。

- 誤検出 13 件はルール厳格化で解消: `tools/prh-rules/index.yml` の GITHUB / AI / JavaScript パターンに、ハイフン・アンダースコア・ドットを語境界として追加。`GITHUB_TOKEN`（環境変数識別子）、`awesome-ai-devtools`（実在リポジトリ名のURLスラッグ）、`serialize-javascript`（npmパッケージ名）への部分一致誤検出を止めた。
- 真の指摘 1 件は本文修正で解消: `docs/CLI-architecture.md:54` の「バンドル済み JS」→「バンドル済み JavaScript」。
- `tools/textlint/docs.textlintrc.json` で `prh`（`tools/prh-rules/index.yml`）を有効化し、冒頭コメントの記述を現状に更新。他 3 ルールの一時無効はそのまま。
- canary テスト `tests/prh-rules-canary.test.mjs` を追加。実際に textlint の `prh` ルールを実行し、(1) 上記 13 件の誤検出パターンが再発しないこと、(2) `github`/`GITHUB`/`javascript`/`JS`/`ai` 単体の真の検出が引き続き機能すること、の両方向を担保する（`.claude/rules/review-core.md` #1070 準拠）。

残る段階: 2-b `no-doubled-joshi`(42) / 2-c `sentence-length`(50) / 2-d `no-mix-dearu-desumasu`(87)

Ref: #1786 (close しない)

## Test plan

- [x] `npm run lint:text:docs` → exit 0, 0 violations
- [x] `npm run lint:text:pages` → exit 0, 0 violations（厳格化後も既存 green を維持、`--no-cache` で実測確認済み）
- [x] `node --test tests/prh-rules-canary.test.mjs` → 8/8 pass
- [x] `npm run lint` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)