### PR TITLE
fix(scripts): 512B 超の heredoc を排除しテストの孤児プロセスを止める

### DIFF
--- a/.claude/hooks/no-force-push.sh
+++ b/.claude/hooks/no-force-push.sh
@@ -161,8 +161,15 @@ if ! printf '%s' "$SANITIZED" | grep -qE "$BLOCK_RE"; then
 fi
 
 EXCERPT="$(printf '%s' "$COMMAND" | tr '\n' ' ' | cut -c1-200)"
-cat >&2 <<EOF
-[no-force-push] BLOCKED: destructive git command.
+# The message below was a `cat >&2 <<EOF` heredoc until #1950. bash 5.3.15
+# (homebrew) deadlocks deterministically when a heredoc body exceeds 512 bytes;
+# this body is 564, so the guard hung at the exact moment it tried to BLOCK a
+# destructive command — the one path that must never fail. A quoted multi-line
+# string fed to `printf` reproduces the heredoc byte for byte (double quotes
+# keep `${EXCERPT}` expanding, and the body contains no other `$`, backtick,
+# backslash or `"`), and unlike a split heredoc it has no size ceiling at all.
+# Do NOT convert this back to a heredoc — see #1950.
+BLOCKED_MESSAGE="[no-force-push] BLOCKED: destructive git command.
   command: ${EXCERPT}
   AGENTS.md Safety bans rewriting already-pushed branch history
   (git push --force / -f / --force-with-lease) and discarding work
@@ -171,6 +178,6 @@ cat >&2 <<EOF
   Instead: take the remote in with 'git merge origin/<branch>' or
   'git merge --ff-only origin/<branch>', then push a fast-forward.
   If history still looks like it must be rewritten, do not work around this
-  hook — stop and escalate to the organizer / human.
-EOF
+  hook — stop and escalate to the organizer / human."
+printf '%s\n' "$BLOCKED_MESSAGE" >&2
 exit 2

