### PR TITLE
fix(action): サマリーの自己申告 Scope ラベルを SSoT 経由で除去する

### DIFF
--- a/runners/github-action/post-inline-comments.cjs
+++ b/runners/github-action/post-inline-comments.cjs
@@ -18,6 +18,15 @@ const fs = require('fs');
  * `tests/action-esm-require-canary.test.mjs` — an npm dependency or a
  * top-level `await` anywhere in that graph would break this require on the
  * user's runner while CI (which has `node_modules`) stayed green.
+ *
+ * RUNTIME PRECONDITION: the step that loads this file must stay on
+ * `actions/github-script@v8` or newer. The action's runtime is set by that
+ * version — v7 declares `using: node20` and v8 declares `using: node24` — and
+ * `require(ESM)` is only available from Node 22.12. **Downgrading the `uses:`
+ * pin in `action.yml` breaks this line on the user's runner while CI stays
+ * green.** The same canary above asserts the version, so a downgrade fails
+ * there first; if it did, this paragraph is why. Reverting the pin means
+ * reverting this require to a CommonJS implementation as well.
  */
 const { stripSelfReportedScope } = require('../../src/lib/finding-factory.mjs');
 

--- a/runners/github-action/post-inline-comments.cjs
+++ b/runners/github-action/post-inline-comments.cjs
@@ -1,5 +1,26 @@
 const fs = require('fs');
 
+/**
+ * #1929: the SSoT for the self-reported `Scope:` label grammar, imported —
+ * not re-derived.
+ *
+ * This file is a standalone CommonJS `actions/github-script` runner, but
+ * `require()` of an ESM module is stable from Node 22.12 and this step runs on
+ * `actions/github-script@v8` (node24), so the ESM SSoT in `src/lib/` can be
+ * called directly instead of mirroring its regex here. `../..` is the same
+ * repo-root hop the action already depends on in production (`action.yml`
+ * sets `RIVER_REPO_ROOT: ${{ github.action_path }}/../..`, and the release
+ * tarball carries `src/lib/`).
+ *
+ * The load works without `node_modules` because `finding-factory.mjs` reaches
+ * only `node:crypto` and `./scoring/breakdown.mjs`. That property is not
+ * self-evident from here, so it is pinned by
+ * `tests/action-esm-require-canary.test.mjs` — an npm dependency or a
+ * top-level `await` anywhere in that graph would break this require on the
+ * user's runner while CI (which has `node_modules`) stayed green.
+ */
+const { stripSelfReportedScope } = require('../../src/lib/finding-factory.mjs');
+
 const COMMENT_MARKER = '<!-- river-reviewer -->';
 const SEVERITY_EMOJI = { critical: '🔴', major: '🟠', minor: '🟡', info: 'ℹ️' };
 const MAX_INLINE_BODY = 65000;
@@ -49,6 +70,31 @@ function formatScopeMarker(scope) {
   return scope === PRE_EXISTING_SCOPE ? ' _(pre-existing)_' : '';
 }
 