--- a/scripts/count-in-clean-tree.sh
+++ b/scripts/count-in-clean-tree.sh
@@ -41,8 +41,13 @@ REF="origin/main"
 RAW=0
 
 usage() {
-  cat <<'EOF'
-Usage: scripts/count-in-clean-tree.sh [--ref <ref>] [--raw] [--] <command> [args...]
+  # 以下は #1950 まで `cat <<'EOF'` の heredoc だった。bash 5.3.15（homebrew）は
+  # 本体が 512 バイトを超える heredoc で決定論的に deadlock し、この本体は 518
+  # バイトなので `--help` と usage エラーがそのまま固まっていた。単一引用符の
+  # 複数行文字列を `printf` へ渡すと quoted heredoc と同じ「一切展開しない」
+  # 意味論のままバイト単位で同一の出力になり、しかもサイズ上限が無い。
+  # heredoc へ戻さないこと（#1950）。
+  printf '%s\n' 'Usage: scripts/count-in-clean-tree.sh [--ref <ref>] [--raw] [--] <command> [args...]
 
 Options:
   --ref <ref>   展開する git ref（既定: origin/main）
@@ -50,8 +55,7 @@ Options:
   -h, --help    このヘルプを表示する
 
 出力は既定で「そのまま doc へ貼れる」fenced block になる。ref・解決した SHA・
-実行コマンド・出力が 1 ブロックに収まるため、公開した数値の再現手段が残る。
-EOF
+実行コマンド・出力が 1 ブロックに収まるため、公開した数値の再現手段が残る。'
 }
 
 while [ $# -gt 0 ]; do

--- a/scripts/setup_river_review.sh
+++ b/scripts/setup_river_review.sh
@@ -26,8 +26,12 @@
 #
 set -euo pipefail
 
-cat >&2 <<'EODEPRECATED'
-================================================================================
+# 以下は #1950 まで heredoc だった。bash 5.3.15（homebrew）は本体が 512 バイトを
+# 超える heredoc で決定論的に deadlock するため、この script は手で実行すると
+# 固まっていた。単一引用符の複数行文字列を printf へ渡すと quoted heredoc と
+# 同じ「一切展開しない」意味論のままバイト単位で同一の出力になり、サイズ上限も
+# 無い。heredoc へ戻さないこと（#1950）。
+printf '%s\n' '================================================================================
   DEPRECATED: scripts/setup_river_review.sh
 
   This script REWRITES README.md, docs/glossary.md, docs/skill-schema.md,
@@ -37,8 +41,7 @@ cat >&2 <<'EODEPRECATED'
 
   It has no callers and is scheduled for deletion on or after 2026-11-12.
   Press Ctrl-C now if you did not mean to run it.
-================================================================================
-EODEPRECATED
+================================================================================' >&2
 sleep 10
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -53,8 +56,8 @@ mkdir -p "$ROOT/scripts" "$ROOT/docs" "$ROOT/docs/tutorials" "$ROOT/docs/how-to"
   "$ROOT/.github/workflows"
 
 write_readme() {
-  cat <<'EORD' > "$ROOT/README.md"
-# River Review
+  # heredoc へ戻さないこと。理由は上の #1950 の注記を参照。
+  printf '%s\n' '# River Review
 
 ![River Review logo](assets/logo/river-review-logo.svg)
 
@@ -135,8 +138,7 @@ See `CONTRIBUTING.md` for guidance. Issues and PRs are welcome as we expand Rive
 
 - `LICENSE`: Apache-2.0 for repository scaffolding/config
 - `LICENSE-CODE`: MIT for code and scripts
-- `LICENSE-CONTENT`: CC BY 4.0 for docs and media
-EORD
+- `LICENSE-CONTENT`: CC BY 4.0 for docs and media' > "$ROOT/README.md"
 }
 
 if [[ ! -f "$ROOT/README.md" ]]; then
@@ -149,19 +151,18 @@ else
   echo "README.md exists; use --force to overwrite. Skipping README update."
 fi
 
-cat <<'EOG' > "$ROOT/docs/glossary.md"
-# River Review Glossary
+# heredoc へ戻さないこと。理由は上の #1950 の注記を参照。
+printf '%s\n' '# River Review Glossary
 
 - **Upstream**: requirements, design, and architecture phase (including ADRs) where early review prevents costly rework.
 - **Midstream**: implementation and pull request phase focused on code quality, security, and developer experience.
 - **Downstream**: test, QA, and release-prep phase to verify coverage, resilience, and regression protection.
 - **Skill**: a YAML frontmatter + Markdown unit of review guidance executed by River Review.
 - **Stream Router**: logic that selects and runs skills based on the requested phase and change context.
-- **Riverbed Memory (Future)**: persistent context layer for previous findings, ADR references, and WontFix decisions to keep reviews consistent over time.
-EOG
+- **Riverbed Memory (Future)**: persistent context layer for previous findings, ADR references, and WontFix decisions to keep reviews consistent over time.' > "$ROOT/docs/glossary.md"
 
-cat <<'EOS' > "$ROOT/docs/skill-schema.md"
-# Skill Schema
+# heredoc へ戻さないこと。理由は上の #1950 の注記を参照。
+printf '%s\n' '# Skill Schema
 
 River Review skills use YAML frontmatter for metadata and Markdown for guidance. The metadata fields are validated by `schemas/skill.schema.json`.
 
@@ -193,11 +194,10 @@ description: Flag midstream changes that risk latency regressions or heavy resou
 ---
 
 Ensure changed code paths avoid unnecessary synchronous I/O, unbounded concurrency, and repeated heavy computations. Recommend benchmarks when touching hot paths.
-```
-EOS
+```' > "$ROOT/docs/skill-schema.md"
 
-cat <<'EOJ' > "$ROOT/schemas/skill.schema.json"
-{
+# heredoc へ戻さないこと。理由は上の #1950 の注記を参照。
+printf '%s\n' '{
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "River Review Skill Metadata Schema",
   "type": "object",
@@ -239,9 +239,11 @@ cat <<'EOJ' > "$ROOT/schemas/skill.schema.json"
       "minLength": 1
     }
   }
-}
-EOJ
+}' > "$ROOT/schemas/skill.schema.json"
 
+# このファイルで唯一残した heredoc。本体が 364 バイトで #1950 の 512 バイト閾値を
+# 下回るため、そのままにしてある。行を足すときはバイト数を確認し、512 を超えるなら
+# 上の printf 形式へ寄せること（512 を超えた heredoc は bash 5.3.15 で固まる）。
 cat <<'EOW' > "$ROOT/.github/workflows/river-review.yml"
 name: River Review (placeholder)
 

--- a/tests/count-in-clean-tree.test.mjs
+++ b/tests/count-in-clean-tree.test.mjs
@@ -1,10 +1,10 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { spawnSync } from 'node:child_process';
 import { chmodSync, existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { spawnSyncGuarded } from './helpers/spawn-guard.mjs';
 
 // scripts/count-in-clean-tree.sh を実プロセス実行で検証する（refs #1827）。
 // 使い捨ての git repo を作り、追跡済み / 追跡外 / .gitignore 対象の 3 種類を置いて、
@@ -18,8 +18,12 @@ const SCRIPT = join(
 
 const MARKER = 'CLEAN_TREE_MARKER';
 
+// 子プロセスの起動は `spawnSyncGuarded` 経由に統一する（#1950）。素の spawnSync だと
+// script が固まったときにテストごと固まり、さらに ppid=1 の孤児が残る。既定の
+// タイムアウトは 30 秒で、実測ではこのファイル全体が 3〜4 秒、最も遅い 1 呼び出しでも
+// 1 秒未満なので、遅いマシンでも偽陽性にならない。
 function git(cwd, ...args) {
-  const res = spawnSync('git', args, { cwd, encoding: 'utf8' });
+  const res = spawnSyncGuarded('git', args, { cwd, encoding: 'utf8' });
   assert.equal(res.status, 0, `git ${args.join(' ')} failed: ${res.stderr}`);
   return res.stdout.trim();
 }
@@ -47,7 +51,7 @@ function makeRepo(t) {
 }
 
 function runScript(repo, args, env) {
-  return spawnSync('bash', [SCRIPT, ...args], {
+  return spawnSyncGuarded('bash', [SCRIPT, ...args], {
     cwd: repo,
     encoding: 'utf8',
     ...(env ? { env: { ...process.env, ...env } } : {}),
@@ -65,7 +69,7 @@ test('clean tree では追跡外ファイルが数えられない', (t) => {
   const repo = makeRepo(t);
 
   // 作業ツリーで直接走査すると、追跡外と .gitignore 対象まで数えてしまう。
-  const dirty = spawnSync(SCAN[0], SCAN.slice(1), { cwd: repo, encoding: 'utf8' });
+  const dirty = spawnSyncGuarded(SCAN[0], SCAN.slice(1), { cwd: repo, encoding: 'utf8' });
   assert.equal(dirty.status, 0, dirty.stderr);
   const dirtyFiles = dirty.stdout.trim().split(' ').filter(Boolean).sort();
   assert.deepEqual(dirtyFiles, ['./Working/draft.md', './tracked.md', './untracked.md']);
@@ -140,7 +144,9 @@ test('既定出力は ref と SHA とコマンドを含む貼り付け可能な�
 // ファイル経由（`-f`）なら本物の tar に委譲する。読み手が必ず先に抜けるので、
 // パイプを使う実装なら確定的に 141 で落ち、中間ファイルを使う実装なら影響を受けない。
 function makeEarlyExitTarShim(t) {
-  const realTar = spawnSync('sh', ['-c', 'command -v tar'], { encoding: 'utf8' }).stdout.trim();
+  const realTar = spawnSyncGuarded('sh', ['-c', 'command -v tar'], {
+    encoding: 'utf8',
+  }).stdout.trim();
   assert.ok(realTar, 'tar が PATH に見つかること');
 
   const bin = mkdtempSync(join(tmpdir(), 'rr-clean-tree-tarshim-'));

--- a/tests/helpers/README.md
+++ b/tests/helpers/README.md
@@ -10,12 +10,21 @@
 
 ## 提供しているヘルパー
 
-| ファイル        | 主な API                                                                           |
-| --------------- | ---------------------------------------------------------------------------------- |
-| `temp-dir.mjs`  | `createTempDir()`, `cleanupTempDir()`, `withTempDir(fn)`                           |
-| `temp-repo.mjs` | `createTempGitRepo(opts)`, `createRepoWithSilentCatchChange()`, `runGit()`         |
-| `cli.mjs`       | `runCliAsSubprocess(argv, opts)`, `runCliInProcess(argv, opts)`                    |
-| `memory.mjs`    | `createTempMemory({ layout, entries })`, `makeMemoryEntry()`, `writeMemoryIndex()` |
+| ファイル          | 主な API                                                                           |
+| ----------------- | ---------------------------------------------------------------------------------- |
+| `temp-dir.mjs`    | `createTempDir()`, `cleanupTempDir()`, `withTempDir(fn)`                           |
+| `temp-repo.mjs`   | `createTempGitRepo(opts)`, `createRepoWithSilentCatchChange()`, `runGit()`         |
+| `cli.mjs`         | `runCliAsSubprocess(argv, opts)`, `runCliInProcess(argv, opts)`                    |
+| `memory.mjs`      | `createTempMemory({ layout, entries })`, `makeMemoryEntry()`, `writeMemoryIndex()` |
+| `spawn-guard.mjs` | `spawnSyncGuarded(command, args, options)`, `SPAWN_TIMEOUT_MS`                     |
+
+## 子プロセスを起動するテスト
+
+`spawnSync` を直接呼ばず `spawnSyncGuarded` を使う。素の `spawnSync` は、子が固まると
+テストごと固まるうえ、`node --test` がランナーを終了させても子は kill されず ppid=1 の
+孤児として残る（#1950 で 5 時間以上生き残った孤児が 14 個観測された）。
+`spawnSyncGuarded` は既定 30 秒のタイムアウトに加え、子をプロセスグループのリーダーに
+してグループごと SIGKILL するため、子がさらに fork していても孫まで確実に消える。
 
 ## CLI ヘルパーの使い分け
 

--- a/tests/helpers/spawn-guard.mjs
+++ b/tests/helpers/spawn-guard.mjs
@@ -1,0 +1,55 @@
+// 子プロセスを起動するテストが孤児プロセスを残さないようにするヘルパー（#1950）。
+//
+// 背景: `node --test` のタイムアウトは node 自身しか終わらせない。`spawnSync` が
+// ブロックしている最中にランナーが node を殺すと、起動済みの子は kill されずに
+// ppid=1 の孤児として残る。bash 5.3.15 の heredoc deadlock では、5 時間以上生き
+// 残った孤児が 14 個観測された（#1950）。
+//
+// 対策は 2 段構えである。
+//
+//   1. `timeout` + `killSignal: 'SIGKILL'` — spawnSync 自身に子を殺させる。これで
+//      テスト実行そのものは必ず有限時間で終わる。
+//   2. `detached: true` + プロセスグループへの止め — 1 だけでは足りない。spawnSync
+//      が SIGKILL を送るのは自分が起動した pid だけで、その子が fork していると
+//      孫は生き残る。実測: `timeout` + `killSignal` のみで hang した bash を殺すと、
+//      fork された側が ppid=1 の孤児として残った。しかも hang した bash は heredoc
+//      パイプの両端を自分で握る（`lsof` で fd 3 と fd 4 が同一パイプ）ため、
+//      読み手が消えても EPIPE を受け取れず永久に解放されない。
+//      `detached: true` で子をプロセスグループのリーダーにしておき、タイムアウト
+//      時にグループ全体へ SIGKILL を送ると孫まで確実に消える。
+import { spawnSync } from 'node:child_process';
+
+export const SPAWN_TIMEOUT_MS = 30_000;
+
+/**
+ * `spawnSync` のうち、タイムアウト時にプロセスグループごと確実に終了させる版。
+ * タイムアウトした場合は例外を投げる（黙って pass させない）。
+ *
+ * @param {string} command 実行するコマンド
+ * @param {string[]} args 引数
+ * @param {import('node:child_process').SpawnSyncOptions} [options] spawnSync のオプション
+ * @returns {import('node:child_process').SpawnSyncReturns<string>} spawnSync の戻り値
+ */
+export function spawnSyncGuarded(command, args, options = {}) {
+  const res = spawnSync(command, args, {
+    ...options,
+    timeout: options.timeout ?? SPAWN_TIMEOUT_MS,
+    killSignal: 'SIGKILL',
+    detached: true,
+  });
+  if (res.signal === 'SIGKILL' && typeof res.pid === 'number') {
+    try {
+      // 負の pid = プロセスグループ全体。リーダーは既に死んでいてもグループは残る。
+      process.kill(-res.pid, 'SIGKILL');
+    } catch {
+      // グループが既に消えている場合は ESRCH になる。想定内なので無視する。
+    }
+  }
+  if (res.error && res.error.code === 'ETIMEDOUT') {
+    throw new Error(
+      `spawnSyncGuarded timed out after ${options.timeout ?? SPAWN_TIMEOUT_MS}ms: ` +
+        `${command} ${args.join(' ')}`
+    );
+  }
+  return res;
+}

--- a/tests/no-force-push-hook.test.mjs
+++ b/tests/no-force-push-hook.test.mjs
@@ -1,8 +1,8 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { spawnSync } from 'node:child_process';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { spawnSyncGuarded } from './helpers/spawn-guard.mjs';
 
 // .claude/hooks/no-force-push.sh (PreToolUse hook) を実プロセス実行で検証する。
 // 本物の PreToolUse ペイロードを stdin に流し、exit code だけで判定する
@@ -16,8 +16,11 @@ const HOOK = join(
   'no-force-push.sh'
 );
 
+// 子プロセスの起動は `spawnSyncGuarded` 経由に統一する（#1950）。素の spawnSync だと
+// hook が固まったときにテストごと固まり、さらに ppid=1 の孤児が残る。既定の
+// タイムアウトは 30 秒で、実測 40〜210ms／呼び出しに対して 100 倍以上の余裕がある。
 function runHook(command) {
-  const res = spawnSync('bash', [HOOK], {
+  const res = spawnSyncGuarded('bash', [HOOK], {
     input: JSON.stringify({
       session_id: 'test',
       hook_event_name: 'PreToolUse',
@@ -170,7 +173,7 @@ test('passing commands produce no stderr noise', () => {
 
 test('empty or malformed stdin payload passes', () => {
   for (const input of ['', '{not json', '{}', '{"tool_input":{}}']) {
-    const res = spawnSync('bash', [HOOK], { input, encoding: 'utf8' });
+    const res = spawnSyncGuarded('bash', [HOOK], { input, encoding: 'utf8' });
     assert.equal(res.status, 0, JSON.stringify(input));
   }
 });


### PR DESCRIPTION
Closes #1950

## なぜ緊急か — 安全ガードが死んでいた

`.claude/hooks/no-force-push.sh` は `git push --force` / `git reset --hard` / `git stash drop` を PreToolUse で止める安全ガードです。そのブロックメッセージは 564 バイトの heredoc で書かれていました。

homebrew の bash 5.3.15 は、本体が 512 バイトを超える heredoc で決定論的に deadlock します。つまりこのガードは、**破壊的コマンドをブロックしようとしたその瞬間に固まる**状態でした。

```console
$ echo '{"tool_name":"Bash","tool_input":{"command":"git push --force origin main"}}' \
    | timeout -k 2 5 /opt/homebrew/bin/bash .claude/hooks/no-force-push.sh
EXIT=124
```

通過対象（`git status` 等）では heredoc に到達しないので EXIT=0 になります。**ブロック対象のときだけ発火するため、通常操作では気づけません。** `tests/no-force-push-hook.test.mjs` は最初のブロックケースで固まり、`npm test` が完走しなくなっていました。

`scripts/count-in-clean-tree.sh --help`（518 バイト）と `scripts/setup_river_review.sh` の 5 箇所も同じ形です。

## B: 書き換え方の選択理由 — printf + 複数行クォート文字列

`printf` の 1 行ずつ連結でも、512 バイト未満の heredoc への分割でもなく、**本文をそのまま 1 つのクォート文字列に入れて `printf '%s\n'` へ渡す**形にしました。

```sh
printf '%s\n' '# River Review Glossary

- **Upstream**: ...' > "$ROOT/docs/glossary.md"
```

理由は 3 点です。

- **可読性が落ちない。** 本文は heredoc のときと 1 バイトも変わらず、そのまま素直に読めます。`printf '%s\n' 'line1' 'line2' ...` の連結だと 1 行ごとにクォートが挟まって読みづらくなります。
- **将来また 512 バイトを超えない。** 分割案は「1 行足したら再発する」余地が残ります（2554 バイトを 6 分割すると 1 チャンクあたりの余裕は 90 バイト程度）。クォート文字列にはサイズ上限そのものがありません。実測で 726 バイトの文字列が bash 5.3.15 で正常に通ることを確認済みです。
- **意味論を保てる。** `<<'TAG'` の「一切展開しない」は単一引用符、`<<TAG` の「展開する」は二重引用符に 1 対 1 で対応します。展開が必要なのは `no-force-push.sh` の `${EXCERPT}` 1 箇所だけで、その本文には `"` / `` ` `` / `\` / 他の `$` が無いことを確認しています。

各箇所には「なぜ heredoc に戻してはいけないか」を #1950 参照つきでコメントに残しました。`setup_river_review.sh` に 1 つだけ残る 364 バイトの heredoc（`EOW`）にも、閾値を確認してから行を足すよう注記しています。

## 出力が byte-identical であることの実測

### no-force-push.sh — 15 ケースの対照実験

変更前のスクリプトを `/private/tmp/` に退避し、**同じシェル（`/bin/bash` 3.2）**で新旧を同じ入力に通して exit code / stdout / stderr をバイト比較しました。

```console
$ node /private/tmp/rr1950-baseline/compare-hook.mjs /bin/bash
SAME exit=2/2 err=582/582B  git push --force origin main
SAME exit=2/2 err=577/577B  git push -f origin main
SAME exit=2/2 err=593/593B  git push origin main --force-with-lease
SAME exit=2/2 err=598/598B  git push --force-with-lease=main origin main
SAME exit=2/2 err=577/577B  git reset --hard HEAD~1
SAME exit=2/2 err=568/568B  git stash drop
SAME exit=2/2 err=569/569B  git stash clear
SAME exit=2/2 err=588/588B  git -C /repo push --force origin x
SAME exit=0/0 err=0/0B  git status
SAME exit=0/0 err=0/0B  git fetch --tags --force
SAME exit=0/0 err=0/0B  git push origin main
SAME exit=0/0 err=0/0B  echo "do not use git push --force"
SAME exit=0/0 err=0/0B  grep -rn -- "--force-with-lease" .
SAME exit=0/0 err=0/0B  ls -f
SAME exit=0/0 err=0/0B  git tag -f v1
--- shell=/bin/bash cases=15 differing=0
```

旧を bash 3.2、新を bash 5.3.15 で走らせた組み合わせでも `differing=0` でした。

### count-in-clean-tree.sh

`--help` / 未知オプション / コマンド未指定の 3 経路で、旧（3.2）と新（5.3.15）の stdout・stderr を `cmp` で比較して一致（すべて RC=0）、exit code も一致（0 / 2 / 2）。

### setup_river_review.sh

破壊的なので `/private/tmp` のサンドボックスで実行しました。旧（3.2）と新（5.3.15）で、生成された 5 ファイル + `.gitkeep` 群を `diff -r` で比較して差分なし、stdout・stderr も `cmp` で一致。

```console
TREE_DIFF=0
OUT=0
ERR=0
```

### 走査で 0 件

`git ls-files` の tracked shell script（`*.sh` / `*.bash` の 11 ファイル + shebang 付き拡張子なし）を走査しました。**サイズはバイトで数えています**（`count-in-clean-tree.sh` の本体は 518 バイト / 309 文字で、文字数だと閾値以下に見えて見逃します）。開始行の正規表現は行末固定していません（`cat <<'EOF' > file` の形を取り逃がすため）。

```console
# 変更前
OVER 564  .claude/hooks/no-force-push.sh:164   <<EOF
OVER 518  scripts/count-in-clean-tree.sh:44    <<EOF
OVER 583  scripts/setup_river_review.sh:29     <<EODEPRECATED
OVER 2554 scripts/setup_river_review.sh:56     <<EORD
OVER 726  scripts/setup_river_review.sh:152    <<EOG
OVER 1276 scripts/setup_river_review.sh:163    <<EOS
OVER 892  scripts/setup_river_review.sh:199    <<EOJ
--- heredocs scanned: 8, over 512B: 7

# 変更後
--- heredocs scanned: 1, over 512B: 0
```

走査だけでは単位や正規表現の誤りを検出できないので、実挙動でも確認しています。

```console
BLOCK_5315=2   # ブロック対象（旧: 124）
PASS_5315=0    # 通過対象
HELP_5315=0    # count-in-clean-tree.sh --help（旧: 124）
```

## C: なぜ B と別に要るのか

B を入れれば今は固まりません。C は**将来また固まる形が入ったときに孤児を作らない**ための防御です。

`node --test` はタイムアウトで node 自体を終了させますが、`spawnSync` が起動した子 bash は kill されず ppid=1 の孤児になります。#1950 では 5 時間以上生き残った孤児が 14 個観測されました。

### 実測で分かった追加事実 — `killSignal` だけでは足りない

issue の案は `timeout` + `killSignal: 'SIGKILL'` でしたが、これだけでは孤児が残ることを実測しました。`spawnSync` が SIGKILL を送るのは自分が起動した pid だけで、その子が fork していると孫が生き残ります。

```console
# timeout + killSignal のみ（fork する子で対照実験）
=== ps after ===
53173     1       00:02 sleep 45
53175     1       00:02 sleep 45      ← ppid=1 の孤児が 2 個
```

さらに、deadlock した bash は **heredoc パイプの両端を自分で握っています**（`lsof` で fd 3 と fd 4 が同一パイプ）。読み手が消えても EPIPE を受け取れないので、放置すると永久に残ります。

そこで `detached: true` で子をプロセスグループのリーダーにし、タイムアウト時にグループ全体へ SIGKILL を送る `tests/helpers/spawn-guard.mjs` を追加し、両テストの `spawnSync` 6 箇所をここへ集約しました（同じロジックの二重管理を避けるため helper 化しています）。

```console
# spawnSyncGuarded で実際に deadlock する script を叩く
ok 1 - guarded helper reaps a deadlocked bash entirely
=== ps after ===
（新規の残留プロセスなし）
```

タイムアウト値は 30 秒にしました。実測で `no-force-push-hook.test.mjs` の 1 呼び出しが 40〜210ms、`count-in-clean-tree.test.mjs` は全体で 3〜4 秒・最も遅い 1 呼び出しでも 1 秒未満なので、遅いマシンでも偽陽性になりません。

## 根治（bash のダウングレード）は対象外

原因バイナリは `/opt/homebrew/Cellar/bash/5.3.15` です。削除・ダウングレードすれば消える問題ですが、bash 5 に依存する他ツールへの影響が読めないため、マシン設定の変更は本 PR では扱いません。repo 側は「512 バイト超の heredoc を書かない」で守ります。

## 検証

| コマンド | 結果 |
| --- | --- |
| `npm test` | tests 3567 / pass 3565 / fail 2 |
| `npm run lint:code` | OK |
| `npm run format:check` | OK |
| `npm run meta:validate` | OK |
| `npm run skills:validate` | OK |
| `npx textlint --no-cache tests/helpers/README.md` | OK |

`npm test` の 2 件の fail は `tests/validate-agents.test.mjs` で、本変更とは無関係です。`scripts/validate-agents.mjs:55-62` が `<repoRoot>/node_modules/ajv/dist/refs/json-schema-draft-07.json` を読みますが、agent worktree には `node_modules` が無いため meta-schema が登録できず落ちます。`node_modules` のある通常のチェックアウト（同一コミット）では同じテストが 2/2 pass します。`npm ci` を走らせる CI では再現しません。

`src/**` は触っていないので dist の再ビルドは不要です。