+/**
+ * #1929: the message body as this surface should show it.
+ *
+ * Same rule as `bodyForMarkdown` (src/cli/render.mjs) and the HTML formatter:
+ * once a finding carries a resolved `scope`, the verifier's verdict outranks
+ * the reviewer's self-reported `Scope:` label, and the summary already draws
+ * the resolved value (`formatScopeMarker`, the pre-existing `<details>`
+ * heading). Rendering both would put two opposite scopes on one finding.
+ *
+ * The `issue.scope ?` guard is deliberate and matches the two ESM surfaces: on
+ * a legacy artifact that predates the `scope` field the self-report is the
+ * only scope information there is, so stripping it would delete information
+ * rather than de-duplicate it. The Action summary is a display surface, not
+ * the audit copy — the raw JSON is echoed to the job log (`action.yml`'s
+ * `cat "${json_out}"`) and exported as the `json_path` output — so it follows
+ * the markdown/HTML rule rather than the YAML formatter's keep-verbatim rule.
+ *
+ * @param {object} issue
+ * @returns {string} body text, or an empty string when there is none
+ */
+function bodyMessage(issue) {
+  if (!issue?.message) return '';
+  return issue.scope ? stripSelfReportedScope(issue.message) : issue.message;
+}
+
 /** `file:line` rendered as inline code, or an empty string when unlocated. */
 function formatLocation(issue) {
   if (!issue.file) return '';
@@ -78,8 +124,9 @@ function formatFindingBody(
   const location = includeLocation ? formatLocation(issue) : '';
   const lines = [`${emoji} **[${issue.severity}]**${consensusBadge} ${issue.title}${location}`];
 
-  if (issue.message && issue.message !== issue.title) {
-    lines.push('', issue.message);
+  const message = bodyMessage(issue);
+  if (message && message !== issue.title) {
+    lines.push('', message);
   }
 
   if (Array.isArray(issue.evidence) && issue.evidence.length > 0) {
@@ -218,8 +265,9 @@ function formatSummaryFromJson(
     for (const issue of remainingIssues) {
       const emoji = SEVERITY_EMOJI[issue.severity] || '🔵';
       lines.push(`- ${emoji} **${issue.title}**${issue.file ? ` (${issue.file})` : ''}`);
-      if (issue.message && issue.message !== issue.title) {
-        lines.push(`  ${issue.message}`);
+      const message = bodyMessage(issue);
+      if (message && message !== issue.title) {
+        lines.push(`  ${message}`);
       }
     }
   }

--- a/tests/action-esm-require-canary.test.mjs
+++ b/tests/action-esm-require-canary.test.mjs
@@ -1,0 +1,112 @@
+// #1929: `runners/github-action/post-inline-comments.cjs` calls
+// `require('../../src/lib/finding-factory.mjs')` so the self-reported `Scope:`
+// grammar is imported from its SSoT instead of mirrored into CommonJS.
+//
+// その require が壊れる条件は、CI では観測できない。
+//
+//   - GitHub Actions のランナーは配布 tarball を展開しただけの木で動く。
+//     `node_modules` は無い。したがって `finding-factory.mjs` の推移的 import に
+//     npm パッケージが 1 つ入った瞬間、利用者環境だけで `ERR_MODULE_NOT_FOUND`
+//     になる。CI には `node_modules` があるので緑のまま通る。
+//   - `require(ESM)` は top-level await を含むモジュールを読めない
+//     （`ERR_REQUIRE_ASYNC_MODULE`）。これは ESM 側からの import では起きない。
+//
+// この 2 条件を機械で固定する canary。落ちたときの選択肢は「その依存を
+// finding-factory の到達グラフから外す」か「案 A（CJS 側へ語彙を切り出す）へ
+// 退避する」のどちらかで、`post-inline-comments.cjs` を放置してはいけない。
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+import { packageBaseOf } from '../scripts/check-code-hygiene.mjs';
+
+const require = createRequire(import.meta.url);
+
+/** require() されるモジュール = canary の対象グラフの根。 */
+const ENTRY = fileURLToPath(new URL('../src/lib/finding-factory.mjs', import.meta.url));
+
+/** CJS 側の呼び出し元。require 指定子をここから読み取る。 */
+const CJS_CALLER = fileURLToPath(
+  new URL('../runners/github-action/post-inline-comments.cjs', import.meta.url)
+);
+
+// `import ... from '...'` / `export ... from '...'` / `import '...'` /
+// `await import('...')` を拾う。相対 specifier のみ再帰の対象にし、bare
+// specifier は npm 依存として報告する。
+const STATIC_FROM_RE = /(?:^|\n)\s*(?:import|export)\b[^'"]*?\bfrom\s*['"]([^'"]+)['"]/g;
+const SIDE_EFFECT_RE = /(?:^|\n)\s*import\s*['"]([^'"]+)['"]/g;
+const DYNAMIC_RE = /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+
+function specifiersOf(source) {
+  const found = [];
+  for (const re of [STATIC_FROM_RE, SIDE_EFFECT_RE, DYNAMIC_RE]) {
+    re.lastIndex = 0;
+    let m;
+    while ((m = re.exec(source)) !== null) found.push(m[1]);
+  }
+  return found;
+}
+
+/**
+ * ENTRY から相対 import だけを辿り、到達したファイルと bare specifier を返す。
+ * @returns {{ files: string[], bare: Array<{ from: string, spec: string }> }}
+ */
+function walkGraph(entry) {
+  const seen = new Set();
+  const bare = [];
+  const queue = [entry];
+  while (queue.length > 0) {
+    const file = queue.shift();
+    if (seen.has(file)) continue;
+    seen.add(file);
+    const source = readFileSync(file, 'utf8');
+    for (const spec of specifiersOf(source)) {
+      if (spec.startsWith('.')) {
+        queue.push(resolve(dirname(file), spec));
+        continue;
+      }
+      const pkg = packageBaseOf(spec);
+      if (pkg !== null) bare.push({ from: file, spec });
+    }
+  }
+  return { files: [...seen], bare };
+}
+
+describe('#1929 canary: the Action runner can require() the ESM SSoT without node_modules', () => {
+  it('post-inline-comments.cjs requires finding-factory.mjs by relative path', () => {
+    const source = readFileSync(CJS_CALLER, 'utf8');
+    assert.match(source, /require\('\.\.\/\.\.\/src\/lib\/finding-factory\.mjs'\)/);
+  });
+
+  it('the require target graph reaches more than the entry file itself', () => {
+    // グラフ探索が黙って 1 ファイルで止まっていたら、以下の assert は
+    // 何も守っていない。到達数の下限を先に固定する。
+    const { files } = walkGraph(ENTRY);
+    assert.ok(
+      files.length >= 2,
+      `expected the import walk to reach the transitive graph, got ${files.length} file(s)`
+    );
+  });
+
+  it('no npm package is reachable from finding-factory.mjs', () => {
+    const { bare } = walkGraph(ENTRY);
+    const rendered = bare.map((b) => `${b.from} -> ${b.spec}`).join('\n');
+    assert.deepEqual(
+      bare,
+      [],
+      `An npm dependency became reachable from src/lib/finding-factory.mjs.\n` +
+        `GitHub Actions ランナーには node_modules が無いため、` +
+        `runners/github-action/post-inline-comments.cjs の require が利用者環境でだけ落ちる。\n${rendered}`
+    );
+  });
+
+  it('the graph loads through require() — i.e. it carries no top-level await', () => {
+    // `require(ESM)` は top-level await を含むグラフで ERR_REQUIRE_ASYNC_MODULE
+    // を投げる。実際に require して確かめる（構文の正規表現判定より確実）。
+    const mod = require(ENTRY);
+    assert.equal(typeof mod.stripSelfReportedScope, 'function');
+  });
+});

--- a/tests/action-esm-require-canary.test.mjs
+++ b/tests/action-esm-require-canary.test.mjs
@@ -109,4 +109,61 @@ describe('#1929 canary: the Action runner can require() the ESM SSoT without nod
     const mod = require(ENTRY);
     assert.equal(typeof mod.stripSelfReportedScope, 'function');
   });
+
+  // 上の 3 件は「グラフが require 可能か」を守るが、「**ランタイムが
+  // `require(ESM)` を許すか**」は守らない。`actions/github-script` の実行
+  // ランタイムは版で変わる（実測: v7 = `using: node20` / v8 = `using: node24`。
+  // `gh api 'repos/actions/github-script/contents/action.yml?ref=vN'`）。
+  // `require(ESM)` が安定したのは Node 22.12 以降なので、**@v7 へ下げる変更が
+  // 入ると canary は緑のまま利用者環境だけが壊れる**。
+  //
+  // コメントによる同期義務では足りないと判断して機械化した。理由は 2 つ。
+  //   1. 失敗が観測不能。canary も CI も緑で、壊れるのは利用者のランナーだけ。
+  //      本 PR が塞いでいるリスクとまったく同じ性質である。
+  //   2. このリポジトリでコメントの同期義務は実際に破れている。#1921 の
+  //      `dependencyStubs` は「Keep this list in sync with …」と書かれていたのに
+  //      `anyOf` の `^custom:.+` 枝を落とし、出荷済みスキル 1 本が計画から消えた。
+  const ACTION_YML = fileURLToPath(new URL('../runners/github-action/action.yml', import.meta.url));
+  const MIN_GITHUB_SCRIPT_MAJOR = 8;
+  const GITHUB_SCRIPT_USES_RE = /uses:\s*actions\/github-script@(\S+)/g;
+
+  it(`every actions/github-script reference is >= v${MIN_GITHUB_SCRIPT_MAJOR} (node24)`, () => {
+    const source = readFileSync(ACTION_YML, 'utf8');
+    GITHUB_SCRIPT_USES_RE.lastIndex = 0;
+    const refs = [...source.matchAll(GITHUB_SCRIPT_USES_RE)].map((m) => m[1]);
+
+    // 参照が 0 件だと以下のループが空回りして何も守らない。先に下限を固定する。
+    assert.ok(
+      refs.length >= 1,
+      'no actions/github-script reference found in runners/github-action/action.yml — ' +
+        'this canary would silently pass. Update it alongside the workflow change.'
+    );
+
+    // 参照は複数ある（現状 2 件）。1 つでも条件を満たさなければ落とす — 生の
+    // message を出す step がどちらに乗るかは将来変わりうるため。
+    const why =
+      `runners/github-action/post-inline-comments.cjs は ` +
+      `require('../../src/lib/finding-factory.mjs') で ESM の SSoT を直接呼ぶ。` +
+      `require(ESM) が使えるのは Node 22.12 以降で、actions/github-script は ` +
+      `v7 = node20 / v8 = node24。v${MIN_GITHUB_SCRIPT_MAJOR} 未満へ下げるなら、` +
+      `先に post-inline-comments.cjs の require を CJS 側の実装へ差し戻すこと。`;
+
+    for (const ref of refs) {
+      // タグ形式（`v8` / `v8.1.2`）のみを許す。SHA pin やブランチ名は、その
+      // ref がどのランタイムに解決されるかをこのテストから判定できないため
+      // skip ではなく fail にする。skip にすると canary が黙って空になり、
+      // 上で機械化した理由（観測不能な失敗）をそのまま作り直すことになる。
+      const major = /^v(\d+)(?:\.\d+)*$/.exec(ref)?.[1];
+      assert.ok(
+        major !== undefined,
+        `actions/github-script@${ref} is not a version tag, so its runtime cannot be ` +
+          `checked here. If the pin is intentional, record which runtime it resolves to ` +
+          `and update this canary. ${why}`
+      );
+      assert.ok(
+        Number(major) >= MIN_GITHUB_SCRIPT_MAJOR,
+        `actions/github-script@${ref} runs on a Node older than 22.12. ${why}`
+      );
+    }
+  });
 });

--- a/tests/action-inline-comments-scope.test.mjs
+++ b/tests/action-inline-comments-scope.test.mjs
@@ -509,3 +509,123 @@ describe('#1644: hard truncation leaves a readable comment', () => {
     }
   });
 });
+
+// #1929: 自己申告 `Scope:` ラベルは Action サマリーからも落とす。
+//
+// 期待値は実装から導かない。`stripSelfReportedScope` を呼んで比較すると、
+// 呼び出しを外しても両辺が同じだけ変わって緑のままになる。ここでは公開経路
+// （postInlineComments）だけを呼び、出力を手書きの literal で固定する。
+//
+// ガードは `issue.scope ?` 付き（src/cli/render.mjs の `bodyForMarkdown` と
+// src/lib/output-formatters/html.mjs と同じ規則）。解決済み scope を持たない
+// レガシー artifact では自己申告が唯一の scope 情報なので残す。
+
+/** pre-existing の印と矛盾する自己申告を持つ finding。 */
+const PRE_EXISTING_SELF_REPORTS_IN_DIFF = {
+  id: 'rr-1929-pre',
+  title: 'legacy helper swallows exceptions',
+  message: 'The surrounding catch block returns silently. Scope: in-diff',
+  severity: 'critical',
+  file: 'src/app.js',
+  line: 3,
+  scope: 'pre-existing',
+};
+
+/** inline に出る finding。自己申告は解決済み scope と逆を主張している。 */
+const IN_DIFF_SELF_REPORTS_PRE_EXISTING = {
+  id: 'rr-1929-in',
+  title: 'null check missing on the new branch',
+  message: 'The added guard clause does not cover the empty-array case. Scope: pre-existing',
+  severity: 'major',
+  file: 'src/app.js',
+  line: 12,
+  scope: 'in-diff',
+};
+
+describe('#1929: the Action summary drops the self-reported Scope label', () => {
+  it('strips the label from the pre-existing <details> body', async () => {
+    const posted = await run(artifact([PRE_EXISTING_SELF_REPORTS_IN_DIFF]));
+
+    assert.ok(
+      posted.summaryBody.includes(
+        '🔴 **[critical]** legacy helper swallows exceptions `src/app.js:3`\n' +
+          '\n' +
+          'The surrounding catch block returns silently.'
+      ),
+      posted.summaryBody
+    );
+    assert.ok(!posted.summaryBody.includes('Scope: in-diff'), posted.summaryBody);
+    // 印そのものは残る（消したのは自己申告だけ）。
+    assert.ok(posted.summaryBody.includes('1 pre-existing finding'), posted.summaryBody);
+  });
+
+  it('strips the label from an inline review comment body', async () => {
+    const posted = await run(artifact([IN_DIFF_SELF_REPORTS_PRE_EXISTING]));
+
+    assert.deepEqual(
+      posted.batchComments.map((c) => c.body),
+      [
+        '🟠 **[major]** null check missing on the new branch\n' +
+          '\n' +
+          'The added guard clause does not cover the empty-array case.',
+      ]
+    );
+  });
+
+  it('strips the label from the "Findings not posted inline" list', async () => {
+    const unlocated = {
+      ...IN_DIFF_SELF_REPORTS_PRE_EXISTING,
+      id: 'rr-1929-unlocated',
+      line: undefined,
+    };
+    const posted = await run(artifact([unlocated]));
+
+    assert.ok(
+      posted.summaryBody.includes(
+        '- 🟠 **null check missing on the new branch** (src/app.js)\n' +
+          '  The added guard clause does not cover the empty-array case.'
+      ),
+      posted.summaryBody
+    );
+    assert.ok(!posted.summaryBody.includes('Scope: pre-existing'), posted.summaryBody);
+  });
+
+  it('keeps the label on a legacy finding that carries no resolved scope', async () => {
+    const legacy = {
+      id: 'rr-1929-legacy',
+      title: 'legacy artifact predates the scope field',
+      message: 'No resolved scope here. Scope: pre-existing',
+      severity: 'minor',
+      file: 'src/legacy.js',
+      line: 9,
+    };
+    const posted = await run(artifact([legacy]));
+
+    assert.deepEqual(
+      posted.batchComments.map((c) => c.body),
+      [
+        '🟡 **[minor]** legacy artifact predates the scope field\n' +
+          '\n' +
+          'No resolved scope here. Scope: pre-existing',
+      ]
+    );
+  });
+
+  it('omits the body when the label was the whole message', async () => {
+    const labelOnly = {
+      id: 'rr-1929-label-only',
+      title: 'title carries the finding',
+      message: 'Scope: in-diff',
+      severity: 'info',
+      file: 'src/app.js',
+      line: 4,
+      scope: 'in-diff',
+    };
+    const posted = await run(artifact([labelOnly]));
+
+    assert.deepEqual(
+      posted.batchComments.map((c) => c.body),
+      ['ℹ️ **[info]** title carries the finding']
+    );
+  });
+});


### PR DESCRIPTION
## 何を直したか

`runners/github-action/post-inline-comments.cjs` が `issue.message` を生で出す 2 箇所（`:81-82` の `formatFindingBody`、`:221-222` の "Findings not posted inline"）で、解決済み `scope` を持つ finding から LLM の自己申告 `Scope:` ラベルを落とす。`pre-existing` の印の下に `Scope: in-diff` が並ぶ矛盾表示が消える。

Closes #1929

## 採った案: 案 B（CJS から ESM の SSoT を直接 `require()` する）

文法も語彙も複製しない。`src/lib/finding-factory.mjs` の `stripSelfReportedScope` を `require('../../src/lib/finding-factory.mjs')` で呼ぶ。

成立の根拠（すべて本 PR 作業中に再実測）:

- `require(ESM)` は Node 22.12 以降で安定。`action.yml:192,202` の `actions/github-script@v8` は node24 で動く。ローカル Node v22.22.2 で、実際に `.cjs` から `finding-factory.mjs` を `require` して `stripSelfReportedScope('Fix: g Scope: pre existing x')` → `"Fix: g x"` を確認
- `post-inline-comments.cjs` は `${GITHUB_ACTION_PATH}` から直接 require される（`action.yml:207`）ので `__dirname` は `runners/github-action/`。`../../src/lib/` に到達する
- `../..` への依存は既に本番稼働中（`action.yml:94` の `RIVER_REPO_ROOT: ${{ github.action_path }}/../..`）
- `finding-factory.mjs` の import は `node:crypto` と `./scoring/breakdown.mjs` の 2 本だけで、`breakdown.mjs` は import 0 件。npm 依存ゼロなので `node_modules` の無いランナーでも読める
- `tests/action-inline-comments-scope.test.mjs:27-30` が `createRequire` で逆向きの同じことをしている前例がある
- `src/**` を触らないので dist 再ビルド不要（`auto-rebuild-action-dist.yml:38-42` の監視対象は `runners/github-action/src/**` / `runners/core/**` / `src/**` / `package-lock.json` の 4 つ）

## 判断 1: strip にガードを付けた（`issue.scope ?`）

**付けた。** 既存 2 サーフェスと同じ規則に揃える。

| サーフェス | strip | 根拠 |
| --- | --- | --- |
| `src/cli/render.mjs:169` | `f.scope ?` 付き | 解決済み scope がある時だけ落とす |
| `src/lib/output-formatters/html.mjs:220` | `f.scope ?` 付き | 同上 |
| `src/lib/output-formatters/yaml.mjs` | strip しない（0 箇所） | 監査証跡として生本文を保持 |
| **Action サマリー（本 PR）** | **`issue.scope ?` 付き** | 表示サーフェスなので markdown / HTML 側 |

Action サマリーが「監査コピー」ではなく「表示サーフェス」である点は自分で確認した: 生 JSON は `action.yml:174-175` で `json_path` として出力され、かつ `cat "${json_out}"` でジョブログに残る。監査証跡は別に存在するので、サマリーは矛盾のない表示を優先してよい。

ガードの意味は「レガシー artifact の保護」。`scope` フィールドが存在しなかった頃の artifact では自己申告が唯一の scope 情報なので、無条件 strip は情報の削除になる。

## 判断 2: canary が守るのは「CI では出ない失敗」

案 B の唯一のリスクは、`finding-factory.mjs` の推移的依存に npm パッケージか top-level await が入った瞬間、**利用者環境でだけ**壊れること。ランナーには `node_modules` が無く、CI にはある。つまり **CI が緑のまま出荷される種類の失敗**である。

`tests/action-esm-require-canary.test.mjs` で機械的に固定した。

1. `post-inline-comments.cjs` が相対パスで `finding-factory.mjs` を require していること
2. import グラフの探索が 2 ファイル以上に到達していること（探索が黙って空振りしたら 3. が何も守らないため、先に下限を固定）
3. `finding-factory.mjs` から到達可能な bare specifier（`node:` 以外）が 0 件であること — `scripts/check-code-hygiene.mjs` の `packageBaseOf` を再利用
4. グラフが `require()` で読めること（top-level await があれば `ERR_REQUIRE_ASYNC_MODULE` で落ちる。正規表現で構文判定するより確実）

落ちた場合の選択肢は「その依存をグラフから外す」か「案 A（CJS 側へ語彙を切り出す）へ退避」で、放置してはいけない旨をファイル冒頭コメントに書いた。

## 変異検証

いずれも `cp` バックアップ + 復元。変異が入ったことを `git diff` で目視確認してから実行した。

| 変異 | `git diff` の実際の行 | 結果 |
| --- | --- | --- |
| M1: strip 呼び出しを外す | `+  return issue.message; // MUTATION 1` | `# fail 4`（strip 期待の 4 件。レガシー保持の 1 件は正しく緑のまま） |
| M2a: `breakdown.mjs` に npm import | `+import Ajv from 'ajv';` | canary `# fail 1`（"An npm dependency became reachable…"） |
| M2b: `breakdown.mjs` に top-level await | `+await Promise.resolve();` | canary `# fail 1`（`code: 'ERR_REQUIRE_ASYNC_MODULE'`） |
| M3: ガードを外して無条件 strip | `+  return stripSelfReportedScope(issue.message); // MUTATION 3: guard removed` | `# fail 1`（レガシー保持の 1 件だけが落ちる） |

M1 と M3 の落ち方が重ならないので、テストは「strip する」と「レガシーでは strip しない」を別々に固定できている。

## テスト

`tests/action-inline-comments-scope.test.mjs` に describe を 1 つ追加（5 件）。期待値は実装から導かず手書きリテラル。公開経路（`postInlineComments`）だけを呼ぶ。

- pre-existing 折りたたみ: `Scope: in-diff` が消え、`1 pre-existing finding` の印は残る
- inline: `Scope: pre-existing` が消える
- "Findings not posted inline": 同上
- `scope` を持たないレガシー finding: ラベルを残す
- message がラベルだけだった場合: 本文行を出さない

## 未検証として明記

- 実利用者のランナー上での実行は未確認（外部利用者が見つからないため）。`node_modules` 非在の再現は「`finding-factory.mjs` の到達グラフに npm 依存が無い」という静的性質の固定で代替しており、実ランナーでの動作確認そのものは行っていない

---

## 追記（2 コミット目）: canary にランタイム版の assert を 1 本足した

レビューで **canary の射程外**が見つかったので塞いだ。

上の 4 assert は「グラフが `require` 可能か」を守るが、「**ランタイムが `require(ESM)` を許すか**」は守らない。`actions/github-script` の実行ランタイムは版で決まる（自分で再実測: `gh api 'repos/actions/github-script/contents/action.yml?ref=v7'` → `using: node20` / `?ref=v8` → `using: node24`）。`require(ESM)` は Node 22.12 以降なので、`action.yml` の `uses:` を `@v7` へ下げると **canary も CI も緑のまま利用者環境だけが壊れる**。

### assert の設計判断

| 論点 | 判断 | 理由 |
| --- | --- | --- |
| 版の比較 | `^v(\d+)(\.\d+)*$` を許し major >= 8 | `action.yml` に現れるのはタグ形式のみ（`github-script@v8` ×2、`setup-node@v6`）。`v8.1.2` 形も通す |
| SHA pin / ブランチ名 | **skip ではなく fail** | その ref がどのランタイムに解決されるかはテストから判定できない。skip にすると canary が黙って空になり、この PR が塞いでいる「観測不能な失敗」をそのまま作り直す。意図的な pin ならどのランタイムかを記録して canary を更新せよ、というメッセージを出す |
| 参照が 2 件（`:192` / `:202`） | 両方を見て 1 つでも条件を満たさなければ fail | 生の `message` を出す step がどちらに乗るかは将来変わりうる |
| 参照 0 件 | 先に `refs.length >= 1` を assert | ループが空回りして黙って通るのを防ぐ |

失敗メッセージには「なぜ v8 以上が必要か」（`require(ESM)` = Node 22.12+ / v7 = node20 / v8 = node24 / 下げるなら CJS 実装へ差し戻す）を書いた。

### コメントではなく機械化した理由

1. **失敗が観測不能**。canary も CI も緑で、壊れるのは利用者のランナーだけ。この PR が塞いでいるリスクと同じ性質
2. **このリポジトリでコメントの同期義務は実際に破れている**。#1921 の `dependencyStubs` は「Keep this list in sync with …」と書かれていたのに `anyOf` の `^custom:.+` 枝を落とし、出荷済みスキル 1 本が計画から消えた

コメントも併せて `post-inline-comments.cjs` の `require` の直上に残した（canary が落ちたときに理由を読む先が要るため）。

### 追加の変異検証

`action.yml` は `cp` バックアップから復元済み。挿入行は `git diff` で目視確認した。

| 変異 | `git diff` の実際の行 | # fail |
| --- | --- | --- |
| 2 件とも `@v8` → `@v7` | `-      uses: actions/github-script@v8` / `+      uses: actions/github-script@v7`（2 箇所） | **1**（`actions/github-script@v7 runs on a Node older than 22.12.`） |
| **2 件目だけ** `@v7` | 同上を 1 箇所のみ | **1** |
| 1 件目を SHA pin に置換 | `+      uses: actions/github-script@60a0d830…` | **1**（`… is not a version tag, so its runtime cannot be checked here.`） |
